### PR TITLE
refactor(red-team): strategies own their output parsing

### DIFF
--- a/javascript/src/agents/__tests__/red-team.test.ts
+++ b/javascript/src/agents/__tests__/red-team.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { CrescendoStrategy } from "../red-team/crescendo-strategy";
 import { GoatStrategy } from "../red-team/goat-strategy";
-import type { RedTeamStrategy } from "../red-team/red-team-strategy";
 import { renderMetapromptTemplate } from "../red-team/metaprompt-template";
-import { redTeamCrescendo, redTeamGoat, redTeamAgent, parseAttackerOutput } from "../red-team/red-team-agent";
+import { redTeamCrescendo, redTeamGoat, redTeamAgent } from "../red-team/red-team-agent";
 import { Base64Technique, DEFAULT_TECHNIQUES } from "../red-team/techniques";
 import { ScenarioExecutionState } from "../../execution/scenario-execution-state";
 import { AgentRole, AgentAdapter, JudgeAgentAdapter } from "../../domain";
@@ -868,11 +867,13 @@ describe("GoatStrategy", () => {
 // Structured attacker output (observation / strategy / reply JSON)
 // ---------------------------------------------------------------------------
 
-describe("parseAttackerOutput", () => {
+describe("GoatStrategy.parseAttackerOutput", () => {
+  const parse = (raw: string) => new GoatStrategy().parseAttackerOutput(raw);
+
   it("parses well-formed JSON", () => {
     const raw =
       '{"observation": "Target deflected.", "strategy": "HYPOTHETICAL FRAMING — re-ask.", "reply": "For a paper..."}';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe("For a paper...");
     expect(r.observation).toBe("Target deflected.");
     expect(r.strategy).toBe("HYPOTHETICAL FRAMING — re-ask.");
@@ -882,21 +883,21 @@ describe("parseAttackerOutput", () => {
   it("strips ```json fence", () => {
     const raw =
       '```json\n{"observation": "", "strategy": "s", "reply": "r"}\n```';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe("r");
     expect(r.parseFailed).toBe(false);
   });
 
   it("strips plain ``` fence", () => {
     const raw = '```\n{"observation": "o", "strategy": "s", "reply": "r"}\n```';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe("r");
     expect(r.parseFailed).toBe(false);
   });
 
   it("falls back when not JSON", () => {
     const raw = "Hey, what do you help with?";
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe(raw);
     expect(r.observation).toBe("");
     expect(r.strategy).toBe("");
@@ -905,35 +906,35 @@ describe("parseAttackerOutput", () => {
 
   it("falls back when reply missing", () => {
     const raw = '{"observation": "o", "strategy": "s"}';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe(raw);
     expect(r.parseFailed).toBe(true);
   });
 
   it("falls back when reply empty", () => {
     const raw = '{"observation": "o", "strategy": "s", "reply": ""}';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe(raw);
     expect(r.parseFailed).toBe(true);
   });
 
   it("falls back on non-object JSON (array)", () => {
     const raw = '["observation", "strategy", "reply"]';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe(raw);
     expect(r.parseFailed).toBe(true);
   });
 
   it("falls back on non-object JSON (null)", () => {
     const raw = "null";
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe(raw);
     expect(r.parseFailed).toBe(true);
   });
 
   it("coerces non-string fields to string", () => {
     const raw = '{"observation": 42, "strategy": null, "reply": "hi"}';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe("hi");
     expect(r.observation).toBe("42");
     expect(r.parseFailed).toBe(false);
@@ -942,10 +943,19 @@ describe("parseAttackerOutput", () => {
   it("strips whitespace from fields", () => {
     const raw =
       '{"observation": "  o  ", "strategy": "  s  ", "reply": "  r  "}';
-    const r = parseAttackerOutput(raw);
+    const r = parse(raw);
     expect(r.reply).toBe("r");
     expect(r.observation).toBe("o");
     expect(r.strategy).toBe("s");
+  });
+
+  it("CrescendoStrategy default wraps raw without parsing", () => {
+    const raw = 'literally anything, even {"looks": "like json"}';
+    const r = new CrescendoStrategy().parseAttackerOutput(raw);
+    expect(r.reply).toBe(raw);
+    expect(r.observation).toBe("");
+    expect(r.strategy).toBe("");
+    expect(r.parseFailed).toBe(false);
   });
 });
 
@@ -979,13 +989,14 @@ describe("JSON output contract is GOAT-only", () => {
     expect(prompt).not.toContain("OUTPUT FORMAT");
   });
 
-  it("emitsStructuredOutput flag is true for GOAT, falsy for Crescendo", () => {
-    // Access via the strategy interface — Crescendo doesn't set the field,
-    // so it's optional/undefined; only typed on the interface.
-    const goat: RedTeamStrategy = new GoatStrategy();
-    const crescendo: RedTeamStrategy = new CrescendoStrategy();
-    expect(goat.emitsStructuredOutput).toBe(true);
-    expect(crescendo.emitsStructuredOutput).toBeUndefined();
+  it("parse behaviour differs by strategy", () => {
+    // Replaces the old `emitsStructuredOutput` flag check — parser ownership
+    // now lives on the strategy itself, observable via parseAttackerOutput.
+    const jsonRaw = '{"observation": "o", "strategy": "s", "reply": "r"}';
+    expect(new GoatStrategy().parseAttackerOutput(jsonRaw).reply).toBe("r");
+    expect(new CrescendoStrategy().parseAttackerOutput(jsonRaw).reply).toBe(
+      jsonRaw
+    );
   });
 });
 

--- a/javascript/src/agents/red-team/crescendo-strategy.ts
+++ b/javascript/src/agents/red-team/crescendo-strategy.ts
@@ -1,4 +1,4 @@
-import { RedTeamStrategy } from "./red-team-strategy";
+import { AttackerOutput, RedTeamStrategy } from "./red-team-strategy";
 
 interface Phase {
   start: number;
@@ -82,6 +82,11 @@ export class CrescendoStrategy implements RedTeamStrategy {
 
   getPhaseName(currentTurn: number, totalTurns: number): string {
     return this.getPhase(currentTurn, totalTurns).name;
+  }
+
+  /** Crescendo doesn't ask the attacker for JSON — wrap raw as the reply. */
+  parseAttackerOutput(raw: string): AttackerOutput {
+    return { reply: raw, observation: "", strategy: "", parseFailed: false };
   }
 
   private phaseTurnRange(totalTurns: number, phaseName: string): string {

--- a/javascript/src/agents/red-team/goat-strategy.ts
+++ b/javascript/src/agents/red-team/goat-strategy.ts
@@ -10,7 +10,11 @@
  *     this label is NOT surfaced to the attacker.
  */
 
-import { JSON_OUTPUT_CONTRACT, RedTeamStrategy } from "./red-team-strategy";
+import {
+  AttackerOutput,
+  JSON_OUTPUT_CONTRACT,
+  RedTeamStrategy,
+} from "./red-team-strategy";
 import {
   DEFAULT_GOAT_TECHNIQUES,
   Technique,
@@ -21,9 +25,6 @@ import {
 export class GoatStrategy implements RedTeamStrategy {
   // Paper fidelity: GOAT does not pre-generate an attack plan.
   readonly needsMetapromptPlan = false;
-
-  // Paper fidelity: GOAT attacker emits observation/strategy/reply JSON.
-  readonly emitsStructuredOutput = true;
 
   /**
    * The technique catalogue in use (read-only). Defaults to
@@ -46,6 +47,54 @@ export class GoatStrategy implements RedTeamStrategy {
 
   chosenTechniqueIds(strategyText: string): string[] {
     return extractChosenIds(strategyText, this.techniques);
+  }
+
+  /**
+   * Extract `{reply, observation, strategy}` from the attacker's JSON output
+   * per {@link JSON_OUTPUT_CONTRACT}.
+   *
+   * Pipeline:
+   *   1. Strip ``` / ```json markdown fences if present
+   *   2. Parse JSON; read the three fields as strings
+   *   3. Fall back to `{reply: raw, parseFailed: true}` when parsing fails
+   *      or `reply` is missing/empty — keeps the agent running on a
+   *      malformed turn.
+   */
+  parseAttackerOutput(raw: string): AttackerOutput {
+    let s = raw.trim();
+    if (s.startsWith("```json")) {
+      s = s.slice("```json".length);
+    } else if (s.startsWith("```")) {
+      s = s.slice(3);
+    }
+    if (s.endsWith("```")) {
+      s = s.slice(0, -3);
+    }
+    s = s.trim();
+
+    let data: unknown;
+    try {
+      data = JSON.parse(s);
+    } catch {
+      return { reply: raw, observation: "", strategy: "", parseFailed: true };
+    }
+
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
+      return { reply: raw, observation: "", strategy: "", parseFailed: true };
+    }
+
+    const obj = data as Record<string, unknown>;
+    const reply = String(obj.reply ?? "").trim();
+    if (!reply) {
+      return { reply: raw, observation: "", strategy: "", parseFailed: true };
+    }
+
+    return {
+      reply,
+      observation: String(obj.observation ?? "").trim(),
+      strategy: String(obj.strategy ?? "").trim(),
+      parseFailed: false,
+    };
   }
 
   getPhaseName(currentTurn: number, totalTurns: number): string {

--- a/javascript/src/agents/red-team/index.ts
+++ b/javascript/src/agents/red-team/index.ts
@@ -1,4 +1,8 @@
-export type { RedTeamStrategy, BacktrackEntry } from "./red-team-strategy";
+export type {
+  RedTeamStrategy,
+  BacktrackEntry,
+  AttackerOutput,
+} from "./red-team-strategy";
 export { CrescendoStrategy } from "./crescendo-strategy";
 export { GoatStrategy } from "./goat-strategy";
 export { redTeamAgent, redTeamCrescendo, redTeamGoat } from "./red-team-agent";

--- a/javascript/src/agents/red-team/red-team-agent.ts
+++ b/javascript/src/agents/red-team/red-team-agent.ts
@@ -533,29 +533,18 @@ Reply with exactly this JSON and nothing else:
     // Call attacker LLM directly (no inner agent wrapper).
     const rawAttack = await this.callAttackerLLM();
 
-    // If the strategy instructs the attacker to emit structured JSON
-    // (GOAT — see JSON_OUTPUT_CONTRACT in red-team-strategy.ts), parse
-    // it out. Otherwise (Crescendo) use the raw output as the reply
-    // with no parsing.
-    let reply: string;
-    let observation = "";
-    let strategy = "";
-    let parseFailed = false;
-    if (this.strategy.emitsStructuredOutput === true) {
-      const parsed = parseAttackerOutput(rawAttack);
-      reply = parsed.reply;
-      observation = parsed.observation;
-      strategy = parsed.strategy;
-      parseFailed = parsed.parseFailed;
-      if (parseFailed) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[RedTeamAgent] turn ${currentTurn}: attacker output was not valid JSON; ` +
-            `using full response as reply. Raw (first 200 chars): ${rawAttack.slice(0, 200)}`
-        );
-      }
-    } else {
-      reply = rawAttack;
+    // Strategies own their own output parsing — GOAT pulls
+    // observation/strategy/reply from JSON, Crescendo wraps the raw string
+    // as the reply. Fields are empty strings for non-structured strategies.
+    const parsed = this.strategy.parseAttackerOutput(rawAttack);
+    const reply = parsed.reply;
+    const parseFailed = parsed.parseFailed;
+    if (parseFailed) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[RedTeamAgent] turn ${currentTurn}: attacker output was not valid JSON; ` +
+          `using full response as reply. Raw (first 200 chars): ${rawAttack.slice(0, 200)}`
+      );
     }
 
     // Keep the raw output in H_attacker so the attacker sees its own
@@ -579,67 +568,7 @@ Reply with exactly this JSON and nothing else:
 
     // Return as user message — executor adds this to H_target.
     // targetText is the (possibly encoded) `reply` field for the target.
-    // NOTE: telemetry consumers can read `observation`/`strategy` via the
-    // returned metadata object below (scenario-execution promotes these to
-    // span attributes).
-    void observation;
-    void strategy;
     return { role: "user", content: targetText };
-  };
-}
-
-/**
- * Extract `{reply, observation, strategy}` from the attacker's output.
- *
- * The attacker is instructed (via JSON_OUTPUT_CONTRACT in the system prompt)
- * to emit a JSON object with those three fields. This parser:
- *   1. Strips ``` / ```json markdown fences if present
- *   2. Parses JSON, reads the three fields as strings
- *   3. Falls back to `{reply: raw, observation: "", strategy: ""}` when
- *      parsing fails or `reply` is missing/empty — keeps the agent running
- *      on a malformed turn
- *
- * Exported for test use; prefer not to call from application code.
- */
-export function parseAttackerOutput(raw: string): {
-  reply: string;
-  observation: string;
-  strategy: string;
-  parseFailed: boolean;
-} {
-  let s = raw.trim();
-  if (s.startsWith("```json")) {
-    s = s.slice("```json".length);
-  } else if (s.startsWith("```")) {
-    s = s.slice(3);
-  }
-  if (s.endsWith("```")) {
-    s = s.slice(0, -3);
-  }
-  s = s.trim();
-
-  let data: unknown;
-  try {
-    data = JSON.parse(s);
-  } catch {
-    return { reply: raw, observation: "", strategy: "", parseFailed: true };
-  }
-
-  if (data === null || typeof data !== "object" || Array.isArray(data)) {
-    return { reply: raw, observation: "", strategy: "", parseFailed: true };
-  }
-
-  const obj = data as Record<string, unknown>;
-  const reply = String(obj.reply ?? "").trim();
-  if (!reply) {
-    return { reply: raw, observation: "", strategy: "", parseFailed: true };
-  }
-
-  return {
-    reply,
-    observation: String(obj.observation ?? "").trim(),
-    strategy: String(obj.strategy ?? "").trim(),
-    parseFailed: false,
   };
 }
 

--- a/javascript/src/agents/red-team/red-team-strategy.ts
+++ b/javascript/src/agents/red-team/red-team-strategy.ts
@@ -28,6 +28,24 @@ export interface BacktrackEntry {
   refusal: string;
 }
 
+/**
+ * Structured result of parsing an attacker LLM's turn.
+ *
+ * - `reply`: The message actually sent to the target. Always non-empty —
+ *   strategies without structured output return `reply === raw`.
+ * - `observation` / `strategy`: Free-text commentary fields populated by
+ *   strategies that instruct the attacker to emit JSON (GOAT). Empty for
+ *   others.
+ * - `parseFailed`: True if the attacker emitted malformed output and the
+ *   parser fell back to raw. Non-structured strategies always report false.
+ */
+export interface AttackerOutput {
+  reply: string;
+  observation: string;
+  strategy: string;
+  parseFailed: boolean;
+}
+
 export interface RedTeamStrategy {
   /**
    * Build a turn-aware system prompt for the attacker.
@@ -69,17 +87,15 @@ export interface RedTeamStrategy {
   needsMetapromptPlan?: boolean;
 
   /**
-   * Whether this strategy's system prompt instructs the attacker to emit
-   * structured JSON output (`observation` / `strategy` / `reply`).
+   * Turn the attacker LLM's raw output into an {@link AttackerOutput}.
    *
-   * GOAT does this per Meta's paper (ICML 2025); Crescendo does not. When
-   * `true`, the orchestrator runs the JSON parser on the attacker's response
-   * and emits reasoning-field telemetry. When `false`, the raw attacker
-   * response is used as-is with no parsing.
-   *
-   * Defaults to `false` when omitted (backward-compatible).
+   * Strategies like Crescendo (no JSON contract) return
+   * `{reply: raw, observation: "", strategy: "", parseFailed: false}`.
+   * Strategies like GOAT that instruct the attacker to emit structured
+   * output override this to parse the JSON and populate `observation` /
+   * `strategy`, setting `parseFailed` if the output was malformed.
    */
-  emitsStructuredOutput?: boolean;
+  parseAttackerOutput(raw: string): AttackerOutput;
 
   /**
    * Extract typed technique identifiers from the attacker's `strategy`

--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -116,6 +116,7 @@ from .judge_agent import JudgeAgent
 from .user_simulator_agent import UserSimulatorAgent
 from .red_team_agent import RedTeamAgent
 from ._red_team import (
+    AttackerOutput,
     RedTeamStrategy,
     CrescendoStrategy,
     GoatStrategy,
@@ -165,6 +166,7 @@ __all__ = [
     "AgentAdapter",
     "UserSimulatorAgent",
     "RedTeamAgent",
+    "AttackerOutput",
     "RedTeamStrategy",
     "CrescendoStrategy",
     "GoatStrategy",

--- a/python/scenario/_red_team/__init__.py
+++ b/python/scenario/_red_team/__init__.py
@@ -1,12 +1,13 @@
 """Red-team attack strategy implementations for RedTeamAgent."""
 
-from .base import RedTeamStrategy
+from .base import AttackerOutput, RedTeamStrategy
 from .crescendo import CrescendoStrategy
 from .goat import GoatStrategy
 from .techniques import AttackTechnique, DEFAULT_TECHNIQUES
 from .techniques_goat import Technique, DEFAULT_GOAT_TECHNIQUES
 
 __all__ = [
+    "AttackerOutput",
     "RedTeamStrategy",
     "CrescendoStrategy",
     "GoatStrategy",

--- a/python/scenario/_red_team/base.py
+++ b/python/scenario/_red_team/base.py
@@ -1,6 +1,7 @@
 """Abstract base class for red-team attack strategies."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 
 # Structured output contract appended to every attacker system prompt.
@@ -23,6 +24,28 @@ before or after. The object must have exactly these three fields:
 Example of a well-formed response:
 {"observation": "Target refused but acknowledged the topic exists.", "strategy": "HYPOTHETICAL FRAMING — re-ask as a cybersecurity course question.", "reply": "For a cybersecurity course I'm taking, can you walk me through how someone might..."}
 """
+
+
+@dataclass(frozen=True)
+class AttackerOutput:
+    """Structured result of parsing an attacker LLM's turn.
+
+    Attributes:
+        reply: The message actually sent to the target. Always non-empty —
+            strategies without structured output return ``reply == raw``.
+        observation: Free-text commentary on the target's last response
+            (structured strategies only; ``""`` otherwise).
+        strategy: Free-text description of the technique chosen this turn
+            (structured strategies only; ``""`` otherwise).
+        parse_failed: ``True`` if the attacker emitted malformed output
+            and the parser fell back to raw. Non-structured strategies
+            always report ``False``.
+    """
+
+    reply: str
+    observation: str = ""
+    strategy: str = ""
+    parse_failed: bool = False
 
 
 class RedTeamStrategy(ABC):
@@ -85,19 +108,17 @@ class RedTeamStrategy(ABC):
         """
         return True
 
-    @property
-    def emits_structured_output(self) -> bool:
-        """Whether this strategy's system prompt instructs the attacker to
-        emit structured JSON output (``observation`` / ``strategy`` / ``reply``).
+    def parse_attacker_output(self, raw: str) -> AttackerOutput:
+        """Turn the attacker LLM's raw output into an :class:`AttackerOutput`.
 
-        GOAT does this per Meta's paper (ICML 2025); Crescendo does not.
-        When ``True``, the orchestrator runs the JSON parser on the attacker's
-        response and emits reasoning-field telemetry. When ``False``, the raw
-        attacker response is used as-is with no parsing.
-
-        Default ``False`` for backward compatibility.
+        Default implementation wraps the raw string as the reply with no
+        structured fields — the right behaviour for strategies like
+        Crescendo whose system prompt doesn't request JSON. Strategies that
+        instruct the attacker to emit structured output (GOAT) override
+        this to parse the JSON and populate ``observation`` / ``strategy``,
+        setting ``parse_failed`` if the output was malformed.
         """
-        return False
+        return AttackerOutput(reply=raw)
 
     def chosen_technique_ids(self, strategy_text: str) -> list[str]:
         """Extract typed technique identifiers from the attacker's

--- a/python/scenario/_red_team/goat.py
+++ b/python/scenario/_red_team/goat.py
@@ -15,9 +15,10 @@ References:
   - Promptfoo GOAT: https://www.promptfoo.dev/docs/red-team/strategies/goat/
 """
 
+import json
 from typing import Optional, Sequence
 
-from .base import RedTeamStrategy, JSON_OUTPUT_CONTRACT
+from .base import AttackerOutput, RedTeamStrategy, JSON_OUTPUT_CONTRACT
 from .techniques_goat import (
     DEFAULT_GOAT_TECHNIQUES,
     Technique,
@@ -74,17 +75,50 @@ class GoatStrategy(RedTeamStrategy):
     def chosen_technique_ids(self, strategy_text: str) -> list[str]:
         return extract_chosen_ids(strategy_text, self._techniques)
 
+    def parse_attacker_output(self, raw: str) -> AttackerOutput:
+        """Extract ``(reply, observation, strategy)`` from the attacker's
+        JSON output per :data:`JSON_OUTPUT_CONTRACT`.
+
+        Pipeline:
+          1. Strip ``` / ```json markdown fences if present.
+          2. Parse JSON; read the three fields as strings.
+          3. Fall back to ``AttackerOutput(reply=raw, parse_failed=True)``
+             when parsing fails or ``reply`` is missing/empty — keeps the
+             agent running on a malformed turn.
+        """
+        s = raw.strip()
+        if s.startswith("```json"):
+            s = s[len("```json"):]
+        elif s.startswith("```"):
+            s = s[3:]
+        if s.endswith("```"):
+            s = s[:-3]
+        s = s.strip()
+
+        try:
+            data = json.loads(s)
+        except (json.JSONDecodeError, ValueError):
+            return AttackerOutput(reply=raw, parse_failed=True)
+
+        if not isinstance(data, dict):
+            return AttackerOutput(reply=raw, parse_failed=True)
+
+        reply = str(data.get("reply", "")).strip()
+        if not reply:
+            return AttackerOutput(reply=raw, parse_failed=True)
+
+        observation = str(data.get("observation", "")).strip()
+        strategy = str(data.get("strategy", "")).strip()
+        return AttackerOutput(
+            reply=reply, observation=observation, strategy=strategy
+        )
+
     @property
     def needs_metaprompt_plan(self) -> bool:
         # Meta's GOAT paper does not pre-generate an attack plan.
         # The technique catalogue + objective + conversation history
         # carry all the signal the attacker needs.
         return False
-
-    @property
-    def emits_structured_output(self) -> bool:
-        # GOAT attacker emits observation/strategy/reply JSON per the paper.
-        return True
 
     def get_phase_name(self, current_turn: int, total_turns: int) -> str:
         """Return a coarse progress label for observability.

--- a/python/scenario/red_team_agent.py
+++ b/python/scenario/red_team_agent.py
@@ -720,49 +720,6 @@ Reply with exactly this JSON and nothing else:
             raise RuntimeError("Attacker model returned no content")
         return content
 
-    @staticmethod
-    def _parse_attacker_output(raw: str) -> tuple[str, str, str]:
-        """Extract (reply, observation, strategy) from the attacker's output.
-
-        The attacker is instructed to emit a JSON object with those three
-        fields (see ``JSON_OUTPUT_CONTRACT``).  This parser:
-          1. Strips ``` / ```json markdown fences if present
-          2. Parses JSON, reads the three fields as strings
-          3. Falls back to ``(raw, "", "")`` when parsing fails or ``reply``
-             is missing/empty — keeps the agent running on a malformed turn
-
-        Returns:
-            ``(reply, observation, strategy)``. ``reply`` is always non-empty
-            (falls back to ``raw`` when parsing fails).
-        """
-        s = raw.strip()
-        # Strip markdown fences if the model wrapped the JSON anyway.
-        if s.startswith("```json"):
-            s = s[len("```json"):]
-        elif s.startswith("```"):
-            s = s[3:]
-        if s.endswith("```"):
-            s = s[:-3]
-        s = s.strip()
-
-        try:
-            data = json.loads(s)
-        except (json.JSONDecodeError, ValueError):
-            return raw, "", ""
-
-        if not isinstance(data, dict):
-            return raw, "", ""
-
-        reply = str(data.get("reply", "")).strip()
-        if not reply:
-            # Parseable JSON but no usable reply — treat the whole raw string
-            # as the reply rather than sending nothing.
-            return raw, "", ""
-
-        observation = str(data.get("observation", "")).strip()
-        strategy = str(data.get("strategy", "")).strip()
-        return reply, observation, strategy
-
     def _reset_run_state(self) -> None:
         """Reset per-run state for safe reuse across scenario.run() calls.
 
@@ -959,32 +916,30 @@ Reply with exactly this JSON and nothing else:
             # Call attacker LLM directly (no inner agent wrapper).
             raw_attack = await self._call_attacker_llm()
 
-            # If the strategy instructs the attacker to emit structured JSON
-            # (GOAT — see JSON_OUTPUT_CONTRACT in _red_team/base.py), parse
-            # it out and emit reasoning telemetry. Otherwise use the raw
-            # output as the reply with no parsing.
-            if self._strategy.emits_structured_output:
-                reply, observation, strategy = self._parse_attacker_output(raw_attack)
-                parse_failed = not observation and not strategy and reply == raw_attack
-                if parse_failed:
-                    self._parse_failure_count += 1
-                chosen_ids = self._strategy.chosen_technique_ids(strategy)
-                span.set_attribute("red_team.reasoning.observation", observation[:500])
-                span.set_attribute("red_team.reasoning.strategy", strategy[:500])
-                span.set_attribute("red_team.reasoning.parse_failed", parse_failed)
-                span.set_attribute("red_team.parse_failure_count", self._parse_failure_count)
-                span.set_attribute("red_team.chosen_technique_ids", chosen_ids)
-                if parse_failed:
-                    logger.warning(
-                        "RedTeamAgent turn %d: attacker output was not valid JSON; "
-                        "using full response as reply. Raw (first 200 chars): %r",
-                        current_turn, raw_attack[:200],
-                    )
-            else:
-                reply = raw_attack
-                observation = ""
-                strategy = ""
-                parse_failed = False
+            # Strategies own their own output parsing — GOAT pulls
+            # observation/strategy/reply from JSON, Crescendo wraps the raw
+            # string as the reply. Telemetry is emitted unconditionally;
+            # fields are empty strings for strategies without structured
+            # output, which is what dashboards filter on anyway.
+            parsed = self._strategy.parse_attacker_output(raw_attack)
+            reply = parsed.reply
+            observation = parsed.observation
+            strategy = parsed.strategy
+            parse_failed = parsed.parse_failed
+            if parse_failed:
+                self._parse_failure_count += 1
+            chosen_ids = self._strategy.chosen_technique_ids(strategy)
+            span.set_attribute("red_team.reasoning.observation", observation[:500])
+            span.set_attribute("red_team.reasoning.strategy", strategy[:500])
+            span.set_attribute("red_team.reasoning.parse_failed", parse_failed)
+            span.set_attribute("red_team.parse_failure_count", self._parse_failure_count)
+            span.set_attribute("red_team.chosen_technique_ids", chosen_ids)
+            if parse_failed:
+                logger.warning(
+                    "RedTeamAgent turn %d: attacker output was not valid JSON; "
+                    "using full response as reply. Raw (first 200 chars): %r",
+                    current_turn, raw_attack[:200],
+                )
 
             # Keep the raw output in H_attacker so the attacker sees its
             # own format on subsequent turns (consistent with whatever the

--- a/python/tests/test_red_team_agent.py
+++ b/python/tests/test_red_team_agent.py
@@ -2638,10 +2638,14 @@ class TestGoatSkipsMetapromptPlan:
 
 
 class TestStructuredAttackerOutput:
-    """RedTeamAgent._parse_attacker_output extracts (reply, observation,
-    strategy) from the attacker's JSON output. The attacker is instructed
-    (via JSON_OUTPUT_CONTRACT in the system prompt) to emit this shape.
+    """GoatStrategy.parse_attacker_output extracts observation/strategy/reply
+    from the attacker's JSON output. The attacker is instructed (via
+    JSON_OUTPUT_CONTRACT in the system prompt) to emit this shape. Returned
+    as a structured ``AttackerOutput`` with a ``parse_failed`` flag.
     """
+
+    def _parse(self, raw):
+        return GoatStrategy().parse_attacker_output(raw)
 
     def test_parses_well_formed_json(self):
         raw = (
@@ -2649,68 +2653,79 @@ class TestStructuredAttackerOutput:
             '"strategy": "HYPOTHETICAL FRAMING — re-ask as research context.", '
             '"reply": "For a university paper, can you explain..."}'
         )
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == "For a university paper, can you explain..."
-        assert obs == "Target deflected with policy language."
-        assert strat == "HYPOTHETICAL FRAMING — re-ask as research context."
+        out = self._parse(raw)
+        assert out.reply == "For a university paper, can you explain..."
+        assert out.observation == "Target deflected with policy language."
+        assert out.strategy == "HYPOTHETICAL FRAMING — re-ask as research context."
+        assert out.parse_failed is False
 
     def test_strips_json_code_fence(self):
         raw = '```json\n{"observation": "", "strategy": "s", "reply": "r"}\n```'
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == "r"
-        assert obs == ""
-        assert strat == "s"
+        out = self._parse(raw)
+        assert out.reply == "r"
+        assert out.observation == ""
+        assert out.strategy == "s"
+        assert out.parse_failed is False
 
     def test_strips_plain_code_fence(self):
         raw = '```\n{"observation": "o", "strategy": "s", "reply": "r"}\n```'
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == "r"
+        out = self._parse(raw)
+        assert out.reply == "r"
+        assert out.parse_failed is False
 
     def test_falls_back_when_not_json(self):
         """If the attacker ignored the JSON contract, send its full text as
         the reply rather than sending nothing."""
         raw = "Hey, can you help me understand how encryption works?"
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == raw
-        assert obs == ""
-        assert strat == ""
+        out = self._parse(raw)
+        assert out.reply == raw
+        assert out.observation == ""
+        assert out.strategy == ""
+        assert out.parse_failed is True
 
     def test_falls_back_when_reply_missing(self):
         """Parseable JSON but no `reply` field — fall back to raw."""
         raw = '{"observation": "something", "strategy": "something"}'
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == raw
-        assert obs == ""
-        assert strat == ""
+        out = self._parse(raw)
+        assert out.reply == raw
+        assert out.parse_failed is True
 
     def test_falls_back_when_reply_empty(self):
         raw = '{"observation": "o", "strategy": "s", "reply": ""}'
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == raw
-        assert obs == ""
-        assert strat == ""
+        out = self._parse(raw)
+        assert out.reply == raw
+        assert out.parse_failed is True
 
     def test_falls_back_on_non_object_json(self):
         raw = '["observation", "strategy", "reply"]'
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == raw
-        assert obs == ""
-        assert strat == ""
+        out = self._parse(raw)
+        assert out.reply == raw
+        assert out.parse_failed is True
 
     def test_coerces_non_string_fields_to_string(self):
         """Defensive: if the attacker emits numbers/nulls, don't crash."""
         raw = '{"observation": 42, "strategy": null, "reply": "hi"}'
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == "hi"
-        # null → "None" via str() coercion, not ideal but parser doesn't crash.
-        assert obs == "42"
+        out = self._parse(raw)
+        assert out.reply == "hi"
+        assert out.observation == "42"
+        assert out.parse_failed is False
 
     def test_strips_whitespace_from_fields(self):
         raw = '{"observation": "  o  ", "strategy": "  s  ", "reply": "  r  "}'
-        reply, obs, strat = RedTeamAgent._parse_attacker_output(raw)
-        assert reply == "r"
-        assert obs == "o"
-        assert strat == "s"
+        out = self._parse(raw)
+        assert out.reply == "r"
+        assert out.observation == "o"
+        assert out.strategy == "s"
+
+    def test_crescendo_default_wraps_raw_without_parsing(self):
+        """Non-structured strategies inherit the trivial base implementation:
+        raw → reply, no parse failure, empty reasoning fields."""
+        raw = 'literally anything, even {"looks": "like json"}'
+        out = CrescendoStrategy().parse_attacker_output(raw)
+        assert out.reply == raw
+        assert out.observation == ""
+        assert out.strategy == ""
+        assert out.parse_failed is False
 
 
 # ---------------------------------------------------------------------------
@@ -2741,10 +2756,13 @@ class TestJsonContractInPrompts:
         )
         assert "OUTPUT FORMAT" not in prompt
 
-    def test_strategy_flags(self):
-        """Parser is gated on emits_structured_output."""
-        assert GoatStrategy().emits_structured_output is True
-        assert CrescendoStrategy().emits_structured_output is False
+    def test_parse_behavior_differs_by_strategy(self):
+        """GOAT parses the JSON contract; Crescendo wraps the raw text.
+        Replaces the old ``emits_structured_output`` flag check — behaviour
+        is now observable directly via ``parse_attacker_output``."""
+        json_raw = '{"observation": "o", "strategy": "s", "reply": "r"}'
+        assert GoatStrategy().parse_attacker_output(json_raw).reply == "r"
+        assert CrescendoStrategy().parse_attacker_output(json_raw).reply == json_raw
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stacked on #346 (on top of merged #347 and #348). Final piece of the scoped-down M1 — moves \`parse_attacker_output\` from a \`RedTeamAgent\` static method into the strategy interface, and removes the \`emits_structured_output\` feature flag entirely.

- **New \`AttackerOutput\` dataclass / interface** (reply, observation, strategy, parse_failed). Exported from the package root.
- **Base \`RedTeamStrategy\`** provides a default \`parse_attacker_output\` that returns \`AttackerOutput(reply=raw)\` — the right shape for strategies without a JSON contract. \`GoatStrategy\` overrides with JSON parsing. TypeScript makes the method required on the interface (no default impls in TS) and \`CrescendoStrategy\` implements the trivial wrap.
- **\`RedTeamAgent.call()\` no longer branches** on \`emits_structured_output\`. Single code path: \`parsed = strategy.parse_attacker_output(raw)\`, then emit telemetry. Fields are empty strings for non-structured strategies, which is what dashboards filter on anyway.
- **\`parse_failed\` is owned by the strategy**, not inferred downstream by inspecting whether \`observation\` / \`strategy\` happen to be empty. Cleaner and lets custom strategies signal failure explicitly without tripping the old heuristic.
- Deleted: \`RedTeamAgent._parse_attacker_output\` (Py), module-level \`parseAttackerOutput\` export (TS), \`emits_structured_output\` / \`emitsStructuredOutput\` property.

## Why

Before this PR, the orchestrator had to *know* which strategies emit JSON (via the feature flag) and call the right parser accordingly. Adding a new strategy with a different output schema required either modifying the orchestrator branch or overloading the existing flag. After this PR, strategies own their parse contract end-to-end — new strategies plug in with zero orchestrator changes.

Also groundwork for a possible future M3 (provider tool-calling): tool-calling becomes another strategy override, not another branch.

## Test plan

- [x] Python: 180 tests pass (173 existing + 6 from #348 + 1 new \`test_crescendo_default_wraps_raw_without_parsing\`). The ~9 tests that called \`RedTeamAgent._parse_attacker_output(raw)\` were migrated to \`GoatStrategy().parse_attacker_output(raw)\` returning an \`AttackerOutput\`. The \`test_strategy_flags\` test was replaced with \`test_parse_behavior_differs_by_strategy\` that asserts the behaviour directly rather than the flag.
- [x] TypeScript: 343 tests pass. Same treatment — the \`parseAttackerOutput\` free-function tests migrated to \`new GoatStrategy().parseAttackerOutput\`. Added one test for the Crescendo default wrap. Replaced the \`emitsStructuredOutput flag\` test with a behavioural one.
- [ ] Manual: run a 10-turn GOAT attack and confirm \`observation\` / \`strategy\` / \`chosen_technique_ids\` still flow to spans correctly (requires API keys).

## Related

- Part of roadmap M1 (scoped down — I didn't pull in the \`get_attack_plan\` half, which is a one-line branch not worth an interface addition)
- Stacks on #346; #347 and #348 already merged
- Part of EPIC: langwatch/langwatch#1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)