### PR TITLE
fix: refresh approval check on new commits for firefighting/approvals

### DIFF
--- a/.github/workflows/low-risk-evaluation.yml
+++ b/.github/workflows/low-risk-evaluation.yml
@@ -296,3 +296,63 @@ jobs:
 
               core.info(`PR #${prNumber} does not qualify as low-risk.`);
             }
+
+      - name: Refresh approval check for firefighting or approvals
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const labelNames = labels.map(l => l.name);
+
+            // firefighting label → pass the check regardless of evaluation
+            if (labelNames.includes("firefighting")) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: pr.data.head.sha,
+                name: "check-approval-or-label",
+                status: "completed",
+                conclusion: "success",
+                output: { title: "Approved", summary: "PR has firefighting label." },
+              });
+              core.info("Refreshed approval check for firefighting label.");
+              return;
+            }
+
+            // Existing approval → pass the check
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const approvedUsers = new Set();
+            for (const review of reviews.data) {
+              if (review.state === "APPROVED") {
+                approvedUsers.add(review.user.login);
+              }
+            }
+            if (approvedUsers.size >= 1) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: pr.data.head.sha,
+                name: "check-approval-or-label",
+                status: "completed",
+                conclusion: "success",
+                output: { title: "Approved", summary: `PR has ${approvedUsers.size} approval(s).` },
+              });
+              core.info("Refreshed approval check for existing approval.");
+            }


### PR DESCRIPTION
## Summary
Add a final step to `low-risk-evaluation.yml` that checks for `firefighting` label or existing approvals on every push, creating a passing `check-approval-or-label` for the new SHA.

## Problem
After removing `synchronize` from `approval-or-hotfix.yml` (PR #262), firefighting PRs and approved PRs get stuck as "Expected — Waiting" after follow-up commits — nothing creates the required check for the new SHA.

## Fix
Piggyback on `low-risk-evaluation.yml` which already triggers on `synchronize`. After the evaluation result is applied, check if `firefighting` or approvals exist and refresh the check accordingly.

## Test plan
- [ ] Push new commit to firefighting PR → check refreshes to passing
- [ ] Push new commit to approved PR → check refreshes to passing

Port of langwatch/langwatch#2052.