### PR TITLE
fix(judge): prevent grep_trace/expand_trace leaking past discovery loop

### DIFF
--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -564,5 +564,124 @@ describe("JudgeAgent", () => {
       expect(result!.metCriteria).toContain("Agent responds politely");
       expect(result!.unmetCriteria).toContain("Agent uses tools");
     });
+
+    it("strips toolset to finish_test only on the forced-verdict call", async () => {
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent works correctly"],
+        spanCollector: collector,
+        maxDiscoverySteps: 2,
+      };
+
+      const agent = judgeAgent(config);
+
+      let callCount = 0;
+      let forcedCallTools: string[] | undefined;
+      agent.invokeLLM = async (params) => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            text: "",
+            content: [],
+            toolCalls: [
+              {
+                toolName: "expand_trace",
+                input: { span_ids: ["0000000000000000"] },
+                type: "tool-call" as const,
+                toolCallId: "tc-1",
+              },
+            ],
+            toolResults: [],
+          } as unknown as InvokeLLMResult;
+        }
+        forcedCallTools = Object.keys(params.tools ?? {});
+        return mockLLMResult("finish_test", {
+          criteria: { agent_works_correctly: "true" },
+          reasoning: "ok",
+          verdict: "success",
+        });
+      };
+
+      await agent.call(createBaseInput());
+
+      expect(callCount).toBe(2);
+      expect(forcedCallTools).toEqual(["finish_test"]);
+      expect(forcedCallTools).not.toContain("expand_trace");
+      expect(forcedCallTools).not.toContain("grep_trace");
+      expect(forcedCallTools).not.toContain("continue_test");
+    });
+
+    it("returns inconclusive verdict when forced call still leaks expand_trace", async () => {
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent works correctly"],
+        spanCollector: collector,
+        maxDiscoverySteps: 2,
+      };
+
+      const agent = judgeAgent(config);
+
+      let callCount = 0;
+      agent.invokeLLM = async () => {
+        callCount++;
+        return {
+          text: "",
+          content: [],
+          toolCalls: [
+            {
+              toolName: "expand_trace",
+              input: { span_ids: ["0000000000000000"] },
+              type: "tool-call" as const,
+              toolCallId: `tc-${callCount}`,
+            },
+          ],
+          toolResults: [],
+        } as unknown as InvokeLLMResult;
+      };
+
+      const result = await agent.call(createBaseInput());
+
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+      expect(result!.reasoning).not.toContain("Unknown tool call");
+      expect(result!.reasoning).toContain("trace discovery");
+      expect(result!.metCriteria).toEqual([]);
+      expect(result!.unmetCriteria).toContain("Agent works correctly");
+    });
+
+    it("returns inconclusive verdict when forced call still leaks grep_trace", async () => {
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent works correctly"],
+        spanCollector: collector,
+        maxDiscoverySteps: 2,
+      };
+
+      const agent = judgeAgent(config);
+
+      let callCount = 0;
+      agent.invokeLLM = async () => {
+        callCount++;
+        return {
+          text: "",
+          content: [],
+          toolCalls: [
+            {
+              toolName: "grep_trace",
+              input: { pattern: "anything" },
+              type: "tool-call" as const,
+              toolCallId: `tc-${callCount}`,
+            },
+          ],
+          toolResults: [],
+        } as unknown as InvokeLLMResult;
+      };
+
+      const result = await agent.call(createBaseInput());
+
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+      expect(result!.reasoning).not.toContain("Unknown tool call");
+      expect(result!.reasoning).toContain("trace discovery");
+      expect(result!.metCriteria).toEqual([]);
+      expect(result!.unmetCriteria).toContain("Agent works correctly");
+    });
   });
 });

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -376,10 +376,19 @@ class JudgeAgent extends JudgeAgentAdapter {
       prompt: _p,
       messages: prevMessages,
       toolChoice: _tc,
+      tools: prevTools,
       ...rest
     } = params;
+    // Strip discovery tools so the model physically cannot return grep_trace/
+    // expand_trace again — some providers don't strictly honor tool_choice.
+    const finishOnlyTools: ToolSet | undefined = prevTools
+      ? Object.fromEntries(
+          Object.entries(prevTools).filter(([name]) => name === "finish_test")
+        )
+      : undefined;
     return this.invokeLLM({
       ...rest,
+      tools: finishOnlyTools,
       messages: [
         ...(prevMessages ?? []),
         {
@@ -436,6 +445,21 @@ class JudgeAgent extends JudgeAgentAdapter {
           return null;
 
         default:
+          if (
+            toolCall.toolName === "expand_trace" ||
+            toolCall.toolName === "grep_trace"
+          ) {
+            this.logger.warn(
+              `Discovery tool ${toolCall.toolName} leaked past discovery loop without reaching a terminal verdict`
+            );
+            return {
+              success: false,
+              reasoning:
+                "JudgeAgent: trace discovery did not converge on a verdict within the step budget",
+              metCriteria: [],
+              unmetCriteria: criteria,
+            };
+          }
           return {
             success: false,
             reasoning: `JudgeAgent: Unknown tool call: ${toolCall.toolName}`,


### PR DESCRIPTION
## Summary
- When the judge's progressive-discovery loop exhausts its step budget, `forceVerdict()` re-invoked the LLM with `tool_choice: finish_test`, but some providers (e.g. Grok, some OpenAI-compatible endpoints) don't strictly honor `tool_choice`. The model could still return `grep_trace`/`expand_trace`, which then landed in `parseToolCalls`' default branch and surfaced as `JudgeAgent: Unknown tool call: grep_trace`, hard-failing the judge on the platform.
- `forceVerdict()` now strips the toolset down to `finish_test` only, so the model physically cannot emit a discovery tool.
- `parseToolCalls`' default branch now recognizes leaked `expand_trace`/`grep_trace` and returns an inconclusive verdict with a clearer reason, as a safety net.

## Acceptance Criteria
- When `forceVerdict()` is invoked, the `tools` passed to the LLM contains **only** `finish_test` — no `expand_trace`, `grep_trace`, or `continue_test`.
- If a provider still emits `expand_trace` or `grep_trace` on the forced call, `parseToolCalls` returns a structured inconclusive verdict (`success: false`, all criteria unmet, reasoning mentions trace discovery did not converge) and logs a warning — **not** a `JudgeAgent: Unknown tool call: …` failure.
- Truly unknown tool names (anything other than `finish_test`/`continue_test`/`expand_trace`/`grep_trace`) still fall through to the original `Unknown tool call` fallback — unchanged.
- The normal (non-exhausted) discovery path and the small-trace path are unchanged: same tools, same messages, same verdict semantics.

## Nothing lost — explicit check
- `continue_test` is filtered out of the forced-verdict toolset. This is intentional and aligned with the force-verdict prompt ("give your final verdict now"); `continue_test` at that point would contradict intent and reopen a scenario that already spent its discovery budget.
- Diagnostic signal for truly misbehaving providers is preserved via `logger.warn` on the safety-net branch, just not surfaced as a user-facing hard-failure string.
- Messages, model, system prompt, and scenario context passed to `forceVerdict` are unchanged — only `tools` and `toolChoice` are touched.

## Tests
- `javascript/src/agents/judge/__tests__/judge-agent.test.ts`:
  - `strips toolset to finish_test only on the forced-verdict call` — asserts the forced call's tools equal `["finish_test"]`.
  - `returns inconclusive verdict when forced call still leaks expand_trace` — asserts the safety-net path for `expand_trace`.
  - `returns inconclusive verdict when forced call still leaks grep_trace` — asserts the safety-net path for `grep_trace`.
- All 18 judge-agent tests pass locally.

## Manual test plan
- [ ] Run a scenario against a trace large enough to exceed `tokenThreshold` (default 8192) so the discovery loop engages.
- [ ] Confirm that when the discovery step limit is hit, the judge returns a real verdict instead of `JudgeAgent: Unknown tool call: grep_trace`.
- [ ] Existing judge tests in `javascript/src/agents/judge/__tests__/` still pass.
- [ ] Once merged and released (bump + rebuild), swap the new tarball into `langwatch/vendor/` and re-run an affected platform scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)