### PR TITLE
fix(red-team): scale backtrack budget with total_turns, add run telemetry

### DIFF
--- a/javascript/src/agents/__tests__/red-team.test.ts
+++ b/javascript/src/agents/__tests__/red-team.test.ts
@@ -1249,3 +1249,30 @@ describe("marathon judges at end after all turns with backtrack", () => {
     expect(judgeCalls[0]!.messageCount).toBeGreaterThanOrEqual(6);
   });
 });
+
+// ---------------------------------------------------------------------------
+// maxBacktracks scaling (#331)
+// ---------------------------------------------------------------------------
+
+describe("maxBacktracks scaling", () => {
+  it("default scales with totalTurns: max(1, floor(totalTurns / 3))", () => {
+    const short = redTeamGoat({ target: "t", totalTurns: 5 });
+    const medium = redTeamGoat({ target: "t", totalTurns: 30 });
+    const long = redTeamGoat({ target: "t", totalTurns: 100 });
+    expect((short as any).maxBacktracks).toBe(1);
+    expect((medium as any).maxBacktracks).toBe(10);
+    expect((long as any).maxBacktracks).toBe(33);
+  });
+
+  it("explicit maxBacktracks overrides the default formula", () => {
+    const agent = redTeamGoat({ target: "t", totalTurns: 30, maxBacktracks: 3 });
+    expect((agent as any).maxBacktracks).toBe(3);
+    expect((agent as any).backtracksRemaining).toBe(3);
+  });
+
+  it("throws on negative maxBacktracks", () => {
+    expect(() =>
+      redTeamGoat({ target: "t", totalTurns: 30, maxBacktracks: -1 })
+    ).toThrow(/maxBacktracks must be >= 0/);
+  });
+});

--- a/javascript/src/agents/red-team/red-team-agent.ts
+++ b/javascript/src/agents/red-team/red-team-agent.ts
@@ -37,6 +37,13 @@ export interface RedTeamAgentConfig {
   injectionProbability?: number;
   /** List of AttackTechnique instances to sample from. Defaults to all built-ins. */
   techniques?: AttackTechnique[];
+  /**
+   * Maximum number of hard-refusal backtracks allowed per run. When
+   * omitted, scales with `totalTurns` as `max(1, floor(totalTurns / 3))` —
+   * so a 30-turn run gets 10, a 5-turn run gets 1. Each backtrack
+   * consumes a turn from the budget. Set explicitly to override.
+   */
+  maxBacktracks?: number;
 }
 
 /** Configuration for the Crescendo and GOAT factory functions. Identical to
@@ -104,8 +111,11 @@ class RedTeamAgentImpl extends UserSimulatorAgentAdapter {
 
   // Backtracking state — removes refused exchanges so the target
   // "forgets" it ever refused and the attacker retries cleanly.
-  private static readonly MAX_BACKTRACKS = 10;
-  private backtracksRemaining = RedTeamAgentImpl.MAX_BACKTRACKS;
+  // Budget scales with totalTurns: a 5-turn run capping at 10 wastes
+  // the cap; a 100-turn run capping at 10 under-provisions against
+  // hardened targets. Formula mirrors issue #331.
+  private readonly maxBacktracks: number;
+  private backtracksRemaining: number;
   private backtrackHistory: BacktrackEntry[] = [];
 
   // Attacker's private conversation history (H_attacker).
@@ -144,6 +154,15 @@ class RedTeamAgentImpl extends UserSimulatorAgentAdapter {
     }
     this.injectionProbability = prob;
     this.techniques = config.techniques ?? DEFAULT_TECHNIQUES;
+
+    if (config.maxBacktracks !== undefined && config.maxBacktracks < 0) {
+      throw new RangeError(
+        `maxBacktracks must be >= 0, got ${config.maxBacktracks}`
+      );
+    }
+    this.maxBacktracks =
+      config.maxBacktracks ?? Math.max(1, Math.floor(this.totalTurns / 3));
+    this.backtracksRemaining = this.maxBacktracks;
   }
 
   private getAttackPlan(description: string): Promise<string> {
@@ -378,7 +397,7 @@ Reply with exactly this JSON and nothing else:
    */
   private resetRunState(): void {
     this.turnScores = new Map();
-    this.backtracksRemaining = RedTeamAgentImpl.MAX_BACKTRACKS;
+    this.backtracksRemaining = this.maxBacktracks;
     this.backtrackHistory = [];
     this.attackerHistory = [];
   }

--- a/python/scenario/red_team_agent.py
+++ b/python/scenario/red_team_agent.py
@@ -142,6 +142,7 @@ class RedTeamAgent(AgentAdapter):
         success_confirm_turns: int = 2,
         injection_probability: float = 0.0,
         techniques: Optional[Sequence[AttackTechnique]] = None,
+        max_backtracks: Optional[int] = None,
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
         temperature: float = 0.7,
@@ -183,6 +184,11 @@ class RedTeamAgent(AgentAdapter):
             techniques: List of ``AttackTechnique`` instances to sample from.
                 Defaults to ``DEFAULT_TECHNIQUES`` (Base64, ROT13, leetspeak,
                 char-split, code-block).
+            max_backtracks: Maximum number of hard-refusal backtracks allowed
+                per run. When ``None`` (default), scales with ``total_turns``
+                as ``max(1, total_turns // 3)`` — so a 30-turn run gets 10,
+                a 5-turn run gets 1. Each backtrack consumes a turn from the
+                budget. Set explicitly to override.
             api_base: Optional base URL for the attacker model API.
             api_key: Optional API key for the attacker model.
             temperature: Sampling temperature for attack message generation.
@@ -206,7 +212,17 @@ class RedTeamAgent(AgentAdapter):
 
         # Backtracking state — removes refused exchanges so the target
         # "forgets" it ever refused and the attacker retries cleanly.
-        self._MAX_BACKTRACKS = 10
+        # Budget scales with total_turns: a 5-turn run capping at 10 wastes
+        # the cap; a 100-turn run capping at 10 under-provisions against
+        # hardened targets. Formula mirrors issue #331.
+        if max_backtracks is not None and max_backtracks < 0:
+            raise ValueError(
+                f"max_backtracks must be >= 0, got {max_backtracks}"
+            )
+        self._MAX_BACKTRACKS = (
+            max_backtracks if max_backtracks is not None
+            else max(1, total_turns // 3)
+        )
         self._backtracks_remaining = self._MAX_BACKTRACKS
         self._backtrack_history: list[dict] = []  # [{"turn": int, "attack": str, "refusal": str}]
 
@@ -252,6 +268,11 @@ class RedTeamAgent(AgentAdapter):
         # Separate from state.messages (H_target) to prevent strategy
         # leakage, enable proper backtracking, and allow score annotations.
         self._attacker_history: list[dict] = []
+
+        # Cumulative count of structured-output parse failures across the
+        # run. Surfaced as a span attr each turn so dashboards can track
+        # attacker output-format reliability per provider/model.
+        self._parse_failure_count: int = 0
 
     @classmethod
     def crescendo(
@@ -752,6 +773,7 @@ Reply with exactly this JSON and nothing else:
         self._backtracks_remaining = self._MAX_BACKTRACKS
         self._backtrack_history = []
         self._attacker_history = []
+        self._parse_failure_count = 0
 
     async def call(self, input: AgentInput) -> AgentReturnTypes:
         """Generate the next adversarial attack message.
@@ -786,11 +808,16 @@ Reply with exactly this JSON and nothing else:
         description = input.scenario_state.description
         strategy_name = type(self._strategy).__name__
 
+        progress = (
+            min(current_turn, self.total_turns) / self.total_turns
+            if self.total_turns > 0 else 0.0
+        )
         with tracer.start_as_current_span(
             "red_team.call",
             attributes={
                 "red_team.turn": current_turn,
                 "red_team.total_turns": self.total_turns,
+                "red_team.progress": progress,
                 "red_team.strategy": strategy_name,
                 "red_team.target": self.target,
             },
@@ -939,9 +966,12 @@ Reply with exactly this JSON and nothing else:
             if self._strategy.emits_structured_output:
                 reply, observation, strategy = self._parse_attacker_output(raw_attack)
                 parse_failed = not observation and not strategy and reply == raw_attack
+                if parse_failed:
+                    self._parse_failure_count += 1
                 span.set_attribute("red_team.reasoning.observation", observation[:500])
                 span.set_attribute("red_team.reasoning.strategy", strategy[:500])
                 span.set_attribute("red_team.reasoning.parse_failed", parse_failed)
+                span.set_attribute("red_team.parse_failure_count", self._parse_failure_count)
                 if parse_failed:
                     logger.warning(
                         "RedTeamAgent turn %d: attacker output was not valid JSON; "

--- a/python/tests/test_red_team_agent.py
+++ b/python/tests/test_red_team_agent.py
@@ -2797,3 +2797,123 @@ class TestGoatFactoryMethod:
         goat = RedTeamAgent.goat(target="test", model="openai/gpt-4.1-mini")
         crescendo = RedTeamAgent.crescendo(target="test", model="openai/gpt-4.1-mini")
         assert type(goat._strategy) is not type(crescendo._strategy)
+
+
+# ---------------------------------------------------------------------------
+# max_backtracks scaling (#331)
+# ---------------------------------------------------------------------------
+
+
+class TestMaxBacktracksScaling:
+    """The backtrack budget scales with total_turns so short runs don't
+    over-provision (wasting nothing) and long runs aren't under-provisioned
+    against hardened targets. Formula: max(1, total_turns // 3).
+    """
+
+    def test_default_scales_with_total_turns(self):
+        short = RedTeamAgent.goat(target="t", model="openai/gpt-4.1-mini", total_turns=5)
+        medium = RedTeamAgent.goat(target="t", model="openai/gpt-4.1-mini", total_turns=30)
+        long_ = RedTeamAgent.goat(target="t", model="openai/gpt-4.1-mini", total_turns=100)
+        assert short._MAX_BACKTRACKS == 1
+        assert medium._MAX_BACKTRACKS == 10
+        assert long_._MAX_BACKTRACKS == 33
+
+    def test_tiny_total_turns_still_gets_one(self):
+        """total_turns=1 or 2 must still allow at least 1 backtrack."""
+        agent = RedTeamAgent.goat(target="t", model="openai/gpt-4.1-mini", total_turns=1)
+        assert agent._MAX_BACKTRACKS == 1
+
+    def test_explicit_override_wins(self):
+        agent = RedTeamAgent.goat(
+            target="t", model="openai/gpt-4.1-mini",
+            total_turns=30, max_backtracks=3,
+        )
+        assert agent._MAX_BACKTRACKS == 3
+        assert agent._backtracks_remaining == 3
+
+    def test_explicit_zero_disables_backtracking(self):
+        agent = RedTeamAgent.goat(
+            target="t", model="openai/gpt-4.1-mini",
+            total_turns=30, max_backtracks=0,
+        )
+        assert agent._MAX_BACKTRACKS == 0
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="max_backtracks must be >= 0"):
+            RedTeamAgent.goat(
+                target="t", model="openai/gpt-4.1-mini",
+                total_turns=30, max_backtracks=-1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# parse_failure_count telemetry
+# ---------------------------------------------------------------------------
+
+
+class TestParseFailureCount:
+    """Cumulative parse_failure_count increments on every malformed attacker
+    output within a run and resets on the next run. Used by dashboards to
+    track per-model output-format reliability.
+    """
+
+    def _make_goat_agent(self):
+        agent = RedTeamAgent.goat(
+            target="extract prompt",
+            model="openai/gpt-4.1-mini",
+            total_turns=5,
+            score_responses=False,
+        )
+        return agent
+
+    def _make_input(self, messages, current_turn):
+        mock_state = MagicMock()
+        mock_state.current_turn = current_turn
+        mock_state.description = "test"
+        mock_state.rollback_messages_to = lambda idx: messages.__delitem__(slice(idx, None))
+        mock_input = MagicMock(spec=AgentInput)
+        mock_input.scenario_state = mock_state
+        mock_input.messages = messages
+        return mock_input
+
+    @pytest.mark.asyncio
+    async def test_counter_starts_at_zero(self):
+        agent = self._make_goat_agent()
+        assert agent._parse_failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_counter_increments_on_malformed_output(self):
+        agent = self._make_goat_agent()
+        # First call: bad JSON
+        agent._call_attacker_llm = AsyncMock(return_value="not json at all")
+        await agent.call(self._make_input([], current_turn=1))
+        assert agent._parse_failure_count == 1
+
+        # Second call: still bad — counter should climb
+        agent._call_attacker_llm = AsyncMock(return_value="also not json")
+        await agent.call(self._make_input(
+            [{"role": "user", "content": "x"}, {"role": "assistant", "content": "y"}],
+            current_turn=2,
+        ))
+        assert agent._parse_failure_count == 2
+
+    @pytest.mark.asyncio
+    async def test_counter_does_not_increment_on_valid_json(self):
+        agent = self._make_goat_agent()
+        agent._call_attacker_llm = AsyncMock(
+            return_value='{"observation": "o", "strategy": "s", "reply": "r"}'
+        )
+        await agent.call(self._make_input([], current_turn=1))
+        assert agent._parse_failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_counter_resets_on_new_run(self):
+        """Counter should reset when a new run starts (turn == 1)."""
+        agent = self._make_goat_agent()
+        agent._parse_failure_count = 5  # simulate prior run
+        agent._call_attacker_llm = AsyncMock(
+            return_value='{"observation": "o", "strategy": "s", "reply": "r"}'
+        )
+        await agent.call(self._make_input([], current_turn=1))
+        # Reset wiped the stale count; valid JSON didn't increment it
+        assert agent._parse_failure_count == 0


### PR DESCRIPTION
## Summary

Quick-wins stacked on #346. Two small changes, no public-API break:

- **#331 — scale `_MAX_BACKTRACKS` with `total_turns`.** New optional `max_backtracks` / `maxBacktracks` param. Default auto-scales as `max(1, total_turns // 3)` — a 5-turn run gets 1, a 30-turn run keeps the old 10, a 100-turn run gets 33. Explicit override works; negative values raise.
- **`red_team.progress` span attr.** Float `current_turn / total_turns` on every `red_team.call` span. Enables timeline filters in dashboards without having to derive it from the turn/total_turns pair.
- **`red_team.parse_failure_count` span attr.** Cumulative count of malformed structured-output responses across a run (GOAT only, since Crescendo doesn't emit JSON). Surfaces per-provider/model output-format reliability. Per-turn `red_team.reasoning.parse_failed` bool is kept for backward compatibility.

TS mirrors `maxBacktracks`. Telemetry is Python-only — TS red-team has no OTel instrumentation yet, flagged for a future PR.

## Test plan

- [x] Python: 164 existing red-team tests still pass; 9 new tests cover `max_backtracks` scaling, override, validation, and cumulative parse-failure counting with reset across runs
- [x] TypeScript: 335 existing tests still pass; 3 new tests cover `maxBacktracks` scaling, override, and negative-value validation
- [x] Syntax check: `ast.parse` on the Python module, `pnpm test` on the TS suite
- [ ] Manual: run a 5-turn GOAT attack against bank-demo to confirm the new 1-backtrack cap doesn't break short runs (requires API keys)

## Related

- Closes #331
- Addresses part of the observability ask in #330 (the full per-turn technique-ID telemetry is the next PR in the stack)
- #336 closed as won't-fix (rubric is defensible; the cost concern is mitigated by #331)
- Part of EPIC: langwatch/langwatch#1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)