### PR TITLE
fix: approval check — handle all edge cases (triggers, dismissals, new commits)

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [labeled, unlabeled]
   pull_request_review:
-    types: [submitted]
+    types: [submitted, dismissed]
 
 concurrency:
   group: approval-check-${{ github.event.pull_request.number }}
@@ -104,4 +104,14 @@ jobs:
               return;
             }
 
-            core.setFailed("PR requires at least 1 approval, or a label: firefighting (manual) / low-risk-change (automation only).");
+            const failReason = "PR requires at least 1 approval, or a label: firefighting (manual) / low-risk-change (automation only).";
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: pr.head.sha,
+              name: "check-approval-or-label",
+              status: "completed",
+              conclusion: "failure",
+              output: { title: "Review required", summary: failReason },
+            });
+            core.setFailed(failReason);


### PR DESCRIPTION
## Summary
Three fixes to the approval/exception check system:

1. **Remove early-fail triggers** — Drop `opened, reopened, synchronize` from `approval-or-hotfix.yml` so the check doesn't fail immediately on PR open (before any approval or label exists), creating a stale failed check that blocks the PR
2. **Handle approval dismissals** — Add `dismissed` to `pull_request_review` triggers and use `checks.create` with `conclusion: failure` on the failure path, so removing an approval correctly re-blocks the PR
3. **Refresh check on new commits** — Add a step in `low-risk-evaluation.yml` that checks for `firefighting` label or existing approvals on every push, creating a passing check for the new SHA. Without this, firefighting PRs and approved PRs get stuck as "Expected — Waiting" after follow-up commits

## Changes
- `.github/workflows/approval-or-hotfix.yml`: trigger cleanup + dismissal handling + failure-path `checks.create`
- `.github/workflows/low-risk-evaluation.yml`: new final step to refresh approval check for non-evaluation paths

## Test plan
- [ ] Open a PR → check stays as "Expected" (not failed)
- [ ] Low-risk evaluation qualifies → check passes
- [ ] Add `firefighting` label → check passes
- [ ] Push new commit to firefighting PR → check refreshes to passing
- [ ] Approve PR → check passes
- [ ] Push new commit to approved PR → check refreshes to passing
- [ ] Dismiss approval → check flips to failed

Port of langwatch/langwatch#2052.