### PR TITLE
fix: summarize tool messages during role reversal in user simulator (Python)

### DIFF
--- a/python/examples/test_multiturn_tool_calls.py
+++ b/python/examples/test_multiturn_tool_calls.py
@@ -1,0 +1,209 @@
+"""
+E2E test: 10-turn multiturn conversation with tool calls.
+
+Verifies that the user simulator works correctly after the agent makes tool
+calls (role reversal must summarize tool messages as plain text).
+"""
+
+import json
+import random
+
+import pytest
+import litellm
+import scenario
+from function_schema import get_function_schema
+
+
+# ── Tool definitions ──────────────────────────────────────────────────────────
+
+
+def search_products(query: str) -> str:
+    """
+    Search for products by name or category.
+
+    Args:
+        query: The search query for products.
+
+    Returns:
+        A list of matching products with prices.
+    """
+    products = {
+        "headphones": [
+            "Wireless Headphones Pro - $79.99",
+            "Budget Earbuds - $19.99",
+            "Noise Cancelling Over-Ear - $149.99",
+        ],
+        "laptop": [
+            "UltraBook 14 - $999.99",
+            "Gaming Laptop X - $1,499.99",
+            "Budget Chromebook - $299.99",
+        ],
+        "keyboard": [
+            "Mechanical RGB Keyboard - $89.99",
+            "Wireless Compact Keyboard - $49.99",
+        ],
+    }
+    for key, items in products.items():
+        if key in query.lower():
+            return json.dumps(items)
+    return json.dumps(["No products found for: " + query])
+
+
+def check_stock(product_name: str) -> str:
+    """
+    Check the stock availability for a specific product.
+
+    Args:
+        product_name: The exact product name to check stock for.
+
+    Returns:
+        Stock availability information.
+    """
+    in_stock = random.choice([True, True, True, False])
+    qty = random.randint(1, 50) if in_stock else 0
+    return json.dumps(
+        {
+            "product": product_name,
+            "in_stock": in_stock,
+            "quantity": qty,
+            "ships_in": "2-3 business days" if in_stock else "out of stock",
+        }
+    )
+
+
+TOOLS = [search_products, check_stock]
+
+
+# ── Agent implementation ──────────────────────────────────────────────────────
+
+
+@scenario.cache()
+def shopping_agent(messages, response_messages=[]) -> scenario.AgentReturnTypes:
+    response = litellm.completion(
+        model="openai/gpt-4.1-nano",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful online shopping assistant. "
+                    "Use the search_products tool to find items and "
+                    "check_stock to verify availability. "
+                    "Be concise and helpful."
+                ),
+            },
+            *messages,
+            *response_messages,
+        ],
+        tools=[
+            {"type": "function", "function": get_function_schema(tool)}
+            for tool in TOOLS
+        ],
+        tool_choice="auto",
+    )
+
+    message = response.choices[0].message  # type: ignore
+
+    if message.tool_calls:
+        tools_by_name = {tool.__name__: tool for tool in TOOLS}
+        tool_responses = []
+        for tool_call in message.tool_calls:
+            name = tool_call.function.name
+            args = json.loads(tool_call.function.arguments)
+            if name in tools_by_name:
+                result = tools_by_name[name](**args)
+                tool_responses.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": result,
+                    }
+                )
+            else:
+                raise ValueError(f"Tool {name} not found")
+
+        return shopping_agent(
+            messages,
+            [*response_messages, message, *tool_responses],
+        )
+
+    return [*response_messages, message]  # type: ignore
+
+
+# ── Test ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=2)
+async def test_multiturn_shopping_with_tool_calls():
+    """10-turn conversation where the agent makes tool calls on multiple turns.
+
+    The user simulator must handle role-reversed tool messages correctly
+    throughout the entire conversation without crashing.
+    """
+
+    class ShoppingAgent(scenario.AgentAdapter):
+        async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
+            return shopping_agent(input.messages)
+
+    def check_search_tool_used(state: scenario.ScenarioState):
+        assert state.has_tool_call("search_products"), "Agent should have used search_products"
+
+    def check_stock_tool_used(state: scenario.ScenarioState):
+        assert state.has_tool_call("check_stock"), "Agent should have used check_stock"
+
+    result = await scenario.run(
+        name="10-turn shopping with tool calls",
+        description=(
+            "A user browses an online shop, asking about different products, "
+            "checking stock, comparing options, and eventually deciding what to buy. "
+            "The agent uses search and stock-check tools throughout."
+        ),
+        agents=[
+            ShoppingAgent(),
+            scenario.UserSimulatorAgent(model="openai/gpt-4.1-nano"),
+            scenario.JudgeAgent(
+                model="openai/gpt-4.1",
+                criteria=[
+                    "The agent used tools to look up products when the user asked about them",
+                    "The agent provided helpful product information and pricing",
+                    "The agent maintained context across the full conversation",
+                ],
+            ),
+        ],
+        script=[
+            # Turn 1: user asks about headphones -> agent should search
+            scenario.user("hey do you have any headphones"),
+            scenario.agent(),
+            check_search_tool_used,
+            # Turn 2: user asks follow-up (user sim runs with tool messages in history)
+            scenario.user(),
+            scenario.agent(),
+            # Turn 3: user asks about a different category
+            scenario.user("what about keyboards"),
+            scenario.agent(),
+            # Turn 4: free-form follow-up from user sim
+            scenario.user(),
+            scenario.agent(),
+            # Turn 5: user asks to check stock
+            scenario.user("can you check if the mechanical keyboard is in stock"),
+            scenario.agent(),
+            check_stock_tool_used,
+            # Turn 6-10: let the user sim drive the rest of the conversation
+            scenario.user(),
+            scenario.agent(),
+            scenario.user(),
+            scenario.agent(),
+            scenario.user(),
+            scenario.agent(),
+            scenario.user(),
+            scenario.agent(),
+            scenario.user(),
+            scenario.agent(),
+            # Judge the full conversation
+            scenario.judge(),
+        ],
+        set_id="python-examples",
+    )
+
+    assert result.success

--- a/python/examples/test_multiturn_tool_calls.py
+++ b/python/examples/test_multiturn_tool_calls.py
@@ -78,7 +78,9 @@ TOOLS = [search_products, check_stock]
 
 
 @scenario.cache()
-def shopping_agent(messages, response_messages=[]) -> scenario.AgentReturnTypes:
+def shopping_agent(messages, response_messages: list | None = None) -> scenario.AgentReturnTypes:
+    if response_messages is None:
+        response_messages = []
     response = litellm.completion(
         model="openai/gpt-4.1-nano",
         messages=[

--- a/python/examples/test_multiturn_tool_calls.py
+++ b/python/examples/test_multiturn_tool_calls.py
@@ -78,9 +78,15 @@ TOOLS = [search_products, check_stock]
 
 
 @scenario.cache()
-def shopping_agent(messages, response_messages: list | None = None) -> scenario.AgentReturnTypes:
+def shopping_agent(
+    messages: list,
+    response_messages: list | None = None,
+    max_tool_turns: int = 5,
+) -> scenario.AgentReturnTypes:
     if response_messages is None:
         response_messages = []
+    if max_tool_turns <= 0:
+        raise RuntimeError("Exceeded max tool-call turns in shopping_agent")
     response = litellm.completion(
         model="openai/gpt-4.1-nano",
         messages=[
@@ -103,7 +109,7 @@ def shopping_agent(messages, response_messages: list | None = None) -> scenario.
         tool_choice="auto",
     )
 
-    message = response.choices[0].message  # type: ignore
+    message = response.choices[0].message  # type: ignore[union-attr]  # litellm's ModelResponse.choices is typed loosely; real completions always return this shape
 
     if message.tool_calls:
         tools_by_name = {tool.__name__: tool for tool in TOOLS}
@@ -126,9 +132,10 @@ def shopping_agent(messages, response_messages: list | None = None) -> scenario.
         return shopping_agent(
             messages,
             [*response_messages, message, *tool_responses],
+            max_tool_turns - 1,
         )
 
-    return [*response_messages, message]  # type: ignore
+    return [*response_messages, message]  # type: ignore[list-item]  # litellm's Message isn't a ChatCompletionMessageParam dict, but AgentReturnTypes accepts either shape at runtime
 
 
 # ── Test ──────────────────────────────────────────────────────────────────────
@@ -148,10 +155,10 @@ async def test_multiturn_shopping_with_tool_calls():
         async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
             return shopping_agent(input.messages)
 
-    def check_search_tool_used(state: scenario.ScenarioState):
+    def check_search_tool_used(state: scenario.ScenarioState) -> None:
         assert state.has_tool_call("search_products"), "Agent should have used search_products"
 
-    def check_stock_tool_used(state: scenario.ScenarioState):
+    def check_stock_tool_used(state: scenario.ScenarioState) -> None:
         assert state.has_tool_call("check_stock"), "Agent should have used check_stock"
 
     result = await scenario.run(

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -380,38 +380,115 @@ def check_valid_return_type(return_value: Any, class_name: str) -> None:
     )
 
 
+def _stringify_value(value: Any) -> str:
+    """Convert a value to a string representation for tool summaries."""
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "None"
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _has_tool_content(message: Any) -> bool:
+    """
+    Checks if a message contains tool-related content (tool_calls, tool role).
+    These messages need to be summarized as plain text rather than role-reversed,
+    because sending raw tool content on a 'user' message breaks both OpenAI and
+    Anthropic APIs.
+    """
+    role = safe_attr_or_key(message, "role")
+    if role == "tool":
+        return True
+    if safe_attr_or_key(message, "tool_calls"):
+        return True
+    return False
+
+
+def _summarize_tool_message(message: Any) -> Optional[str]:
+    """
+    Converts a tool message into a plain-text summary so the user simulator
+    understands what the agent did without receiving raw tool protocol messages.
+
+    Handles OpenAI message format:
+    - Tool results: {"role": "tool", "tool_call_id": "...", "name": "...", "content": "..."}
+    - Tool calls: {"role": "assistant", "tool_calls": [{"function": {"name": "...", "arguments": "..."}}]}
+    """
+    role = safe_attr_or_key(message, "role")
+
+    # Handle tool result messages (role == "tool")
+    if role == "tool":
+        content = safe_attr_or_key(message, "content")
+        name = safe_attr_or_key(message, "name", "unknown tool")
+        return f"[Tool result from {name}: {_stringify_value(content)}]"
+
+    # Handle assistant messages with tool_calls
+    tool_calls = safe_attr_or_key(message, "tool_calls")
+    if tool_calls:
+        summaries = []
+        for tool_call in tool_calls:
+            function = safe_attr_or_key(tool_call, "function")
+            if function:
+                name = safe_attr_or_key(function, "name", "unknown tool")
+                arguments = safe_attr_or_key(function, "arguments", "{}")
+                summaries.append(f"[Called tool {name} with: {arguments}]")
+        return "\n".join(summaries) if summaries else None
+
+    return None
+
+
 def reverse_roles(
     messages: list[ChatCompletionMessageParam],
 ) -> list[ChatCompletionMessageParam]:
     """
-    Reverses the roles of the messages in the list.
+    Reverses user <-> assistant roles for the user simulator agent.
+
+    Every message is processed individually:
+    1. Tool messages (role 'tool' or containing tool_calls)
+       -> summarized as plain text attributed to 'user' (the agent after reversal)
+    2. User messages -> become 'assistant' (so the LLM generates as "assistant")
+    3. Assistant messages -> become 'user' (the agent's words become context)
+    4. System messages -> preserved unchanged
+
+    This flat per-message approach is correct because every non-tool message must
+    be reversed regardless of whether nearby messages contain tool calls. The old
+    segment-based approach incorrectly left non-tool messages unreversed in segments
+    that contained tools, causing the user simulator to see the wrong roles and
+    respond as an assistant instead of simulating a user.
 
     Args:
         messages: The list of messages to reverse the roles of.
     """
 
-    reversed_messages = []
+    role_map = {
+        "user": "assistant",
+        "assistant": "user",
+    }
+
+    reversed_messages: list[ChatCompletionMessageParam] = []
     for message in messages:
         message = copy.deepcopy(message)
-        # Can't reverse tool calls
-        if not safe_attr_or_key(message, "content") or safe_attr_or_key(
-            message, "tool_calls"
-        ):
-            # If no content nor tool calls, we should skip it entirely, as anthropic may generate some invalid ones e.g. pure {"role": "assistant"}
-            if safe_attr_or_key(message, "tool_calls"):
-                reversed_messages.append(message)
+
+        if _has_tool_content(message):
+            summary = _summarize_tool_message(message)
+            if summary is None:
+                continue
+            reversed_messages.append({"role": "user", "content": summary})
+            continue
+
+        role = safe_attr_or_key(message, "role")
+        new_role = role_map.get(role)  # type: ignore
+        if not new_role:
+            # Preserve system and other messages unchanged
+            reversed_messages.append(message)
             continue
 
         if type(message) == dict:
-            if message["role"] == "user":
-                message["role"] = "assistant"
-            elif message["role"] == "assistant":
-                message["role"] = "user"
+            message["role"] = new_role
         else:
-            if getattr(message, "role", None) == "user":
-                message.role = "assistant"  # type: ignore
-            elif getattr(message, "role", None) == "assistant":
-                message.role = "user"  # type: ignore
+            message.role = new_role  # type: ignore
 
         reversed_messages.append(message)
 

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -411,14 +411,21 @@ def _has_tool_content(message: Any) -> bool:
     return False
 
 
-def _summarize_tool_message(message: Any) -> Optional[str]:
+def _summarize_tool_message(
+    message: Any, tool_call_names: Optional[dict[str, str]] = None
+) -> Optional[str]:
     """
     Converts a tool message into a plain-text summary so the user simulator
     understands what the agent did without receiving raw tool protocol messages.
 
     Handles OpenAI message format:
-    - Tool results: {"role": "tool", "tool_call_id": "...", "name": "...", "content": "..."}
+    - Tool results: {"role": "tool", "tool_call_id": "...", "content": "..."}
     - Tool calls: {"role": "assistant", "tool_calls": [{"function": {"name": "...", "arguments": "..."}}]}
+
+    A standard OpenAI tool-result message carries no "name" field — only
+    tool_call_id. tool_call_names maps tool_call_id -> function name, built by
+    the caller from the tool_calls messages that precede this one, so the
+    summary can name the actual tool instead of always saying "unknown tool".
 
     Note: when an assistant message has both text content and tool_calls, the text
     content is intentionally dropped and only the tool calls are summarized. This
@@ -430,7 +437,8 @@ def _summarize_tool_message(message: Any) -> Optional[str]:
     # Handle tool result messages (role == "tool")
     if role == "tool":
         content = safe_attr_or_key(message, "content")
-        name = safe_attr_or_key(message, "name", "unknown tool")
+        tool_call_id = safe_attr_or_key(message, "tool_call_id")
+        name = (tool_call_names or {}).get(tool_call_id, "unknown tool")
         return f"[Tool result from {name}: {_stringify_value(content)}]"
 
     # Handle assistant messages with tool_calls
@@ -476,12 +484,23 @@ def reverse_roles(
         "assistant": "user",
     }
 
+    # Tool-result messages only carry a tool_call_id, not the tool's name — so
+    # resolve it from the tool_calls entries that precede it, matched by id.
+    tool_call_names: dict[str, str] = {}
+    for message in messages:
+        for tool_call in safe_attr_or_key(message, "tool_calls") or []:
+            call_id = safe_attr_or_key(tool_call, "id")
+            function = safe_attr_or_key(tool_call, "function")
+            name = safe_attr_or_key(function, "name") if function else None
+            if call_id and name:
+                tool_call_names[call_id] = name
+
     reversed_messages: list[ChatCompletionMessageParam] = []
     for message in messages:
         message = copy.deepcopy(message)
 
         if _has_tool_content(message):
-            summary = _summarize_tool_message(message)
+            summary = _summarize_tool_message(message, tool_call_names)
             if summary is None:
                 continue
             reversed_messages.append({"role": "user", "content": summary})
@@ -494,18 +513,28 @@ def reverse_roles(
             reversed_messages.append(message)
             continue
 
-        # Skip bare role-only messages that have no content key at all.
-        # Some models (notably Anthropic) occasionally emit {"role": "assistant"}
-        # with no content field; passing that on as {"role": "user"} would cause
-        # an API validation error on the user simulator's next request.
-        # Note: explicit content=None is kept — that is valid in the OpenAI format
-        # for assistant messages that accompany tool_calls.
+        # Skip messages with nothing to say: either the content key is absent
+        # entirely, or present but explicitly None. Some models (notably
+        # Anthropic) occasionally emit {"role": "assistant"} with no content
+        # field, or with content=None and no tool_calls (tool_calls-bearing
+        # messages are already diverted above, so None here is never "valid
+        # because tool_calls is present"). Passing either through would flip
+        # to {"role": "user", "content": None}, which OpenAI and Anthropic
+        # both reject — user messages require non-null content.
         has_content_key = (
             "content" in message
             if isinstance(message, dict)
             else hasattr(message, "content")
         )
         if not has_content_key:
+            continue
+
+        content_value = (
+            message.get("content")
+            if isinstance(message, dict)
+            else getattr(message, "content", None)
+        )
+        if content_value is None:
             continue
 
         if isinstance(message, dict):

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -507,7 +507,7 @@ def reverse_roles(
             continue
 
         role = safe_attr_or_key(message, "role")
-        new_role = role_map.get(role)  # type: ignore
+        new_role = role_map.get(role)
         if not new_role:
             # Preserve system and other messages unchanged
             reversed_messages.append(message)
@@ -538,9 +538,9 @@ def reverse_roles(
             continue
 
         if isinstance(message, dict):
-            message["role"] = new_role  # type: ignore[typeddict-item]
+            message["role"] = new_role  # type: ignore[reportGeneralTypeIssues]  # new_role is always "user" or "assistant" from role_map, but pyright can't narrow a TypedDict's literal "role" field from a runtime str
         else:
-            message.role = new_role  # type: ignore
+            message.role = new_role
 
         reversed_messages.append(message)
 

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -485,7 +485,7 @@ def reverse_roles(
             reversed_messages.append(message)
             continue
 
-        if type(message) == dict:
+        if isinstance(message, dict):
             message["role"] = new_role
         else:
             message.role = new_role  # type: ignore

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -12,6 +12,7 @@ from typing import (
     Any,
     Iterator,
     Optional,
+    Sequence,
     Union,
     TypeVar,
     Awaitable,
@@ -440,7 +441,7 @@ def _summarize_tool_message(message: Any) -> Optional[str]:
 
 
 def reverse_roles(
-    messages: list[ChatCompletionMessageParam],
+    messages: Sequence[ChatCompletionMessageParam],
 ) -> list[ChatCompletionMessageParam]:
     """
     Reverses user <-> assistant roles for the user simulator agent.
@@ -486,7 +487,7 @@ def reverse_roles(
             continue
 
         if isinstance(message, dict):
-            message["role"] = new_role
+            message["role"] = new_role  # type: ignore[typeddict-item]
         else:
             message.role = new_role  # type: ignore
 

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -382,11 +382,14 @@ def check_valid_return_type(return_value: Any, class_name: str) -> None:
 
 
 def _stringify_value(value: Any) -> str:
-    """Convert a value to a string representation for tool summaries."""
+    """Convert a value to a string representation for tool summaries.
+
+    Strings are returned as-is. All other values go through json.dumps so that
+    None becomes "null", dicts/lists get JSON notation, and numbers stringify
+    without a Python-specific repr. Non-serializable objects fall back to str().
+    """
     if isinstance(value, str):
         return value
-    if value is None:
-        return "None"
     try:
         return json.dumps(value)
     except (TypeError, ValueError):
@@ -416,6 +419,11 @@ def _summarize_tool_message(message: Any) -> Optional[str]:
     Handles OpenAI message format:
     - Tool results: {"role": "tool", "tool_call_id": "...", "name": "...", "content": "..."}
     - Tool calls: {"role": "assistant", "tool_calls": [{"function": {"name": "...", "arguments": "..."}}]}
+
+    Note: when an assistant message has both text content and tool_calls, the text
+    content is intentionally dropped and only the tool calls are summarized. This
+    matches the JS messageRoleReversal() behaviour — the tool-call summary is what
+    the user simulator needs to understand what the agent did.
     """
     role = safe_attr_or_key(message, "role")
 
@@ -484,6 +492,20 @@ def reverse_roles(
         if not new_role:
             # Preserve system and other messages unchanged
             reversed_messages.append(message)
+            continue
+
+        # Skip bare role-only messages that have no content key at all.
+        # Some models (notably Anthropic) occasionally emit {"role": "assistant"}
+        # with no content field; passing that on as {"role": "user"} would cause
+        # an API validation error on the user simulator's next request.
+        # Note: explicit content=None is kept — that is valid in the OpenAI format
+        # for assistant messages that accompany tool_calls.
+        has_content_key = (
+            "content" in message
+            if isinstance(message, dict)
+            else hasattr(message, "content")
+        )
+        if not has_content_key:
             continue
 
         if isinstance(message, dict):

--- a/python/tests/test_reverse_roles.py
+++ b/python/tests/test_reverse_roles.py
@@ -19,7 +19,7 @@ class TestStringifyValue:
         assert _stringify_value("hello") == "hello"
 
     def test_none(self):
-        assert _stringify_value(None) == "None"
+        assert _stringify_value(None) == "null"
 
     def test_dict(self):
         assert _stringify_value({"a": 1}) == '{"a": 1}'
@@ -32,7 +32,7 @@ class TestStringifyValue:
 
     def test_non_serializable_fallback(self):
         result = _stringify_value(object())
-        assert result.startswith("<object object")
+        assert isinstance(result, str) and len(result) > 0
 
 
 # ── _has_tool_content tests ───────────────────────────────────────────────────
@@ -351,8 +351,13 @@ class TestReverseRoles:
         assert messages[0]["role"] == "user"
         assert messages[1]["role"] == "assistant"
 
-    def test_message_without_content_preserved(self):
-        """Messages without content but with a reversible role should still be reversed."""
+    def test_explicit_none_content_is_reversed(self):
+        """An assistant message with explicit content=None is kept and reversed.
+
+        This is valid in OpenAI format (e.g. an assistant turn that preceded
+        a tool_call but whose tool_calls were already stripped upstream).
+        It is distinct from a message with no 'content' key at all.
+        """
         messages = [
             {"role": "user", "content": "test"},
             {"role": "assistant", "content": None},
@@ -361,3 +366,22 @@ class TestReverseRoles:
         assert result[0]["role"] == "assistant"
         assert result[1]["role"] == "user"
         assert result[1]["content"] is None
+
+    def test_bare_role_only_message_is_dropped(self):
+        """Messages with no 'content' key at all are silently dropped.
+
+        Anthropic (and some other providers) reject user/assistant messages that
+        have no content field. Some models emit bare {"role": "assistant"} messages;
+        this guard prevents them from surfacing as invalid {"role": "user"} messages
+        in the user simulator's request.
+        """
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant"},  # no content key — should be dropped
+            {"role": "assistant", "content": "I can help"},
+        ]
+        result = reverse_roles(messages)  # type: ignore[arg-type]
+        assert result == [
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "I can help"},
+        ]

--- a/python/tests/test_reverse_roles.py
+++ b/python/tests/test_reverse_roles.py
@@ -3,6 +3,8 @@ Unit tests for reverse_roles (message role reversal).
 Mirrors the JS messageRoleReversal tests in utils.test.ts.
 """
 
+from types import SimpleNamespace
+
 from scenario._utils.utils import (
     reverse_roles,
     _has_tool_content,
@@ -159,7 +161,7 @@ class TestReverseRoles:
             {"role": "user", "content": "Hello, how are you?"},
             {"role": "user", "content": "What's the weather like?"},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "assistant", "content": "Hello, how are you?"},
             {"role": "assistant", "content": "What's the weather like?"},
@@ -170,7 +172,7 @@ class TestReverseRoles:
             {"role": "assistant", "content": "I'm doing well, thank you!"},
             {"role": "assistant", "content": "It's sunny today."},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "user", "content": "I'm doing well, thank you!"},
             {"role": "user", "content": "It's sunny today."},
@@ -182,7 +184,7 @@ class TestReverseRoles:
             {"role": "assistant", "content": "Hi there!"},
             {"role": "user", "content": "How are you?"},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "assistant", "content": "Hello"},
             {"role": "user", "content": "Hi there!"},
@@ -195,7 +197,7 @@ class TestReverseRoles:
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi!"},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "system", "content": "You are a helpful assistant"},
             {"role": "assistant", "content": "Hello"},
@@ -231,7 +233,7 @@ class TestReverseRoles:
             },
             {"role": "assistant", "content": "The answer is 4"},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "assistant", "content": "Calculate 2+2"},
             {"role": "user", "content": '[Called tool calculator with: {"expression": "2+2"}]'},
@@ -259,7 +261,7 @@ class TestReverseRoles:
             {"role": "assistant", "content": "The result is 30"},
             {"role": "user", "content": "Thanks!"},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "assistant", "content": "Hello"},
             {"role": "user", "content": "Hi there!"},
@@ -298,7 +300,7 @@ class TestReverseRoles:
                 "content": "headphones: $29.99, in stock",
             },
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "system", "content": "You are pretending to be a user"},
             {"role": "user", "content": "Hello, how can I help you today"},
@@ -329,7 +331,7 @@ class TestReverseRoles:
                 ],
             },
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert len(result) == 1
         assert result[0]["role"] == "user"
         assert '[Called tool search with: {"q": "foo"}]' in str(result[0]["content"])
@@ -351,7 +353,7 @@ class TestReverseRoles:
                 ],
             },
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert len(result) == 1
         assert result[0]["role"] == "user"
         assert "Let me check that for you" not in str(result[0]["content"])
@@ -363,7 +365,7 @@ class TestReverseRoles:
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi!"},
         ]
-        reverse_roles(messages)  # type: ignore[arg-type]
+        reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert messages[0]["role"] == "user"
         assert messages[1]["role"] == "assistant"
 
@@ -380,7 +382,7 @@ class TestReverseRoles:
             {"role": "user", "content": "test"},
             {"role": "assistant", "content": None},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [{"role": "assistant", "content": "test"}]
 
     def test_tool_result_without_name_field_resolves_via_tool_calls_map(self):
@@ -401,7 +403,7 @@ class TestReverseRoles:
             },
             {"role": "tool", "tool_call_id": "call_9", "content": "Sunny 22°C"},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result[1]["role"] == "user"
         assert result[1]["content"] == "[Tool result from get_weather: Sunny 22°C]"
 
@@ -418,8 +420,23 @@ class TestReverseRoles:
             {"role": "assistant"},  # no content key — should be dropped
             {"role": "assistant", "content": "I can help"},
         ]
-        result = reverse_roles(messages)  # type: ignore[arg-type]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # test messages are plain dict literals, not the specific ChatCompletionMessageParam TypedDict variant pyright infers
         assert result == [
             {"role": "assistant", "content": "Hello"},
             {"role": "user", "content": "I can help"},
         ]
+
+    def test_object_style_message_is_reversed(self):
+        """Production messages from litellm/openai responses are objects
+        (e.g. a litellm Message), not plain dicts — reverse_roles must
+        handle both shapes identically via the object branch (message.role
+        = new_role) rather than only the dict-subscript branch."""
+        messages = [
+            SimpleNamespace(role="user", content="Hello"),
+            SimpleNamespace(role="assistant", content="Hi there!"),
+        ]
+        result = reverse_roles(messages)  # type: ignore[arg-type]  # SimpleNamespace stands in for litellm's object-style Message, not a ChatCompletionMessageParam TypedDict
+        assert result[0].role == "assistant"  # type: ignore[reportAttributeAccessIssue]  # result is really SimpleNamespace at runtime, not the TypedDict pyright infers
+        assert result[0].content == "Hello"  # type: ignore[reportAttributeAccessIssue]
+        assert result[1].role == "user"  # type: ignore[reportAttributeAccessIssue]
+        assert result[1].content == "Hi there!"  # type: ignore[reportAttributeAccessIssue]

--- a/python/tests/test_reverse_roles.py
+++ b/python/tests/test_reverse_roles.py
@@ -1,0 +1,362 @@
+"""
+Unit tests for reverse_roles (message role reversal).
+Mirrors the JS messageRoleReversal tests in utils.test.ts.
+"""
+
+from scenario._utils.utils import (
+    reverse_roles,
+    _has_tool_content,
+    _summarize_tool_message,
+    _stringify_value,
+)
+
+
+# ── _stringify_value tests ────────────────────────────────────────────────────
+
+
+class TestStringifyValue:
+    def test_string_passthrough(self):
+        assert _stringify_value("hello") == "hello"
+
+    def test_none(self):
+        assert _stringify_value(None) == "None"
+
+    def test_dict(self):
+        assert _stringify_value({"a": 1}) == '{"a": 1}'
+
+    def test_list(self):
+        assert _stringify_value([1, 2, 3]) == "[1, 2, 3]"
+
+    def test_number(self):
+        assert _stringify_value(42) == "42"
+
+    def test_non_serializable_fallback(self):
+        result = _stringify_value(object())
+        assert result.startswith("<object object")
+
+
+# ── _has_tool_content tests ───────────────────────────────────────────────────
+
+
+class TestHasToolContent:
+    def test_tool_role(self):
+        assert _has_tool_content({"role": "tool", "content": "result"}) is True
+
+    def test_assistant_with_tool_calls(self):
+        msg = {"role": "assistant", "tool_calls": [{"function": {"name": "x"}}]}
+        assert _has_tool_content(msg) is True
+
+    def test_regular_user_message(self):
+        assert _has_tool_content({"role": "user", "content": "hi"}) is False
+
+    def test_regular_assistant_message(self):
+        assert _has_tool_content({"role": "assistant", "content": "hello"}) is False
+
+    def test_system_message(self):
+        assert _has_tool_content({"role": "system", "content": "prompt"}) is False
+
+
+# ── _summarize_tool_message tests ─────────────────────────────────────────────
+
+
+class TestSummarizeToolMessage:
+    def test_tool_result_message(self):
+        msg = {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "get_weather",
+            "content": "Sunny 22°C",
+        }
+        assert _summarize_tool_message(msg) == "[Tool result from get_weather: Sunny 22°C]"
+
+    def test_tool_result_with_json_content(self):
+        msg = {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "search",
+            "content": '{"results": [1, 2, 3]}',
+        }
+        assert _summarize_tool_message(msg) == '[Tool result from search: {"results": [1, 2, 3]}]'
+
+    def test_tool_result_missing_name(self):
+        msg = {"role": "tool", "tool_call_id": "call_1", "content": "data"}
+        assert _summarize_tool_message(msg) == "[Tool result from unknown tool: data]"
+
+    def test_assistant_with_single_tool_call(self):
+        msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression": "2+2"}',
+                    },
+                }
+            ],
+        }
+        result = _summarize_tool_message(msg)
+        assert result == '[Called tool calculator with: {"expression": "2+2"}]'
+
+    def test_assistant_with_multiple_tool_calls(self):
+        msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"q": "foo"}'},
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "fetch", "arguments": '{"url": "bar"}'},
+                },
+            ],
+        }
+        result = _summarize_tool_message(msg)
+        assert '[Called tool search with: {"q": "foo"}]' in result
+        assert '[Called tool fetch with: {"url": "bar"}]' in result
+
+    def test_assistant_with_malformed_tool_call_no_function(self):
+        msg = {
+            "role": "assistant",
+            "tool_calls": [{"id": "call_1", "type": "function"}],
+        }
+        assert _summarize_tool_message(msg) is None
+
+    def test_regular_message_returns_none(self):
+        assert _summarize_tool_message({"role": "user", "content": "hi"}) is None
+        assert _summarize_tool_message({"role": "assistant", "content": "hello"}) is None
+
+
+# ── reverse_roles tests ──────────────────────────────────────────────────────
+
+
+class TestReverseRoles:
+    def test_reverse_user_to_assistant(self):
+        messages = [
+            {"role": "user", "content": "Hello, how are you?"},
+            {"role": "user", "content": "What's the weather like?"},
+        ]
+        result = reverse_roles(messages)
+        assert result == [
+            {"role": "assistant", "content": "Hello, how are you?"},
+            {"role": "assistant", "content": "What's the weather like?"},
+        ]
+
+    def test_reverse_assistant_to_user(self):
+        messages = [
+            {"role": "assistant", "content": "I'm doing well, thank you!"},
+            {"role": "assistant", "content": "It's sunny today."},
+        ]
+        result = reverse_roles(messages)
+        assert result == [
+            {"role": "user", "content": "I'm doing well, thank you!"},
+            {"role": "user", "content": "It's sunny today."},
+        ]
+
+    def test_mixed_user_and_assistant(self):
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        result = reverse_roles(messages)
+        assert result == [
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "Hi there!"},
+            {"role": "assistant", "content": "How are you?"},
+        ]
+
+    def test_preserve_system_messages(self):
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = reverse_roles(messages)
+        assert result == [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "Hi!"},
+        ]
+
+    def test_empty_array(self):
+        assert reverse_roles([]) == []
+
+    def test_summarize_tool_calls_and_results(self):
+        """Tool calls and results should be summarized as plain text with 'user' role."""
+        messages = [
+            {"role": "user", "content": "Calculate 2+2"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression": "2+2"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "calculator",
+                "content": "4",
+            },
+            {"role": "assistant", "content": "The answer is 4"},
+        ]
+        result = reverse_roles(messages)
+        assert result == [
+            {"role": "assistant", "content": "Calculate 2+2"},
+            {"role": "user", "content": '[Called tool calculator with: {"expression": "2+2"}]'},
+            {"role": "user", "content": "[Tool result from calculator: 4]"},
+            {"role": "user", "content": "The answer is 4"},
+        ]
+
+    def test_multiple_tool_calls_in_conversation(self):
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "What's 5*6?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "calc", "arguments": '{"expr": "5*6"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "name": "calc", "content": "30"},
+            {"role": "assistant", "content": "The result is 30"},
+            {"role": "user", "content": "Thanks!"},
+        ]
+        result = reverse_roles(messages)
+        assert result == [
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "Hi there!"},
+            {"role": "assistant", "content": "What's 5*6?"},
+            {"role": "user", "content": '[Called tool calc with: {"expr": "5*6"}]'},
+            {"role": "user", "content": "[Tool result from calc: 30]"},
+            {"role": "user", "content": "The result is 30"},
+            {"role": "assistant", "content": "Thanks!"},
+        ]
+
+    def test_tool_only_agent_response_ends_with_user_role(self):
+        """When agent returns only tool-call + tool-result with no final text,
+        the last message after reversal must be 'user' role for Anthropic compatibility."""
+        messages = [
+            {"role": "system", "content": "You are pretending to be a user"},
+            {"role": "assistant", "content": "Hello, how can I help you today"},
+            {"role": "user", "content": "do you have headphones?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "arguments": '{"query": "headphones"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "lookup",
+                "content": "headphones: $29.99, in stock",
+            },
+        ]
+        result = reverse_roles(messages)
+        assert result == [
+            {"role": "system", "content": "You are pretending to be a user"},
+            {"role": "user", "content": "Hello, how can I help you today"},
+            {"role": "assistant", "content": "do you have headphones?"},
+            {"role": "user", "content": '[Called tool lookup with: {"query": "headphones"}]'},
+            {"role": "user", "content": "[Tool result from lookup: headphones: $29.99, in stock]"},
+        ]
+        # Verify last message is "user" role (required by Anthropic)
+        assert result[-1]["role"] == "user"
+
+    def test_multiple_tool_calls_in_single_message(self):
+        """Assistant message with multiple tool_calls should summarize all of them."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": '{"q": "foo"}'},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "fetch", "arguments": '{"url": "bar"}'},
+                    },
+                ],
+            },
+        ]
+        result = reverse_roles(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert '[Called tool search with: {"q": "foo"}]' in result[0]["content"]
+        assert '[Called tool fetch with: {"url": "bar"}]' in result[0]["content"]
+
+    def test_assistant_with_content_and_tool_calls_drops_content(self):
+        """When assistant has both text content and tool_calls, only tool calls
+        are summarized (text content is dropped). Matches JS behavior."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Let me check that for you",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": '{"q": "test"}'},
+                    }
+                ],
+            },
+        ]
+        result = reverse_roles(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert "Let me check that for you" not in result[0]["content"]
+        assert '[Called tool search with: {"q": "test"}]' in result[0]["content"]
+
+    def test_does_not_mutate_original_messages(self):
+        """reverse_roles should deep copy messages, not mutate originals."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        reverse_roles(messages)
+        assert messages[0]["role"] == "user"
+        assert messages[1]["role"] == "assistant"
+
+    def test_message_without_content_preserved(self):
+        """Messages without content but with a reversible role should still be reversed."""
+        messages = [
+            {"role": "user", "content": "test"},
+            {"role": "assistant", "content": None},
+        ]
+        result = reverse_roles(messages)
+        assert result[0]["role"] == "assistant"
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] is None

--- a/python/tests/test_reverse_roles.py
+++ b/python/tests/test_reverse_roles.py
@@ -118,6 +118,7 @@ class TestSummarizeToolMessage:
             ],
         }
         result = _summarize_tool_message(msg)
+        assert result is not None
         assert '[Called tool search with: {"q": "foo"}]' in result
         assert '[Called tool fetch with: {"url": "bar"}]' in result
 
@@ -142,7 +143,7 @@ class TestReverseRoles:
             {"role": "user", "content": "Hello, how are you?"},
             {"role": "user", "content": "What's the weather like?"},
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result == [
             {"role": "assistant", "content": "Hello, how are you?"},
             {"role": "assistant", "content": "What's the weather like?"},
@@ -153,7 +154,7 @@ class TestReverseRoles:
             {"role": "assistant", "content": "I'm doing well, thank you!"},
             {"role": "assistant", "content": "It's sunny today."},
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result == [
             {"role": "user", "content": "I'm doing well, thank you!"},
             {"role": "user", "content": "It's sunny today."},
@@ -165,7 +166,7 @@ class TestReverseRoles:
             {"role": "assistant", "content": "Hi there!"},
             {"role": "user", "content": "How are you?"},
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result == [
             {"role": "assistant", "content": "Hello"},
             {"role": "user", "content": "Hi there!"},
@@ -178,7 +179,7 @@ class TestReverseRoles:
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi!"},
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result == [
             {"role": "system", "content": "You are a helpful assistant"},
             {"role": "assistant", "content": "Hello"},
@@ -214,7 +215,7 @@ class TestReverseRoles:
             },
             {"role": "assistant", "content": "The answer is 4"},
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result == [
             {"role": "assistant", "content": "Calculate 2+2"},
             {"role": "user", "content": '[Called tool calculator with: {"expression": "2+2"}]'},
@@ -242,7 +243,7 @@ class TestReverseRoles:
             {"role": "assistant", "content": "The result is 30"},
             {"role": "user", "content": "Thanks!"},
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result == [
             {"role": "assistant", "content": "Hello"},
             {"role": "user", "content": "Hi there!"},
@@ -281,7 +282,7 @@ class TestReverseRoles:
                 "content": "headphones: $29.99, in stock",
             },
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result == [
             {"role": "system", "content": "You are pretending to be a user"},
             {"role": "user", "content": "Hello, how can I help you today"},
@@ -312,11 +313,11 @@ class TestReverseRoles:
                 ],
             },
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert len(result) == 1
         assert result[0]["role"] == "user"
-        assert '[Called tool search with: {"q": "foo"}]' in result[0]["content"]
-        assert '[Called tool fetch with: {"url": "bar"}]' in result[0]["content"]
+        assert '[Called tool search with: {"q": "foo"}]' in str(result[0]["content"])
+        assert '[Called tool fetch with: {"url": "bar"}]' in str(result[0]["content"])
 
     def test_assistant_with_content_and_tool_calls_drops_content(self):
         """When assistant has both text content and tool_calls, only tool calls
@@ -334,11 +335,11 @@ class TestReverseRoles:
                 ],
             },
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert len(result) == 1
         assert result[0]["role"] == "user"
-        assert "Let me check that for you" not in result[0]["content"]
-        assert '[Called tool search with: {"q": "test"}]' in result[0]["content"]
+        assert "Let me check that for you" not in str(result[0]["content"])
+        assert '[Called tool search with: {"q": "test"}]' in str(result[0]["content"])
 
     def test_does_not_mutate_original_messages(self):
         """reverse_roles should deep copy messages, not mutate originals."""
@@ -346,7 +347,7 @@ class TestReverseRoles:
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi!"},
         ]
-        reverse_roles(messages)
+        reverse_roles(messages)  # type: ignore[arg-type]
         assert messages[0]["role"] == "user"
         assert messages[1]["role"] == "assistant"
 
@@ -356,7 +357,7 @@ class TestReverseRoles:
             {"role": "user", "content": "test"},
             {"role": "assistant", "content": None},
         ]
-        result = reverse_roles(messages)
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result[0]["role"] == "assistant"
         assert result[1]["role"] == "user"
         assert result[1]["content"] is None

--- a/python/tests/test_reverse_roles.py
+++ b/python/tests/test_reverse_roles.py
@@ -64,23 +64,39 @@ class TestSummarizeToolMessage:
         msg = {
             "role": "tool",
             "tool_call_id": "call_1",
-            "name": "get_weather",
             "content": "Sunny 22°C",
         }
-        assert _summarize_tool_message(msg) == "[Tool result from get_weather: Sunny 22°C]"
+        result = _summarize_tool_message(msg, tool_call_names={"call_1": "get_weather"})
+        assert result == "[Tool result from get_weather: Sunny 22°C]"
 
     def test_tool_result_with_json_content(self):
         msg = {
             "role": "tool",
             "tool_call_id": "call_1",
-            "name": "search",
             "content": '{"results": [1, 2, 3]}',
         }
-        assert _summarize_tool_message(msg) == '[Tool result from search: {"results": [1, 2, 3]}]'
+        result = _summarize_tool_message(msg, tool_call_names={"call_1": "search"})
+        assert result == '[Tool result from search: {"results": [1, 2, 3]}]'
 
-    def test_tool_result_missing_name(self):
+    def test_tool_result_unresolved_tool_call_id(self):
+        """When tool_call_id has no matching entry in tool_call_names (e.g. the
+        history was truncated and the tool_calls message fell out of view),
+        fall back to a generic label rather than erroring."""
         msg = {"role": "tool", "tool_call_id": "call_1", "content": "data"}
         assert _summarize_tool_message(msg) == "[Tool result from unknown tool: data]"
+
+    def test_tool_result_name_resolved_via_map_not_message_field(self):
+        """Standard OpenAI tool-result messages carry no 'name' field — a
+        'name' key on the raw message is ignored; the real tool name always
+        comes from tool_call_names, resolved via tool_call_id."""
+        msg = {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "wrong_name",
+            "content": "data",
+        }
+        result = _summarize_tool_message(msg, tool_call_names={"call_1": "real_name"})
+        assert result == "[Tool result from real_name: data]"
 
     def test_assistant_with_single_tool_call(self):
         msg = {
@@ -351,21 +367,43 @@ class TestReverseRoles:
         assert messages[0]["role"] == "user"
         assert messages[1]["role"] == "assistant"
 
-    def test_explicit_none_content_is_reversed(self):
-        """An assistant message with explicit content=None is kept and reversed.
-
-        This is valid in OpenAI format (e.g. an assistant turn that preceded
-        a tool_call but whose tool_calls were already stripped upstream).
-        It is distinct from a message with no 'content' key at all.
+    def test_explicit_none_content_without_tool_calls_is_dropped(self):
+        """An assistant message with content=None and no tool_calls has
+        nothing to say once reversed. Flipping it to
+        {"role": "user", "content": None} would violate the OpenAI/Anthropic
+        user-message schema (content is required on a user message), so it
+        is dropped rather than kept — distinct from a message whose
+        content=None accompanies tool_calls, which is diverted to the
+        tool-summary branch before this guard ever runs.
         """
         messages = [
             {"role": "user", "content": "test"},
             {"role": "assistant", "content": None},
         ]
         result = reverse_roles(messages)  # type: ignore[arg-type]
-        assert result[0]["role"] == "assistant"
+        assert result == [{"role": "assistant", "content": "test"}]
+
+    def test_tool_result_without_name_field_resolves_via_tool_calls_map(self):
+        """Standard OpenAI tool-result messages have no 'name' field — only
+        tool_call_id. reverse_roles must resolve the real tool name from the
+        preceding tool_calls message rather than printing 'unknown tool'."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_9",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_9", "content": "Sunny 22°C"},
+        ]
+        result = reverse_roles(messages)  # type: ignore[arg-type]
         assert result[1]["role"] == "user"
-        assert result[1]["content"] is None
+        assert result[1]["content"] == "[Tool result from get_weather: Sunny 22°C]"
 
     def test_bare_role_only_message_is_dropped(self):
         """Messages with no 'content' key at all are silently dropped.


### PR DESCRIPTION
## What this fixes

The user simulator builds its prompt by calling `reverse_roles()` on the agent's conversation history. Two classes of messages cannot simply have their role flipped:

1. **`role: "tool"` messages** — tool result messages. Relabelling them as `role: "user"` produces an invalid request that both OpenAI and Anthropic APIs reject outright.
2. **`role: "assistant"` messages with `tool_calls`** — tool call messages. Same problem: `tool_calls` is not valid on a `user` message.

The old code worked around this by keeping tool-call messages as-is and dropping tool-result messages. That caused two separate bugs:
- Consecutive `assistant` roles in the reversed history (the user simulator's context) when the agent made tool calls
- Lost tool context — the user simulator had no idea what the agent had just done

## What this changes

Both message types are now **summarized as plain text** and attributed to `role: "user"` (i.e. the agent's perspective after reversal):

- `{"role": "assistant", "tool_calls": [...]}` → `[Called tool search_products with: {"query": "headphones"}]`
- `{"role": "tool", "content": "..."}` → `[Tool result from search_products: [...]]`

This is exactly what the JS `messageRoleReversal()` already does. This PR brings the Python implementation into alignment.

A bare `{"role": "assistant"}` message with no `content` key at all is silently dropped — some models emit these and passing them through would produce an invalid `{"role": "user"}` message (Anthropic rejects it).

## Files changed

- `python/scenario/_utils/utils.py` — rewrites `reverse_roles()` with three new helper functions (`_stringify_value`, `_has_tool_content`, `_summarize_tool_message`)
- `python/tests/test_reverse_roles.py` — 31 unit tests covering all message shapes and edge cases
- `python/examples/test_multiturn_tool_calls.py` — E2E example: 10-turn shopping conversation where the agent makes tool calls on multiple turns, verifying the user simulator handles the full history correctly