### PR TITLE
fix(red-team): three edge-case hardening fixes (#337, #333a, #333b)

### DIFF
--- a/python/scenario/red_team_agent.py
+++ b/python/scenario/red_team_agent.py
@@ -262,6 +262,15 @@ class RedTeamAgent(AgentAdapter):
                 f"injection_probability must be between 0.0 and 1.0, got {injection_probability}"
             )
         self._injection_probability = injection_probability
+        # Explicit empty list is a contradiction when injection is on — fail loud
+        # rather than silently skipping injection (issue #333).
+        if injection_probability > 0 and techniques is not None and len(techniques) == 0:
+            raise ValueError(
+                "techniques cannot be empty when injection_probability > 0 — "
+                "either disable injection (injection_probability=0.0) or provide "
+                "at least one AttackTechnique. Omit the techniques arg to use "
+                "DEFAULT_TECHNIQUES."
+            )
         self._techniques = techniques if techniques is not None else DEFAULT_TECHNIQUES
 
         # Attacker's private conversation history (H_attacker).
@@ -534,9 +543,15 @@ class RedTeamAgent(AgentAdapter):
 
                 if hasattr(response, "choices") and len(response.choices) > 0:
                     plan = cast(Choices, response.choices[0]).message.content
-                    if plan is None:
-                        raise Exception(
-                            f"Metaprompt model returned no content: {response.__repr__()}"
+                    # Treat None, empty, and whitespace-only alike — a strategy
+                    # that uses a plan (needs_metaprompt_plan=True) requires real
+                    # content; proceeding with an empty plan silently degrades
+                    # attack quality without signalling the failure (issue #333b).
+                    if plan is None or not plan.strip():
+                        raise RuntimeError(
+                            f"Metaprompt model returned empty/whitespace plan "
+                            f"(content={plan!r}). Check the metaprompt model's "
+                            f"output — the attacker needs a non-empty plan."
                         )
                     self._attack_plan = plan
                     logger.debug(

--- a/python/tests/test_red_team_agent.py
+++ b/python/tests/test_red_team_agent.py
@@ -3016,3 +3016,141 @@ class TestTechniquesAsData:
     def test_crescendo_chosen_ids_empty_by_default(self):
         """Strategies without a catalogue return [] — no telemetry noise."""
         assert CrescendoStrategy().chosen_technique_ids("any text") == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #337 — regression test for the KeyError helper in _generate_attack_plan
+# ---------------------------------------------------------------------------
+
+
+class TestMetapromptTemplateKeyErrorHelper:
+    """Asserts the helpful ValueError fires when a metaprompt template
+    references a placeholder that the strategy doesn't provide.
+
+    This guards the friendly-error-message code added during GOAT PR review —
+    a future refactor that drops the try/except would silently lose the
+    helpful hint, surfacing only a raw KeyError to users.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unknown_placeholder_raises_helpful_value_error(self):
+        bad_template = "Target: {target}\nDescription: {description}\nTotal: {total_turns}\nUnknown: {nonexistent_var}"
+        agent = RedTeamAgent.crescendo(
+            target="x",
+            model="openai/gpt-4",
+            metaprompt_template=bad_template,
+        )
+        with pytest.raises(ValueError) as exc_info:
+            await agent._generate_attack_plan("any description")
+        msg = str(exc_info.value)
+        assert "nonexistent_var" in msg
+        assert "Available variables" in msg
+        # The message should mention the Crescendo/GOAT template mismatch
+        # pathway so users can recognize the common cause.
+        assert "Crescendo" in msg or "GOAT" in msg
+
+
+# ---------------------------------------------------------------------------
+# Issue #333a — validate empty techniques list when injection is enabled
+# ---------------------------------------------------------------------------
+
+
+class TestTechniquesListValidation:
+    """An empty techniques list plus injection_probability > 0 is a
+    contradiction. Before this fix the code silently skipped injection on
+    every turn (falsy empty list short-circuited the `and self._techniques`
+    check in call()), so users got no encoding and no warning.
+    """
+
+    def test_empty_techniques_with_injection_raises(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            RedTeamAgent.crescendo(
+                target="x",
+                model="openai/gpt-4",
+                injection_probability=0.5,
+                techniques=[],
+            )
+
+    def test_empty_techniques_without_injection_ok(self):
+        # injection_probability=0 means techniques list doesn't matter —
+        # empty is fine, no contradiction.
+        agent = RedTeamAgent.crescendo(
+            target="x",
+            model="openai/gpt-4",
+            injection_probability=0.0,
+            techniques=[],
+        )
+        assert agent._injection_probability == 0.0
+
+    def test_none_techniques_with_injection_uses_defaults(self):
+        # Omitting techniques entirely should fall back to DEFAULT_TECHNIQUES.
+        from scenario._red_team.techniques import DEFAULT_TECHNIQUES
+        agent = RedTeamAgent.crescendo(
+            target="x",
+            model="openai/gpt-4",
+            injection_probability=0.5,
+            techniques=None,
+        )
+        assert agent._techniques is DEFAULT_TECHNIQUES
+
+
+# ---------------------------------------------------------------------------
+# Issue #333b — empty metaprompt plan must fail loud, not silently degrade
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyMetapromptPlanRaises:
+    """A strategy that uses a plan (Crescendo, `needs_metaprompt_plan=True`)
+    requires real content. If the metaprompt LLM returns empty/whitespace,
+    proceeding silently would render a labeled-but-empty "ATTACK PLAN:" block
+    that the attacker reads as "your plan is nothing," degrading attack
+    quality without any signal. `_generate_attack_plan` should raise instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_string_plan_raises(self, monkeypatch):
+        agent = RedTeamAgent.crescendo(target="x", model="openai/gpt-4")
+
+        async def fake_acompletion(*args, **kwargs):
+            class M: content = ""
+            class C: message = M()
+            class R:
+                choices = [C()]
+                def __repr__(self): return "<fake empty response>"
+            return R()
+
+        monkeypatch.setattr("litellm.acompletion", fake_acompletion)
+        with pytest.raises(RuntimeError, match="empty/whitespace plan"):
+            await agent._generate_attack_plan("some description")
+
+    @pytest.mark.asyncio
+    async def test_whitespace_plan_raises(self, monkeypatch):
+        agent = RedTeamAgent.crescendo(target="x", model="openai/gpt-4")
+
+        async def fake_acompletion(*args, **kwargs):
+            class M: content = "   \n\t  \n\n   "
+            class C: message = M()
+            class R:
+                choices = [C()]
+                def __repr__(self): return "<fake ws response>"
+            return R()
+
+        monkeypatch.setattr("litellm.acompletion", fake_acompletion)
+        with pytest.raises(RuntimeError, match="empty/whitespace plan"):
+            await agent._generate_attack_plan("some description")
+
+    @pytest.mark.asyncio
+    async def test_real_plan_passes_through(self, monkeypatch):
+        agent = RedTeamAgent.crescendo(target="x", model="openai/gpt-4")
+
+        async def fake_acompletion(*args, **kwargs):
+            class M: content = "1. Warm up\n2. Probe\n3. Escalate"
+            class C: message = M()
+            class R:
+                choices = [C()]
+                def __repr__(self): return "<fake ok response>"
+            return R()
+
+        monkeypatch.setattr("litellm.acompletion", fake_acompletion)
+        plan = await agent._generate_attack_plan("some description")
+        assert "Warm up" in plan


### PR DESCRIPTION
Small correctness hardening on three red-team edge cases. All three turn "fails silent" bugs into "fails loud" signals. Each has its own test class; one PR because they're tiny and thematically identical.

## What changed

### #337 — Regression test for the KeyError helper

\`_generate_attack_plan\` already wraps \`template.format()\` in a try/except that turns a raw \`KeyError\` into a friendly \`ValueError\` pointing at the common cause (Crescendo ↔ GOAT template mismatch). No test existed — a future refactor could silently lose the hint.

New test: construct an agent with a bogus placeholder, assert the ValueError fires and the message mentions the unknown key, the available keys, and the Crescendo/GOAT hint.

### #333a — Validate empty \`techniques\` list

Before: \`RedTeamAgent.crescendo(injection_probability=0.5, techniques=[])\` silently skipped injection every turn — the falsy empty list short-circuited \`and self._techniques\` in \`call()\`. Users thought injection was on but got no encoded attacks.

After: raise \`ValueError\` at construction pointing at both fixes (disable injection, or provide at least one technique). \`techniques=None\` still falls back to \`DEFAULT_TECHNIQUES\` — unchanged.

### #333b — Empty plan must fail loud, not silently degrade

Strategies that use a plan (Crescendo, \`needs_metaprompt_plan=True\`) **require** a non-empty plan by design. Before this fix, \`_generate_attack_plan\` only rejected None content — an empty or whitespace-only response from the metaprompt LLM would be silently stored and then rendered as a labeled-but-blank "ATTACK PLAN:" section. The attacker LLM reads that as "your plan is nothing" and drops to generic attacks. The user gets no signal the metaprompt call silently failed.

**Design note**: an earlier version of this PR instead quietly omitted the "ATTACK PLAN:" section when empty. That was wrong — it prettified the malformed state instead of preventing it. The correct layer is \`_generate_attack_plan\`: reject the bad content at source.

Fix: treat None, empty string, and all-whitespace alike in \`_generate_attack_plan\`; raise \`RuntimeError\` with a message pointing at the upstream metaprompt LLM.

## Scope note

Part c of issue #333 (scorer-failure WARN threshold) is NOT in this PR — it needs a counter + log-level bump and is tracked for a follow-up.

## Test plan

- [x] 7 new tests: KeyError-helper × 1, techniques-validation × 3, empty-plan-raises × 3
- [x] All 187 existing red-team tests still pass
- [x] No behavioral change for users not hitting these edge cases

## Closes / addresses

- Closes langwatch/scenario#337
- Addresses parts a + b of langwatch/scenario#333
- Part of EPIC: langwatch/langwatch#1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)