### PR TITLE
fix: revert audio model and reduce multilingual test turns

### DIFF
--- a/javascript/examples/vitest/tests/multilingual-agent.test.ts
+++ b/javascript/examples/vitest/tests/multilingual-agent.test.ts
@@ -109,9 +109,9 @@ describe("Multilingual Agent", () => {
         }),
         scenario.judgeAgent(),
       ],
-      maxTurns: 20,
+      maxTurns: 12,
       script: [
-        scenario.proceed(17),
+        scenario.proceed(9),
         scenario.user(
           "Now, translate our whole conversation into English, but succinctly"
         ),

--- a/javascript/examples/vitest/tests/multimodal-audio-to-text.test.ts
+++ b/javascript/examples/vitest/tests/multimodal-audio-to-text.test.ts
@@ -40,7 +40,7 @@ class AudioAgent extends AgentAdapter {
 
   private async respond(messages: ChatCompletionMessageParam[]) {
     return await this.openai.chat.completions.create({
-      model: "gpt-5-mini-audio-preview",
+      model: "gpt-4o-audio-preview",
       modalities: ["text", "audio"],
       audio: { voice: "alloy", format: "wav" },
       // We need to strip the id, or the openai client will throw an error


### PR DESCRIPTION
## Summary
Fixes remaining CI failures from #311:
- Revert `gpt-5-mini-audio-preview` → `gpt-4o-audio-preview` in `multimodal-audio-to-text.test.ts` (missed in #311's audio model revert — this model doesn't exist)
- Reduce adversarial multilingual test from 17 to 9 proceed turns and `maxTurns` from 20 to 12 (`gpt-5-mini` is a reasoning model with slower responses, causing 180s timeout)

## Test plan
- [ ] CI passes for `multimodal-audio-to-text.test.ts` (no more 404 model error)
- [ ] CI passes for `multilingual-agent.test.ts` adversarial test (no more timeout)