### PR TITLE
docs(red-team): document injection_probability and techniques params

### DIFF
--- a/docs/docs/pages/advanced/red-teaming.mdx
+++ b/docs/docs/pages/advanced/red-teaming.mdx
@@ -231,6 +231,8 @@ const attacker = scenario.redTeamCrescendo({
 | Custom plan | `attack_plan` | `attackPlan` | auto-generated | Skip the planner LLM call. |
 | Custom template | `metaprompt_template` | `metapromptTemplate`* | built-in | Override planning prompt. *TS: only via `redTeamAgent()`. |
 | Max tokens | `max_tokens` | `maxTokens` | model default | Cap tokens per attack message. |
+| Injection probability | `injection_probability` | `injectionProbability` | `0.0` | Probability (0.0–1.0) of wrapping each attack message with a random single-turn technique (e.g. Base64, ROT13). `0.0` disables injection. |
+| Technique catalogue | `techniques` | `techniques` | all built-ins | List of `AttackTechnique` instances to sample from when injection triggers. Defaults to `DEFAULT_TECHNIQUES`. |
 | API base | `api_base` | — | global | Custom API endpoint (Python only). |
 | API key | `api_key` | — | env | API key override (Python only). |
 


### PR DESCRIPTION
## Summary
- Add `injection_probability` / `injectionProbability` and `techniques` rows to the RedTeamAgent configuration table in `docs/docs/pages/advanced/red-teaming.mdx`
- Both parameters are already accepted by `RedTeamAgent.crescendo()` (Python) and `redTeamCrescendo()` (TypeScript) but were missing from the documented parameter table — this closes that gap
- No code changes; docs-only

## Test plan
- [ ] Docs site builds without errors
- [ ] Parameter table renders correctly with the two new rows in the right position

🤖 Generated with [Claude Code](https://claude.com/claude-code)