### PR TITLE
refactor: simplify scenario execution by removing complex turn manage…

### DIFF
--- a/.cursor/rules/file-structure.mdc
+++ b/.cursor/rules/file-structure.mdc
@@ -6,7 +6,14 @@ alwaysApply: false
 We want thin files that aim to have a single responsibility and a single export.
 We should have a single export per file.
 
-Specific directories:
-- hooks: for hooks
-- components: for components
-- pages: for pages
+Special files:
+
+## Utils
+File name convention: *.utils.ts
+Single export: XXXUtils
+example: 
+
+export const RunnerUtils = {
+    runnerFunction1,
+    runnerFunction2,
+}

--- a/javascript/src/domain/scenarios/script-commands.ts
+++ b/javascript/src/domain/scenarios/script-commands.ts
@@ -1,0 +1,80 @@
+import { CoreMessage } from "ai";
+import { ScenarioExecutionStateLike, ScenarioExecutionLike } from "../index";
+
+/**
+ * Represents a typed script command that describes a specific action to take
+ * during scenario execution. Commands are data structures that can be serialized
+ * and provide type safety for scenario scripts.
+ */
+export type ScriptCommand =
+  | MessageCommand
+  | UserCommand
+  | AgentCommand
+  | JudgeCommand
+  | ProceedCommand
+  | SucceedCommand
+  | FailCommand;
+
+/**
+ * Command to add a specific message directly to the conversation.
+ * Useful for simulating tool responses, system messages, or specific conversational states.
+ */
+export interface MessageCommand {
+  readonly type: "message";
+  readonly message: CoreMessage;
+}
+
+/**
+ * Command to generate or specify a user message in the conversation.
+ * If content is not provided, the user simulator agent will generate content automatically.
+ */
+export interface UserCommand {
+  readonly type: "user";
+  readonly content?: string | CoreMessage;
+}
+
+/**
+ * Command to generate or specify an agent response in the conversation.
+ * If content is not provided, the agent under test will generate content automatically.
+ */
+export interface AgentCommand {
+  readonly type: "agent";
+  readonly content?: string | CoreMessage;
+}
+
+/**
+ * Command to invoke the judge agent to evaluate the current conversation state.
+ * The judge will evaluate based on its configured criteria and may end the scenario.
+ */
+export interface JudgeCommand {
+  readonly type: "judge";
+  readonly content?: string | CoreMessage;
+}
+
+/**
+ * Command to let the scenario proceed automatically for a specified number of turns.
+ * Agents will interact naturally according to their roles until the turn limit is reached
+ * or the judge decides to end the scenario.
+ */
+export interface ProceedCommand {
+  readonly type: "proceed";
+  readonly turns?: number;
+  readonly onTurn?: (state: ScenarioExecutionStateLike) => void | Promise<void>;
+  readonly onStep?: (state: ScenarioExecutionStateLike) => void | Promise<void>;
+}
+
+/**
+ * Command to immediately end the scenario with a success verdict.
+ */
+export interface SucceedCommand {
+  readonly type: "succeed";
+  readonly reasoning?: string;
+}
+
+/**
+ * Command to immediately end the scenario with a failure verdict.
+ */
+export interface FailCommand {
+  readonly type: "fail";
+  readonly reasoning?: string;
+}

--- a/javascript/src/domain/scenarios/script-commands.ts
+++ b/javascript/src/domain/scenarios/script-commands.ts
@@ -1,5 +1,5 @@
 import { CoreMessage } from "ai";
-import { ScenarioExecutionStateLike, ScenarioExecutionLike } from "../index";
+import { ScenarioExecutionStateLike } from "../index";
 
 /**
  * Represents a typed script command that describes a specific action to take

--- a/javascript/src/execution/scenario-execution.utils.ts
+++ b/javascript/src/execution/scenario-execution.utils.ts
@@ -1,0 +1,68 @@
+import { ModelMessage } from "ai";
+import { AgentReturnTypes } from "../domain";
+
+/**
+ * Utility functions for scenario execution.
+ */
+export const ScenarioExecutionUtils = {
+  /**
+   * Converts agent return types to ModelMessage format.
+   *
+   * This utility function handles the various return types that agents can return
+   * and converts them to a standardized ModelMessage format. Agents can return:
+   * - A string (converted to a message with the specified role)
+   * - An array of ModelMessage objects (returned as-is)
+   * - A single ModelMessage object (wrapped in an array)
+   * - Any other type (returns empty array)
+   *
+   * @param response - The response from an agent (string, ModelMessage, or array of ModelMessage)
+   * @param role - The role to assign if the response is a string ("user" or "assistant")
+   * @returns An array of ModelMessage objects
+   */
+  convertAgentReturnTypesToMessages(
+    response: AgentReturnTypes,
+    role: "user" | "assistant"
+  ): ModelMessage[] {
+    if (typeof response === "string")
+      return [{ role, content: response } as ModelMessage];
+
+    if (Array.isArray(response)) return response;
+
+    if (response && typeof response === "object" && "role" in response)
+      return [response];
+
+    return [];
+  },
+
+  /**
+   * Extracts structured error information for logging and reporting.
+   *
+   * This function takes any thrown error (unknown type) and returns an object
+   * containing the error's name, message, and stack trace if available.
+   * If the input is not an instance of Error, it provides a generic name and
+   * stringified value for message.
+   *
+   * @param error - The error object or value to extract information from.
+   * @returns An object with 'name', optional 'message', and optional 'stack' properties.
+   */
+  extractErrorInfo(error: unknown): {
+    name: string;
+    message?: string;
+    stack?: string;
+  } {
+    // Extracts error information in a structured way for logging and reporting.
+    // Returns an object with name, message, and stack if available.
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      };
+    }
+    // If not an Error instance, provide a generic name and stringified value.
+    return {
+      name: typeof error,
+      message: String(error),
+    };
+  },
+};


### PR DESCRIPTION
…ment

- Remove pendingRolesOnTurn, pendingAgentsOnTurn, and turn orchestration logic
- Simplify user(), agent(), judge() methods to call agents directly
- Replace complex proceed() with simple user→agent→judge loop
- Remove scriptCallAgent and callAgent abstraction layers
- Keep fail-fast judge evaluation behavior
- Reduce code complexity from 682 lines to 136 lines in execution system

This maintains the same functionality while dramatically simplifying the codebase.