### PR TITLE
fix(security): pin litellm<=1.82.6 to mitigate supply chain attack

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "pytest>=8.1.1",
     "pytest-rerunfailures>=14.0",
-    "litellm>=1.49.0",
+    "litellm>=1.49.0,<=1.82.6",
     "openai>=1.88.0",
     "python-dotenv>=1.0.1",
     "termcolor>=2.4.0",


### PR DESCRIPTION
## Summary

- Pins `litellm<=1.82.6` in `python/pyproject.toml` to block compromised versions 1.82.7–1.82.8
- litellm was compromised via PyPI account takeover by TeamPCP (same group behind the Trivy compromise)
- Malicious versions contain `.pth` auto-execution payload targeting crypto wallets and API keys
- Our lockfile already pins 1.81.13 (safe), but the open `>=1.49.0` range would pull malicious versions on a fresh resolve

## Impact assessment

**This project was NOT compromised.** Our `uv.lock` pins litellm at 1.81.13, which predates the malicious versions (1.82.7–1.82.8). This pin is a preventive measure to ensure no future resolve can pull the affected versions.

## CI status

**CI failure is expected.** PyPI has quarantined the entire `litellm` package (all versions, not just the malicious ones). Since this PR changes `pyproject.toml`, `uv run` tries to re-resolve against PyPI and fails. This is transient — once PyPI restores the safe versions, the lockfile can be regenerated and CI will pass. Note: `main` would also fail if any change triggered `python-ci.yml` right now.

**To merge:** regenerate `uv.lock` after PyPI restores litellm, then push.

## Test plan

- [ ] Regenerate `uv.lock` once PyPI restores litellm (run `uv lock` in `python/`)
- [ ] Verify CI passes after lockfile update
- [ ] Remove `<=1.82.6` pin once litellm publishes a verified clean release

Ref: https://news.ycombinator.com/item?id=47501729

🤖 Generated with [Claude Code](https://claude.com/claude-code)