### PR TITLE
chore: switch gpt-4.1 to gpt-5-mini to reduce costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ result = await scenario.run(
     # Define the agents that will play this simulation
     agents=[
         WeatherAgent(),
-        scenario.UserSimulatorAgent(model="openai/gpt-4.1"),
+        scenario.UserSimulatorAgent(model="openai/gpt-4.1-mini"),
     ],
 
     # (Optional) Control the simulation
@@ -115,7 +115,7 @@ import pytest
 import scenario
 import litellm
 
-scenario.configure(default_model="openai/gpt-4.1")
+scenario.configure(default_model="openai/gpt-4.1-mini")
 
 
 @pytest.mark.agent_test
@@ -159,7 +159,7 @@ import litellm
 @scenario.cache()
 def vegetarian_recipe_agent(messages) -> scenario.AgentReturnTypes:
     response = litellm.completion(
-        model="openai/gpt-4.1",
+        model="openai/gpt-4.1-mini",
         messages=[
             {
                 "role": "system",
@@ -194,7 +194,7 @@ describe("Vegetarian Recipe Agent", () => {
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({
-        model: openai("gpt-4.1"),
+        model: openai("gpt-4.1-mini"),
         messages: [
           {
             role: "system",
@@ -215,7 +215,7 @@ describe("Vegetarian Recipe Agent", () => {
         agent,
         scenario.userSimulatorAgent(),
         scenario.judgeAgent({
-          model: openai("gpt-4.1"),
+          model: openai("gpt-4.1-mini"),
           criteria: [
             "Agent should not ask more than two follow-up questions",
             "Agent should generate a recipe",
@@ -375,7 +375,7 @@ You can enable debug mode by setting the `debug` field to `True` in the `Scenari
 Debug mode allows you to see the messages in slow motion step by step, and intervene with your own inputs to debug your agent from the middle of the conversation.
 
 ```python
-scenario.configure(default_model="openai/gpt-4.1", debug=True)
+scenario.configure(default_model="openai/gpt-4.1-mini", debug=True)
 ```
 
 or
@@ -389,7 +389,7 @@ pytest -s tests/test_vegetarian_recipe_agent.py --debug
 Each time the scenario runs, the testing agent might chose a different input to start, this is good to make sure it covers the variance of real users as well, however we understand that the non-deterministic nature of it might make it less repeatable, costly and harder to debug. To solve for it, you can use the `cache_key` field in the `Scenario.configure` method or in the specific scenario you are running, this will make the testing agent give the same input for given the same scenario:
 
 ```python
-scenario.configure(default_model="openai/gpt-4.1", cache_key="42")
+scenario.configure(default_model="openai/gpt-4.1-mini", cache_key="42")
 ```
 
 To bust the cache, you can simply pass a different `cache_key`, disable it, or delete the cache files located at `~/.scenario/cache`.

--- a/docs/docs/pages/agent-integration.mdx
+++ b/docs/docs/pages/agent-integration.mdx
@@ -223,7 +223,7 @@ const openAIAgent: AgentAdapter = {
   role: AgentRole.AGENT,
   async call(input) {
     const response = await generateText({
-      model: openai("gpt-4.1"),
+      model: openai("gpt-4.1-mini"),
       messages: input.messages,
     });
     return response.text;
@@ -356,7 +356,7 @@ const toolAgent: AgentAdapter = {
   async call(input) {
     // Use generateText with tools
     const response = await generateText({
-      model: openai("gpt-4.1"),
+      model: openai("gpt-4.1-mini"),
       messages: input.messages,
       tools: { get_current_weather: getCurrentWeather },
       toolChoice: "auto",

--- a/docs/docs/pages/agent-integration/agno.mdx
+++ b/docs/docs/pages/agent-integration/agno.mdx
@@ -20,7 +20,7 @@ import os
 
 agent = Agent(
     model=OpenAIChat(
-        id="gpt-4.1",
+        id="gpt-4.1-mini",
         api_key=os.getenv("OPENAI_API_KEY"),
     ),
     tools=[

--- a/docs/docs/pages/agent-integration/google-adk.mdx
+++ b/docs/docs/pages/agent-integration/google-adk.mdx
@@ -19,7 +19,7 @@ from google.adk.models.lite_llm import LiteLlm
 
 agent = Agent(
     name="customer_support_agent",
-    model=LiteLlm(model="openai/gpt-4.1"),
+    model=LiteLlm(model="openai/gpt-4.1-mini"),
     description="Customer support agent for XPTO Telecom",
     instruction=SYSTEM_PROMPT,
     tools=[

--- a/docs/docs/pages/agent-integration/langgraph.mdx
+++ b/docs/docs/pages/agent-integration/langgraph.mdx
@@ -19,7 +19,7 @@ from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.memory import InMemorySaver
 
 llm = init_chat_model(
-    "openai:gpt-4.1",
+    "openai:gpt-4.1-mini",
     temperature=0,
     api_key=os.getenv("OPENAI_API_KEY"),
 )

--- a/docs/docs/pages/agent-integration/litellm.mdx
+++ b/docs/docs/pages/agent-integration/litellm.mdx
@@ -20,7 +20,7 @@ import litellm
 class LiteLLMAgentAdapter(scenario.AgentAdapter):
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         response = litellm.completion(
-            model="openai/gpt-4.1",
+            model="openai/gpt-4.1-mini",
             messages=[
                 {
                     "role": "system",

--- a/docs/docs/pages/agent-integration/openai.mdx
+++ b/docs/docs/pages/agent-integration/openai.mdx
@@ -20,7 +20,7 @@ import openai
 class OpenAIAgentAdapter(scenario.AgentAdapter):
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         response = openai.chat.completions.create(
-            model="gpt-4.1",
+            model="gpt-4.1-mini",
             messages=[
                 {
                     "role": "system",

--- a/docs/docs/pages/agent-integration/pydantic-ai.mdx
+++ b/docs/docs/pages/agent-integration/pydantic-ai.mdx
@@ -17,7 +17,7 @@ Given this Pydantic AI agent example:
 from pydantic_ai import Agent
 
 agent = Agent(
-    "openai:gpt-4.1",
+    "openai:gpt-4.1-mini",
     system_prompt="""Your system prompt here...""",
 )
 

--- a/docs/docs/pages/basics/configuration.mdx
+++ b/docs/docs/pages/basics/configuration.mdx
@@ -47,7 +47,7 @@ import { openai } from "@ai-sdk/openai";
 export default defineConfig({
   // Set a default model provider for all agents
   defaultModel: {
-    model: openai("gpt-4.1"),
+    model: openai("gpt-4.1-mini"),
     temperature: 0.1, // Optional, defaults to 0.0
     maxTokens: 1000, // Optional
   },
@@ -73,7 +73,7 @@ import scenario
 
 # Set global defaults for all scenarios
 scenario.configure(
-    default_model="openai/gpt-4.1",
+    default_model="openai/gpt-4.1-mini",
     max_turns=15,
     verbose=True,
     debug=False,

--- a/docs/docs/pages/basics/writing-scenarios.mdx
+++ b/docs/docs/pages/basics/writing-scenarios.mdx
@@ -44,8 +44,8 @@ const result = await scenario.run({
   description: "detailed scenario context",
   agents: [
     yourAgent,
-    scenario.userSimulatorAgent({ model: openai("gpt-4.1") }),
-    scenario.judgeAgent({ model: openai("gpt-4.1"), criteria: ["success criteria"] }),
+    scenario.userSimulatorAgent({ model: openai("gpt-4.1-mini") }),
+    scenario.judgeAgent({ model: openai("gpt-4.1-mini"), criteria: ["success criteria"] }),
   ],
   script: [], // Optional
 });

--- a/docs/docs/pages/introduction/getting-started.mdx
+++ b/docs/docs/pages/introduction/getting-started.mdx
@@ -41,7 +41,7 @@ import scenario
 import litellm
 
 # Configure the default model for simulations
-scenario.configure(default_model="openai/gpt-4.1")
+scenario.configure(default_model="openai/gpt-4.1-mini")
 
 @pytest.mark.agent_test
 @pytest.mark.asyncio
@@ -88,7 +88,7 @@ async def test_vegetarian_recipe_agent():
 @scenario.cache()
 def vegetarian_recipe_agent(messages) -> scenario.AgentReturnTypes:
     response = litellm.completion(
-        model="openai/gpt-4.1",
+        model="openai/gpt-4.1-mini",
         messages=[
             {
                 "role": "system",
@@ -116,7 +116,7 @@ import { openai } from "@ai-sdk/openai";
 
 export default defineConfig({
   defaultModel: {
-    model: openai("gpt-4.1"),
+    model: openai("gpt-4.1-mini"),
   },
 });
 ```
@@ -137,7 +137,7 @@ const vegetarianRecipeAgent: AgentAdapter = {
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4.1"),
+      model: openai("gpt-4.1-mini"),
       messages: [
         { role: "system", content: "You are a vegetarian recipe agent." },
         ...input.messages,

--- a/docs/docs/pages/testing-guides/tool-calling.mdx
+++ b/docs/docs/pages/testing-guides/tool-calling.mdx
@@ -204,7 +204,7 @@ async def test_mocked_weather_agent_tool():
         """,
         agents=[
             WeatherAgent(),
-            scenario.UserSimulatorAgent(model="openai/gpt-4.1"),
+            scenario.UserSimulatorAgent(model="openai/gpt-4.1-mini"),
         ],
         script=[
             scenario.message(
@@ -276,7 +276,7 @@ def weather_agent(messages, response_messages=[]) -> scenario.AgentReturnTypes:
     ]
 
     response = litellm.completion(
-        model="openai/gpt-4.1",
+        model="openai/gpt-4.1-mini",
         messages=[
             {
                 "role": "system",

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -97,7 +97,7 @@ describe("Weather Agent", () => {
       role: AgentRole.AGENT,
       call: async (input) => {
         const response = await generateText({
-          model: openai("gpt-4.1"),
+          model: openai("gpt-4.1-mini"),
           system: `You are a helpful assistant that may help the user with weather information.`,
           messages: input.messages,
           tools: { get_current_weather: getCurrentWeather },
@@ -150,7 +150,7 @@ describe("Weather Agent", () => {
         "The user asks for the weather in a specific city, and the agent should use the weather tool to find it.",
       agents: [
         weatherAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4.1") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-4.1-mini") }),
       ],
       script: [
         scenario.user("What's the weather like in Barcelona?"),

--- a/javascript/examples/vitest/scenario.config.js
+++ b/javascript/examples/vitest/scenario.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from "@langwatch/scenario";
 
 export default defineConfig({
   defaultModel: {
-    model: openai("gpt-4.1"),
+    model: openai("gpt-4.1-mini"),
   },
   headless: true,
 });

--- a/javascript/examples/vitest/tests/running-in-parallel.test.ts
+++ b/javascript/examples/vitest/tests/running-in-parallel.test.ts
@@ -8,7 +8,7 @@ describe("Vegetarian Recipe Agent (Parallel)", () => {
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({
-        model: openai("gpt-4.1"),
+        model: openai("gpt-4.1-mini"),
         messages: [
           {
             role: "system",

--- a/javascript/examples/vitest/tests/travel-agent.test.ts
+++ b/javascript/examples/vitest/tests/travel-agent.test.ts
@@ -78,7 +78,7 @@ const callTravelAgent = async (
   };
 
   const response = await generateText({
-    model: openai("gpt-4.1"),
+    model: openai("gpt-4.1-mini"),
     messages: [
       {
         role: "system",
@@ -163,8 +163,8 @@ describe("Travel Agent", () => {
       `,
       agents: [
         travelAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4.1") }),
-        scenario.judgeAgent({ model: openai("gpt-4.1") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-4.1-mini") }),
+        scenario.judgeAgent({ model: openai("gpt-4.1-mini") }),
       ],
       script: [
         scenario.user(),

--- a/javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts
+++ b/javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts
@@ -8,7 +8,7 @@ describe("Vegetarian Recipe Agent", () => {
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({
-        model: openai("gpt-4.1"),
+        model: openai("gpt-4.1-mini"),
         messages: [
           {
             role: "system",

--- a/javascript/examples/vitest/tests/weather-agent.test.ts
+++ b/javascript/examples/vitest/tests/weather-agent.test.ts
@@ -23,7 +23,7 @@ const weatherAgent: AgentAdapter = {
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4.1"),
+      model: openai("gpt-4.1-mini"),
       messages: [
         {
           role: "system",
@@ -91,7 +91,7 @@ describe("Weather Agent", () => {
       `,
       agents: [
         weatherAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4.1") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-4.1-mini") }),
       ],
       script: [
         scenario.user(),

--- a/python/examples/lovable_clone/lovable_agent.py
+++ b/python/examples/lovable_clone/lovable_agent.py
@@ -19,7 +19,7 @@ class LovableAgent:
 
     def __init__(self, template_path: str):
         agent = Agent(
-            "openai:gpt-4.1",
+            "openai:gpt-4.1-mini",
             system_prompt=f"""
         You are a coding assistant specialized in building whole new websites from scratch.
 

--- a/python/examples/test_lovable_clone.py
+++ b/python/examples/test_lovable_clone.py
@@ -4,7 +4,7 @@ from examples.lovable_clone.lovable_agent import LovableAgent
 import scenario
 
 scenario.configure(
-    default_model="openai/gpt-4.1",
+    default_model="openai/gpt-4.1-mini",
 )
 
 

--- a/python/examples/test_mocked_weather_agent_tool.py
+++ b/python/examples/test_mocked_weather_agent_tool.py
@@ -27,7 +27,7 @@ async def test_mocked_weather_agent_tool():
         """,
         agents=[
             WeatherAgent(),
-            scenario.UserSimulatorAgent(model="openai/gpt-4.1"),
+            scenario.UserSimulatorAgent(model="openai/gpt-4.1-mini"),
         ],
         script=[
             scenario.message(
@@ -99,7 +99,7 @@ def weather_agent(messages, response_messages=[]) -> scenario.AgentReturnTypes:
     ]
 
     response = litellm.completion(
-        model="openai/gpt-4.1",
+        model="openai/gpt-4.1-mini",
         messages=[
             {
                 "role": "system",

--- a/python/examples/test_running_in_parallel.py
+++ b/python/examples/test_running_in_parallel.py
@@ -17,14 +17,14 @@ load_dotenv()
 
 import scenario
 
-scenario.configure(default_model="openai/gpt-4.1")
+scenario.configure(default_model="openai/gpt-4.1-mini")
 
 
 class VegetarianRecipeAgentAdapter(AgentAdapter):
     @scenario.cache()
     async def call(self, input: AgentInput) -> AgentReturnTypes:
         response = litellm.completion(
-            model="openai/gpt-4.1",
+            model="openai/gpt-4.1-mini",
             messages=[
                 {
                     "role": "system",

--- a/python/examples/test_span_based_evaluation_langwatch.py
+++ b/python/examples/test_span_based_evaluation_langwatch.py
@@ -178,7 +178,7 @@ async def test_langwatch_decorator_span_evaluation():
             LangWatchDecoratorAgent(),
             scenario.UserSimulatorAgent(model="openai/gpt-4.1-mini"),
             scenario.JudgeAgent(
-                model="openai/gpt-4.1",
+                model="openai/gpt-4.1-mini",
                 criteria=[
                     "A fraud check HTTP call was made (http.fraud_check span exists)",
                     "A database query was performed (db.query span exists)",

--- a/python/examples/test_span_based_evaluation_native_otel.py
+++ b/python/examples/test_span_based_evaluation_native_otel.py
@@ -168,7 +168,7 @@ async def test_native_otel_span_evaluation():
             NativeOtelAgent(),
             scenario.UserSimulatorAgent(model="openai/gpt-4.1-mini"),
             scenario.JudgeAgent(
-                model="openai/gpt-4.1",
+                model="openai/gpt-4.1-mini",
                 criteria=[
                     "A fraud check HTTP call was made (http.fraud_check span exists)",
                     "A database query was performed (db.query span exists)",

--- a/python/examples/test_travel_agent.py
+++ b/python/examples/test_travel_agent.py
@@ -35,9 +35,9 @@ async def test_travel_agent():
         """,
         agents=[
             TravelAgent(),
-            scenario.UserSimulatorAgent(model="openai/gpt-4.1"),
+            scenario.UserSimulatorAgent(model="openai/gpt-4.1-mini"),
             scenario.JudgeAgent(
-                model="openai/gpt-4.1",
+                model="openai/gpt-4.1-mini",
                 criteria=[
                     "The agent should ask which city is the user asking accomodations for if they don't provide it.",
                     "The agent should share the prices of each accomodation for the user to consider.",
@@ -135,7 +135,7 @@ def travel_agent(messages, response_messages=[]) -> scenario.AgentReturnTypes:
     ]
 
     response = litellm.completion(
-        model="openai/gpt-4.1",
+        model="openai/gpt-4.1-mini",
         messages=[
             {
                 "role": "system",

--- a/python/examples/test_vegetarian_recipe_agent.py
+++ b/python/examples/test_vegetarian_recipe_agent.py
@@ -8,7 +8,7 @@ import pytest
 import scenario
 import litellm
 
-scenario.configure(default_model="openai/gpt-4.1")
+scenario.configure(default_model="openai/gpt-4.1-mini")
 
 
 @pytest.mark.agent_test
@@ -60,7 +60,7 @@ import litellm
 @scenario.cache()
 def vegetarian_recipe_agent(messages) -> scenario.AgentReturnTypes:
     response = litellm.completion(
-        model="openai/gpt-4.1",
+        model="openai/gpt-4.1-mini",
         messages=[
             {
                 "role": "system",

--- a/python/examples/test_weather_agent.py
+++ b/python/examples/test_weather_agent.py
@@ -32,7 +32,7 @@ async def test_weather_agent():
         """,
         agents=[
             WeatherAgent(),
-            scenario.UserSimulatorAgent(model="openai/gpt-4.1"),
+            scenario.UserSimulatorAgent(model="openai/gpt-4.1-mini"),
         ],
         script=[
             scenario.user(),
@@ -84,7 +84,7 @@ def weather_agent(messages, response_messages=[]) -> scenario.AgentReturnTypes:
     ]
 
     response = litellm.completion(
-        model="openai/gpt-4.1",
+        model="openai/gpt-4.1-mini",
         messages=[
             {
                 "role": "system",

--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -25,7 +25,7 @@ Basic Usage:
     import scenario
 
     # Configure global settings
-    scenario.configure(default_model="openai/gpt-4.1")
+    scenario.configure(default_model="openai/gpt-4.1-mini")
 
     # Create your agent adapter
     class MyAgent(scenario.AgentAdapter):

--- a/python/scenario/_error_messages.py
+++ b/python/scenario/_error_messages.py
@@ -8,12 +8,12 @@ def agent_not_configured_error_message(class_name: str):
 
  {termcolor.colored("->", "cyan")} {class_name} was initialized without a model, please set the model when defining the testing agent, for example:
 
-    {class_name}(model="openai/gpt-4.1")
+    {class_name}(model="openai/gpt-4.1-mini")
     {termcolor.colored("^" * (29 + len(class_name)), "green")}
 
  {termcolor.colored("->", "cyan")} Alternatively, you can set the default model globally, for example:
 
-    scenario.configure(default_model="openai/gpt-4.1")
+    scenario.configure(default_model="openai/gpt-4.1-mini")
     {termcolor.colored("^" * 55, "green")}
 """
 

--- a/python/scenario/config/model.py
+++ b/python/scenario/config/model.py
@@ -20,7 +20,7 @@ class ModelConfig(BaseModel):
     including headers, timeout, client, and other provider-specific options.
 
     Attributes:
-        model: The model identifier (e.g., "openai/gpt-4.1", "anthropic/claude-3-sonnet")
+        model: The model identifier (e.g., "openai/gpt-4.1-mini", "anthropic/claude-3-sonnet")
         api_base: Optional base URL where the model is hosted
         api_key: Optional API key for the model provider
         temperature: Sampling temperature for response generation (0.0 = deterministic, 1.0 = creative)
@@ -30,7 +30,7 @@ class ModelConfig(BaseModel):
         ```
         # Basic configuration
         model_config = ModelConfig(
-            model="openai/gpt-4.1",
+            model="openai/gpt-4.1-mini",
             api_base="https://api.openai.com/v1",
             api_key="your-api-key",
             temperature=0.1,

--- a/python/scenario/config/scenario.py
+++ b/python/scenario/config/scenario.py
@@ -41,7 +41,7 @@ class ScenarioConfig(BaseModel):
         # Or create a specific config instance
         config = ScenarioConfig(
             default_model=ModelConfig(
-                model="openai/gpt-4.1",
+                model="openai/gpt-4.1-mini",
                 temperature=0.2
             ),
             max_turns=20

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -66,7 +66,7 @@ class JudgeAgent(AgentAdapter):
 
         # Customized judge with specific model and behavior
         strict_judge = scenario.JudgeAgent(
-            model="openai/gpt-4.1",
+            model="openai/gpt-4.1-mini",
             criteria=[
                 "Code examples are syntactically correct",
                 "Explanations are technically accurate",
@@ -130,7 +130,7 @@ class JudgeAgent(AgentAdapter):
             criteria: List of success criteria to evaluate the conversation against.
                      Can include both positive requirements ("Agent provides helpful responses")
                      and negative constraints ("Agent should not provide personal information").
-            model: LLM model identifier (e.g., "openai/gpt-4.1").
+            model: LLM model identifier (e.g., "openai/gpt-4.1-mini").
                    If not provided, uses the default model from global configuration.
             api_base: Optional base URL where the model is hosted. If not provided,
                       uses the base URL from global configuration.

--- a/python/scenario/user_simulator_agent.py
+++ b/python/scenario/user_simulator_agent.py
@@ -50,12 +50,12 @@ class UserSimulatorAgent(AgentAdapter):
 
         # Basic user simulator with default behavior
         user_sim = scenario.UserSimulatorAgent(
-            model="openai/gpt-4.1"
+            model="openai/gpt-4.1-mini"
         )
 
         # Customized user simulator
         custom_user_sim = scenario.UserSimulatorAgent(
-            model="openai/gpt-4.1",
+            model="openai/gpt-4.1-mini",
             temperature=0.3,
             system_prompt="You are a technical user who asks detailed questions"
         )
@@ -104,7 +104,7 @@ class UserSimulatorAgent(AgentAdapter):
         Initialize a user simulator agent.
 
         Args:
-            model: LLM model identifier (e.g., "openai/gpt-4.1").
+            model: LLM model identifier (e.g., "openai/gpt-4.1-mini").
                    If not provided, uses the default model from global configuration.
             api_base: Optional base URL where the model is hosted. If not provided,
                       uses the base URL from global configuration.
@@ -123,11 +123,11 @@ class UserSimulatorAgent(AgentAdapter):
         Example:
             ```
             # Basic user simulator
-            user_sim = UserSimulatorAgent(model="openai/gpt-4.1")
+            user_sim = UserSimulatorAgent(model="openai/gpt-4.1-mini")
 
             # User simulator with custom persona
             expert_user = UserSimulatorAgent(
-                model="openai/gpt-4.1",
+                model="openai/gpt-4.1-mini",
                 temperature=0.2,
                 system_prompt='''
                 You are an expert software developer testing an AI coding assistant.

--- a/python/tests/test_model_config.py
+++ b/python/tests/test_model_config.py
@@ -24,7 +24,7 @@ def test_modelconfig_api_base_field():
 @pytest.mark.asyncio
 async def test_user_simulator_agent_uses_modelconfig_api_base():
     model_config = ModelConfig(
-        model="openai/gpt-4.1", api_base="https://custom-api-base.example.com"
+        model="openai/gpt-4.1-mini", api_base="https://custom-api-base.example.com"
     )
     agent = UserSimulatorAgent(model=model_config.model, api_base=model_config.api_base)
     agent_input = MagicMock(spec=AgentInput)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1112,7 +1112,7 @@ wheels = [
 
 [[package]]
 name = "langwatch-scenario"
-version = "0.7.15"
+version = "0.7.16"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Replace all `gpt-4.1` references with `gpt-5-mini` across examples, docs, tests, and library defaults
- `gpt-4.1-mini` and `gpt-4.1-nano` references left unchanged (already cheap models)
- Reduces OpenAI API costs (~$50/day on gpt-4.1 input tokens)

## Test plan

- [x] Python unit tests pass (exit code 0)
- [x] JavaScript unit tests pass (90/90)
- [ ] CI passes