### PR TITLE
docs(red-team): follow-up fixes to Quick Start

### DIFF
--- a/docs/docs/pages/advanced/red-teaming/quick-start.mdx
+++ b/docs/docs/pages/advanced/red-teaming/quick-start.mdx
@@ -47,7 +47,7 @@ Works with Claude Code, Cursor, Claude Desktop, Codex, and any MCP-compatible cl
 }
 ```
 
-Restart the client. Full reference: [LangWatch MCP Server](https://langwatch.ai/docs/integration/mcp).
+Grab your API key from [app.langwatch.ai](https://app.langwatch.ai) → **Settings → API Keys**, then restart your client. Full reference: [LangWatch MCP Server](https://langwatch.ai/docs/integration/mcp).
 
 ## 3. Ask your assistant to generate the test
 
@@ -150,21 +150,11 @@ describe("Agent security", () => {
 
 ## 4. Run it
 
-:::code-group
-
-```bash [python]
-pytest tests/red_team/ -v
-```
-
-```bash [typescript]
-npm test -- tests/red-team
-```
-
-:::
+Run your usual test command, or just ask your coding assistant to run it and monitor it for you. Red team runs are long — 50 turns can take several minutes and will consume real LLM tokens on both the attacker and target models — so make sure your runner's per-test timeout is generous.
 
 Each turn prints the attacker's message, your agent's response, and a per-turn score. A failing test includes the full transcript and the judge's reasoning — you see exactly which turn broke the agent and how.
 
-## 5. View the run in LangWatch (optional)
+## 5. View the run in LangWatch
 
 If you've instrumented your agent with LangWatch, every red team run appears in the Simulations dashboard: full attack transcripts, per-turn scores, and side-by-side comparison across runs to track whether a prompt change made your agent more or less resilient.
 


### PR DESCRIPTION
## Summary

Follow-up polish for the Red Teaming Quick Start page (#324) after a careful re-read against best-in-class docs (Stripe / OpenAI / LangWatch).

- **Step 2 — API key discoverability.** The `LANGWATCH_API_KEY` placeholder had no hint about where to get a key. Added a one-liner pointing to app.langwatch.ai → Settings → API Keys.
- **Step 4 — soften test commands.** The hardcoded `pytest tests/red_team/` and `npm test -- tests/red-team` assumed a directory structure the MCP may not produce, and omitted the long per-test timeouts red team runs actually need. Replaced with "run your tests, or ask your coding assistant to run and monitor it for you" + explicit cost/time awareness (50 turns × LLM calls on two models = real tokens).
- **Step 5 — drop "(optional)".** Viewing the run in LangWatch is the natural next step, not an aside.

## Test plan

- [ ] Quick Start renders without errors
- [ ] "Settings → API Keys" link resolves to app.langwatch.ai
- [ ] Step 4 no longer shows broken path assumptions
- [ ] No regressions to the Python/TS code-group in Step 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)