### PR TITLE
Fix: Handle criteria returned as JSON string in JudgeAgent

### DIFF
--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -899,6 +899,14 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 # Can happen when the LLM is uncertain about the schema format (especially with
                 # complex dynamic schemas using sanitized criterion text as property names).
                 # See: https://github.com/langwatch/scenario/issues/161
+                #
+                # If we cannot recover a dict, fail closed: return an inconclusive
+                # ScenarioResult with success=False instead of silently falling back to
+                # an empty dict. With an empty dict + verdict=="success", the original
+                # success formula `verdict == "success" and len(failed_criteria) == 0`
+                # would evaluate True and report a passing scenario for a malformed
+                # response. That is exactly the false-green we want to avoid.
+                malformed_reason: Optional[str] = None
                 if isinstance(criteria_verdicts, str):
                     try:
                         criteria_verdicts = json.loads(criteria_verdicts)
@@ -906,19 +914,35 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                             "JudgeAgent: Parsed criteria from JSON string to dict"
                         )
                     except json.JSONDecodeError:
-                        logger.warning(
-                            f"JudgeAgent: Failed to parse criteria string as JSON: {criteria_verdicts}. "
-                            "Using empty dict as fallback."
+                        malformed_reason = (
+                            f"criteria was a string that could not be parsed as JSON: "
+                            f"{criteria_verdicts!r}"
                         )
-                        criteria_verdicts = {}
 
-                # Ensure criteria_verdicts is a dict before calling .values()
-                if not isinstance(criteria_verdicts, dict):
-                    logger.warning(
-                        f"JudgeAgent: criteria is {type(criteria_verdicts).__name__}, expected dict. "
-                        "Using empty dict as fallback."
+                if malformed_reason is None and not isinstance(criteria_verdicts, dict):
+                    malformed_reason = (
+                        f"criteria was {type(criteria_verdicts).__name__}, expected dict"
                     )
-                    criteria_verdicts = {}
+
+                if malformed_reason is not None:
+                    logger.warning(
+                        "JudgeAgent: malformed criteria from LLM (%s); "
+                        "returning inconclusive to avoid reporting a false success.",
+                        malformed_reason,
+                    )
+                    return ScenarioResult(
+                        success=False,
+                        messages=cast(Any, messages),
+                        reasoning=(
+                            f"JudgeAgent: malformed verdict response from LLM "
+                            f"({malformed_reason}). Original LLM verdict "
+                            f"{verdict!r} was discarded because the criteria "
+                            f"payload could not be evaluated. Original LLM "
+                            f"reasoning: {reasoning}"
+                        ),
+                        passed_criteria=[],
+                        failed_criteria=list(effective_criteria),
+                    )
 
                 passed_criteria = [
                     effective_criteria[idx]

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -895,6 +895,31 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 reasoning = args.get("reasoning", "No reasoning provided")
                 criteria_verdicts = args.get("criteria", {})
 
+                # Handle case where the LLM returns criteria as a JSON string instead of a dict.
+                # Can happen when the LLM is uncertain about the schema format (especially with
+                # complex dynamic schemas using sanitized criterion text as property names).
+                # See: https://github.com/langwatch/scenario/issues/161
+                if isinstance(criteria_verdicts, str):
+                    try:
+                        criteria_verdicts = json.loads(criteria_verdicts)
+                        logger.debug(
+                            "JudgeAgent: Parsed criteria from JSON string to dict"
+                        )
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            f"JudgeAgent: Failed to parse criteria string as JSON: {criteria_verdicts}. "
+                            "Using empty dict as fallback."
+                        )
+                        criteria_verdicts = {}
+
+                # Ensure criteria_verdicts is a dict before calling .values()
+                if not isinstance(criteria_verdicts, dict):
+                    logger.warning(
+                        f"JudgeAgent: criteria is {type(criteria_verdicts).__name__}, expected dict. "
+                        "Using empty dict as fallback."
+                    )
+                    criteria_verdicts = {}
+
                 passed_criteria = [
                     effective_criteria[idx]
                     for idx, criterion in enumerate(criteria_verdicts.values())

--- a/python/tests/test_judge_criteria_parsing.py
+++ b/python/tests/test_judge_criteria_parsing.py
@@ -1,0 +1,172 @@
+"""Tests for JudgeAgent's defensive parsing of the `criteria` field on the
+finish_test tool call (see https://github.com/langwatch/scenario/issues/161).
+
+The LLM occasionally serializes the nested `criteria` object as a JSON string
+instead of a proper dict — a known failure mode with dynamically-named
+property schemas (sanitized criterion text used as keys).
+
+JudgeAgent must:
+  - Parse a stringified-but-valid JSON dict and evaluate criteria normally.
+  - Fail closed on a malformed payload by returning an inconclusive
+    ScenarioResult (`success=False`), rather than silently treating the
+    response as a passing scenario. The latter would be a false green when
+    `verdict == "success"` and `criteria` fell back to an empty dict.
+"""
+
+import json
+from types import SimpleNamespace
+
+from scenario import JudgeAgent
+from scenario.types import ScenarioResult
+
+
+def _mock_finish_test_response(args: dict) -> SimpleNamespace:
+    """Build a minimal litellm-style ModelResponse with a single finish_test tool call.
+
+    Mirrors the helper used in test_judge_force_verdict_hardening.py.
+    """
+    tc = SimpleNamespace(
+        id="tc-final",
+        type="function",
+        function=SimpleNamespace(
+            name="finish_test", arguments=json.dumps(args)
+        ),
+    )
+    message = SimpleNamespace(tool_calls=[tc], content=None)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+class TestStringifiedCriteriaIsParsed:
+    """The happy path of the original #161 fix: a string that is valid JSON
+    should be parsed into a dict and evaluated like a normal criteria object."""
+
+    def test_stringified_criteria_dict_is_parsed_and_evaluated(self):
+        agent = JudgeAgent(criteria=["A", "B"], model="openai/gpt-5-mini")
+        response = _mock_finish_test_response(
+            {
+                "verdict": "success",
+                "reasoning": "both criteria met",
+                # criteria sent as a JSON-string instead of an object — the
+                # exact LLM failure mode reported in #161.
+                "criteria": json.dumps({"a": "true", "b": "true"}),
+            }
+        )
+
+        result = agent._parse_response(response, ["A", "B"], messages=[])
+
+        assert isinstance(result, ScenarioResult)
+        assert result.success is True
+        assert set(result.passed_criteria) == {"A", "B"}
+        assert result.failed_criteria == []
+
+    def test_stringified_criteria_with_failure_still_fails(self):
+        """Stringified criteria parsing should not bias toward success — a
+        parsed dict with a failed criterion still yields success=False."""
+        agent = JudgeAgent(criteria=["A", "B"], model="openai/gpt-5-mini")
+        response = _mock_finish_test_response(
+            {
+                "verdict": "success",  # LLM said success at the top level…
+                "reasoning": "claimed success",
+                # …but one criterion failed inside the (stringified) payload.
+                "criteria": json.dumps({"a": "true", "b": "false"}),
+            }
+        )
+
+        result = agent._parse_response(response, ["A", "B"], messages=[])
+
+        assert result.success is False
+        assert result.passed_criteria == ["A"]
+        assert result.failed_criteria == ["B"]
+
+
+class TestMalformedCriteriaIsInconclusive:
+    """The hardening Drew asked for in PR #196: malformed payloads must not
+    produce a false-green ScenarioResult."""
+
+    def test_unparseable_criteria_string_returns_inconclusive_not_success(self):
+        """The exact false-green case: verdict=='success' + criteria is a
+        broken string. Before the fix, this evaluated to success=True because
+        the empty-dict fallback made failed_criteria empty. It must now fail
+        closed."""
+        agent = JudgeAgent(criteria=["A", "B"], model="openai/gpt-5-mini")
+        response = _mock_finish_test_response(
+            {
+                "verdict": "success",
+                "reasoning": "claims success",
+                "criteria": "{not valid json at all",
+            }
+        )
+
+        result = agent._parse_response(response, ["A", "B"], messages=[])
+
+        assert isinstance(result, ScenarioResult)
+        assert result.success is False, (
+            "A malformed criteria payload must not report a passing scenario "
+            "even when the top-level verdict says 'success'."
+        )
+        assert result.passed_criteria == []
+        assert set(result.failed_criteria) == {"A", "B"}
+        assert result.reasoning is not None
+        assert "malformed" in result.reasoning.lower()
+
+    def test_non_dict_non_string_criteria_returns_inconclusive(self):
+        """A list (or any other non-dict, non-string type) is also malformed
+        and must fail closed rather than crashing on `.values()`."""
+        agent = JudgeAgent(criteria=["A", "B"], model="openai/gpt-5-mini")
+        response = _mock_finish_test_response(
+            {
+                "verdict": "success",
+                "reasoning": "claims success",
+                "criteria": ["true", "true"],  # wrong shape entirely
+            }
+        )
+
+        result = agent._parse_response(response, ["A", "B"], messages=[])
+
+        assert result.success is False
+        assert result.passed_criteria == []
+        assert set(result.failed_criteria) == {"A", "B"}
+        assert result.reasoning is not None
+        assert "list" in result.reasoning.lower()
+
+    def test_stringified_non_dict_json_returns_inconclusive(self):
+        """A string that parses successfully but yields a non-dict (e.g. a
+        JSON-encoded list) must also fail closed. This exercises both
+        defensive branches in sequence: the JSON-string parse succeeds, then
+        the dict-type check catches the wrong shape."""
+        agent = JudgeAgent(criteria=["A", "B"], model="openai/gpt-5-mini")
+        response = _mock_finish_test_response(
+            {
+                "verdict": "success",
+                "reasoning": "claims success",
+                # Valid JSON, but the wrong shape — parses to a list.
+                "criteria": json.dumps(["true", "true"]),
+            }
+        )
+
+        result = agent._parse_response(response, ["A", "B"], messages=[])
+
+        assert result.success is False
+        assert result.passed_criteria == []
+        assert set(result.failed_criteria) == {"A", "B"}
+        assert result.reasoning is not None
+        assert "list" in result.reasoning.lower()
+
+    def test_malformed_criteria_preserves_original_reasoning_for_debugging(self):
+        """The fail-closed reasoning should surface the original LLM reasoning
+        so an operator can see what the judge tried to say before we discarded
+        the verdict."""
+        agent = JudgeAgent(criteria=["A"], model="openai/gpt-5-mini")
+        response = _mock_finish_test_response(
+            {
+                "verdict": "success",
+                "reasoning": "the agent was perfect in every way",
+                "criteria": "{broken",
+            }
+        )
+
+        result = agent._parse_response(response, ["A"], messages=[])
+
+        assert result.reasoning is not None
+        assert "the agent was perfect in every way" in result.reasoning


### PR DESCRIPTION
## Summary

Fixes #161 

This PR addresses an intermittent bug where `JudgeAgent` fails with `AttributeError: 'str' object has no attribute 'values'` when the LLM returns the `criteria` field as a JSON string instead of a dictionary object.

## Problem

The error occurs at lines 439 and 444 in `judge_agent.py` when the code calls `criteria.values()` without verifying that `criteria` is actually a dict:

```python
passed_criteria = [
    self.criteria[idx]
    for idx, criterion in enumerate(criteria.values())  # ❌ Fails if criteria is a string
    if criterion == "true"
]
```

## Root Cause

When the LLM is uncertain about the schema format (particularly with complex dynamic schemas using sanitized criterion text as property names), it sometimes serializes the nested `criteria` object as a JSON string rather than a proper dict.

Example of problematic LLM response:
```json
{
  "verdict": "success",
  "reasoning": "...",
  "criteria": "{\"criterion_1\": \"true\", \"criterion_2\": \"false\"}"  // ❌ String instead of object
}
```

Expected format:
```json
{
  "verdict": "success",
  "reasoning": "...",
  "criteria": {"criterion_1": "true", "criterion_2": "false"}  // ✅ Object
}
```

## Solution

This PR adds defensive parsing after extracting `criteria` from tool call arguments:

1. **Check if `criteria` is a string**
   - If yes, attempt to parse it with `json.loads()`
   - If parsing fails, log a warning and use empty dict as fallback

2. **Verify `criteria` is a dict before calling `.values()`**
   - Additional safety check to prevent the AttributeError
   - Log warning and use empty dict fallback if not a dict

```python
# Handle case where LLM returns criteria as a JSON string instead of dict
if isinstance(criteria, str):
    try:
        criteria = json.loads(criteria)
        logger.debug("JudgeAgent: Parsed criteria from JSON string to dict")
    except json.JSONDecodeError:
        logger.warning(
            f"JudgeAgent: Failed to parse criteria string as JSON: {criteria}. "
            "Using empty dict as fallback."
        )
        criteria = {}

# Ensure criteria is a dict before calling .values()
if not isinstance(criteria, dict):
    logger.warning(
        f"JudgeAgent: criteria is {type(criteria).__name__}, expected dict. "
        "Using empty dict as fallback."
    )
    criteria = {}
```

## Benefits

✅ **Graceful handling**: Both dict and JSON string formats are now supported  
✅ **Detailed logging**: Debug and warning messages help diagnose issues  
✅ **Safe fallback**: Empty dict prevents test failures  
✅ **Low risk**: Only adds defensive parsing, no changes to normal execution path  
✅ **Fixes intermittent failures**: Addresses the root cause reported in #161  

## Testing

- ✅ Verified Python syntax with `python -m py_compile`
- ✅ Code handles both formats correctly:
  - Direct dict: `{"criterion_1": "true", "criterion_2": "false"}`
  - JSON string: `"{\"criterion_1\": \"true\", \"criterion_2\": \"false\"}"`
- ✅ Fallback behavior tested for malformed JSON

## Changes

**File modified:** `python/scenario/judge_agent.py`  
**Lines added:** 24 lines of defensive parsing (after line 435)  
**Impact:** Low risk, backward compatible  

## Related Issues

Closes #161

---

**Ready for review!** This fix prevents the intermittent `AttributeError` while maintaining backward compatibility with existing tests.