### PR TITLE
feat: add extensible metadata support to ScenarioConfig

### DIFF
--- a/javascript/src/domain/scenarios/index.ts
+++ b/javascript/src/domain/scenarios/index.ts
@@ -61,6 +61,13 @@ export interface ScenarioConfig {
    * If not provided, the scenario will not be grouped into a set.
    */
   setId?: string;
+
+  /**
+   * Optional metadata to attach to the scenario run.
+   * Accepts arbitrary key-value pairs (e.g. prompt IDs, environments, versions).
+   * The `langwatch` key is reserved for platform-internal use.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 /**

--- a/javascript/src/events/schema.ts
+++ b/javascript/src/events/schema.ts
@@ -75,7 +75,7 @@ export const scenarioRunStartedSchema = baseScenarioEventSchema.extend({
   metadata: z.object({
     name: z.string().optional(),
     description: z.string().optional(),
-  }),
+  }).catchall(z.unknown()),
 });
 
 /**

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -214,6 +214,7 @@ export class ScenarioExecution implements ScenarioExecutionLike {
       maxTurns: config.maxTurns ?? DEFAULT_MAX_TURNS,
       threadId: config.threadId ?? generateThreadId(),
       setId: config.setId,
+      metadata: config.metadata,
     } satisfies ScenarioConfigFinal;
 
     this.state = new ScenarioExecutionState(this.config);
@@ -1307,6 +1308,7 @@ export class ScenarioExecution implements ScenarioExecutionLike {
       ...this.makeBaseEvent({ scenarioRunId }),
       type: ScenarioEventType.RUN_STARTED,
       metadata: {
+        ...this.config.metadata,
         name: this.config.name,
         description: this.config.description,
       },

--- a/javascript/src/runner/__tests__/run.test.ts
+++ b/javascript/src/runner/__tests__/run.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { run, type RunOptions } from "../run";
-import { AgentRole, type AgentAdapter, type AgentInput } from "../../domain";
+import { AgentRole, type AgentAdapter, type AgentInput, type ScenarioConfig } from "../../domain";
 import type { ScenarioEvent } from "../../events/schema";
 
 // Mock the EventBus - must use function keyword for constructor
@@ -63,7 +63,7 @@ class TestJudgeAgent implements AgentAdapter {
   }
 }
 
-function createScenarioConfig(name = "Test Scenario") {
+function createScenarioConfig(name = "Test Scenario"): ScenarioConfig {
   return {
     name,
     description: `Scenario ${name}`,
@@ -245,6 +245,34 @@ describe("run", () => {
 
       expect(runStartedA?.metadata?.name).toBe("Scenario-A");
       expect(runStartedB?.metadata?.name).toBe("Scenario-B");
+    });
+  });
+
+  describe("metadata", () => {
+    it("includes user metadata in RUN_STARTED event", async () => {
+      const { capturedEvents } = await mockEventBusWithEventCapture();
+
+      const config = createScenarioConfig();
+      config.metadata = { promptId: "abc-123", environment: "staging" };
+
+      await run(config);
+
+      const runStartedEvent = capturedEvents.find((e) => e.type === "SCENARIO_RUN_STARTED");
+      expect(runStartedEvent?.metadata?.promptId).toBe("abc-123");
+      expect(runStartedEvent?.metadata?.environment).toBe("staging");
+    });
+
+    it("preserves name and description over user metadata", async () => {
+      const { capturedEvents } = await mockEventBusWithEventCapture();
+
+      const config = createScenarioConfig("My Scenario");
+      config.metadata = { name: "overridden", description: "overridden" };
+
+      await run(config);
+
+      const runStartedEvent = capturedEvents.find((e) => e.type === "SCENARIO_RUN_STARTED");
+      expect(runStartedEvent?.metadata?.name).toBe("My Scenario");
+      expect(runStartedEvent?.metadata?.description).toBe("Scenario My Scenario");
     });
   });
 });

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -9,6 +9,7 @@ and judge agents to determine test success or failure.
 import json
 import sys
 from typing import (
+    Any,
     Awaitable,
     Callable,
     Dict,
@@ -137,6 +138,7 @@ class ScenarioExecutor:
         debug: Optional[bool] = None,
         event_bus: Optional[ScenarioEventBus] = None,
         set_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize a scenario executor.
@@ -159,11 +161,15 @@ class ScenarioExecutor:
                   Overrides global configuration for this scenario.
             event_bus: Optional event bus that will subscribe to this executor's events
             set_id: Optional set identifier for grouping related scenarios
+            metadata: Optional metadata to attach to the scenario run.
+                     Accepts arbitrary key-value pairs. The ``langwatch`` key
+                     is reserved for platform-internal use.
         """
         self.name = name
         self.description = description
         self.agents = agents
         self.script = script or [proceed()]
+        self.metadata = metadata
 
         config = ScenarioConfig(
             max_turns=max_turns,
@@ -892,6 +898,10 @@ class ScenarioExecutor:
             name=self.name,
             description=self.description,
         )
+        if self.metadata:
+            for key, value in self.metadata.items():
+                if key not in ("name", "description"):
+                    metadata.additional_properties[key] = value
 
         event = ScenarioRunStartedEvent(
             **common_fields,
@@ -968,6 +978,7 @@ async def run(
     debug: Optional[bool] = None,
     script: Optional[List[ScriptStep]] = None,
     set_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> ScenarioResult:
     """
     High-level interface for running a scenario test.
@@ -986,6 +997,9 @@ async def run(
         debug: Enable debug mode for step-by-step execution
         script: Optional script steps to control scenario flow
         set_id: Optional set identifier for grouping related scenarios
+        metadata: Optional metadata to attach to the scenario run.
+                 Accepts arbitrary key-value pairs. The ``langwatch`` key
+                 is reserved for platform-internal use.
 
     Returns:
         ScenarioResult containing the test outcome, conversation history,
@@ -1041,6 +1055,7 @@ async def run(
         debug=debug,
         script=script,
         set_id=set_id,
+        metadata=metadata,
     )
 
     # We'll use a thread pool to run the execution logic, we

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -280,3 +280,69 @@ async def test_error_includes_agent_class_name() -> None:
 
     # Error should include the agent class name
     assert "FailingAgent" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_user_metadata_appears_in_run_started_event() -> None:
+    """User metadata should appear in RUN_STARTED event's additional_properties."""
+    mock_reporter = MockEventReporter()
+    event_bus = ScenarioEventBus(event_reporter=mock_reporter)
+
+    executor = ScenarioExecutor(
+        name="metadata scenario",
+        description="test metadata",
+        agents=[
+            MockAgent(),
+            MockUserSimulatorAgent(model="none"),
+            MockJudgeAgent(model="none", criteria=["test criteria"]),
+        ],
+        event_bus=event_bus,
+        metadata={"promptId": "abc-123", "environment": "staging"},
+    )
+
+    events: List[ScenarioEvent] = []
+    executor.events.subscribe(events.append)
+    await executor.run()
+
+    start_event: ScenarioRunStartedEvent = next(
+        e for e in events if isinstance(e, ScenarioRunStartedEvent)
+    )
+
+    metadata_dict = start_event.metadata.to_dict()
+    assert metadata_dict["promptId"] == "abc-123"
+    assert metadata_dict["environment"] == "staging"
+    assert metadata_dict["name"] == "metadata scenario"
+    assert metadata_dict["description"] == "test metadata"
+
+
+@pytest.mark.asyncio
+async def test_name_and_description_take_precedence_over_metadata() -> None:
+    """Config name/description should take precedence over same keys in metadata."""
+    mock_reporter = MockEventReporter()
+    event_bus = ScenarioEventBus(event_reporter=mock_reporter)
+
+    executor = ScenarioExecutor(
+        name="real name",
+        description="real description",
+        agents=[
+            MockAgent(),
+            MockUserSimulatorAgent(model="none"),
+            MockJudgeAgent(model="none", criteria=["test criteria"]),
+        ],
+        event_bus=event_bus,
+        metadata={"name": "overridden", "description": "overridden"},
+    )
+
+    events: List[ScenarioEvent] = []
+    executor.events.subscribe(events.append)
+    await executor.run()
+
+    start_event: ScenarioRunStartedEvent = next(
+        e for e in events if isinstance(e, ScenarioRunStartedEvent)
+    )
+
+    assert start_event.metadata.name == "real name"
+    assert start_event.metadata.description == "real description"
+    metadata_dict = start_event.metadata.to_dict()
+    assert metadata_dict["name"] == "real name"
+    assert metadata_dict["description"] == "real description"


### PR DESCRIPTION
## Summary

- Add `metadata?: Record<string, unknown>` field to `ScenarioConfig` (JS) and `ScenarioExecutor`/`run()` (Python) for attaching custom key-value pairs (prompt IDs, environments, versions) to scenario runs
- Spread user metadata into `SCENARIO_RUN_STARTED` event, with built-in `name`/`description` always taking precedence
- Add `.catchall(z.unknown())` to the Zod metadata schema to align with ADR-008's server-side `.passthrough()` change

Closes #228

## Test plan

- [x] JS: user metadata appears in `RUN_STARTED` event
- [x] JS: `name`/`description` from config take precedence over same keys in metadata
- [x] JS: existing tests pass (99/99)
- [x] Python: user metadata appears in `RUN_STARTED` event's `additional_properties`/`to_dict()`
- [x] Python: `name`/`description` from config take precedence over same keys in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)