### PR TITLE
chore: add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ docs/docs/public/reference/python/**/*
 !docs/docs/public/reference/python/.gitkeep
 
 .claude/worktrees
+.worktrees


### PR DESCRIPTION
## Summary
- Adds `.worktrees` to `.gitignore` to prevent worktree directories from being tracked

## Test plan
- [x] Verify `.worktrees/` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)