### PR TITLE
chore: update README license text to match actual license

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,4 +505,4 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+AGPL-3.0 - see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -505,4 +505,4 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## License
 
-AGPL-3.0 - see [LICENSE](LICENSE) for details.
+AGPL-3.0 License - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
The README still listed the license as MIT, but the project moved to AGPL-3.0 about a month ago (see #258). This PR corrects this.