### PR TITLE
feat: add @langwatch/scenario/config shorthand export

### DIFF
--- a/javascript/src/config/index.ts
+++ b/javascript/src/config/index.ts
@@ -1,3 +1,4 @@
 export * from "./env";
 export * from "./log-levels";
 export * from "./get-project-config";
+export { defineConfig, type ScenarioProjectConfig } from "../domain/core/config";

--- a/javascript/tsup.config.ts
+++ b/javascript/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/integrations/vitest/*.ts"],
+  entry: ["src/index.ts", "src/config/index.ts", "src/integrations/vitest/*.ts"],
   format: ["cjs", "esm"],
   dts: true,
   clean: true,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
       "require": "./javascript/dist/index.js",
       "import": "./javascript/dist/index.mjs"
     },
+    "./config": {
+      "types": "./javascript/dist/config/index.d.ts",
+      "require": "./javascript/dist/config/index.js",
+      "import": "./javascript/dist/config/index.mjs"
+    },
     "./integrations/vitest/reporter": {
       "types": "./javascript/dist/integrations/vitest/reporter.d.ts",
       "require": "./javascript/dist/integrations/vitest/reporter.js",


### PR DESCRIPTION
## Summary

- Adds `./config` package export so users can write `import { defineConfig } from "@langwatch/scenario/config"` instead of the unwieldy `@langwatch/scenario/integrations/vitest/config`
- `defineConfig` (the project config with `defaultModel`, `headless`, `observability`) was already exported from `@langwatch/scenario` main entry but had no short subpath
- The `./integrations/vitest/config` path still works — this is additive, not breaking
- Note: `./integrations/vitest/config` exports `withScenario` (vitest-specific wrapper), while `./config` exports `defineConfig` (framework-agnostic project config) — they're different functions

## Test plan
- [ ] `import { defineConfig } from "@langwatch/scenario/config"` resolves correctly
- [ ] `import { withScenario } from "@langwatch/scenario/integrations/vitest/config"` still works
- [ ] `import { defineConfig } from "@langwatch/scenario"` still works (main entry)