### PR TITLE
feat: add runId to results and langwatch config options

### DIFF
--- a/docs/adr/001-scenario-concurrency-model.md
+++ b/docs/adr/001-scenario-concurrency-model.md
@@ -1,0 +1,34 @@
+# ADR-001: Scenario Concurrency Model — Per-Call Isolation
+
+**Date:** 2026-02-20
+
+**Status:** Accepted
+
+## Context
+
+The `@langwatch/scenario` test runner needs to support concurrent execution of scenario tests, where each run may target a different LangWatch project with its own API key and endpoint.
+
+The original implementation used environment variables (`LANGWATCH_API_KEY`, `LANGWATCH_ENDPOINT`, `SCENARIO_BATCH_RUN_ID`) as the configuration mechanism. Because environment variables are process-wide shared state, concurrent `run()` calls would overwrite each other's config, causing events to be routed to the wrong project. This required a mutex to serialize runs, eliminating any concurrency benefit.
+
+The LangWatch platform orchestrates batch scenario runs on behalf of multiple projects simultaneously, making true concurrency a hard requirement.
+
+## Decision
+
+We will use per-call programmatic configuration instead of environment variables. Each call to `run()` accepts an optional `RunOptions` parameter containing `LangwatchConfig` (endpoint, apiKey) and `batchRunId`. Each call creates its own `EventBus` instance scoped to that configuration.
+
+Environment variables remain as a fallback for single-project CLI usage, but programmatic config takes precedence via nullish coalescing (`options?.langwatch?.apiKey ?? envConfig.LANGWATCH_API_KEY`).
+
+The `batchRunId` is resolved once at the `run()` boundary and passed as a constructor argument to `ScenarioExecution`, rather than being read from the environment at event-emit time.
+
+## Consequences
+
+- **Concurrent runs are fully isolated.** Each `run()` call gets its own EventBus, its own config, and its own batchRunId. No mutex needed.
+- **No process-wide state mutation.** Config flows through function arguments, not environment variables.
+- **Backward compatible.** Existing users relying on env vars continue to work without changes.
+- **`LangwatchConfig` fields are optional.** Callers can override just the API key, just the endpoint, or both — unset fields fall back to env vars.
+- **`ScenarioExecution` constructor now requires `batchRunId`.** This is a breaking change for any direct consumers of `ScenarioExecution` (not `run()`), though this class is not part of the public API.
+
+## References
+
+- PR: https://github.com/langwatch/scenario/pull/207
+- Upstream consumer: https://github.com/langwatch/langwatch/pull/1074

--- a/javascript/src/domain/core/execution.ts
+++ b/javascript/src/domain/core/execution.ts
@@ -12,6 +12,11 @@ import type { ScenarioConfig } from "../scenarios";
  */
 export interface ScenarioResult {
   /**
+   * Unique identifier for this scenario run.
+   */
+  runId: string;
+
+  /**
    * Indicates whether the scenario was successful.
    */
   success: boolean;

--- a/javascript/src/execution/__tests__/scenario-execution-inline-criteria.test.ts
+++ b/javascript/src/execution/__tests__/scenario-execution-inline-criteria.test.ts
@@ -90,7 +90,8 @@ describe("Inline criteria on judge()", () => {
         user("follow up"),
         agent(),
         succeed(),
-      ]
+      ],
+      "test-batch-id"
     );
 
     const result = await execution.execute();
@@ -127,7 +128,8 @@ describe("Inline criteria on judge()", () => {
         user("should not reach"),
         agent(),
         succeed(),
-      ]
+      ],
+      "test-batch-id"
     );
 
     const result = await execution.execute();
@@ -154,7 +156,8 @@ describe("Inline criteria on judge()", () => {
         user("more"),
         agent(),
         judge({ criteria: ["criterion B passes", "criterion C passes"] }),
-      ]
+      ],
+      "test-batch-id"
     );
 
     const result = await execution.execute();
@@ -179,7 +182,8 @@ describe("Inline criteria on judge()", () => {
         user("hello"),
         agent(),
         judge({ criteria: ["criterion A passes"] }),
-      ]
+      ],
+      "test-batch-id"
     );
 
     const result = await execution.execute();
@@ -205,7 +209,8 @@ describe("Inline criteria on judge()", () => {
         agent(),
         judge({ criteria: ["inline criterion passes"] }),
         succeed(),
-      ]
+      ],
+      "test-batch-id"
     );
 
     await execution.execute();
@@ -230,7 +235,8 @@ describe("Inline criteria on judge()", () => {
         user("more"),
         agent(),
         judge({ criteria: ["this will fail"] }),
-      ]
+      ],
+      "test-batch-id"
     );
 
     const result = await execution.execute();

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -38,7 +38,6 @@ import {
   generateScenarioId,
   generateScenarioRunId,
   generateThreadId,
-  getBatchRunId,
 } from "../utils/ids";
 import { Logger } from "../utils/logger";
 
@@ -187,13 +186,24 @@ export class ScenarioExecution implements ScenarioExecutionLike {
   public readonly events$: Observable<ScenarioEvent> =
     this.eventSubject.asObservable();
 
+  /** Batch run ID for grouping scenario runs */
+  private batchRunId: string;
+
+  /** The run ID for the current execution */
+  private scenarioRunId?: string;
+
   /**
    * Creates a new ScenarioExecution instance.
    *
    * @param config - The scenario configuration containing agents, settings, and metadata
    * @param script - The ordered sequence of script steps that define the test flow
+   * @param batchRunId - Batch run ID for grouping scenario runs
    */
-  constructor(config: ScenarioConfig, script: ScriptStep[]) {
+  constructor(config: ScenarioConfig, script: ScriptStep[], batchRunId: string) {
+    if (!batchRunId) {
+      throw new Error("batchRunId is required");
+    }
+    this.batchRunId = batchRunId;
     this.config = {
       id: config.id ?? generateScenarioId(),
       name: config.name,
@@ -247,8 +257,12 @@ export class ScenarioExecution implements ScenarioExecutionLike {
    * @param result - The final scenario result (without messages/timing, which will be added automatically)
    */
   private setResult(
-    result: Omit<ScenarioResult, "messages" | "totalTime" | "agentTime">
+    result: Omit<ScenarioResult, "runId" | "messages" | "totalTime" | "agentTime">
   ): ScenarioResult {
+    if (!this.scenarioRunId) {
+      throw new Error("Cannot set result: scenarioRunId has not been initialized. This is a bug in ScenarioExecution.");
+    }
+
     const agentRoleAgentsIdx = this.agents
       .map((agent, i) => ({ agent, idx: i }))
       .filter(({ agent }) => agent.role === AgentRole.AGENT)
@@ -261,13 +275,12 @@ export class ScenarioExecution implements ScenarioExecutionLike {
     const totalAgentTime = agentTimes.reduce((sum, time) => sum + time, 0);
 
     this._result = {
+      runId: this.scenarioRunId,
       ...result,
       messages: this.state.messages,
       totalTime: this.totalTime,
       agentTime: totalAgentTime,
     };
-
-    return this._result;
 
     this.logger.debug(`[${this.config.id}] Result set`, {
       success: result.success,
@@ -276,6 +289,8 @@ export class ScenarioExecution implements ScenarioExecutionLike {
       agentTime: totalAgentTime,
       messageCount: this.state.messages.length,
     });
+
+    return this._result;
   }
 
   /**
@@ -321,6 +336,7 @@ export class ScenarioExecution implements ScenarioExecutionLike {
     this.reset();
 
     const scenarioRunId = generateScenarioRunId();
+    this.scenarioRunId = scenarioRunId;
     this.logger.debug(`[${this.config.id}] Generated run ID: ${scenarioRunId}`);
     this.emitRunStarted({ scenarioRunId });
 
@@ -1276,7 +1292,7 @@ export class ScenarioExecution implements ScenarioExecutionLike {
     return {
       type: "placeholder", // This will be replaced by the specific event type
       timestamp: Date.now(),
-      batchRunId: getBatchRunId(),
+      batchRunId: this.batchRunId,
       scenarioId: this.config.id,
       scenarioRunId,
       scenarioSetId: this.config.setId,

--- a/javascript/src/runner/__tests__/run.test.ts
+++ b/javascript/src/runner/__tests__/run.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { run, type RunOptions } from "../run";
+import { AgentRole, type AgentAdapter, type AgentInput } from "../../domain";
+import type { ScenarioEvent } from "../../events/schema";
+
+// Mock the EventBus - must use function keyword for constructor
+vi.mock("../../events/event-bus", () => ({
+  EventBus: vi.fn().mockImplementation(function (this: unknown, config: unknown) {
+    return {
+      config,
+      listen: vi.fn(),
+      subscribeTo: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+      drain: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+}));
+
+// Mock the tracing setup
+vi.mock("../../tracing/setup", () => ({
+  observabilityHandle: undefined,
+}));
+
+// Mock getLangWatchTracer
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: vi.fn().mockReturnValue({
+    startSpan: vi.fn().mockReturnValue({
+      end: vi.fn(),
+      spanContext: vi.fn().mockReturnValue({ traceId: "test-trace-id" }),
+    }),
+    withActiveSpan: vi.fn().mockImplementation(async (_name, _opts, _ctx, fn) => {
+      const mockSpan = {
+        setType: vi.fn(),
+        setInput: vi.fn(),
+        setOutput: vi.fn(),
+        setMetrics: vi.fn(),
+        spanContext: vi.fn().mockReturnValue({ traceId: "test-trace-id" }),
+      };
+      return fn(mockSpan);
+    }),
+  }),
+}));
+
+class TestAgent implements AgentAdapter {
+  name = "TestAgent";
+  role = AgentRole.AGENT;
+
+  async call(_input: AgentInput): Promise<string> {
+    return "Test response";
+  }
+}
+
+class TestJudgeAgent implements AgentAdapter {
+  name = "TestJudge";
+  role = AgentRole.JUDGE;
+
+  async call(_input: AgentInput) {
+    return {
+      success: true,
+      reasoning: "Test passed",
+      metCriteria: ["criterion1"],
+      unmetCriteria: [],
+    };
+  }
+}
+
+function createScenarioConfig(name = "Test Scenario") {
+  return {
+    name,
+    description: `Scenario ${name}`,
+    agents: [new TestAgent(), new TestJudgeAgent()],
+    script: [
+      async (_state: unknown, executor: { succeed: (msg: string) => Promise<unknown> }) => {
+        await executor.succeed(`Success from ${name}`);
+      },
+    ],
+  };
+}
+
+async function mockEventBusWithEventCapture() {
+  const { EventBus } = await import("../../events/event-bus");
+  const capturedEvents: ScenarioEvent[] = [];
+
+  vi.mocked(EventBus).mockImplementation(function (this: unknown, config: unknown) {
+    return {
+      config,
+      listen: vi.fn(),
+      subscribeTo: vi.fn().mockImplementation((events$) => {
+        const subscription = events$.subscribe((event: ScenarioEvent) => {
+          capturedEvents.push(event);
+        });
+        return subscription;
+      }),
+      drain: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  return { EventBus, capturedEvents };
+}
+
+describe("run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("runId", () => {
+    it("includes runId in the result", async () => {
+      const result = await run(createScenarioConfig());
+
+      expect(result.runId).toBeDefined();
+      expect(result.runId).toMatch(/^scenariorun_/);
+    });
+
+    it("generates unique runIds for each run", async () => {
+      const config = createScenarioConfig();
+
+      const result1 = await run(config);
+      const result2 = await run(config);
+
+      expect(result1.runId).not.toBe(result2.runId);
+    });
+  });
+
+  describe("batchRunId", () => {
+    it("uses provided batchRunId from options", async () => {
+      const { capturedEvents } = await mockEventBusWithEventCapture();
+
+      await run(createScenarioConfig(), { batchRunId: "custom_batch_123" });
+
+      const runStartedEvent = capturedEvents.find((e) => e.type === "SCENARIO_RUN_STARTED");
+      expect(runStartedEvent?.batchRunId).toBe("custom_batch_123");
+    });
+
+    it("auto-generates batchRunId when not provided", async () => {
+      const { capturedEvents } = await mockEventBusWithEventCapture();
+
+      await run(createScenarioConfig());
+
+      const runStartedEvent = capturedEvents.find((e) => e.type === "SCENARIO_RUN_STARTED");
+      expect(runStartedEvent?.batchRunId).toBeDefined();
+      expect(runStartedEvent?.batchRunId).toMatch(/^scenariobatch_/);
+    });
+  });
+
+  describe("langwatch config", () => {
+    it("uses provided langwatch config for EventBus", async () => {
+      const { EventBus } = await import("../../events/event-bus");
+
+      const options: RunOptions = {
+        langwatch: {
+          endpoint: "https://custom.endpoint.com",
+          apiKey: "custom-api-key",
+        },
+      };
+
+      await run(createScenarioConfig(), options);
+
+      expect(EventBus).toHaveBeenCalledWith({
+        endpoint: "https://custom.endpoint.com",
+        apiKey: "custom-api-key",
+      });
+    });
+  });
+
+  describe("concurrency safety", () => {
+    it("creates separate EventBus instances for concurrent runs", async () => {
+      const { EventBus } = await import("../../events/event-bus");
+      const eventBusConfigs: Array<{ endpoint: string; apiKey: string | undefined }> = [];
+
+      vi.mocked(EventBus).mockImplementation(function (this: unknown, config: { endpoint: string; apiKey: string | undefined }) {
+        eventBusConfigs.push(config);
+        return {
+          config,
+          listen: vi.fn(),
+          subscribeTo: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+          drain: vi.fn().mockResolvedValue(undefined),
+        };
+      });
+
+      await Promise.all([
+        run(createScenarioConfig(), {
+          langwatch: { endpoint: "https://api.example.com", apiKey: "project-a-key" },
+        }),
+        run(createScenarioConfig(), {
+          langwatch: { endpoint: "https://api.example.com", apiKey: "project-b-key" },
+        }),
+        run(createScenarioConfig(), {
+          langwatch: { endpoint: "https://api.example.com", apiKey: "project-c-key" },
+        }),
+      ]);
+
+      expect(EventBus).toHaveBeenCalledTimes(3);
+
+      const apiKeys = eventBusConfigs.map((c) => c.apiKey);
+      expect(apiKeys).toContain("project-a-key");
+      expect(apiKeys).toContain("project-b-key");
+      expect(apiKeys).toContain("project-c-key");
+
+      expect(apiKeys.filter((k) => k === "project-a-key")).toHaveLength(1);
+      expect(apiKeys.filter((k) => k === "project-b-key")).toHaveLength(1);
+      expect(apiKeys.filter((k) => k === "project-c-key")).toHaveLength(1);
+    });
+
+    it("isolates events between concurrent runs", async () => {
+      const { EventBus } = await import("../../events/event-bus");
+      const eventsByApiKey = new Map<string, ScenarioEvent[]>();
+
+      vi.mocked(EventBus).mockImplementation(function (this: unknown, config: { endpoint: string; apiKey: string | undefined }) {
+        const events: ScenarioEvent[] = [];
+        eventsByApiKey.set(config.apiKey ?? "", events);
+
+        return {
+          config,
+          listen: vi.fn(),
+          subscribeTo: vi.fn().mockImplementation((events$) => {
+            const subscription = events$.subscribe((event: ScenarioEvent) => {
+              events.push(event);
+            });
+            return subscription;
+          }),
+          drain: vi.fn().mockResolvedValue(undefined),
+        };
+      });
+
+      await Promise.all([
+        run(createScenarioConfig("Scenario-A"), {
+          langwatch: { endpoint: "https://api.example.com", apiKey: "key-a" },
+        }),
+        run(createScenarioConfig("Scenario-B"), {
+          langwatch: { endpoint: "https://api.example.com", apiKey: "key-b" },
+        }),
+      ]);
+
+      const eventsA = eventsByApiKey.get("key-a") ?? [];
+      const eventsB = eventsByApiKey.get("key-b") ?? [];
+
+      expect(eventsA.length).toBeGreaterThanOrEqual(2);
+      expect(eventsB.length).toBeGreaterThanOrEqual(2);
+
+      const runStartedA = eventsA.find((e) => e.type === "SCENARIO_RUN_STARTED");
+      const runStartedB = eventsB.find((e) => e.type === "SCENARIO_RUN_STARTED");
+
+      expect(runStartedA?.metadata?.name).toBe("Scenario-A");
+      expect(runStartedB?.metadata?.name).toBe("Scenario-B");
+    });
+  });
+});

--- a/javascript/src/runner/run.ts
+++ b/javascript/src/runner/run.ts
@@ -1,9 +1,11 @@
 /**
  * Scenario execution engine for agent testing.
  *
- * This file contains the core `run` function that orchestrates the execution
- * of scenario tests, managing the interaction between user simulators, agents under test,
- * and judge agents to determine test success or failure.
+ * Orchestrates the execution of scenario tests, managing user simulators,
+ * agents under test, and judge agents. Each `run()` call creates an isolated
+ * EventBus, enabling safe concurrent execution with different configs.
+ *
+ * @see docs/adr/001-scenario-concurrency-model.md
  */
 import { AssistantContent, ToolContent, ModelMessage } from "ai";
 import { Subscription } from "rxjs";
@@ -17,7 +19,27 @@ import {
 import { EventBus } from "../events/event-bus";
 import { ScenarioExecution } from "../execution";
 import { proceed } from "../script";
-import { generateThreadId } from "../utils/ids";
+import { generateThreadId, getBatchRunId } from "../utils/ids";
+/**
+ * Configuration for LangWatch event reporting.
+ * All fields are optional — any omitted fields fall back to environment variables.
+ */
+export interface LangwatchConfig {
+  /** The endpoint URL to send events to. Falls back to LANGWATCH_ENDPOINT env var. */
+  endpoint?: string;
+  /** The API key for authentication. Falls back to LANGWATCH_API_KEY env var. */
+  apiKey?: string;
+}
+
+/**
+ * Options for running a scenario.
+ */
+export interface RunOptions {
+  /** LangWatch configuration for event reporting. Overrides environment variables. */
+  langwatch?: LangwatchConfig;
+  /** Batch run ID for grouping scenario runs. Overrides SCENARIO_BATCH_RUN_ID env var. */
+  batchRunId?: string;
+}
 
 /**
  * High-level interface for running a scenario test.
@@ -68,7 +90,7 @@ import { generateThreadId } from "../utils/ids";
  * main();
  * ```
  */
-export async function run(cfg: ScenarioConfig): Promise<ScenarioResult> {
+export async function run(cfg: ScenarioConfig, options?: RunOptions): Promise<ScenarioResult> {
   if (!cfg.name) {
     throw new Error("Scenario name is required");
   }
@@ -96,16 +118,19 @@ export async function run(cfg: ScenarioConfig): Promise<ScenarioResult> {
   }
 
   const steps = cfg.script || [proceed()];
-  const execution = new ScenarioExecution(cfg, steps);
+
+  const batchRunId = options?.batchRunId ?? getBatchRunId();
+  const execution = new ScenarioExecution(cfg, steps, batchRunId);
 
   let eventBus: EventBus | null = null;
   let subscription: Subscription | null = null;
 
   try {
     const envConfig = getEnv();
+    // Use programmatic config if provided, otherwise fall back to env vars
     eventBus = new EventBus({
-      endpoint: envConfig.LANGWATCH_ENDPOINT,
-      apiKey: envConfig.LANGWATCH_API_KEY,
+      endpoint: options?.langwatch?.endpoint ?? envConfig.LANGWATCH_ENDPOINT,
+      apiKey: options?.langwatch?.apiKey ?? envConfig.LANGWATCH_API_KEY,
     });
     eventBus.listen();
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@langwatch/scenario",
+  "version": "0.4.0",
+  "private": true,
+  "scripts": {
+    "prepare": "cd javascript && npm install --legacy-peer-deps && npm run build"
+  },
+  "main": "javascript/dist/index.js",
+  "module": "javascript/dist/index.mjs",
+  "types": "javascript/dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./javascript/dist/index.d.ts",
+      "require": "./javascript/dist/index.js",
+      "import": "./javascript/dist/index.mjs"
+    },
+    "./integrations/vitest/reporter": {
+      "types": "./javascript/dist/integrations/vitest/reporter.d.ts",
+      "require": "./javascript/dist/integrations/vitest/reporter.js",
+      "import": "./javascript/dist/integrations/vitest/reporter.mjs"
+    },
+    "./integrations/vitest/setup": {
+      "types": "./javascript/dist/integrations/vitest/setup.d.ts",
+      "require": "./javascript/dist/integrations/vitest/setup.js",
+      "import": "./javascript/dist/integrations/vitest/setup.mjs"
+    },
+    "./integrations/vitest/setup-global": {
+      "types": "./javascript/dist/integrations/vitest/setup-global.d.ts",
+      "require": "./javascript/dist/integrations/vitest/setup-global.js",
+      "import": "./javascript/dist/integrations/vitest/setup-global.mjs"
+    },
+    "./integrations/vitest/config": {
+      "types": "./javascript/dist/integrations/vitest/config.d.ts",
+      "require": "./javascript/dist/integrations/vitest/config.js",
+      "import": "./javascript/dist/integrations/vitest/config.mjs"
+    }
+  }
+}


### PR DESCRIPTION
- Add runId field to ScenarioResult for tracking scenario runs
- Add RunOptions parameter to run() with langwatch config and batchId
- Allow programmatic override of env vars for langwatch integration

Changes for: https://github.com/langwatch/langwatch/pull/1074