### PR TITLE
fix: add connection retry for flaky realtime API tests

### DIFF
--- a/javascript/examples/vitest/tests/helpers/connect-with-retry.ts
+++ b/javascript/examples/vitest/tests/helpers/connect-with-retry.ts
@@ -1,0 +1,25 @@
+import type { RealtimeAgentAdapter } from "@langwatch/scenario";
+
+/**
+ * Connects a RealtimeAgentAdapter with retry logic for transient failures
+ * (e.g. 504 Gateway Timeout from OpenAI's Realtime API).
+ */
+export async function connectWithRetry(
+  adapter: RealtimeAgentAdapter,
+  { maxRetries = 3, delayMs = 2000 }: { maxRetries?: number; delayMs?: number } = {}
+): Promise<void> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await adapter.connect();
+      return;
+    } catch (error) {
+      if (attempt === maxRetries) throw error;
+
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `[connectWithRetry] Attempt ${attempt}/${maxRetries} failed: ${message}. Retrying in ${delayMs}ms...`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}

--- a/javascript/examples/vitest/tests/scenario-expert-realtime.test.ts
+++ b/javascript/examples/vitest/tests/scenario-expert-realtime.test.ts
@@ -16,6 +16,7 @@ import scenario, {
   type AudioResponseEvent,
 } from "@langwatch/scenario";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { connectWithRetry } from "./helpers/connect-with-retry";
 import { wrapJudgeForAudioTranscription } from "./helpers/wrap-judge-for-audio-transcription";
 import { AudioUtils } from "./utils/audio/audio.utils";
 import {
@@ -71,8 +72,11 @@ describe("Scenario Expert Agent (Realtime API)", () => {
       collectedAudio.push(event);
     });
 
-    // Connect both sessions (adapter handles connection)
-    await Promise.all([realtimeAdapter.connect(), audioUserSim.connect()]);
+    // Connect with retry to handle transient 504s from OpenAI's Realtime API
+    await Promise.all([
+      connectWithRetry(realtimeAdapter),
+      connectWithRetry(audioUserSim),
+    ]);
 
     // Start real-time audio player and hook into both transports
     // to stream audio chunks as they arrive from each speaker

--- a/javascript/examples/vitest/tests/vegetarian-recipe-realtime.test.ts
+++ b/javascript/examples/vitest/tests/vegetarian-recipe-realtime.test.ts
@@ -16,6 +16,7 @@ import scenario, {
   type AudioResponseEvent,
 } from "@langwatch/scenario";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { connectWithRetry } from "./helpers/connect-with-retry";
 import { wrapJudgeForAudioTranscription } from "./helpers/wrap-judge-for-audio-transcription";
 import { AudioUtils } from "./utils/audio/audio.utils";
 import { createUserSimulatorSession } from "../../openai-realtime-demo/agents/realtime-user-simulator.agent";
@@ -81,8 +82,11 @@ describe("Vegetarian Recipe Agent (Realtime API)", () => {
       collectedAudio.push(event);
     });
 
-    // Connect user simulator (adapter handles connection)
-    await Promise.all([realtimeAdapter.connect(), audioUserSim.connect()]);
+    // Connect with retry to handle transient 504s from OpenAI's Realtime API
+    await Promise.all([
+      connectWithRetry(realtimeAdapter),
+      connectWithRetry(audioUserSim),
+    ]);
   }, 60000); // Longer timeout for connection
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

- Add `connectWithRetry` helper that retries WebSocket connections up to 3 times with 2s delay
- Apply to both `vegetarian-recipe-realtime.test.ts` and `scenario-expert-realtime.test.ts`
- Handles transient 504 Gateway Timeout from OpenAI's Realtime API in `beforeAll`

## Why

Vitest's `retry: 3` config only retries the test function, not `beforeAll` hooks. When the OpenAI Realtime API returns a 504 during connection setup, the entire describe block fails with no retry. This was breaking CI on both main and feature branches.

## Test plan

- [x] Core tests pass (97/97)
- [ ] CI should show fewer flaky failures on realtime tests

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)