### PR TITLE
fix(js): correct consumeUntilRole and red-team backtrack mutation

### DIFF
--- a/javascript/src/agents/red-team/red-team-agent.ts
+++ b/javascript/src/agents/red-team/red-team-agent.ts
@@ -349,13 +349,16 @@ Reply with exactly this JSON and nothing else:
           refusal: lastContent.slice(0, 200),
         });
         // Remove the refused exchange: find last user msg, delete from there
-        for (let i = input.messages.length - 1; i >= 0; i--) {
-          const msg = input.messages[i];
+        // Create a copy to avoid mutating shared state (message snapshots rely on original)
+        const pruned = [...input.messages];
+        for (let i = pruned.length - 1; i >= 0; i--) {
+          const msg = pruned[i];
           if (msg && "role" in msg && msg.role === "user") {
-            input.messages.splice(i);
+            pruned.splice(i);
             break;
           }
         }
+        input.messages = pruned;
         this.backtracksRemaining--;
         didBacktrack = true;
         // Cache a score of 0 for this turn (no LLM call needed)

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -1259,7 +1259,7 @@ export class ScenarioExecution implements ScenarioExecutionLike {
     while (this.pendingRolesOnTurn.length > 0) {
       const nextRole = this.pendingRolesOnTurn[0];
       if (nextRole === role) break;
-      this.pendingRolesOnTurn.pop();
+      this.pendingRolesOnTurn.shift();
     }
   }
 


### PR DESCRIPTION
## Summary
- **consumeUntilRole** used `.pop()` (removes last element) instead of `.shift()` (removes first), causing the `pendingRolesOnTurn` array to empty incorrectly — now matches the Python implementation which uses `pop(0)`
- **Red team backtracking** mutated the shared messages array in-place via `splice()`, causing `MESSAGE_SNAPSHOT` events to show inconsistent state (user messages without agent responses on the UI). Now creates a shallow copy before pruning, matching the Python implementation

## Test plan
- [x] All 70 red-team unit tests pass
- [x] All 8 execution unit tests pass
- [x] Run data-demo (TypeScript) scenario tests end-to-end
- [x] Run bank-demo (Python) scenario tests end-to-end
- [x] Verify on LangWatch cloud platform that user/agent message pairs display correctly during red team backtracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)