### PR TITLE
fix: add flaky markers to all LLM-calling example tests

### DIFF
--- a/python/examples/test_api_service_mocking.py
+++ b/python/examples/test_api_service_mocking.py
@@ -101,6 +101,7 @@ class UserDataAgent(scenario.AgentAdapter):
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_api_service_mocking():
     """Test mocking HTTP calls within tools while using real LLM tool calling."""

--- a/python/examples/test_audio_to_text.py
+++ b/python/examples/test_audio_to_text.py
@@ -158,6 +158,7 @@ class AudioToTextAgent(scenario.AgentAdapter):
 SET_ID = "multimodal-audio-to-text-test"
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_audio_to_text():
     """

--- a/python/examples/test_azure_api_gateway.py
+++ b/python/examples/test_azure_api_gateway.py
@@ -73,6 +73,7 @@ def create_custom_openai_client():
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_azure_gateway_with_custom_client():
     """

--- a/python/examples/test_custom_judge_llm.py
+++ b/python/examples/test_custom_judge_llm.py
@@ -111,6 +111,7 @@ class PoliteAgent(scenario.AgentAdapter):
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_custom_llm_judge():
     """Custom LLM judge evaluates a polite agent response."""

--- a/python/examples/test_database_tool_mocking.py
+++ b/python/examples/test_database_tool_mocking.py
@@ -111,6 +111,7 @@ class DatabaseAgent(scenario.AgentAdapter):
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_database_service_mocking():
     """Test mocking database connections within tools while using real LLM tool calling."""

--- a/python/examples/test_false_assumptions.py
+++ b/python/examples/test_false_assumptions.py
@@ -26,6 +26,7 @@ class Agent(scenario.AgentAdapter):
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_early_assumption_bias():
     result = await scenario.run(

--- a/python/examples/test_lovable_clone.py
+++ b/python/examples/test_lovable_clone.py
@@ -21,6 +21,7 @@ class LovableAgentAdapter(scenario.AgentAdapter):
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_lovable_clone():
     template_path = LovableAgent.clone_template()

--- a/python/examples/test_mocked_weather_agent_tool.py
+++ b/python/examples/test_mocked_weather_agent_tool.py
@@ -11,6 +11,7 @@ from function_schema import get_function_schema
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_mocked_weather_agent_tool():
     # Integrate with your agent

--- a/python/examples/test_running_in_parallel.py
+++ b/python/examples/test_running_in_parallel.py
@@ -40,6 +40,7 @@ class VegetarianRecipeAgentAdapter(AgentAdapter):
         return [cast(ChatCompletionMessageParam, message)]
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent")
 async def test_vegetarian_recipe_agent():
     # Define the scenario

--- a/python/examples/test_simple_tool_mocking.py
+++ b/python/examples/test_simple_tool_mocking.py
@@ -102,6 +102,7 @@ class UserDataAgent(scenario.AgentAdapter):
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_simple_tool_mocking():
     """Test mocking tools while using real LLM tool calling."""

--- a/python/examples/test_span_based_evaluation_langwatch.py
+++ b/python/examples/test_span_based_evaluation_langwatch.py
@@ -158,6 +158,7 @@ When asked about products, use the check_inventory tool.""",
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_langwatch_decorator_span_evaluation():
     """

--- a/python/examples/test_span_based_evaluation_native_otel.py
+++ b/python/examples/test_span_based_evaluation_native_otel.py
@@ -145,6 +145,7 @@ When asked about products, use the check_inventory tool.""",
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_native_otel_span_evaluation():
     """

--- a/python/examples/test_testing_remote_agents_json.py
+++ b/python/examples/test_testing_remote_agents_json.py
@@ -93,6 +93,7 @@ async def test_server():
     await runner.cleanup()
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_json_response(test_server):
     """

--- a/python/examples/test_testing_remote_agents_sse.py
+++ b/python/examples/test_testing_remote_agents_sse.py
@@ -153,6 +153,7 @@ async def test_server():
     await runner.cleanup()
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_sse_response(test_server):
     """

--- a/python/examples/test_testing_remote_agents_stateful.py
+++ b/python/examples/test_testing_remote_agents_stateful.py
@@ -142,6 +142,7 @@ async def test_server():
     conversations.clear()
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_stateful_conversation(test_server):
     """

--- a/python/examples/test_testing_remote_agents_streaming.py
+++ b/python/examples/test_testing_remote_agents_streaming.py
@@ -126,6 +126,7 @@ async def test_server():
     await runner.cleanup()
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_streaming_response(test_server):
     """

--- a/python/examples/test_tool_failure_simulation.py
+++ b/python/examples/test_tool_failure_simulation.py
@@ -143,6 +143,7 @@ def check_success_in_message(state: scenario.ScenarioState) -> None:
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_tool_timeout_simulation():
     """Test agent's ability to handle tool timeouts."""
@@ -175,6 +176,7 @@ async def test_tool_timeout_simulation():
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_tool_rate_limit_simulation():
     """Test agent's ability to handle rate limits."""

--- a/python/examples/test_travel_agent.py
+++ b/python/examples/test_travel_agent.py
@@ -10,6 +10,7 @@ import litellm
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_travel_agent():
     # Integrate with your agent

--- a/python/examples/test_vegetarian_recipe_agent.py
+++ b/python/examples/test_vegetarian_recipe_agent.py
@@ -12,6 +12,7 @@ scenario.configure(default_model="openai/gpt-4.1-mini")
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_vegetarian_recipe_agent():
     class Agent(scenario.AgentAdapter):

--- a/python/examples/test_weather_agent__gemini.py
+++ b/python/examples/test_weather_agent__gemini.py
@@ -14,6 +14,7 @@ from scenario.judge_agent import JudgeAgent
 
 
 @pytest.mark.agent_test
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_weather_agent():
     # Integrate with your agent


### PR DESCRIPTION
## Summary
- Add `@pytest.mark.flaky(reruns=2)` to 20 Python example tests that make real LLM API calls but were missing the retry marker
- Previously only 5 of ~25 LLM-calling tests had this decorator, leading to inconsistent CI flakiness behavior
- Tests that are fully mocked (`test_llm_provider_mocking`, `test_custom_judge_with_traces`) are intentionally left without the marker

## Context
The recent CI failures on main (commit 716c8b7) were caused entirely by OpenAI quota exhaustion, not by the trace expansion changes. Re-running CI after quota was restored confirmed all tests pass. This PR addresses the broader flakiness issue by ensuring all LLM-calling tests have retry support for transient failures (rate limits, non-deterministic LLM behavior, etc.).

Note: JS tests already have `retry: 3` configured globally in the vitest config.

## Test plan
- [x] All 172 Python unit tests pass locally
- [x] CI re-runs on main pass with quota restored
- [x] Verified no changes to test logic, only added `@pytest.mark.flaky(reruns=2)` decorators