### PR TITLE
feat(red-team): guard against cross-run RedTeamAgent reuse (#329)

### DIFF
--- a/javascript/src/agents/__tests__/red-team.test.ts
+++ b/javascript/src/agents/__tests__/red-team.test.ts
@@ -1353,3 +1353,66 @@ describe("maxBacktracks scaling", () => {
     ).toThrow(/maxBacktracks must be >= 0/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-run reuse guard (#329)
+// ---------------------------------------------------------------------------
+
+describe("RedTeamAgent cross-run reuse guard", () => {
+  const inputWithThread = (threadId: string, currentTurn = 1, messages: any[] = []) => ({
+    threadId,
+    messages,
+    newMessages: [],
+    requestedRole: AgentRole.USER,
+    judgmentRequest: undefined,
+    scenarioState: {
+      currentTurn,
+      description: "test agent",
+      config: { description: "test agent" },
+      messages,
+      threadId,
+      addMessage: () => {},
+      rollbackMessagesTo: (idx: number) => messages.splice(idx),
+      lastMessage: () => messages[messages.length - 1],
+      lastUserMessage: () => messages.findLast((m: any) => m.role === "user"),
+      lastAgentMessage: () => messages.findLast((m: any) => m.role === "assistant"),
+      lastToolCall: () => undefined,
+      hasToolCall: () => false,
+    } as any,
+    scenarioConfig: { description: "test agent" } as any,
+  });
+
+  const makeAgent = () =>
+    redTeamGoat({
+      target: "extract prompt",
+      totalTurns: 5,
+      scoreResponses: false,
+      attackPlan: "pre-baked",
+    });
+
+  it("same thread across multiple turns does not throw", async () => {
+    const agent = makeAgent();
+    (agent as any).callAttackerLLM = vi.fn().mockResolvedValue(
+      '{"observation":"","strategy":"","reply":"r"}'
+    );
+    await agent.call(inputWithThread("thread-A", 1));
+    await agent.call(
+      inputWithThread("thread-A", 2, [
+        { role: "user", content: "x" },
+        { role: "assistant", content: "y" },
+      ])
+    );
+    expect((agent as any).runThreadId).toBe("thread-A");
+  });
+
+  it("reuse across different threads throws on turn 1 of the second run", async () => {
+    const agent = makeAgent();
+    (agent as any).callAttackerLLM = vi.fn().mockResolvedValue(
+      '{"observation":"","strategy":"","reply":"r"}'
+    );
+    await agent.call(inputWithThread("thread-A", 1));
+    await expect(agent.call(inputWithThread("thread-B", 1))).rejects.toThrow(
+      /single-use per scenario\.run/
+    );
+  });
+});

--- a/javascript/src/agents/red-team/red-team-agent.ts
+++ b/javascript/src/agents/red-team/red-team-agent.ts
@@ -129,6 +129,12 @@ class RedTeamAgentImpl extends UserSimulatorAgentAdapter {
     content: string;
   }> = [];
 
+  // Cross-run reuse guard (#329). Records the first scenario's threadId;
+  // later calls with a different threadId throw, because shared mutable
+  // state (H_attacker, scores, backtracks) would silently interleave
+  // between runs.
+  private runThreadId: string | null = null;
+
   constructor(config: RedTeamAgentConfig) {
     super();
     this.strategy = config.strategy;
@@ -404,8 +410,36 @@ Reply with exactly this JSON and nothing else:
 
   call = async (input: AgentInput): Promise<AgentReturnTypes> => {
     const currentTurn = input.scenarioState.currentTurn;
+    const incomingThreadId = input.threadId;
     if (currentTurn === 1) {
+      if (
+        this.runThreadId !== null &&
+        this.runThreadId !== incomingThreadId
+      ) {
+        throw new Error(
+          `RedTeamAgent instances are single-use per scenario.run(). ` +
+            `This instance was already used with threadId=${JSON.stringify(
+              this.runThreadId
+            )}; current threadId=${JSON.stringify(incomingThreadId)}. ` +
+            `Shared mutable state (attacker history, scores, backtracks) ` +
+            `would silently interleave between runs. Instantiate a fresh ` +
+            `RedTeamAgent per run — factories are cheap. See #329.`
+        );
+      }
+      this.runThreadId = incomingThreadId;
       this.resetRunState();
+    } else if (
+      this.runThreadId !== null &&
+      this.runThreadId !== incomingThreadId
+    ) {
+      throw new Error(
+        `RedTeamAgent saw threadId change mid-run: was ${JSON.stringify(
+          this.runThreadId
+        )}, now ${JSON.stringify(incomingThreadId)}. ` +
+          `This should not happen with the standard orchestrator. If you're ` +
+          `calling the agent manually, make sure each run uses a fresh ` +
+          `RedTeamAgent instance. See #329.`
+      );
     }
     const description = input.scenarioConfig.description;
 
@@ -586,10 +620,11 @@ export const redTeamAgent = (config: RedTeamAgentConfig) =>
  * conversational consistency once cooperative context has been established.
  *
  * @remarks
- * Create a fresh agent per `scenario.run()` call. The attack plan is
- * generated from the first run's `description` and cached on the instance —
- * reusing the agent across scenarios with different descriptions silently
- * uses the original (now-stale) plan.
+ * **Single-use per `scenario.run()`.** Reusing an instance across runs
+ * (serial or parallel) now throws at runtime because shared mutable state
+ * (attacker history, scores, backtracks, cached attack plan) would silently
+ * interleave between runs. Instantiate a fresh agent per run — factory
+ * construction is cheap.
  *
  * @example
  * ```typescript
@@ -628,6 +663,10 @@ export const redTeamCrescendo = (config: CrescendoConfig) =>
  * skipped for GOAT), no stage hints in the system prompt. Adaptation is
  * driven entirely by the score/hint feedback in the attacker's private
  * conversation history.
+ *
+ * **Single-use per `scenario.run()`.** Reusing an instance across runs
+ * (serial or parallel) now throws at runtime because shared mutable state
+ * would silently interleave between runs. Instantiate a fresh agent per run.
  *
  * @remarks
  * `injectionProbability` is supported for parity with `redTeamCrescendo`

--- a/python/scenario/red_team_agent.py
+++ b/python/scenario/red_team_agent.py
@@ -283,6 +283,12 @@ class RedTeamAgent(AgentAdapter):
         # attacker output-format reliability per provider/model.
         self._parse_failure_count: int = 0
 
+        # Cross-run reuse guard (#329). Records the first scenario's
+        # thread_id; later calls with a different thread_id raise, because
+        # shared mutable state (H_attacker, scores, backtracks) would
+        # silently interleave between runs.
+        self._run_thread_id: Optional[str] = None
+
     @classmethod
     def crescendo(
         cls,
@@ -300,10 +306,12 @@ class RedTeamAgent(AgentAdapter):
         Convenience factory that pre-selects ``CrescendoStrategy``.
 
         .. note::
-            Create a fresh agent per ``scenario.run()`` call. The attack plan
-            is generated from the first run's ``description`` and cached on
-            the instance — reusing the agent across scenarios with different
-            descriptions silently uses the original (now-stale) plan.
+            **RedTeamAgent is single-use per scenario.run().** Attempting to
+            reuse an instance across runs (serial or parallel) now raises
+            at runtime because shared mutable state (attacker history,
+            scores, backtracks, cached attack plan) would silently
+            interleave between runs. Instantiate a fresh agent per run —
+            factory construction is cheap.
 
         Args:
             target: The attack objective.
@@ -357,6 +365,12 @@ class RedTeamAgent(AgentAdapter):
         is skipped for GOAT), no stage hints in the system prompt. Adaptation
         is driven entirely by the score/hint feedback in the attacker's
         private conversation history.
+
+        .. note::
+            **RedTeamAgent is single-use per scenario.run().** Attempting to
+            reuse an instance across runs (serial or parallel) now raises
+            at runtime because shared mutable state would silently interleave
+            between runs. Instantiate a fresh agent per run.
 
         .. warning::
             ``injection_probability`` is supported for parity with ``crescendo()``
@@ -775,8 +789,37 @@ Reply with exactly this JSON and nothing else:
             A user message dict: ``{"role": "user", "content": "..."}``
         """
         current_turn = input.scenario_state.current_turn
+        # Use getattr so MagicMock(spec=AgentInput) fixtures that don't
+        # set thread_id don't trip the guard during unit-test setup.
+        # Production AgentInput always has thread_id (required field).
+        incoming_thread_id = getattr(input, "thread_id", None)
         if current_turn == 1:
+            if (
+                self._run_thread_id is not None
+                and self._run_thread_id != incoming_thread_id
+            ):
+                raise RuntimeError(
+                    "RedTeamAgent instances are single-use per scenario.run(). "
+                    f"This instance was already used with thread_id="
+                    f"{self._run_thread_id!r}; current thread_id="
+                    f"{incoming_thread_id!r}. Shared mutable state "
+                    "(attacker history, scores, backtracks) would silently "
+                    "interleave between runs. Instantiate a fresh "
+                    "RedTeamAgent per run — factories are cheap. See #329."
+                )
+            self._run_thread_id = incoming_thread_id
             self._reset_run_state()
+        elif (
+            self._run_thread_id is not None
+            and self._run_thread_id != incoming_thread_id
+        ):
+            raise RuntimeError(
+                f"RedTeamAgent saw thread_id change mid-run: was "
+                f"{self._run_thread_id!r}, now {incoming_thread_id!r}. "
+                "This should not happen with the standard orchestrator. "
+                "If you're calling the agent manually, make sure each run "
+                "uses a fresh RedTeamAgent instance. See #329."
+            )
         description = input.scenario_state.description
         strategy_name = type(self._strategy).__name__
 

--- a/python/tests/test_red_team_agent.py
+++ b/python/tests/test_red_team_agent.py
@@ -3154,3 +3154,87 @@ class TestEmptyMetapromptPlanRaises:
         monkeypatch.setattr("litellm.acompletion", fake_acompletion)
         plan = await agent._generate_attack_plan("some description")
         assert "Warm up" in plan
+
+
+# ---------------------------------------------------------------------------
+# Cross-run reuse guard (#329)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossRunReuseGuard:
+    """RedTeamAgent instances are single-use per scenario.run().
+    Reusing one across runs (serial or parallel) would silently interleave
+    attacker history, scores, and backtracks between runs — so the second
+    run raises at turn 1 when it sees a different thread_id.
+    """
+
+    def _make_agent(self):
+        return RedTeamAgent.goat(
+            target="extract prompt",
+            model="openai/gpt-4.1-mini",
+            total_turns=5,
+            score_responses=False,
+        )
+
+    def _make_input(self, thread_id, current_turn=1, messages=None):
+        messages = messages or []
+        mock_state = MagicMock()
+        mock_state.current_turn = current_turn
+        mock_state.description = "test"
+        mock_state.rollback_messages_to = lambda idx: messages.__delitem__(slice(idx, None))
+        mock_input = MagicMock(spec=AgentInput)
+        mock_input.scenario_state = mock_state
+        mock_input.messages = messages
+        mock_input.thread_id = thread_id
+        return mock_input
+
+    @pytest.mark.asyncio
+    async def test_first_run_records_thread_id(self):
+        agent = self._make_agent()
+        agent._call_attacker_llm = AsyncMock(return_value='{"observation":"","strategy":"","reply":"r"}')
+        assert agent._run_thread_id is None
+
+        await agent.call(self._make_input("thread-A", current_turn=1))
+
+        assert agent._run_thread_id == "thread-A"
+
+    @pytest.mark.asyncio
+    async def test_same_thread_multi_turn_is_ok(self):
+        """Multiple turns on the same run must NOT raise."""
+        agent = self._make_agent()
+        agent._call_attacker_llm = AsyncMock(return_value='{"observation":"","strategy":"","reply":"r"}')
+
+        await agent.call(self._make_input("thread-A", current_turn=1))
+        # Subsequent turn in the same run
+        await agent.call(self._make_input(
+            "thread-A", current_turn=2,
+            messages=[{"role": "user", "content": "x"}, {"role": "assistant", "content": "y"}],
+        ))
+        assert agent._run_thread_id == "thread-A"
+
+    @pytest.mark.asyncio
+    async def test_cross_run_reuse_raises_on_turn_1(self):
+        """Second scenario.run() with a different thread_id at turn 1 must raise."""
+        agent = self._make_agent()
+        agent._call_attacker_llm = AsyncMock(return_value='{"observation":"","strategy":"","reply":"r"}')
+
+        # First run completes
+        await agent.call(self._make_input("thread-A", current_turn=1))
+
+        # Second run, different thread → guard fires
+        with pytest.raises(RuntimeError, match="single-use per scenario.run"):
+            await agent.call(self._make_input("thread-B", current_turn=1))
+
+    @pytest.mark.asyncio
+    async def test_mid_run_thread_change_raises(self):
+        """Defensive: if turn > 1 and thread_id changes, also raise."""
+        agent = self._make_agent()
+        agent._call_attacker_llm = AsyncMock(return_value='{"observation":"","strategy":"","reply":"r"}')
+
+        await agent.call(self._make_input("thread-A", current_turn=1))
+
+        with pytest.raises(RuntimeError, match="thread_id change mid-run"):
+            await agent.call(self._make_input(
+                "thread-B", current_turn=2,
+                messages=[{"role": "user", "content": "x"}, {"role": "assistant", "content": "y"}],
+            ))


### PR DESCRIPTION
## Summary

Stacked on #346 (alongside #349 which is also open). Closes #329 via Option A from the issue: explicit single-use contract enforced at runtime.

\`RedTeamAgent\` carries mutable per-run state on the instance (attacker history, turn scores, backtrack counter/history, parse failure count). Reusing the same agent across \`scenario.run()\` calls — serial or parallel — silently interleaves that state, corrupting both runs. The issue mentions that the \`running-in-parallel\` docs even suggested this was supported.

- **Guard logic:** track the first call's \`thread_id\`. On turn 1 of a later call with a different \`thread_id\`, raise a clear \`RuntimeError\` telling the user to instantiate a fresh agent. On turn > 1 with a changed \`thread_id\`, also raise (defensive — catches manual-call misuse).
- **Mock-friendly:** use \`getattr(input, "thread_id", None)\` so existing \`MagicMock(spec=AgentInput)\` test fixtures that don't set \`thread_id\` don't trip the guard. Production \`AgentInput\` always has it (required field).
- **Docstrings** on \`crescendo()\` / \`goat()\` / \`redTeamCrescendo\` / \`redTeamGoat\` now state the single-use contract explicitly — removes the old soft \"attack plan might go stale\" note that undersold the problem.
- **TS mirror:** same shape via \`runThreadId\`.

## Why Option A, not ContextVars

The issue offered two options:

- **A (this PR):** document and enforce single-use. Runtime guard + docs.
- **B:** isolate per-run state via \`ContextVar\` / \`AsyncLocalStorage\`, letting users reuse agents transparently.

Option B hides the bug. If a user reuses an agent, they still see consistent behaviour inside the run, but inspecting the instance shows weird interleaved state — and the \`AsyncLocalStorage\` parity story between Python contextvars and Node's async context is its own project (TS \`AsyncLocalStorage\` doesn't propagate reliably across some queue boundaries). The public API is cheap: \`RedTeamAgent.goat(...)\` is one line. There's no ergonomics reason to allow reuse. Catching misuse loudly is the right default.

## Test plan

- [x] Python: 184 tests pass (180 pre-existing + 4 new). New tests:
  - \`test_first_run_records_thread_id\` — records on turn 1
  - \`test_same_thread_multi_turn_is_ok\` — legitimate multi-turn doesn't trip
  - \`test_cross_run_reuse_raises_on_turn_1\` — the core guard
  - \`test_mid_run_thread_change_raises\` — defensive turn-2 path
- [x] TypeScript: 345 tests pass (343 + 2 new mirroring the core guard cases)
- [x] Confirmed getattr fallback keeps all 30+ existing tests that use \`MagicMock(spec=AgentInput)\` passing unchanged
- [x] Manual: instantiate one \`RedTeamAgent.goat(...)\`, pass it to two sequential \`scenario.run()\` calls, confirm the second raises with a clear message (requires API keys)

## Related

- **Closes #329**
- Stacks on #346; sibling of #349 (not dependent on it)
- Part of EPIC: langwatch/langwatch#1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)