### PR TITLE
fix: stop capturing errors, rethrow for much better debuggability

### DIFF
--- a/javascript/examples/vitest/tests/travel-agent.test.ts
+++ b/javascript/examples/vitest/tests/travel-agent.test.ts
@@ -1,0 +1,184 @@
+import { openai } from "@ai-sdk/openai";
+import scenario, {
+  type AgentAdapter,
+  AgentReturnTypes,
+  AgentRole,
+} from "@langwatch/scenario";
+import { CoreMessage, generateText, tool } from "ai";
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+// Define the weather tool using zod for parameters
+const getCurrentWeather = tool({
+  description: "Get the current weather in a given city.",
+  parameters: z.object({
+    city: z.string().describe("The city to get the weather for."),
+    date_range: z.string().describe("The date range to get the weather for."),
+  }),
+  execute: async ({
+    city,
+    date_range,
+  }: {
+    city: string;
+    date_range: string;
+  }) => {
+    // Simulate weather
+    const choices = ["sunny", "cloudy", "rainy", "snowy"];
+    const temperature = Math.floor(Math.random() * 31);
+    const weather = choices[Math.floor(Math.random() * choices.length)];
+    return `The weather in ${city} is ${weather} with a temperature of ${temperature}°C.`;
+  },
+});
+
+const getAccomodation = tool({
+  description: "Get the accomodation in a given city.",
+  parameters: z.object({
+    city: z.string().describe("The city to get the accomodation for."),
+    weather: z.string().describe("The weather in the city."),
+  }),
+  execute: async ({ city, weather }: { city: string; weather: string }) => {
+    if (weather === "sunny") {
+      return [
+        "Water Park Inn - $100 per night",
+        "Beach Resort La Playa - $150 per night",
+        "Hotelito - $200 per night",
+      ];
+    }
+
+    if (weather === "cloudy" || weather === "rainy") {
+      return [
+        "Hotel Barcelona - $100 per night",
+        "Hotel Rome - $150 per night",
+        "Hotel Venice - $200 per night",
+      ];
+    }
+
+    if (weather === "snowy") {
+      return [
+        "Mountains Peak Lodge - $100 per night",
+        "Snowy Mountain Inn - $150 per night",
+        "Snowy Mountain Resort - $200 per night",
+      ];
+    }
+
+    throw new Error(`Invalid weather: ${weather}`);
+  },
+});
+
+const callTravelAgent = async (
+  messages: CoreMessage[],
+  responseMessages: CoreMessage[] = []
+): Promise<AgentReturnTypes> => {
+  const response = await generateText({
+    model: openai("gpt-4.1"),
+    messages: [
+      {
+        role: "system",
+        content: `
+            You are a helpful assistant that may help the user with weather information.
+            Do not guess the city if they don't provide it.
+            You can make multiple tool calls if they ask multiple cities.
+
+            Today is Friday, 25th July 2025.
+          `,
+      },
+      ...messages,
+      ...responseMessages,
+    ],
+    tools: {
+      get_current_weather: getCurrentWeather,
+      get_accomodation: getAccomodation,
+    },
+    toolChoice: "auto",
+    temperature: 0.0,
+  });
+
+  if (response.toolCalls && response.toolCalls.length > 0) {
+    const toolCall = response.toolCalls[0];
+    // Agent executes the tool directly and returns both messages
+    const toolResult = await getCurrentWeather.execute(toolCall.args, {
+      toolCallId: toolCall.toolCallId,
+      messages: messages,
+    });
+    return callTravelAgent(messages, [
+      ...responseMessages,
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            args: toolCall.args,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolName: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            result: toolResult,
+          },
+        ],
+      },
+    ]);
+  }
+
+  return [
+    ...responseMessages,
+    {
+      role: "assistant",
+      content: response.text,
+    },
+  ];
+};
+
+const travelAgent: AgentAdapter = {
+  role: AgentRole.AGENT,
+  call: async (input) => {
+    return callTravelAgent(input.messages);
+  },
+};
+
+describe("Travel Agent", () => {
+  it("should provide the weather and accomodation options based on it", async () => {
+    const result = await scenario.run({
+      name: "boat trip travel planning",
+      description: `
+        The user is planning a boat trip from Barcelona to Rome,
+        and is wondering what the weather will be like.
+
+        The user will ask for different accomodation options
+        depending on the weather.
+      `,
+      agents: [
+        travelAgent,
+        scenario.userSimulatorAgent({ model: openai("gpt-4.1") }),
+        scenario.judgeAgent({
+          model: openai("gpt-4.1"),
+          criteria: [
+            "The agent should ask which city is the user asking accomodations for if they don't provide it.",
+            "The agent should share the prices of each accomodation for the user to consider.",
+            "The agent should not bias the user towards a specific accomodation.",
+          ],
+        }),
+      ],
+      script: [
+        scenario.user(),
+        scenario.agent(),
+        (state) => expect(state.hasToolCall("get_current_weather2")).toBe(true),
+        scenario.user(),
+        scenario.agent(),
+        scenario.user(),
+        scenario.agent(),
+        (state) => expect(state.hasToolCall("get_accomodation")).toBe(true),
+        scenario.judge(),
+      ],
+      setId: "javascript-examples",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -193,7 +193,9 @@ export class ScenarioExecution implements ScenarioExecutionLike {
         status: ScenarioRunStatus.ERROR,
         result: errorResult,
       });
-      return errorResult;
+
+      // Re-throw the error in case it was a vitest assertion error
+      throw error;
     }
   }
 
@@ -760,8 +762,8 @@ export class ScenarioExecution implements ScenarioExecutionLike {
         }
       );
 
-      // Re-throw the error with additional context
-      throw new Error(`Script step ${stepIndex + 1} failed: ${errorMessage}`);
+      // Re-throw the error in case it was a vitest assertion error
+      throw error;
     }
   }
 }

--- a/javascript/src/integrations/vitest/reporter.ts
+++ b/javascript/src/integrations/vitest/reporter.ts
@@ -124,6 +124,8 @@ class VitestReporter implements Reporter {
               roleLabel = chalk.cyan("Agent");
             else if (role.toLowerCase() === "assistant")
               roleLabel = chalk.cyan("Assistant");
+            else if (role.toLowerCase() === "tool")
+              roleLabel = chalk.yellow("Tool");
             else roleLabel = chalk.yellow(role);
             console.log(`${roleLabel}: ${m.content}`);
           }

--- a/javascript/src/integrations/vitest/reporter.ts
+++ b/javascript/src/integrations/vitest/reporter.ts
@@ -39,6 +39,10 @@ function getFullTestName(task: { name: string; suite?: SuiteLike }): string {
   return name;
 }
 
+function indent(str: string, n: number = 2) {
+  return str.replace(/^/gm, " ".repeat(n));
+}
+
 class VitestReporter implements Reporter {
   private results: Array<{
     name: string;
@@ -108,7 +112,7 @@ class VitestReporter implements Reporter {
       }
 
       if (messages.length) {
-        console.log("Chat log:");
+        console.log("Chat log:\n");
         let lastMessageCount = 0;
         for (const msg of messages) {
           const allMessages =
@@ -118,15 +122,56 @@ class VitestReporter implements Reporter {
           // Only print new messages
           for (const m of allMessages.slice(lastMessageCount)) {
             const role = m.role;
+
+            if (
+              role.toLowerCase() === "assistant" &&
+              "toolCalls" in m &&
+              Array.isArray(m.toolCalls) &&
+              m.toolCalls.length > 0
+            ) {
+              for (const toolCall of m.toolCalls) {
+                const functionName = toolCall.function.name;
+                let parsedJson = "";
+                try {
+                  parsedJson = JSON.stringify(
+                    JSON.parse(toolCall.function.arguments),
+                    null,
+                    2
+                  );
+                } catch {
+                  parsedJson = toolCall.function.arguments;
+                }
+                const role = chalk.magenta(`ToolCall(${functionName}):`);
+                console.log(`${role}:\n\n${indent(parsedJson)}\n`);
+              }
+              continue;
+            }
+
             let roleLabel = role;
             if (role.toLowerCase() === "user") roleLabel = chalk.green("User");
             else if (role.toLowerCase() === "agent")
               roleLabel = chalk.cyan("Agent");
             else if (role.toLowerCase() === "assistant")
-              roleLabel = chalk.cyan("Assistant");
-            else if (role.toLowerCase() === "tool")
-              roleLabel = chalk.yellow("Tool");
-            else roleLabel = chalk.yellow(role);
+              if (
+                Array.isArray(m.content) &&
+                typeof m.content.at(0) === "object" &&
+                (m.content.at(0) as unknown as { type: string })?.type ===
+                  "tool-call"
+              )
+                roleLabel = chalk.cyan("ToolCall");
+              else roleLabel = chalk.cyan("Assistant");
+            else if (role.toLowerCase() === "tool") {
+              roleLabel = chalk.magenta("ToolResult");
+              let parsedJson = "";
+              try {
+                parsedJson = JSON.stringify(JSON.parse(m.content), null, 2);
+              } catch {
+                parsedJson = m.content;
+              }
+              console.log(`${roleLabel}:\n\n${indent(parsedJson)}\n`);
+              continue;
+            } else roleLabel = chalk.yellow(role);
+
             console.log(`${roleLabel}: ${m.content}`);
           }
           lastMessageCount = allMessages.length;

--- a/javascript/src/utils/ids.ts
+++ b/javascript/src/utils/ids.ts
@@ -41,8 +41,6 @@ export function getBatchRunId(): string {
 
   // If the batch run id is set in the environment, use it
   if (process.env.SCENARIO_BATCH_RUN_ID) {
-    console.log("process.env.SCENARIO_BATCH_RUN_ID", process.env.SCENARIO_BATCH_RUN_ID);
-
     return (batchRunId = process.env.SCENARIO_BATCH_RUN_ID);
   }
 

--- a/python/examples/test_travel_agent.py
+++ b/python/examples/test_travel_agent.py
@@ -1,0 +1,180 @@
+"""
+Example test for a weather agent.
+
+This example demonstrates testing an AI agent that provides weather information.
+"""
+
+import pytest
+import scenario
+import litellm
+from function_schema import get_function_schema
+
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio
+async def test_travel_agent():
+    # Integrate with your agent
+    class TravelAgent(scenario.AgentAdapter):
+        async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
+            return travel_agent(input.messages)
+
+    def check_for_weather_tool_call(state: scenario.ScenarioState):
+        assert state.has_tool_call("get_current_weather")
+
+    def check_for_accomodation_tool_call(state: scenario.ScenarioState):
+        assert state.has_tool_call("get_accomodation")
+
+    # Run the scenario
+    result = await scenario.run(
+        name="boat trip travel planning",
+        description="""
+            The user is planning a boat trip from Barcelona to Rome,
+            and is wondering what the weather will be like.
+
+            The user will ask for different accomodation options
+            depending on the weather.
+        """,
+        agents=[
+            TravelAgent(),
+            scenario.UserSimulatorAgent(model="openai/gpt-4.1"),
+            scenario.JudgeAgent(
+                model="openai/gpt-4.1",
+                criteria=[
+                    "The agent should ask which city is the user asking accomodations for if they don't provide it.",
+                    "The agent should share the prices of each accomodation for the user to consider.",
+                    "The agent should not bias the user towards a specific accomodation.",
+                ],
+            ),
+        ],
+        script=[
+            scenario.user("check weather barcelona to rome next week"),
+            scenario.agent(),
+            check_for_weather_tool_call,
+            scenario.user(),
+            scenario.agent(),
+            scenario.user(),
+            scenario.agent(),
+            check_for_accomodation_tool_call,
+            scenario.judge(),
+        ],
+        set_id="python-examples",
+    )
+
+    # Assert the simulation was successful
+    assert result.success
+
+
+# Example agent implementation, without any frameworks
+import litellm
+import random
+import json
+
+
+def get_current_weather(city: str, date_range: str) -> str:
+    """
+    Get the current weather in a given city.
+
+    Args:
+        city: The city to get the weather for.
+
+    Returns:
+        The current weather in the given city.
+    """
+
+    choices = [
+        "sunny",
+        "cloudy",
+        "rainy",
+        "snowy",
+    ]
+    temperature = random.randint(0, 30)
+    return f"The weather in {city} is {random.choice(choices)} with a temperature of {temperature}°C."
+
+
+def get_accomodation(city: str, weather: str) -> list[str]:
+    """
+    Get the accomodation in a given city.
+    """
+    if weather == "sunny":
+        return [
+            "Water Park Inn - $100 per night",
+            "Beach Resort La Playa - $150 per night",
+            "Hotelito - $200 per night",
+        ]
+    elif weather == "cloudy" or weather == "rainy":
+        return [
+            "Hotel Barcelona - $100 per night",
+            "Hotel Rome - $150 per night",
+            "Hotel Venice - $200 per night",
+        ]
+    elif weather == "snowy":
+        return [
+            "Mountains Peak Lodge - $100 per night",
+            "Snowy Mountain Inn - $150 per night",
+            "Snowy Mountain Resort - $200 per night",
+        ]
+    else:
+        raise ValueError(f"Invalid weather: {weather}")
+
+
+@scenario.cache()
+def travel_agent(messages, response_messages=[]) -> scenario.AgentReturnTypes:
+    tools = [
+        get_current_weather,
+        get_accomodation,
+    ]
+
+    response = litellm.completion(
+        model="openai/gpt-4.1",
+        messages=[
+            {
+                "role": "system",
+                "content": """
+                    You a helpful assistant that may help the user with weather information.
+                    Do not guess the city if they don't provide it.
+                    You can make multiple tool calls if they ask multiple cities.
+
+                    Today is Friday, 25th July 2025.
+                """,
+            },
+            *messages,
+            *response_messages,
+        ],
+        tools=[
+            {"type": "function", "function": get_function_schema(tool)}
+            for tool in tools
+        ],
+        tool_choice="auto",
+    )
+
+    message = response.choices[0].message  # type: ignore
+
+    if message.tool_calls:
+        tools_by_name = {tool.__name__: tool for tool in tools}
+        tool_responses = []
+        for tool_call in message.tool_calls:
+            tool_call_name = tool_call.function.name
+            tool_call_args = json.loads(tool_call.function.arguments)
+            if tool_call_name in tools_by_name:
+                tool_call_function = tools_by_name[tool_call_name]  # type: ignore
+                tool_call_function_response = tool_call_function(**tool_call_args)
+                tool_responses.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": json.dumps(tool_call_function_response),
+                    }
+                )
+            else:
+                raise ValueError(f"Tool {tool_call_name} not found")
+
+        return travel_agent(
+            messages,
+            [
+                *response_messages,
+                message,
+                *tool_responses,
+            ],
+        )
+
+    return [*response_messages, message]  # type: ignore


### PR DESCRIPTION
Capturing errors prevent vitest from showing me the exact line of code where a script step is failing, if I'm using a lambda assertion in the middle, we shouldn't capture errors from scenario, we should propagate

## Before

Where is the error?
<img width="1473" height="1089" alt="image" src="https://github.com/user-attachments/assets/fce9634b-ebe2-4ca7-b6fb-9a7e90266ef0" />

Seems like it was after the simulation finished, at `expect(result.success).toBe(true);`, but it was not really, it was at step 3

Without rethrowing, it's way more clear

## After

Where is the error now?
<img width="1470" height="1161" alt="image" src="https://github.com/user-attachments/assets/fc99d0c1-3f47-4459-b723-bbd01273e181" />

Much more clear