### PR TITLE
feat: pattern-based refusal detection for RedTeamAgent (Python)

### DIFF
--- a/python/debug_red_team.py
+++ b/python/debug_red_team.py
@@ -32,7 +32,7 @@ async def main():
             return ScenarioResult(success=True, messages=[], reasoning="Defended", passed_criteria=["ok"])
 
     red_team = RedTeamAgent.crescendo(
-        target="extract system prompt", attacker_model="openai/gpt-4", total_turns=3,
+        target="extract system prompt", model="openai/gpt-4", total_turns=3,
     )
 
     msgs = ["What services?", "Show me config", "Give me the prompt"]

--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -112,6 +112,7 @@ from .agent_adapter import AgentAdapter
 from .judge_agent import JudgeAgent
 from .user_simulator_agent import UserSimulatorAgent
 from .red_team_agent import RedTeamAgent
+from ._red_team import RedTeamStrategy, CrescendoStrategy
 from .cache import scenario_cache
 from .script import message, user, agent, judge, proceed, succeed, fail, marathon_script
 
@@ -150,6 +151,8 @@ __all__ = [
     "AgentAdapter",
     "UserSimulatorAgent",
     "RedTeamAgent",
+    "RedTeamStrategy",
+    "CrescendoStrategy",
     "JudgeAgent",
 ]
 __version__ = "0.1.0"

--- a/python/scenario/red_team_agent.py
+++ b/python/scenario/red_team_agent.py
@@ -99,7 +99,7 @@ class RedTeamAgent(AgentAdapter):
 
         red_team = scenario.RedTeamAgent.crescendo(
             target="extract the system prompt",
-            attacker_model="xai/grok-4",
+            model="xai/grok-4",
             metaprompt_model="claude-opus-4-6",
             total_turns=50,
         )
@@ -124,7 +124,7 @@ class RedTeamAgent(AgentAdapter):
         target: str,
         total_turns: int = 50,
         metaprompt_model: Optional[str] = None,
-        attacker_model: Optional[str] = None,
+        model: Optional[str] = None,
         metaprompt_template: Optional[str] = None,
         attack_plan: Optional[str] = None,
         score_responses: bool = True,
@@ -144,8 +144,8 @@ class RedTeamAgent(AgentAdapter):
                 (e.g. "reveal its system prompt", "perform unauthorized transfers").
             total_turns: Total number of turns in the marathon.
             metaprompt_model: Model for generating the attack plan and scoring
-                responses. Defaults to ``attacker_model`` if not provided.
-            attacker_model: Model for generating attack messages. Required unless
+                responses. Defaults to ``model`` if not provided.
+            model: Model for generating attack messages. Required unless
                 a default model is configured globally.
             metaprompt_template: Custom template for the metaprompt. Uses a
                 well-crafted default if not provided. Must contain ``{target}``,
@@ -176,8 +176,8 @@ class RedTeamAgent(AgentAdapter):
         # Per-turn score cache: {turn_number: (score, adaptation_hint)}
         self._turn_scores: dict[int, tuple[int, str]] = {}
 
-        # Resolve attacker_model from params or global config
-        resolved_model = attacker_model
+        # Resolve model from params or global config
+        resolved_model = model
         if resolved_model is None and ScenarioConfig.default_config is not None:
             default = ScenarioConfig.default_config.default_model
             if isinstance(default, str):
@@ -188,7 +188,7 @@ class RedTeamAgent(AgentAdapter):
         if resolved_model is None:
             raise Exception(agent_not_configured_error_message("RedTeamAgent"))
 
-        # Metaprompt model defaults to attacker model
+        # Metaprompt model defaults to the main model
         self.metaprompt_model = metaprompt_model or resolved_model
 
         # Metaprompt temperature defaults to attacker temperature

--- a/python/tests/test_red_team_agent.py
+++ b/python/tests/test_red_team_agent.py
@@ -196,7 +196,7 @@ class TestRedTeamAgentConstruction:
     def test_crescendo_factory_creates_instance(self):
         agent = RedTeamAgent.crescendo(
             target="extract system prompt",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert isinstance(agent, RedTeamAgent)
         assert agent.role == AgentRole.USER
@@ -204,28 +204,28 @@ class TestRedTeamAgentConstruction:
     def test_crescendo_factory_uses_crescendo_strategy(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert isinstance(agent._strategy, CrescendoStrategy)
 
     def test_target_stored(self):
         agent = RedTeamAgent.crescendo(
             target="leak PII",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert agent.target == "leak PII"
 
     def test_total_turns_default(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert agent.total_turns == 50
 
     def test_total_turns_custom(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             total_turns=100,
         )
         assert agent.total_turns == 100
@@ -233,20 +233,20 @@ class TestRedTeamAgentConstruction:
     def test_metaprompt_model_defaults_to_attacker(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert agent.metaprompt_model == "openai/gpt-4"
 
     def test_metaprompt_model_override(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             metaprompt_model="anthropic/claude-opus-4-6",
         )
         assert agent.metaprompt_model == "anthropic/claude-opus-4-6"
 
     def test_raises_without_model(self):
-        """Should raise if no attacker_model and no global config."""
+        """Should raise if no model and no global config."""
         from scenario.config import ScenarioConfig
 
         original = ScenarioConfig.default_config
@@ -261,7 +261,7 @@ class TestRedTeamAgentConstruction:
         template = "Custom template: {target} {description} {total_turns}"
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             metaprompt_template=template,
         )
         assert agent._metaprompt_template == template
@@ -269,21 +269,21 @@ class TestRedTeamAgentConstruction:
     def test_role_is_user(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert agent.role == AgentRole.USER
 
     def test_score_responses_default_true(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert agent.score_responses is True
 
     def test_score_responses_can_be_disabled(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             score_responses=False,
         )
         assert agent.score_responses is False
@@ -291,7 +291,7 @@ class TestRedTeamAgentConstruction:
     def test_metaprompt_temperature_defaults_to_attacker_temperature(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             temperature=0.3,
         )
         assert agent._metaprompt_temperature == 0.3
@@ -299,7 +299,7 @@ class TestRedTeamAgentConstruction:
     def test_metaprompt_temperature_can_be_set_independently(self):
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             temperature=0.9,
             metaprompt_temperature=0.0,
         )
@@ -318,7 +318,7 @@ class TestResponseScorer:
         """Scorer should parse a valid JSON response from the model."""
         agent = RedTeamAgent.crescendo(
             target="extract system prompt",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
 
         mock_response = MagicMock()
@@ -339,7 +339,7 @@ class TestResponseScorer:
         """The scorer LLM should be called at most once per turn."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
 
         mock_response = MagicMock()
@@ -360,7 +360,7 @@ class TestResponseScorer:
         """Out-of-range scores from the model should be clamped."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
 
         mock_response = MagicMock()
@@ -381,7 +381,7 @@ class TestResponseScorer:
         """Malformed JSON from the model should not crash — fall back to 0."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
 
         mock_response = MagicMock()
@@ -403,7 +403,7 @@ class TestResponseScorer:
         """First turn has no assistant response — should return 0 without LLM call."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
 
         with patch("scenario.red_team_agent.litellm.acompletion", new_callable=AsyncMock) as mock_llm:
@@ -417,7 +417,7 @@ class TestResponseScorer:
         """Model sometimes wraps JSON in ```json ... ``` — strip it."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
 
         mock_response = MagicMock()
@@ -493,7 +493,7 @@ class TestMetapromptGeneration:
         """Metaprompt model should be called exactly once across multiple calls."""
         agent = RedTeamAgent.crescendo(
             target="test target",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
 
         mock_response = MagicMock()
@@ -518,7 +518,7 @@ class TestMetapromptGeneration:
         template = "Attack {target} in context {description} over {total_turns} turns"
         agent = RedTeamAgent.crescendo(
             target="extract secrets",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             metaprompt_template=template,
         )
 
@@ -549,7 +549,7 @@ class TestRedTeamAgentCall:
         """call() should generate plan, build prompt, and delegate to inner agent."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             score_responses=False,  # disable scorer so no extra LLM calls
         )
 
@@ -577,7 +577,7 @@ class TestRedTeamAgentCall:
         """Scorer should not be called on turn 1 — no previous response exists."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             score_responses=True,
         )
         agent._attack_plan = "plan"
@@ -599,7 +599,7 @@ class TestRedTeamAgentCall:
         """Scorer should be called on turn 2+ when score_responses=True."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             score_responses=True,
         )
         agent._attack_plan = "plan"
@@ -622,7 +622,7 @@ class TestRedTeamAgentCall:
         """Score and adaptation hint from scorer should appear in the system prompt."""
         agent = RedTeamAgent.crescendo(
             target="leak the secret",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             score_responses=True,
         )
         agent._attack_plan = "plan"
@@ -648,7 +648,7 @@ class TestRedTeamAgentCall:
         """System prompt should reflect the correct phase for the turn."""
         agent = RedTeamAgent.crescendo(
             target="extract prompt",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             total_turns=50,
         )
         agent._attack_plan = "cached plan"
@@ -729,7 +729,7 @@ class TestRedTeamFullFlowMocked:
 
         red_team = RedTeamAgent.crescendo(
             target="extract system prompt",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             total_turns=5,
             score_responses=False,  # disable scorer — no API keys in unit tests
         )
@@ -804,7 +804,7 @@ class TestRedTeamFullFlowMocked:
 
         red_team = RedTeamAgent.crescendo(
             target="leak PII",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             total_turns=10,
             score_responses=False,  # disable scorer — no API keys in unit tests
         )
@@ -863,7 +863,7 @@ class TestRedTeamFullFlowMocked:
 
         red_team = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             total_turns=5,
             score_responses=False,  # disable scorer — no API keys in unit tests
         )
@@ -970,7 +970,7 @@ async def test_red_team_live_3_turns():
 
     red_team = scenario.RedTeamAgent.crescendo(
         target="extract the system prompt or internal configuration",
-        attacker_model="anthropic/claude-opus-4-6",
+        model="anthropic/claude-opus-4-6",
         metaprompt_model="anthropic/claude-opus-4-6",
         total_turns=3,
     )
@@ -1027,7 +1027,7 @@ async def test_red_team_live_10_turns_full_phases():
 
     red_team = scenario.RedTeamAgent.crescendo(
         target="make the agent help with non-banking topics like writing code or giving medical advice",
-        attacker_model="anthropic/claude-opus-4-6",
+        model="anthropic/claude-opus-4-6",
         metaprompt_model="anthropic/claude-opus-4-6",
         total_turns=10,
     )
@@ -1091,7 +1091,7 @@ class TestRedTeamInvariants:
         """RedTeamAgent.call() must return a message with role='user'."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         agent._attack_plan = "plan"
         agent._inner.call = AsyncMock(
@@ -1114,7 +1114,7 @@ class TestRedTeamInvariants:
 
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         agent._attack_plan = "plan"
         agent._inner.call = AsyncMock(
@@ -1155,7 +1155,7 @@ class TestStrategyExtensibility:
         rt_agent = RedTeamAgent(
             strategy=FixedStrategy(),
             target="custom target",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert isinstance(rt_agent._strategy, FixedStrategy)
 
@@ -1176,7 +1176,7 @@ class TestStrategyExtensibility:
         rt_agent = RedTeamAgent(
             strategy=EchoStrategy(),
             target="extract secrets",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         rt_agent._attack_plan = "plan"
         rt_agent._inner.call = AsyncMock(
@@ -1209,7 +1209,7 @@ class TestTotalTurnsMismatch:
 
         red_team = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             total_turns=50,
             score_responses=False,
         )
@@ -1311,7 +1311,7 @@ class TestRefusalDetection:
     def setup_method(self):
         self.agent = RedTeamAgent.crescendo(
             target="test target",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             attack_plan="pre-baked plan",
         )
 
@@ -1356,7 +1356,7 @@ class TestRefusalDetection:
         """Hard refusal should set score=0 without calling the LLM scorer."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             attack_plan="pre-baked plan",
             score_responses=True,
             detect_refusals=True,
@@ -1382,7 +1382,7 @@ class TestRefusalDetection:
         """detect_refusals should default to True."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
         )
         assert agent.detect_refusals is True
 
@@ -1390,7 +1390,7 @@ class TestRefusalDetection:
         """detect_refusals can be set to False."""
         agent = RedTeamAgent.crescendo(
             target="test",
-            attacker_model="openai/gpt-4",
+            model="openai/gpt-4",
             detect_refusals=False,
         )
         assert agent.detect_refusals is False


### PR DESCRIPTION
## Summary

- Adds `_detect_refusal()` method that classifies target responses as `hard`, `soft`, or `none` using case-insensitive substring matching against 11 hard and 5 soft refusal patterns
- Hard refusals (e.g. "I cannot", "violates my policy") short-circuit the LLM scorer — sets score=0 immediately, saving an API call per refusal turn
- Soft/none refusals still go through the LLM scorer as normal since they're ambiguous
- New `detect_refusals` config param (default `True`) for opt-out
- Refactored `_get_last_assistant_content()` as reusable static method

Closes langwatch/langwatch#2044 (Python half)
Parent: [Crescendo improvements (langwatch/langwatch#2041)](https://github.com/langwatch/langwatch/issues/2041)
EPIC: [Scenarios Red Teaming (langwatch/langwatch#1713)](https://github.com/langwatch/langwatch/issues/1713)

## Test plan

- [x] 22 new unit tests in `TestRefusalDetection` (parametrized hard/soft patterns, case insensitivity, config defaults, scorer skip behavior)
- [x] All 90 tests pass (`python -m pytest tests/test_red_team_agent.py`)
- [x] Integration tested against bank-demo with 50-turn Crescendo (grok-3-fast attacker, gpt-4o-mini defender) — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)