### PR TITLE
fix: disable prerelease mode so releases are marked as latest

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,7 @@
       "release-type": "node",
       "include-component-in-tag": true,
       "include-v-in-tag": true,
-      "prerelease": true,
+      "prerelease": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
@@ -21,7 +21,7 @@
       "release-type": "python",
       "include-component-in-tag": true,
       "include-v-in-tag": true,
-      "prerelease": true,
+      "prerelease": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Sets `prerelease: false` for both JavaScript and Python packages in `.release-please-config.json`
- Future GitHub releases will be marked as "latest" instead of "pre-release"

## Test plan
- [ ] Merge and verify next release-please PR creates a release tagged as "latest"