### PR TITLE
fix: revert audio model and reduce multilingual test turns

### DIFF
--- a/javascript/examples/vitest/scenario.config.js
+++ b/javascript/examples/vitest/scenario.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from "@langwatch/scenario";
 
 export default defineConfig({
   defaultModel: {
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-5-mini"),
   },
   headless: true,
 });

--- a/javascript/examples/vitest/tests/00-demo-light.test.ts
+++ b/javascript/examples/vitest/tests/00-demo-light.test.ts
@@ -24,7 +24,7 @@ describe("Demo: Lightweight Scenarios", () => {
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({
-        model: openai("gpt-4o"),
+        model: openai("gpt-5-mini"),
         messages: [
           {
             role: "system",
@@ -33,6 +33,7 @@ describe("Demo: Lightweight Scenarios", () => {
           },
           ...input.messages,
         ],
+        experimental_telemetry: { isEnabled: true },
       });
       return response.text;
     },

--- a/javascript/examples/vitest/tests/api-service-mocking.test.ts
+++ b/javascript/examples/vitest/tests/api-service-mocking.test.ts
@@ -44,10 +44,11 @@ const userDataAgent: AgentAdapter = {
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4o"),
+      model: openai("gpt-5-mini"),
       messages: input.messages,
       tools: { fetch_user_data: fetchUserDataTool },
       toolChoice: "auto",
+      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/custom-judge-llm.test.ts
+++ b/javascript/examples/vitest/tests/custom-judge-llm.test.ts
@@ -44,7 +44,6 @@ class CustomLLMJudge extends AgentAdapter {
 
     const { object: result } = await generateObject({
       model: openai("gpt-5-mini"),
-      temperature: 0,
       schema: z.object({
         pass: z.boolean(),
         reasoning: z.string(),

--- a/javascript/examples/vitest/tests/custom-judge-llm.test.ts
+++ b/javascript/examples/vitest/tests/custom-judge-llm.test.ts
@@ -43,7 +43,7 @@ class CustomLLMJudge extends AgentAdapter {
       .join("\n");
 
     const { object: result } = await generateObject({
-      model: openai("gpt-4o-mini"),
+      model: openai("gpt-5-mini"),
       temperature: 0,
       schema: z.object({
         pass: z.boolean(),
@@ -95,7 +95,7 @@ describe("Custom LLM Judge", () => {
       description: "User greets the agent",
       agents: [
         politeAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4o-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
         new CustomLLMJudge([
           "Agent responds with a greeting",
           "Agent offers to help",

--- a/javascript/examples/vitest/tests/custom-judge-with-traces.test.ts
+++ b/javascript/examples/vitest/tests/custom-judge-with-traces.test.ts
@@ -71,7 +71,7 @@ describe("Custom Judge with Traces", () => {
         "User asks for weather and expects the agent to use a weather tool",
       agents: [
         simpleAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4o-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
         new ToolVerifyingJudge("weather_lookup"),
       ],
       script: [

--- a/javascript/examples/vitest/tests/database-tool-mocking.test.ts
+++ b/javascript/examples/vitest/tests/database-tool-mocking.test.ts
@@ -45,13 +45,14 @@ const databaseAgent: AgentAdapter = {
   call: async (input) => {
     // Agent has access to multiple database tools
     const response = await generateText({
-      model: openai("gpt-4o"),
+      model: openai("gpt-5-mini"),
       messages: input.messages,
       tools: {
         save_user: saveUserTool,
         find_user: findUserTool,
       },
       toolChoice: "auto",
+      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/false-assumptions.test.ts
+++ b/javascript/examples/vitest/tests/false-assumptions.test.ts
@@ -15,11 +15,12 @@ describe("False Assumptions", () => {
       role: AgentRole.AGENT,
       call: async (input) => {
         const response = await generateText({
-          model: openai("gpt-4.1-nano"),
+          model: openai("gpt-5-mini"),
           messages: [
             { role: "system", content: "You are a helpful assistant" },
             ...input.messages,
           ],
+          experimental_telemetry: { isEnabled: true },
         });
 
         return response.text;

--- a/javascript/examples/vitest/tests/helpers/openai-voice-agent.ts
+++ b/javascript/examples/vitest/tests/helpers/openai-voice-agent.ts
@@ -6,7 +6,7 @@
  * - Generate audio output (voice responses)
  * - Handle multi-turn voice conversations
  *
- * Uses OpenAI's gpt-5-mini-audio-preview model which supports voice-to-voice interaction.
+ * Uses OpenAI's gpt-4o-audio-preview model which supports voice-to-voice interaction.
  *
  * Example usage:
  * ```typescript
@@ -128,7 +128,7 @@ ${this.constructor.name} TEXT FALLBACK
   /**
    * Calls OpenAI's audio-enabled model to generate voice response
    *
-   * Uses gpt-5-mini-audio-preview with:
+   * Uses gpt-4o-audio-preview with:
    * - Text and audio modalities
    * - WAV format output
    * - Configured voice (alloy, nova, echo, etc.)
@@ -138,7 +138,7 @@ ${this.constructor.name} TEXT FALLBACK
     messages: ChatCompletionMessageParam[]
   ): Promise<ChatCompletion> {
     return this.openai.chat.completions.create({
-      model: "gpt-5-mini-audio-preview",
+      model: "gpt-4o-audio-preview",
       modalities: ["text", "audio"],
       audio: { voice: this.config.voice, format: "wav" },
       messages: this.systemMessage

--- a/javascript/examples/vitest/tests/helpers/openai-voice-agent.ts
+++ b/javascript/examples/vitest/tests/helpers/openai-voice-agent.ts
@@ -6,7 +6,7 @@
  * - Generate audio output (voice responses)
  * - Handle multi-turn voice conversations
  *
- * Uses OpenAI's gpt-4o-audio-preview model which supports voice-to-voice interaction.
+ * Uses OpenAI's gpt-5-mini-audio-preview model which supports voice-to-voice interaction.
  *
  * Example usage:
  * ```typescript
@@ -128,7 +128,7 @@ ${this.constructor.name} TEXT FALLBACK
   /**
    * Calls OpenAI's audio-enabled model to generate voice response
    *
-   * Uses gpt-4o-audio-preview with:
+   * Uses gpt-5-mini-audio-preview with:
    * - Text and audio modalities
    * - WAV format output
    * - Configured voice (alloy, nova, echo, etc.)
@@ -138,7 +138,7 @@ ${this.constructor.name} TEXT FALLBACK
     messages: ChatCompletionMessageParam[]
   ): Promise<ChatCompletion> {
     return this.openai.chat.completions.create({
-      model: "gpt-4o-audio-preview",
+      model: "gpt-5-mini-audio-preview",
       modalities: ["text", "audio"],
       audio: { voice: this.config.voice, format: "wav" },
       messages: this.systemMessage

--- a/javascript/examples/vitest/tests/judge-tool-calls-without-telemetry.test.ts
+++ b/javascript/examples/vitest/tests/judge-tool-calls-without-telemetry.test.ts
@@ -38,10 +38,11 @@ const weatherAgent: AgentAdapter = {
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4o"),
+      model: openai("gpt-5-mini"),
       messages: input.messages,
       tools: { get_weather: getWeatherTool },
       toolChoice: "auto",
+      experimental_telemetry: { isEnabled: true },
     });
 
     if (response.toolCalls && response.toolCalls.length > 0) {

--- a/javascript/examples/vitest/tests/lightining-fast-agent.test.ts
+++ b/javascript/examples/vitest/tests/lightining-fast-agent.test.ts
@@ -1,0 +1,42 @@
+import { openai } from "@ai-sdk/openai";
+import scenario, { type AgentAdapter, AgentRole } from "@langwatch/scenario";
+import { describe, it, expect } from "vitest";
+
+const lightningFastAgent: AgentAdapter = {
+  role: AgentRole.AGENT,
+  call: async (input) => {
+    await new Promise((resolve) => setTimeout(resolve, 1)); // Simulate lightning fast response time
+    return {
+      role: "assistant",
+      content: `response to ${input.messages[input.messages.length - 1].content}`,
+    };
+  },
+};
+
+describe("Lightning Fast Agent", () => {
+  Array(10)
+    .fill(0)
+    .forEach((_, i) =>
+    it(`fast agent test #${i + 1}`, async () => {
+      const result = await scenario.run({
+        name: `fast agent test #${i + 1}`,
+        description: `
+          This test checks the performance of a lightning fast agent.
+        `,
+        agents: [
+          lightningFastAgent,
+          scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
+        ],
+        script: [
+          scenario.user("foo"),
+          scenario.agent(),
+          scenario.user("bar"),
+          scenario.agent(),
+          scenario.succeed(),
+        ],
+        setId: "javascript-examples",
+      });
+      expect(result.success).toBe(true);
+    })
+  );
+});

--- a/javascript/examples/vitest/tests/llm-provider-mocking.test.ts
+++ b/javascript/examples/vitest/tests/llm-provider-mocking.test.ts
@@ -37,8 +37,9 @@ const chatAgent: AgentAdapter = {
   call: async (input) => {
     // This generateText call will be intercepted by our mock
     const response = await generateText({
-      model: openai("gpt-4o"),
+      model: openai("gpt-5-mini"),
       messages: input.messages,
+      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/mocked-weather-agent-tool.test.ts
+++ b/javascript/examples/vitest/tests/mocked-weather-agent-tool.test.ts
@@ -25,7 +25,7 @@ describe("Mocked Weather Agent Tool", () => {
       role: AgentRole.AGENT,
       call: async (input) => {
         const response = await generateText({
-          model: openai("gpt-4.1-nano"),
+          model: openai("gpt-5-mini"),
           messages: [
             {
               role: "system",
@@ -38,6 +38,7 @@ describe("Mocked Weather Agent Tool", () => {
           ],
           tools: { get_current_weather: getCurrentWeather },
           toolChoice: "auto",
+          experimental_telemetry: { isEnabled: true },
         });
 
         return response.text;

--- a/javascript/examples/vitest/tests/multilingual-agent.test.ts
+++ b/javascript/examples/vitest/tests/multilingual-agent.test.ts
@@ -9,8 +9,9 @@ const createMultilingualAgent = (): AgentAdapter => ({
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4.1-nano"),
+      model: openai("gpt-5-mini"),
       messages: input.messages,
+      experimental_telemetry: { isEnabled: true },
     });
 
     return response.text;
@@ -41,7 +42,7 @@ describe("Multilingual Agent", () => {
       agents: [
         agent,
         scenario.userSimulatorAgent(),
-        scenario.judgeAgent({ model: openai("gpt-4.1-nano") }),
+        scenario.judgeAgent({ model: openai("gpt-5-mini") }),
       ],
       script: [
         scenario.user(

--- a/javascript/examples/vitest/tests/multilingual-agent.test.ts
+++ b/javascript/examples/vitest/tests/multilingual-agent.test.ts
@@ -106,7 +106,6 @@ describe("Multilingual Agent", () => {
       agents: [
         agent,
         scenario.userSimulatorAgent({
-          temperature: 0.9,
         }),
         scenario.judgeAgent(),
       ],

--- a/javascript/examples/vitest/tests/multimodal-audio-to-audio.test.ts
+++ b/javascript/examples/vitest/tests/multimodal-audio-to-audio.test.ts
@@ -58,7 +58,7 @@ describe("Multimodal Audio to Audio Tests", () => {
     } satisfies UserModelMessage;
 
     const audioJudge = wrapJudgeForAudioTranscription(
-      scenario.judgeAgent({ model: openai("gpt-4o") }),
+      scenario.judgeAgent({ model: openai("gpt-5-mini") }),
     );
 
     const result = await scenario.run({

--- a/javascript/examples/vitest/tests/multimodal-audio-to-text.test.ts
+++ b/javascript/examples/vitest/tests/multimodal-audio-to-text.test.ts
@@ -40,7 +40,7 @@ class AudioAgent extends AgentAdapter {
 
   private async respond(messages: ChatCompletionMessageParam[]) {
     return await this.openai.chat.completions.create({
-      model: "gpt-4o-audio-preview",
+      model: "gpt-5-mini-audio-preview",
       modalities: ["text", "audio"],
       audio: { voice: "alloy", format: "wav" },
       // We need to strip the id, or the openai client will throw an error

--- a/javascript/examples/vitest/tests/multimodal-images.test.ts
+++ b/javascript/examples/vitest/tests/multimodal-images.test.ts
@@ -34,7 +34,7 @@ describe("Multimodal Images Tests", () => {
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({
-        model: openai("gpt-4o"),
+        model: openai("gpt-5-mini"),
         messages: [
           {
             role: "system",
@@ -46,6 +46,7 @@ describe("Multimodal Images Tests", () => {
           },
           ...input.messages,
         ],
+        experimental_telemetry: { isEnabled: true },
       });
       return response.text;
     },

--- a/javascript/examples/vitest/tests/multimodal-voice-to-voice-conversation.test.ts
+++ b/javascript/examples/vitest/tests/multimodal-voice-to-voice-conversation.test.ts
@@ -110,7 +110,7 @@ describe("Multimodal Voice-to-Voice Conversation Tests", () => {
     // Create judge agent to evaluate conversation quality
     // Wrap with audio handler to transcribe audio before judging
     const conversationJudge = wrapJudgeForAudioTranscription(
-      scenario.judgeAgent({ model: openai("gpt-4o") })
+      scenario.judgeAgent({ model: openai("gpt-5-mini") })
     );
 
     // Execute the full audio conversation scenario

--- a/javascript/examples/vitest/tests/multiturn-10-scripted.test.ts
+++ b/javascript/examples/vitest/tests/multiturn-10-scripted.test.ts
@@ -8,7 +8,7 @@ const assistant: AgentAdapter = {
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4.1-nano"),
+      model: openai("gpt-5-mini"),
       messages: [
         {
           role: "system",
@@ -17,6 +17,7 @@ const assistant: AgentAdapter = {
         },
         ...input.messages,
       ],
+      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/running-in-parallel.test.ts
+++ b/javascript/examples/vitest/tests/running-in-parallel.test.ts
@@ -8,7 +8,7 @@ describe("Vegetarian Recipe Agent (Parallel)", () => {
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({
-        model: openai("gpt-4.1-mini"),
+        model: openai("gpt-5-mini"),
         messages: [
           {
             role: "system",
@@ -20,6 +20,7 @@ describe("Vegetarian Recipe Agent (Parallel)", () => {
           },
           ...input.messages,
         ],
+        experimental_telemetry: { isEnabled: true },
       });
       return response.text;
     },

--- a/javascript/examples/vitest/tests/simple-tool-mocking.test.ts
+++ b/javascript/examples/vitest/tests/simple-tool-mocking.test.ts
@@ -35,10 +35,11 @@ const userDataAgent: AgentAdapter = {
     // Agent uses generateText with tools
     // The AI SDK handles tool execution automatically here
     const response = await generateText({
-      model: openai("gpt-4o"),
+      model: openai("gpt-5-mini"),
       messages: input.messages,
       tools: { fetch_user_data: fetchUserDataTool },
       toolChoice: "auto",
+      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/span-based-evaluation.test.ts
+++ b/javascript/examples/vitest/tests/span-based-evaluation.test.ts
@@ -67,7 +67,7 @@ const observableAgent: AgentAdapter = {
 
       // LLM call with tool usage
       const response = await generateText({
-        model: openai("gpt-4.1-mini"),
+        model: openai("gpt-5-mini"),
         messages: [
           {
             role: "system",

--- a/javascript/examples/vitest/tests/testing-remote-agents-json.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-json.test.ts
@@ -45,7 +45,6 @@ beforeAll(async () => {
                 content: message,
               },
             ],
-            temperature: 0.7,
             experimental_telemetry: { isEnabled: true },
           });
 

--- a/javascript/examples/vitest/tests/testing-remote-agents-json.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-json.test.ts
@@ -30,7 +30,7 @@ beforeAll(async () => {
 
           // Use real LLM to generate response
           const result = await generateText({
-            model: openai("gpt-4o-mini"),
+            model: openai("gpt-5-mini"),
             messages: [
               {
                 role: "system",
@@ -46,6 +46,7 @@ beforeAll(async () => {
               },
             ],
             temperature: 0.7,
+            experimental_telemetry: { isEnabled: true },
           });
 
           res.writeHead(200, { "Content-Type": "application/json" });
@@ -115,9 +116,9 @@ describe("Testing Remote Agents - JSON Response", () => {
       name: "Weather inquiry via HTTP",
       description: "User asks about weather through HTTP API",
       agents: [
-        scenario.userSimulatorAgent({ model: openai("gpt-4o-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
         jsonAgentAdapter,
-        scenario.judgeAgent({ model: openai("gpt-4o-mini") }),
+        scenario.judgeAgent({ model: openai("gpt-5-mini") }),
       ],
       script: [
         scenario.user("What's the weather like today in Paris? Be specific."),

--- a/javascript/examples/vitest/tests/testing-remote-agents-sse.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-sse.test.ts
@@ -43,7 +43,7 @@ beforeAll(async () => {
 
           // Stream response using real LLM
           const result = streamText({
-            model: openai("gpt-4o-mini"),
+            model: openai("gpt-5-mini"),
             messages: [
               {
                 role: "system",
@@ -56,6 +56,7 @@ beforeAll(async () => {
               },
             ],
             temperature: 0.7,
+            experimental_telemetry: { isEnabled: true },
           });
 
           // Stream chunks in SSE format
@@ -159,9 +160,9 @@ describe("Testing Remote Agents - Server-Sent Events", () => {
       name: "SSE weather response",
       description: "User asks about weather and receives SSE-formatted stream",
       agents: [
-        scenario.userSimulatorAgent({ model: openai("gpt-4o-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
         sseAdapter,
-        scenario.judgeAgent({ model: openai("gpt-4o-mini") }),
+        scenario.judgeAgent({ model: openai("gpt-5-mini") }),
       ],
       script: [
         scenario.user("What's the weather like in Tokyo today?"),

--- a/javascript/examples/vitest/tests/testing-remote-agents-sse.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-sse.test.ts
@@ -55,7 +55,6 @@ beforeAll(async () => {
                 content,
               },
             ],
-            temperature: 0.7,
             experimental_telemetry: { isEnabled: true },
           });
 

--- a/javascript/examples/vitest/tests/testing-remote-agents-stateful.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-stateful.test.ts
@@ -50,7 +50,6 @@ beforeAll(async () => {
               },
               ...history,
             ],
-            temperature: 0.7,
             experimental_telemetry: { isEnabled: true },
           });
 

--- a/javascript/examples/vitest/tests/testing-remote-agents-stateful.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-stateful.test.ts
@@ -41,7 +41,7 @@ beforeAll(async () => {
 
           // Generate response with full history
           const result = await generateText({
-            model: openai("gpt-4o-mini"),
+            model: openai("gpt-5-mini"),
             messages: [
               {
                 role: "system",
@@ -51,6 +51,7 @@ beforeAll(async () => {
               ...history,
             ],
             temperature: 0.7,
+            experimental_telemetry: { isEnabled: true },
           });
 
           // Add assistant response to history
@@ -128,9 +129,9 @@ describe("Testing Remote Agents - Stateful with Thread ID", () => {
       description:
         "User asks about Paris, then asks a follow-up question that requires context from the previous answer",
       agents: [
-        scenario.userSimulatorAgent({ model: openai("gpt-4o-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
         statefulAdapter,
-        scenario.judgeAgent({ model: openai("gpt-4o-mini") }),
+        scenario.judgeAgent({ model: openai("gpt-5-mini") }),
       ],
       script: [
         scenario.user("Tell me about visiting Paris"),

--- a/javascript/examples/vitest/tests/testing-remote-agents-streaming.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-streaming.test.ts
@@ -53,7 +53,6 @@ beforeAll(async () => {
                 content,
               },
             ],
-            temperature: 0.7,
             experimental_telemetry: { isEnabled: true },
           });
 

--- a/javascript/examples/vitest/tests/testing-remote-agents-streaming.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-streaming.test.ts
@@ -41,7 +41,7 @@ beforeAll(async () => {
           });
 
           const result = streamText({
-            model: openai("gpt-4o-mini"),
+            model: openai("gpt-5-mini"),
             messages: [
               {
                 role: "system",
@@ -54,6 +54,7 @@ beforeAll(async () => {
               },
             ],
             temperature: 0.7,
+            experimental_telemetry: { isEnabled: true },
           });
 
           // Stream chunks to client
@@ -128,9 +129,9 @@ describe("Testing Remote Agents - Streaming Response", () => {
       name: "Streaming weather response",
       description: "User asks about weather and receives streamed response",
       agents: [
-        scenario.userSimulatorAgent({ model: openai("gpt-4o-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
         streamingAdapter,
-        scenario.judgeAgent({ model: openai("gpt-4o-mini") }),
+        scenario.judgeAgent({ model: openai("gpt-5-mini") }),
       ],
       script: [
         scenario.user("What's the weather forecast in Amsterdam?"),

--- a/javascript/examples/vitest/tests/tool-call-role-reversal.test.ts
+++ b/javascript/examples/vitest/tests/tool-call-role-reversal.test.ts
@@ -25,7 +25,7 @@ const toolCallingAgent: AgentAdapter = {
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4o"),
+      model: openai("gpt-5-mini"),
       messages: [
         {
           role: "system",
@@ -35,6 +35,7 @@ const toolCallingAgent: AgentAdapter = {
       ],
       tools: { lookup_product: lookupTool },
       toolChoice: "auto",
+      experimental_telemetry: { isEnabled: true },
     });
 
     if (response.toolCalls && response.toolCalls.length > 0) {
@@ -74,13 +75,13 @@ const toolCallingAgent: AgentAdapter = {
 };
 
 describe("Tool call role reversal safety", () => {
-  it("user simulator (OpenAI gpt-4o) works after agent makes tool calls", async () => {
+  it("user simulator (OpenAI gpt-5-mini) works after agent makes tool calls", async () => {
     const result = await scenario.run({
-      name: "tool call then user sim (gpt-4o)",
+      name: "tool call then user sim (gpt-5-mini)",
       description: "User asks about a product, agent uses tool, then user simulator responds",
       agents: [
         toolCallingAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4o") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
         scenario.judgeAgent({
           criteria: ["Agent used the lookup tool and provided product info"],
         }),

--- a/javascript/examples/vitest/tests/tool-failure-simulation.test.ts
+++ b/javascript/examples/vitest/tests/tool-failure-simulation.test.ts
@@ -41,10 +41,11 @@ const resilientAgent: AgentAdapter = {
   call: async (input) => {
     // First LLM call - agent decides if/how to use tools
     const response = await generateText({
-      model: openai("gpt-4o"),
+      model: openai("gpt-5-mini"),
       messages: input.messages,
       tools: { call_external_service: callExternalServiceTool },
       toolChoice: "auto",
+      experimental_telemetry: { isEnabled: true },
     });
 
     // Check if the LLM decided to call any tools

--- a/javascript/examples/vitest/tests/travel-agent.test.ts
+++ b/javascript/examples/vitest/tests/travel-agent.test.ts
@@ -86,6 +86,7 @@ const callTravelAgent = async (
             You are a helpful travel agent that helps the user with weather information and accomodation options, use the tools provided to you.
             Do not guess the city if they don't provide it.
             You can make multiple tool calls if they ask multiple cities.
+            You may ask at most one clarifying question. After that, make reasonable assumptions and proceed with tool calls and recommendations.
 
             Today is Friday, 25th July 2025.
           `,

--- a/javascript/examples/vitest/tests/travel-agent.test.ts
+++ b/javascript/examples/vitest/tests/travel-agent.test.ts
@@ -78,7 +78,7 @@ const callTravelAgent = async (
   };
 
   const response = await generateText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-5-mini"),
     messages: [
       {
         role: "system",
@@ -96,6 +96,7 @@ const callTravelAgent = async (
     tools,
     toolChoice: "auto",
     temperature: 0.0,
+    experimental_telemetry: { isEnabled: true },
   });
 
   if (response.toolCalls && response.toolCalls.length > 0) {
@@ -163,8 +164,8 @@ describe("Travel Agent", () => {
       `,
       agents: [
         travelAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4.1-mini") }),
-        scenario.judgeAgent({ model: openai("gpt-4.1-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
+        scenario.judgeAgent({ model: openai("gpt-5-mini") }),
       ],
       script: [
         scenario.user(),

--- a/javascript/examples/vitest/tests/travel-agent.test.ts
+++ b/javascript/examples/vitest/tests/travel-agent.test.ts
@@ -95,7 +95,6 @@ const callTravelAgent = async (
     ],
     tools,
     toolChoice: "auto",
-    temperature: 0.0,
     experimental_telemetry: { isEnabled: true },
   });
 
@@ -170,9 +169,9 @@ describe("Travel Agent", () => {
       script: [
         scenario.user(),
         scenario.agent(),
-        (state) => expect(state.hasToolCall("get_current_weather")).toBe(true),
         scenario.user(),
         scenario.agent(),
+        (state) => expect(state.hasToolCall("get_current_weather")).toBe(true),
         scenario.user(),
         scenario.agent(),
         (state) => expect(state.hasToolCall("get_accomodation")).toBe(true),

--- a/javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts
+++ b/javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts
@@ -8,7 +8,7 @@ describe("Vegetarian Recipe Agent", () => {
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({
-        model: openai("gpt-4.1-mini"),
+        model: openai("gpt-5-mini"),
         messages: [
           {
             role: "system",

--- a/javascript/examples/vitest/tests/weather-agent.test.ts
+++ b/javascript/examples/vitest/tests/weather-agent.test.ts
@@ -23,7 +23,7 @@ const weatherAgent: AgentAdapter = {
   role: AgentRole.AGENT,
   call: async (input) => {
     const response = await generateText({
-      model: openai("gpt-4.1-mini"),
+      model: openai("gpt-5-mini"),
       messages: [
         {
           role: "system",
@@ -36,6 +36,7 @@ const weatherAgent: AgentAdapter = {
       ],
       tools: { get_current_weather: getCurrentWeather },
       toolChoice: "auto",
+      experimental_telemetry: { isEnabled: true },
     });
 
     if (response.toolCalls && response.toolCalls.length > 0) {
@@ -91,7 +92,7 @@ describe("Weather Agent", () => {
       `,
       agents: [
         weatherAgent,
-        scenario.userSimulatorAgent({ model: openai("gpt-4.1-mini") }),
+        scenario.userSimulatorAgent({ model: openai("gpt-5-mini") }),
       ],
       script: [
         scenario.user(),

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -273,7 +273,7 @@ class JudgeAgent extends JudgeAgentAdapter {
     const completion = await this.invokeLLMWithDiscovery({
       model: mergedConfig.model,
       messages,
-      temperature: mergedConfig.temperature ?? 0.0,
+      temperature: mergedConfig.temperature,
       maxOutputTokens: mergedConfig.maxTokens,
       tools,
       toolChoice,

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -93,9 +93,9 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
  * @param config Optional configuration for the agent.
  * @param config.model The language model to use for generating responses.
  *                     If not provided, a default model will be used.
- * @param config.temperature The temperature for the language model (0.0-1.0).
+ * @param config.temperature Optional temperature for the language model (0.0-1.0).
  *                          Lower values make responses more deterministic.
- *                          Defaults to {@link DEFAULT_TEMPERATURE}.
+ *                          Omitted by default for compatibility with reasoning models.
  * @param config.maxTokens The maximum number of tokens to generate.
  *                        If not provided, uses model defaults.
  * @param config.name The name of the agent.

--- a/javascript/src/domain/core/constants.ts
+++ b/javascript/src/domain/core/constants.ts
@@ -1,2 +1,0 @@
-/** Default temperature for language model inference */
-export const DEFAULT_TEMPERATURE = 0.0;

--- a/javascript/src/domain/core/schemas/model.schema.ts
+++ b/javascript/src/domain/core/schemas/model.schema.ts
@@ -1,7 +1,5 @@
 import { LanguageModel } from "ai";
 import { z } from "zod/v4";
-import { DEFAULT_TEMPERATURE } from "../constants";
-
 /**
  * Schema for a language model.
  */
@@ -17,8 +15,7 @@ export const modelSchema = z.object({
     .min(0.0)
     .max(1.0)
     .optional()
-    .describe("The temperature for the language model.")
-    .default(DEFAULT_TEMPERATURE),
+    .describe("The temperature for the language model."),
   maxTokens: z
     .number()
     .optional()


### PR DESCRIPTION
## Summary
- Revert `gpt-5-mini-audio-preview` → `gpt-4o-audio-preview` in `multimodal-audio-to-text.test.ts` (missed in #311's audio model revert — this model doesn't exist)
- Reduce adversarial multilingual test from 17 to 9 proceed turns and `maxTurns` from 20 to 12 (`gpt-5-mini` is a reasoning model with slower responses, causing 180s timeout)

## Test plan
- [ ] CI passes for `multimodal-audio-to-text.test.ts` (no more 404 model error)
- [ ] CI passes for `multilingual-agent.test.ts` adversarial test (no more timeout)