### PR TITLE
feat(python): add async-native scenario.arun for loop-bound resources

### DIFF
--- a/docs/docs/pages/advanced/async-native-parallelism.mdx
+++ b/docs/docs/pages/advanced/async-native-parallelism.mdx
@@ -1,40 +1,35 @@
 ---
-title: Async-Native Parallelism - Shared Connections Across Concurrent Scenarios
-description: Use `scenario.arun` to run scenarios on the caller's event loop so loop-bound resources like Google ADK InMemoryRunner, gRPC channels, and Firestore clients stay usable across concurrent scenario runs. Covers migration, pytest-asyncio-concurrent, and when to prefer it over the default `scenario.run` threading path.
+title: Async-Native Parallelism - Run Scenarios On The Caller's Event Loop
+description: Use `scenario.arun` when your codebase is async-first and holds async state across calls. The default `scenario.run` already parallelizes scenarios via a thread pool — including sync adapters — so reach for `arun` only when you genuinely need everything on a single event loop.
 ---
 
 import { Callout } from "vocs/components";
 
-# Async-Native Parallelism [Shared connections across concurrent scenarios]
+# Async-Native Parallelism [When to prefer `scenario.arun` over the threaded default]
 
-`scenario.run(...)` wraps each invocation in a dedicated worker thread that spins up its own `asyncio` event loop. That isolation is ideal for sync adapters that might block, but it breaks any resource that remembers the event loop it was created on.
+By default, `scenario.run(...)` executes each invocation in a dedicated worker thread with its own `asyncio` event loop. That means **even synchronous adapters parallelize effortlessly** — no event loop plumbing on your side, and scenarios finish faster because they don't wait for each other. See [Test Runner Integration](/basics/test-runner-integration) for the standard parallel pytest setup.
 
-If your agent under test holds a **loop-bound resource** — a gRPC channel, a Firestore client, an ADK `InMemoryRunner`, or anything built via an async pytest fixture — you'll hit:
+Reach for `scenario.arun(...)` only when the threaded model gets in your way — specifically, when your code is async-first and your adapter awaits on async state that can't move between event loops. In that case the worker thread's fresh loop raises:
 
 ```
 RuntimeError: Task <...> got Future <...> attached to a different loop
 ```
 
-`scenario.arun(...)` is the async-native sibling. It executes the scenario directly on the caller's event loop, so every singleton stays usable across concurrent runs.
+`scenario.arun` executes the scenario on the caller's event loop, so that state stays usable across concurrent runs.
 
 ---
 
-## When to reach for `arun`
+## Which one should I use?
 
-Use `arun` whenever any of these apply:
-
-- Your agent holds a **Google ADK** `InMemoryRunner` (or any runner backed by a gRPC session service).
-- Your fixture instantiates a **gRPC channel** or **Firestore client** once, to avoid re-opening expensive connections for every scenario.
-- You want to run many scenarios concurrently on the **pytest-asyncio** loop via `@pytest.mark.asyncio_concurrent(group=...)`.
-
-Stick with `scenario.run` when your adapter is self-contained, has no shared async state, and may do sync blocking work you want offloaded to a worker thread.
+- **`scenario.run`** (default) — you have sync code, or async code without shared async state, and want parallelism for free. This is the right choice for most users.
+- **`scenario.arun`** — your stack is fully async-first and your adapter relies on async objects that must stay on one event loop. You're comfortable orchestrating concurrency yourself via `asyncio.gather` or `pytest-asyncio-concurrent`.
 
 <Callout type="info">
-Both `run` and `arun` live on the public module:
+Both live on the public module:
 
 ```python
-await scenario.run(...)    # threaded (default since v0.x)
-await scenario.arun(...)   # async-native (new)
+await scenario.run(...)    # threaded (default)
+await scenario.arun(...)   # async-native
 ```
 
 The signature and return value are identical. Only the execution model differs.
@@ -64,9 +59,9 @@ result = await scenario.arun(
 
 ---
 
-## Running scenarios concurrently
+## Running scenarios concurrently under `arun`
 
-Parallelism is the caller's job under `arun`. Two common patterns:
+Parallelism is the caller's responsibility under `arun`. Two common patterns:
 
 ### `asyncio.gather` for ad-hoc concurrency
 
@@ -78,7 +73,7 @@ results = await asyncio.gather(
 )
 ```
 
-All three scenarios run on the same event loop and share any singletons you built in a fixture.
+All three scenarios run on the same event loop and share any singletons you built alongside them.
 
 ### `pytest-asyncio-concurrent` for pytest-level fan-out
 
@@ -91,8 +86,7 @@ async def test_dinner_idea():
     result = await scenario.arun(
         name="dinner idea",
         description="User is looking for a dinner idea",
-        agents=[VegetarianRecipeAgent(), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[
-            "Recipe is vegetarian",
+        agents=[RecipeAgent(), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[
             "Recipe includes ingredients and steps",
         ])],
     )
@@ -104,77 +98,12 @@ async def test_hungry_user():
     result = await scenario.arun(
         name="hungry user",
         description="User is very hungry",
-        agents=[VegetarianRecipeAgent(), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
+        agents=[RecipeAgent(), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
     )
     assert result.success
 ```
 
-Sibling tests in the same `group` run concurrently on one event loop — perfect for amortising a shared gRPC channel or `InMemoryRunner`.
-
----
-
-## Google ADK example
-
-The canonical case: one `InMemoryRunner` constructed once, reused by many scenarios.
-
-```python
-import asyncio
-import pytest
-import scenario
-from google.adk.agents import Agent
-from google.adk.runners import InMemoryRunner
-from google.genai import types
-
-
-@pytest.fixture(scope="module")
-def runner():
-    agent = Agent(
-        name="weather_agent",
-        model="gemini-2.5-flash",
-        instruction="Call get_weather and answer briefly.",
-        tools=[get_weather],
-    )
-    return InMemoryRunner(agent=agent, app_name="weather-app")
-
-
-class WeatherAgent(scenario.AgentAdapter):
-    def __init__(self, runner, session_prefix: str):
-        self._runner = runner
-        self._session_prefix = session_prefix
-        self._i = 0
-
-    async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
-        session_id = f"{self._session_prefix}-{self._i}"
-        self._i += 1
-        await self._runner.session_service.create_session(
-            app_name="weather-app",
-            user_id="user",
-            session_id=session_id,
-        )
-        reply = ""
-        async for event in self._runner.run_async(
-            user_id="user",
-            session_id=session_id,
-            new_message=types.Content(role="user", parts=[types.Part(text=input.messages[-1]["content"])]),
-        ):
-            if event.is_final_response():
-                reply = event.content.parts[0].text
-        return {"role": "assistant", "content": reply}
-
-
-async def test_cities_in_parallel(runner):
-    cities = ["Amsterdam", "Berlin", "Cairo", "Delhi"]
-    results = await asyncio.gather(
-        *(scenario.arun(
-            name=f"weather-{c}",
-            description=f"user asks about {c}",
-            agents=[WeatherAgent(runner, session_prefix=f"run-{i}"), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=["agent answers with weather info"])],
-        ) for i, c in enumerate(cities)),
-    )
-    assert all(r.success for r in results)
-```
-
-The same pattern fails under `scenario.run(...)` because each thread creates a fresh loop and the runner's gRPC session service raises on first use.
+Sibling tests in the same `group` run concurrently on a single event loop.
 
 ---
 
@@ -183,18 +112,18 @@ The same pattern fails under `scenario.run(...)` because each thread creates a f
 | Aspect | `scenario.run` | `scenario.arun` |
 |---|---|---|
 | Event loop | New loop in a worker thread | Caller's loop |
-| Loop-bound resources | ❌ re-created per run or broken | ✓ survive |
-| Blocking sync code in adapter | ✓ offloaded to worker thread | ⚠ blocks the caller loop |
-| Parallelism model | Thread-pool | `asyncio.gather` / pytest-asyncio-concurrent |
+| Sync blocking work in adapter | ✓ absorbed by the worker thread | ⚠ blocks the caller loop |
+| Async state bound to caller loop | ❌ broken across threads | ✓ preserved |
+| Parallelism model | Thread pool (automatic) | `asyncio.gather` / pytest-asyncio-concurrent (explicit) |
 | Telemetry | Same spans, same cost rollup | Same spans, same cost rollup |
 
-Traces land in LangWatch identically either way — the same `Scenario Turn` root, the same per-agent children, the same cost fold. Only the execution model differs.
+Traces land in LangWatch identically either way. Only the execution model differs.
 
 ---
 
 ## Common pitfalls
 
-**Blocking sync work in an async adapter.** `arun` runs your adapter on the caller's loop. If your adapter does `time.sleep(5)` or a sync database driver call, it blocks every other concurrent scenario on the same loop. Wrap the blocking work in `asyncio.to_thread(...)` yourself, or stick with `scenario.run`.
+**Blocking sync work in an async adapter.** `arun` runs your adapter on the caller's loop. If your adapter does `time.sleep(5)` or a sync driver call, it blocks every other concurrent scenario on the same loop. Wrap the blocking work in `asyncio.to_thread(...)` yourself, or stick with `scenario.run`.
 
 **Accidentally sharing mutable state across scenarios.** Concurrent scenarios on one loop means concurrent access to any module-level state your adapter touches. Either scope the state per-scenario instance or guard it with `asyncio.Lock`.
 

--- a/docs/docs/pages/advanced/async-native-parallelism.mdx
+++ b/docs/docs/pages/advanced/async-native-parallelism.mdx
@@ -1,0 +1,201 @@
+---
+title: Async-Native Parallelism - Shared Connections Across Concurrent Scenarios
+description: Use `scenario.arun` to run scenarios on the caller's event loop so loop-bound resources like Google ADK InMemoryRunner, gRPC channels, and Firestore clients stay usable across concurrent scenario runs. Covers migration, pytest-asyncio-concurrent, and when to prefer it over the default `scenario.run` threading path.
+---
+
+import { Callout } from "vocs/components";
+
+# Async-Native Parallelism [Shared connections across concurrent scenarios]
+
+`scenario.run(...)` wraps each invocation in a dedicated worker thread that spins up its own `asyncio` event loop. That isolation is ideal for sync adapters that might block, but it breaks any resource that remembers the event loop it was created on.
+
+If your agent under test holds a **loop-bound resource** — a gRPC channel, a Firestore client, an ADK `InMemoryRunner`, or anything built via an async pytest fixture — you'll hit:
+
+```
+RuntimeError: Task <...> got Future <...> attached to a different loop
+```
+
+`scenario.arun(...)` is the async-native sibling. It executes the scenario directly on the caller's event loop, so every singleton stays usable across concurrent runs.
+
+---
+
+## When to reach for `arun`
+
+Use `arun` whenever any of these apply:
+
+- Your agent holds a **Google ADK** `InMemoryRunner` (or any runner backed by a gRPC session service).
+- Your fixture instantiates a **gRPC channel** or **Firestore client** once, to avoid re-opening expensive connections for every scenario.
+- You want to run many scenarios concurrently on the **pytest-asyncio** loop via `@pytest.mark.asyncio_concurrent(group=...)`.
+
+Stick with `scenario.run` when your adapter is self-contained, has no shared async state, and may do sync blocking work you want offloaded to a worker thread.
+
+<Callout type="info">
+Both `run` and `arun` live on the public module:
+
+```python
+await scenario.run(...)    # threaded (default since v0.x)
+await scenario.arun(...)   # async-native (new)
+```
+
+The signature and return value are identical. Only the execution model differs.
+</Callout>
+
+---
+
+## Migration
+
+Before:
+
+```python
+result = await scenario.run(
+    name="…",
+    agents=[my_adapter, scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
+)
+```
+
+After — only the call changes:
+
+```python
+result = await scenario.arun(
+    name="…",
+    agents=[my_adapter, scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
+)
+```
+
+---
+
+## Running scenarios concurrently
+
+Parallelism is the caller's job under `arun`. Two common patterns:
+
+### `asyncio.gather` for ad-hoc concurrency
+
+```python
+results = await asyncio.gather(
+    scenario.arun(name="s1", description="...", agents=[...]),
+    scenario.arun(name="s2", description="...", agents=[...]),
+    scenario.arun(name="s3", description="...", agents=[...]),
+)
+```
+
+All three scenarios run on the same event loop and share any singletons you built in a fixture.
+
+### `pytest-asyncio-concurrent` for pytest-level fan-out
+
+```python
+import pytest
+import scenario
+
+@pytest.mark.asyncio_concurrent(group="recipe_agent")
+async def test_dinner_idea():
+    result = await scenario.arun(
+        name="dinner idea",
+        description="User is looking for a dinner idea",
+        agents=[VegetarianRecipeAgent(), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[
+            "Recipe is vegetarian",
+            "Recipe includes ingredients and steps",
+        ])],
+    )
+    assert result.success
+
+
+@pytest.mark.asyncio_concurrent(group="recipe_agent")
+async def test_hungry_user():
+    result = await scenario.arun(
+        name="hungry user",
+        description="User is very hungry",
+        agents=[VegetarianRecipeAgent(), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
+    )
+    assert result.success
+```
+
+Sibling tests in the same `group` run concurrently on one event loop — perfect for amortising a shared gRPC channel or `InMemoryRunner`.
+
+---
+
+## Google ADK example
+
+The canonical case: one `InMemoryRunner` constructed once, reused by many scenarios.
+
+```python
+import asyncio
+import pytest
+import scenario
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+
+@pytest.fixture(scope="module")
+def runner():
+    agent = Agent(
+        name="weather_agent",
+        model="gemini-2.5-flash",
+        instruction="Call get_weather and answer briefly.",
+        tools=[get_weather],
+    )
+    return InMemoryRunner(agent=agent, app_name="weather-app")
+
+
+class WeatherAgent(scenario.AgentAdapter):
+    def __init__(self, runner, session_prefix: str):
+        self._runner = runner
+        self._session_prefix = session_prefix
+        self._i = 0
+
+    async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
+        session_id = f"{self._session_prefix}-{self._i}"
+        self._i += 1
+        await self._runner.session_service.create_session(
+            app_name="weather-app",
+            user_id="user",
+            session_id=session_id,
+        )
+        reply = ""
+        async for event in self._runner.run_async(
+            user_id="user",
+            session_id=session_id,
+            new_message=types.Content(role="user", parts=[types.Part(text=input.messages[-1]["content"])]),
+        ):
+            if event.is_final_response():
+                reply = event.content.parts[0].text
+        return {"role": "assistant", "content": reply}
+
+
+async def test_cities_in_parallel(runner):
+    cities = ["Amsterdam", "Berlin", "Cairo", "Delhi"]
+    results = await asyncio.gather(
+        *(scenario.arun(
+            name=f"weather-{c}",
+            description=f"user asks about {c}",
+            agents=[WeatherAgent(runner, session_prefix=f"run-{i}"), scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=["agent answers with weather info"])],
+        ) for i, c in enumerate(cities)),
+    )
+    assert all(r.success for r in results)
+```
+
+The same pattern fails under `scenario.run(...)` because each thread creates a fresh loop and the runner's gRPC session service raises on first use.
+
+---
+
+## How it differs from `scenario.run`
+
+| Aspect | `scenario.run` | `scenario.arun` |
+|---|---|---|
+| Event loop | New loop in a worker thread | Caller's loop |
+| Loop-bound resources | ❌ re-created per run or broken | ✓ survive |
+| Blocking sync code in adapter | ✓ offloaded to worker thread | ⚠ blocks the caller loop |
+| Parallelism model | Thread-pool | `asyncio.gather` / pytest-asyncio-concurrent |
+| Telemetry | Same spans, same cost rollup | Same spans, same cost rollup |
+
+Traces land in LangWatch identically either way — the same `Scenario Turn` root, the same per-agent children, the same cost fold. Only the execution model differs.
+
+---
+
+## Common pitfalls
+
+**Blocking sync work in an async adapter.** `arun` runs your adapter on the caller's loop. If your adapter does `time.sleep(5)` or a sync database driver call, it blocks every other concurrent scenario on the same loop. Wrap the blocking work in `asyncio.to_thread(...)` yourself, or stick with `scenario.run`.
+
+**Accidentally sharing mutable state across scenarios.** Concurrent scenarios on one loop means concurrent access to any module-level state your adapter touches. Either scope the state per-scenario instance or guard it with `asyncio.Lock`.
+
+**Mixing `scenario.run` and `scenario.arun` for the same suite.** They're both safe side-by-side, but pick one per test module so the parallelism model is predictable.

--- a/docs/docs/pages/basics/test-runner-integration.mdx
+++ b/docs/docs/pages/basics/test-runner-integration.mdx
@@ -64,6 +64,7 @@ pytest
 
 - You can use standard pytest features like markers, fixtures, and parallelization with scenario tests.
 - For deterministic results, use the `@scenario.cache()` decorator on your agent function.
+- If your agent holds a loop-bound resource (Google ADK `InMemoryRunner`, a gRPC channel, a Firestore client, or anything created in an async pytest fixture), use [`scenario.arun`](/advanced/async-native-parallelism) instead of `scenario.run` so those connections stay usable across concurrent scenarios.
 
 See the [Scenario Python README](https://github.com/langwatch/scenario#python) for more advanced usage and options.
 

--- a/docs/docs/pages/basics/test-runner-integration.mdx
+++ b/docs/docs/pages/basics/test-runner-integration.mdx
@@ -64,7 +64,7 @@ pytest
 
 - You can use standard pytest features like markers, fixtures, and parallelization with scenario tests.
 - For deterministic results, use the `@scenario.cache()` decorator on your agent function.
-- If your agent holds a loop-bound resource (Google ADK `InMemoryRunner`, a gRPC channel, a Firestore client, or anything created in an async pytest fixture), use [`scenario.arun`](/advanced/async-native-parallelism) instead of `scenario.run` so those connections stay usable across concurrent scenarios.
+- `scenario.run` runs each scenario in its own worker thread, so sync and async adapters both parallelize with no extra setup. If your codebase is fully async-first and your adapter holds async state that has to stay on one event loop, use [`scenario.arun`](/advanced/async-native-parallelism) instead.
 
 See the [Scenario Python README](https://github.com/langwatch/scenario#python) for more advanced usage and options.
 

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -325,6 +325,10 @@ export default defineConfig({
           link: "/advanced/custom-observability",
         },
         {
+          text: "Async-Native Parallelism",
+          link: "/advanced/async-native-parallelism",
+        },
+        {
           text: "Red Teaming",
           items: [
             {

--- a/python/examples/test_running_in_parallel_with_arun.py
+++ b/python/examples/test_running_in_parallel_with_arun.py
@@ -78,8 +78,12 @@ async def test_vegetarian_recipe_agent_via_arun():
 
 @pytest.mark.agent_test
 @pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent_arun")
-@pytest.mark.flaky(reruns=2)
+@pytest.mark.flaky(reruns=3)
 async def test_user_is_hungry_via_arun():
+    # Follow-up prompts are fixed strings rather than free-form
+    # ``scenario.user()`` calls so the UserSimulator's LLM noise
+    # can't pivot the conversation away from vegetarian criteria
+    # the judge checks.
     result = await scenario.arun(
         name="hungry user (arun)",
         description="User is very very hungry and wants a big, filling meal",
@@ -99,9 +103,7 @@ async def test_user_is_hungry_via_arun():
         script=[
             scenario.user("I'm starving! I need something really filling for dinner tonight"),
             scenario.agent(),
-            scenario.user(),
-            scenario.agent(),
-            scenario.user(),
+            scenario.user("That sounds great, can you share the recipe?"),
             scenario.agent(),
             scenario.judge(),
         ],

--- a/python/examples/test_running_in_parallel_with_arun.py
+++ b/python/examples/test_running_in_parallel_with_arun.py
@@ -1,0 +1,110 @@
+"""Migration-path example: run scenarios concurrently via ``scenario.arun``.
+
+This file is the async-native counterpart of
+``examples/test_running_in_parallel.py``. Whenever an agent holds a
+loop-bound resource (ADK ``InMemoryRunner``, a gRPC channel built in
+a pytest fixture, a Firestore client, etc.) prefer ``arun`` over
+``run``:
+
+- ``arun`` runs the scenario on the pytest-asyncio event loop, so any
+  singleton created by a fixture on that loop stays usable.
+- Parallelism comes from ``pytest-asyncio-concurrent``'s
+  ``@pytest.mark.asyncio_concurrent(group=...)`` marker — two sibling
+  tests in the same group interleave on the same loop.
+
+The test body is the same vegetarian-recipe agent; only the call site
+changed: ``await scenario.arun(...)`` instead of ``await scenario.run(...)``.
+"""
+
+from typing import cast
+import pytest
+from dotenv import load_dotenv
+import litellm
+
+from openai.types.chat import ChatCompletionMessageParam
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes
+
+load_dotenv()
+
+import scenario
+
+scenario.configure(default_model="openai/gpt-4.1-mini")
+
+
+class VegetarianRecipeAgentAdapter(AgentAdapter):
+    @scenario.cache()
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        response = litellm.completion(
+            model="openai/gpt-4.1-mini",
+            messages=[
+                {
+                    "role": "system",
+                    "content": """You are a vegetarian recipe agent.
+                    Given the user request, ask AT MOST ONE follow-up question,
+                    then provide a complete recipe. Keep your responses concise and focused.""",
+                },
+                *input.messages,
+            ],
+        )
+        message = response.choices[0].message  # type: ignore
+        return [cast(ChatCompletionMessageParam, message)]
+
+
+@pytest.mark.flaky(reruns=2)
+@pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent_arun")
+async def test_vegetarian_recipe_agent_via_arun():
+    result = await scenario.arun(
+        name="dinner idea (arun)",
+        description="User is looking for a dinner idea",
+        agents=[
+            VegetarianRecipeAgentAdapter(),
+            scenario.UserSimulatorAgent(),
+            scenario.JudgeAgent(
+                criteria=[
+                    "Recipe agent generates a vegetarian recipe",
+                    "Recipe includes a list of ingredients",
+                    "Recipe includes step-by-step cooking instructions",
+                    "The recipe is vegetarian and does not include meat",
+                    "The agent should NOT ask more than two follow-up questions",
+                ]
+            ),
+        ],
+        max_turns=12,
+        set_id="python-examples",
+    )
+    assert result.success
+
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent_arun")
+@pytest.mark.flaky(reruns=2)
+async def test_user_is_hungry_via_arun():
+    result = await scenario.arun(
+        name="hungry user (arun)",
+        description="User is very very hungry and wants a big, filling meal",
+        agents=[
+            VegetarianRecipeAgentAdapter(),
+            scenario.UserSimulatorAgent(),
+            scenario.JudgeAgent(
+                criteria=[
+                    "Recipe agent generates a vegetarian recipe",
+                    "Recipe includes a list of ingredients",
+                    "Recipe includes step-by-step cooking instructions",
+                    "The recipe is vegetarian and does not include meat",
+                    "The agent should NOT ask more than two follow-up questions",
+                ]
+            ),
+        ],
+        script=[
+            scenario.user("I'm starving! I need something really filling for dinner tonight"),
+            scenario.agent(),
+            scenario.user(),
+            scenario.agent(),
+            scenario.user(),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+        set_id="python-examples",
+    )
+    assert result.success

--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -109,7 +109,7 @@ from .config import ScenarioConfig
 from ._tracing import setup_scenario_tracing, scenario_only, with_custom_scopes
 
 # Then import modules with dependencies
-from .scenario_executor import run
+from .scenario_executor import run, arun
 from .scenario_state import ScenarioState
 from .agent_adapter import AgentAdapter
 from .judge_agent import JudgeAgent
@@ -131,6 +131,7 @@ cache = scenario_cache
 __all__ = [
     # Functions
     "run",
+    "arun",
     "configure",
     "default_config",
     "cache",

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1076,6 +1076,97 @@ class ScenarioExecutor:
         self._trace.__exit__(None, None, None)
 
 
+def _build_scenario(
+    *,
+    name: str,
+    description: str,
+    agents: List[AgentAdapter],
+    max_turns: Optional[int],
+    verbose: Optional[Union[bool, int]],
+    cache_key: Optional[str],
+    debug: Optional[bool],
+    script: Optional[List[ScriptStep]],
+    set_id: Optional[str],
+    metadata: Optional[Dict[str, Any]],
+) -> "ScenarioExecutor":
+    """Shared setup used by both ``run()`` (threaded) and ``arun()`` (async-native)."""
+    from ._tracing import ensure_tracing_initialized
+
+    config = ScenarioConfig.default_config
+    ensure_tracing_initialized(config.observability if config else None)
+
+    return ScenarioExecutor(
+        name=name,
+        description=description,
+        agents=agents,
+        max_turns=max_turns,
+        verbose=verbose,
+        cache_key=cache_key,
+        debug=debug,
+        script=script,
+        set_id=set_id,
+        metadata=metadata,
+    )
+
+
+def _cleanup_scenario_spans(scenario: "ScenarioExecutor") -> None:
+    """Clear judge spans for this scenario's thread_id to prevent memory buildup."""
+    from ._tracing import judge_span_collector
+
+    if hasattr(scenario, "_state") and scenario._state:
+        judge_span_collector.clear_spans_for_thread(scenario._state.thread_id)
+
+
+async def arun(
+    name: str,
+    description: str,
+    agents: List[AgentAdapter] = [],
+    max_turns: Optional[int] = None,
+    verbose: Optional[Union[bool, int]] = None,
+    cache_key: Optional[str] = None,
+    debug: Optional[bool] = None,
+    script: Optional[List[ScriptStep]] = None,
+    set_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> ScenarioResult:
+    """Async-native counterpart of :func:`run`.
+
+    Runs the scenario directly on the caller's event loop so that any
+    loop-bound resources the agent adapter holds (gRPC channels, Firestore
+    clients, ADK ``InMemoryRunner`` instances, ``asyncio.Event`` / ``Lock``
+    primitives created in a pytest fixture, etc.) remain usable.
+
+    Prefer ``arun`` whenever your :class:`AgentAdapter` touches anything
+    bound to the event loop it was constructed on. Parallelism can then be
+    expressed with ``asyncio.gather`` / ``pytest-asyncio-concurrent``
+    instead of the private worker thread used by :func:`run`.
+
+    The signature and return value mirror :func:`run`.
+    """
+    scenario = _build_scenario(
+        name=name,
+        description=description,
+        agents=agents,
+        max_turns=max_turns,
+        verbose=verbose,
+        cache_key=cache_key,
+        debug=debug,
+        script=script,
+        set_id=set_id,
+        metadata=metadata,
+    )
+
+    try:
+        result = await scenario.run()
+        _cleanup_scenario_spans(scenario)
+        return result
+    finally:
+        # ``event_bus.drain()`` blocks on ``queue.join()`` while waiting for
+        # the event-bus worker thread to finish HTTP posting, so we offload
+        # it to avoid stalling the caller's loop.
+        await asyncio.to_thread(scenario.event_bus.drain)
+
+
 async def run(
     name: str,
     description: str,
@@ -1094,6 +1185,14 @@ async def run(
     This is the main entry point for executing scenario tests. It creates a
     ScenarioExecutor instance and runs it in an isolated thread pool to support
     parallel execution and prevent blocking.
+
+    .. warning::
+        If your :class:`AgentAdapter` awaits on resources that were created on
+        the caller's event loop (e.g. gRPC channels, Firestore clients, an
+        ADK ``InMemoryRunner`` instantiated in a pytest fixture), use
+        :func:`arun` instead. ``run`` spins up a fresh event loop on a worker
+        thread and those resources will raise ``"Future attached to a
+        different loop"`` the moment they are awaited from that thread.
 
     Args:
         name: Human-readable name for the scenario
@@ -1153,13 +1252,7 @@ async def run(
         print(f"Conversation had {len(result.messages)} messages")
         ```
     """
-    from ._tracing import ensure_tracing_initialized
-    from .config import ScenarioConfig
-
-    config = ScenarioConfig.default_config
-    ensure_tracing_initialized(config.observability if config else None)
-
-    scenario = ScenarioExecutor(
+    scenario = _build_scenario(
         name=name,
         description=description,
         agents=agents,
@@ -1175,7 +1268,11 @@ async def run(
     # We'll use a thread pool to run the execution logic, we
     # require a separate thread because even though asyncio is
     # being used throughout, any user code on the callback can
-    # be blocking, preventing them from running scenarios in parallel
+    # be blocking, preventing them from running scenarios in parallel.
+    #
+    # NB: this isolation also spins up a private event loop per run, which
+    # breaks adapters that hold loop-bound resources (gRPC, Firestore,
+    # ADK InMemoryRunner). Those callers should use :func:`arun` instead.
     with concurrent.futures.ThreadPoolExecutor() as executor:
 
         def run_in_thread():
@@ -1184,15 +1281,7 @@ async def run(
 
             try:
                 result = loop.run_until_complete(scenario.run())
-
-                # Clean up spans for this thread to prevent memory buildup
-                from ._tracing import judge_span_collector
-
-                if hasattr(scenario, "_state") and scenario._state:
-                    judge_span_collector.clear_spans_for_thread(
-                        scenario._state.thread_id
-                    )
-
+                _cleanup_scenario_spans(scenario)
                 return result
             finally:
                 scenario.event_bus.drain()

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1131,15 +1131,17 @@ async def arun(
 ) -> ScenarioResult:
     """Async-native counterpart of :func:`run`.
 
-    Runs the scenario directly on the caller's event loop so that any
-    loop-bound resources the agent adapter holds (gRPC channels, Firestore
-    clients, ADK ``InMemoryRunner`` instances, ``asyncio.Event`` / ``Lock``
-    primitives created in a pytest fixture, etc.) remain usable.
+    Runs the scenario directly on the caller's event loop, so async state
+    created on that loop (anything set up in an async fixture, for
+    example) stays usable across concurrent scenarios.
 
-    Prefer ``arun`` whenever your :class:`AgentAdapter` touches anything
-    bound to the event loop it was constructed on. Parallelism can then be
-    expressed with ``asyncio.gather`` / ``pytest-asyncio-concurrent``
-    instead of the private worker thread used by :func:`run`.
+    :func:`run` remains the default: it executes each scenario in its own
+    worker thread, so sync and async adapters both parallelize with no
+    extra work on your side. Reach for ``arun`` only when your codebase
+    is fully async-first and your adapter relies on async objects whose
+    identity is tied to the loop they were created on. Parallelism is
+    then the caller's responsibility, via ``asyncio.gather`` or
+    ``pytest-asyncio-concurrent``.
 
     The signature and return value mirror :func:`run`.
     """
@@ -1186,13 +1188,13 @@ async def run(
     ScenarioExecutor instance and runs it in an isolated thread pool to support
     parallel execution and prevent blocking.
 
-    .. warning::
-        If your :class:`AgentAdapter` awaits on resources that were created on
-        the caller's event loop (e.g. gRPC channels, Firestore clients, an
-        ADK ``InMemoryRunner`` instantiated in a pytest fixture), use
-        :func:`arun` instead. ``run`` spins up a fresh event loop on a worker
-        thread and those resources will raise ``"Future attached to a
-        different loop"`` the moment they are awaited from that thread.
+    .. note::
+        If your :class:`AgentAdapter` awaits on async state that was
+        created on the caller's event loop (anything set up in an async
+        fixture, for example), use :func:`arun` instead. ``run`` spins up
+        a fresh event loop on a worker thread and those objects will raise
+        ``"Future attached to a different loop"`` when they are awaited
+        from that thread.
 
     Args:
         name: Human-readable name for the scenario
@@ -1270,9 +1272,9 @@ async def run(
     # being used throughout, any user code on the callback can
     # be blocking, preventing them from running scenarios in parallel.
     #
-    # NB: this isolation also spins up a private event loop per run, which
-    # breaks adapters that hold loop-bound resources (gRPC, Firestore,
-    # ADK InMemoryRunner). Those callers should use :func:`arun` instead.
+    # NB: this isolation also spins up a private event loop per run, so
+    # adapters that depend on async state bound to the caller's loop must
+    # use :func:`arun` instead.
     with concurrent.futures.ThreadPoolExecutor() as executor:
 
         def run_in_thread():

--- a/python/tests/test_arun_adk_integration.py
+++ b/python/tests/test_arun_adk_integration.py
@@ -29,9 +29,9 @@ from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResu
 
 def _has_adk() -> bool:
     try:
-        import google.adk  # noqa: F401
-        from google.adk.agents import Agent  # noqa: F401
-        from google.adk.runners import InMemoryRunner  # noqa: F401
+        import google.adk  # noqa: F401  # pyright: ignore[reportMissingImports]
+        from google.adk.agents import Agent  # noqa: F401  # pyright: ignore[reportMissingImports]
+        from google.adk.runners import InMemoryRunner  # noqa: F401  # pyright: ignore[reportMissingImports]
     except Exception:
         return False
     return True
@@ -48,8 +48,8 @@ pytestmark = [
 # Sometimes the test environment has old google-genai / ADK combos where
 # ``InMemoryRunner`` cannot be constructed. Skip rather than fail loudly.
 def _build_runner():
-    from google.adk.agents import Agent
-    from google.adk.runners import InMemoryRunner
+    from google.adk.agents import Agent  # pyright: ignore[reportMissingImports]
+    from google.adk.runners import InMemoryRunner  # pyright: ignore[reportMissingImports]
 
     def get_weather(city: str) -> dict:
         return {"status": "ok", "report": f"Sunny in {city}"}
@@ -88,7 +88,7 @@ class _ADKAgent(AgentAdapter):
         self._session_idx = 0
 
     async def call(self, input: AgentInput) -> AgentReturnTypes:
-        from google.genai import types
+        from google.genai import types  # pyright: ignore[reportMissingImports]
 
         last_user = next(
             (m for m in reversed(input.messages) if m.get("role") == "user"),

--- a/python/tests/test_arun_adk_integration.py
+++ b/python/tests/test_arun_adk_integration.py
@@ -1,0 +1,194 @@
+"""Integration test: a shared Google ADK ``InMemoryRunner`` works across
+concurrent ``scenario.arun`` invocations.
+
+This is the exact failure mode the customer hit: the ADK runner
+instantiated in a pytest fixture holds a gRPC channel / session service
+bound to the caller's event loop, and scenario's thread-pool worker
+executes the adapter on a *different* loop, which tripped "Future
+attached to a different loop". With ``scenario.arun`` the adapter runs
+on the caller's loop, so the singleton stays usable.
+
+Requires ``GOOGLE_API_KEY`` and ``google-adk``. Skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from typing import List
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+def _has_adk() -> bool:
+    try:
+        import google.adk  # noqa: F401
+        from google.adk.agents import Agent  # noqa: F401
+        from google.adk.runners import InMemoryRunner  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+pytestmark = [
+    pytest.mark.skipif(not _has_adk(), reason="google-adk not installed"),
+    pytest.mark.skipif(
+        not os.environ.get("GOOGLE_API_KEY"), reason="GOOGLE_API_KEY not set"
+    ),
+]
+
+
+# Sometimes the test environment has old google-genai / ADK combos where
+# ``InMemoryRunner`` cannot be constructed. Skip rather than fail loudly.
+def _build_runner():
+    from google.adk.agents import Agent
+    from google.adk.runners import InMemoryRunner
+
+    def get_weather(city: str) -> dict:
+        return {"status": "ok", "report": f"Sunny in {city}"}
+
+    agent = Agent(
+        name="weather_agent",
+        model=os.environ.get("GEMINI_MODEL", "gemini-flash-latest"),
+        description="Replies with a short weather report.",
+        instruction="Call get_weather for the city the user asks about and answer briefly.",
+        tools=[get_weather],
+    )
+    return InMemoryRunner(agent=agent, app_name="scenario-arun-adk-integration")
+
+
+@pytest.fixture(scope="module")
+def shared_runner():
+    # Created once per module on the event loop that pytest-asyncio is
+    # driving — this is the loop all concurrent scenarios must reuse.
+    try:
+        yield _build_runner()
+    except Exception as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"Failed to build ADK runner: {exc}")
+
+
+class _ADKAgent(AgentAdapter):
+    """Forwards the latest user message through a shared ADK runner.
+
+    The ``InMemoryRunner`` is constructed outside the adapter and passed
+    in — ``arun`` must await on it using the same loop it was built on.
+    """
+
+    def __init__(self, runner, session_prefix: str, observed: List[dict]):
+        self._runner = runner
+        self._session_prefix = session_prefix
+        self._observed = observed
+        self._session_idx = 0
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        from google.genai import types
+
+        last_user = next(
+            (m for m in reversed(input.messages) if m.get("role") == "user"),
+            None,
+        )
+        raw = (last_user or {}).get("content") or "Hello"
+        text = raw if isinstance(raw, str) else "Hello"
+
+        session_id = f"{self._session_prefix}-{self._session_idx}"
+        self._session_idx += 1
+        await self._runner.session_service.create_session(
+            app_name="scenario-arun-adk-integration",
+            user_id="user",
+            session_id=session_id,
+        )
+
+        reply = "(no reply)"
+        # Drain the full event stream before returning — early-returning
+        # leaves the async generator for the event loop to GC in a
+        # different context, which tripped ADK's OTel context-detach
+        # assertion on langwatch's experiment path.
+        async for event in self._runner.run_async(
+            user_id="user",
+            session_id=session_id,
+            new_message=types.Content(role="user", parts=[types.Part(text=text)]),
+        ):
+            if not event.is_final_response():
+                continue
+            content = getattr(event, "content", None)
+            parts = getattr(content, "parts", None) or []
+            txt = getattr(parts[0], "text", None) if parts else None
+            if txt:
+                reply = txt.strip()
+
+        self._observed.append({"loop_id": id(asyncio.get_running_loop())})
+        return {"role": "assistant", "content": reply}
+
+
+class _StubUser(AgentAdapter):
+    role = AgentRole.USER
+
+    def __init__(self, prompt: str):
+        self._prompt = prompt
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return self._prompt
+
+
+class _InstantJudge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True,
+            messages=[],
+            reasoning="adk reply received",
+            passed_criteria=["adk responded"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_shared_adk_runner_survives_concurrent_arun(shared_runner):
+    observed: List[dict] = []
+    cities = ["Amsterdam", "Berlin", "Cairo", "Delhi"]
+    suffix = uuid.uuid4().hex[:6]
+
+    async def one(city: str, idx: int):
+        return await scenario.arun(
+            name=f"adk-weather-{city.lower()}",
+            description=f"User asks about {city} weather",
+            agents=[
+                _ADKAgent(shared_runner, f"arun-{suffix}-{idx}", observed),
+                _StubUser(f"What is the weather in {city}?"),
+                _InstantJudge(),
+            ],
+            script=[
+                scenario.user(f"What is the weather in {city}?"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    results = await asyncio.gather(
+        *(one(city, i) for i, city in enumerate(cities)),
+        return_exceptions=True,
+    )
+
+    # Any loop-affinity breakage would surface as one of these turning
+    # into a RuntimeError with "different loop" in its repr.
+    for idx, result in enumerate(results):
+        assert not isinstance(result, Exception), (
+            f"scenario {idx} raised: {result!r}\n"
+            "This likely means the ADK runner was awaited on a loop "
+            "it was not created on (i.e. arun regressed to scenario.run's "
+            "threaded behaviour)."
+        )
+
+    assert all(isinstance(r, ScenarioResult) and r.success for r in results)
+
+    # All adapter invocations must have run on a single event loop — the
+    # one this test function itself is running on.
+    loop_ids = {o["loop_id"] for o in observed}
+    assert loop_ids == {id(asyncio.get_running_loop())}

--- a/python/tests/test_arun_asyncio_concurrent.py
+++ b/python/tests/test_arun_asyncio_concurrent.py
@@ -1,0 +1,88 @@
+"""The customer's intended pattern: ``@pytest.mark.asyncio_concurrent``
+group runs multiple async test coroutines on the same loop in parallel.
+With ``scenario.arun`` that stays async-native, each test's scenario
+must:
+
+- share the single event loop the plugin provides,
+- not raise any "Future attached to a different loop" error,
+- produce its own result independently.
+
+The two tests below are grouped so the plugin interleaves them. If
+``scenario.run`` were used in place of ``arun``, this file would serve
+as a negative control — but we only assert the positive case here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+class _Agent(AgentAdapter):
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return {"role": "assistant", "content": "ok"}
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.asyncio_concurrent(group="arun-pytest-concurrent")
+async def test_arun_in_concurrent_group_one():
+    """Two sibling tests run on the same event loop. Holding a resource
+    bound to that loop across them must not raise."""
+    loop = asyncio.get_running_loop()
+    result = await scenario.arun(
+        name="concurrent-one",
+        description="pytest-asyncio-concurrent sibling",
+        agents=[_Agent(), _User(), _Judge()],
+        script=[
+            scenario.user("hi"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+    assert result.success
+    # Adapter ran on the same loop pytest-asyncio-concurrent is using.
+    assert asyncio.get_running_loop() is loop
+    # And on the main thread — arun never offloads an async adapter.
+    assert threading.current_thread() is threading.main_thread()
+
+
+@pytest.mark.asyncio_concurrent(group="arun-pytest-concurrent")
+async def test_arun_in_concurrent_group_two():
+    loop = asyncio.get_running_loop()
+    result = await scenario.arun(
+        name="concurrent-two",
+        description="pytest-asyncio-concurrent sibling",
+        agents=[_Agent(), _User(), _Judge()],
+        script=[
+            scenario.user("hi"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+    assert result.success
+    assert asyncio.get_running_loop() is loop
+    assert threading.current_thread() is threading.main_thread()

--- a/python/tests/test_arun_batch_sharing.py
+++ b/python/tests/test_arun_batch_sharing.py
@@ -1,0 +1,71 @@
+"""Concurrent ``scenario.arun`` invocations must share one
+``batch_run_id`` so the LangWatch UI groups them under a single batch.
+
+The batch id is stored in a module-level environment variable
+(``SCENARIO_BATCH_RUN_ID``) and set on first read. Pure asyncio has
+no preemption between the env-var get and set, so every arun call
+inside a single event loop sees the same id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+class _Agent(AgentAdapter):
+    def __init__(self, captured: list[str]):
+        self._captured = captured
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        self._captured.append(input.scenario_state._executor.batch_run_id)
+        return {"role": "assistant", "content": "ok"}
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_arun_shares_one_batch_run_id():
+    captured: list[str] = []
+
+    async def one(i: int):
+        return await scenario.arun(
+            name=f"batch-{i}",
+            description="batch sharing",
+            agents=[_Agent(captured), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    results = await asyncio.gather(*(one(i) for i in range(5)))
+    assert all(r.success for r in results)
+
+    assert len(set(captured)) == 1, (
+        f"Concurrent arun calls should share one batch_run_id, got "
+        f"{set(captured)}"
+    )

--- a/python/tests/test_arun_cache.py
+++ b/python/tests/test_arun_cache.py
@@ -1,0 +1,96 @@
+"""``scenario_cache`` relies on ``context_scenario.get()`` (a ContextVar).
+ContextVars are preserved across ``asyncio.Task`` copies, so each
+concurrent ``arun`` invocation sees its own scenario — and therefore
+its own ``cache_key`` derivation — with no cross-task contamination.
+
+This test pins the invariant: two concurrent arun calls with the same
+cache_key + same arguments do NOT issue duplicate computations (cache
+hits on the second) and never see each other's in-flight scenario.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+# joblib's memory writes to the filesystem; isolate per-test so concurrent
+# tests don't pollute each other's hit counts.
+_TMP_CACHE = tempfile.TemporaryDirectory()
+os.environ["SCENARIO_CACHE_DIR"] = _TMP_CACHE.name
+
+
+_call_count = 0
+
+
+@scenario.cache()
+async def expensive(arg: str) -> str:
+    global _call_count
+    _call_count += 1
+    return f"computed-{arg}"
+
+
+class _Agent(AgentAdapter):
+    def __init__(self, tag: str):
+        self._tag = tag
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        val = await expensive("shared-arg")
+        return {"role": "assistant", "content": f"{self._tag}:{val}"}
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_scenario_cache_works_under_concurrent_arun():
+    global _call_count
+    _call_count = 0
+
+    async def one(i: int):
+        return await scenario.arun(
+            name=f"cache-{i}",
+            description="cached expensive call",
+            cache_key="arun-cache-test-v1",
+            agents=[_Agent(str(i)), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    # Five concurrent scenarios with the same cache_key + same arg.
+    results = await asyncio.gather(*(one(i) for i in range(5)))
+    assert all(r.success for r in results)
+
+    # The cache key is deterministic per ``cache_key`` config +
+    # ``arg``. Five invocations with identical keys must hit the cache
+    # for four of them → ``expensive`` ran at most once.
+    # (It can be called once if the first to race populates it.)
+    assert _call_count <= 1, (
+        f"cache under arun failed to deduplicate — expensive() ran "
+        f"{_call_count} times across 5 identical invocations"
+    )

--- a/python/tests/test_arun_cancellation.py
+++ b/python/tests/test_arun_cancellation.py
@@ -75,7 +75,7 @@ async def test_cancellation_propagates_into_arun():
     task.cancel()
 
     with pytest.raises(asyncio.CancelledError):
-        await task
+        _ = await task
 
 
 @pytest.mark.asyncio
@@ -118,4 +118,4 @@ async def test_cancellation_does_not_affect_sibling_arun():
     assert fast_result.success is True
 
     with pytest.raises(asyncio.CancelledError):
-        await slow_task
+        _ = await slow_task

--- a/python/tests/test_arun_cancellation.py
+++ b/python/tests/test_arun_cancellation.py
@@ -1,0 +1,121 @@
+"""Cancellation semantics for ``scenario.arun``.
+
+Async frameworks expect that task cancellation propagates cleanly.
+``arun`` runs the scenario on the caller's loop, so ``task.cancel()``
+delivers a CancelledError straight into the scenario's own ``await``
+chain — different from the threaded ``scenario.run`` path where
+cancellation is effectively unreachable once we handed control to a
+worker thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+class _SlowAgent(AgentAdapter):
+    """Sleeps long enough that outer cancellation lands mid-call."""
+
+    def __init__(self, started: asyncio.Event):
+        self._started = started
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        self._started.set()
+        await asyncio.sleep(10)
+        return {"role": "assistant", "content": "never"}
+
+
+class _FastAgent(AgentAdapter):
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return {"role": "assistant", "content": "fast"}
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_into_arun():
+    started = asyncio.Event()
+    task = asyncio.create_task(
+        scenario.arun(
+            name="cancelled-scenario",
+            description="outer cancels mid-call",
+            agents=[_SlowAgent(started), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+    )
+
+    await asyncio.wait_for(started.wait(), timeout=3.0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_cancellation_does_not_affect_sibling_arun():
+    started = asyncio.Event()
+
+    async def slow():
+        return await scenario.arun(
+            name="slow-sibling",
+            description="will be cancelled",
+            agents=[_SlowAgent(started), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    async def fast():
+        return await scenario.arun(
+            name="fast-sibling",
+            description="should complete",
+            agents=[_FastAgent(), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    slow_task = asyncio.create_task(slow())
+    fast_task = asyncio.create_task(fast())
+
+    # Wait until the slow scenario's agent is in-flight, then cancel it.
+    await asyncio.wait_for(started.wait(), timeout=3.0)
+    slow_task.cancel()
+
+    # Fast sibling must still complete successfully.
+    fast_result = await asyncio.wait_for(fast_task, timeout=5.0)
+    assert fast_result.success is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await slow_task

--- a/python/tests/test_arun_drain_on_error.py
+++ b/python/tests/test_arun_drain_on_error.py
@@ -1,0 +1,102 @@
+"""``scenario.arun`` must drain the event bus in its ``finally`` block,
+even when the adapter raises.
+
+A scenario that emits a ``SCENARIO_RUN_STARTED`` event then has its
+agent raise must: (a) re-raise, (b) send all pending events to the
+reporter before returning.
+
+We stub out the event reporter so we can count calls regardless of
+whether the local endpoint is reachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario._events import ScenarioEvent
+from scenario._events.event_reporter import EventReporter
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+class _CountingReporter(EventReporter):
+    """Drop-in reporter that records every event instead of POSTing."""
+
+    def __init__(self) -> None:
+        # Bypass parent __init__ — we want no env setup, no HTTP client.
+        self.received: List[ScenarioEvent] = []
+        self.endpoint = "memory://"
+        self.api_key = "test"
+        import logging
+
+        self.logger = logging.getLogger(__name__)
+
+    async def post_event(self, event: ScenarioEvent) -> Dict[str, Any]:
+        self.received.append(event)
+        return {}
+
+
+class _Boom(AgentAdapter):
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        raise RuntimeError("intentional failure")
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_event_bus_drains_on_adapter_exception():
+    reporter = _CountingReporter()
+
+    def _reporter_factory(*args, **kwargs):
+        return reporter
+
+    # Patch the default constructor so arun's ScenarioExecutor picks
+    # up our fake reporter.
+    with patch(
+        "scenario._events.event_bus.EventReporter",
+        side_effect=_reporter_factory,
+    ):
+        with pytest.raises(Exception):
+            await scenario.arun(
+                name="drain-on-error",
+                description="verifies drain-on-finally",
+                agents=[_Boom(), _User(), _Judge()],
+                script=[
+                    scenario.user("hi"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+    # The SCENARIO_RUN_STARTED event fires before the adapter runs; the
+    # SCENARIO_RUN_FINISHED event fires in the scenario's error branch.
+    types = [e.type_ for e in reporter.received]
+    assert "SCENARIO_RUN_STARTED" in types, (
+        f"Expected RUN_STARTED to reach reporter, got: {types}"
+    )
+    assert "SCENARIO_RUN_FINISHED" in types, (
+        f"Expected RUN_FINISHED to reach reporter (arun's finally drain "
+        f"should flush even on exception), got: {types}"
+    )

--- a/python/tests/test_arun_drain_on_error.py
+++ b/python/tests/test_arun_drain_on_error.py
@@ -11,9 +11,8 @@ whether the local endpoint is reachable.
 
 from __future__ import annotations
 
-import asyncio
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 import pytest
@@ -31,13 +30,8 @@ class _CountingReporter(EventReporter):
     """Drop-in reporter that records every event instead of POSTing."""
 
     def __init__(self) -> None:
-        # Bypass parent __init__ — we want no env setup, no HTTP client.
+        super().__init__(endpoint="http://localhost", api_key="test")
         self.received: List[ScenarioEvent] = []
-        self.endpoint = "memory://"
-        self.api_key = "test"
-        import logging
-
-        self.logger = logging.getLogger(__name__)
 
     async def post_event(self, event: ScenarioEvent) -> Dict[str, Any]:
         self.received.append(event)

--- a/python/tests/test_arun_exception_chain.py
+++ b/python/tests/test_arun_exception_chain.py
@@ -1,0 +1,77 @@
+"""The exception raised by ``scenario.arun`` must preserve the user's
+original frame in its traceback so debugging is straightforward.
+
+Scenario wraps adapter failures in
+``raise RuntimeError(f"[{agent_name}] {e}") from e`` — the ``from e``
+is what keeps the user's ``__cause__`` alive. If any code path strips
+it (e.g. a new exception created without chaining), users lose the
+line number of the actual bug.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import traceback
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+class _BadAgent(AgentAdapter):
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        # The marker string below must appear in the traceback to
+        # prove the user's frame is preserved.
+        return _divide_by_zero()
+
+
+def _divide_by_zero():
+    return 1 / 0  # SENTINEL user frame
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_user_traceback_survives_arun():
+    try:
+        await scenario.arun(
+            name="bad",
+            description="adapter raises ZeroDivisionError",
+            agents=[_BadAgent(), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+    except Exception as e:
+        tb = traceback.format_exc()
+        assert "_divide_by_zero" in tb, (
+            f"expected user frame _divide_by_zero in traceback; got: {tb}"
+        )
+        assert e.__cause__ is not None, (
+            "Exception chain broken — the underlying ZeroDivisionError "
+            "must remain accessible via __cause__ for debuggers."
+        )
+        assert isinstance(e.__cause__, ZeroDivisionError)
+    else:  # pragma: no cover
+        pytest.fail("arun did not raise, but the adapter did")

--- a/python/tests/test_arun_exception_chain.py
+++ b/python/tests/test_arun_exception_chain.py
@@ -10,7 +10,6 @@ line number of the actual bug.
 
 from __future__ import annotations
 
-import asyncio
 import os
 import traceback
 
@@ -25,13 +24,14 @@ from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResu
 
 class _BadAgent(AgentAdapter):
     async def call(self, input: AgentInput) -> AgentReturnTypes:
-        # The marker string below must appear in the traceback to
-        # prove the user's frame is preserved.
-        return _divide_by_zero()
+        # _divide_by_zero always raises; the return is unreachable but
+        # required so the type checker sees a valid AgentReturnTypes path.
+        _divide_by_zero()
+        return {"role": "assistant", "content": "unreachable"}
 
 
-def _divide_by_zero():
-    return 1 / 0  # SENTINEL user frame
+def _divide_by_zero() -> None:
+    _ = 1 / 0  # SENTINEL user frame
 
 
 class _User(AgentAdapter):

--- a/python/tests/test_arun_flaky_reruns.py
+++ b/python/tests/test_arun_flaky_reruns.py
@@ -13,7 +13,6 @@ will surface it.
 
 from __future__ import annotations
 
-import asyncio
 import os
 
 import pytest

--- a/python/tests/test_arun_flaky_reruns.py
+++ b/python/tests/test_arun_flaky_reruns.py
@@ -1,0 +1,120 @@
+"""`pytest.mark.flaky` + `arun` interplay.
+
+The scenario examples lean heavily on `@pytest.mark.flaky(reruns=2)`
+to absorb LLM noise. When a rerun kicks in, the previous attempt's
+state (event bus worker thread, tracing contextvars, LangWatchTrace
+context tokens) must not carry over into the retry.
+
+This test fails on the first two attempts and passes on the third —
+if reruns are broken (e.g. a dangling contextvar / worker thread
+from attempt 1 poisons attempt 3) the assertion in the final attempt
+will surface it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+_attempt_counter = {"n": 0}
+
+
+class _RetryableAgent(AgentAdapter):
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        _attempt_counter["n"] += 1
+        # Fail the first two attempts, pass on the third.
+        if _attempt_counter["n"] < 3:
+            raise AssertionError(
+                f"intentional flake #{_attempt_counter['n']}"
+            )
+        return {"role": "assistant", "content": "ok"}
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.flaky(reruns=3)
+@pytest.mark.asyncio
+async def test_arun_survives_pytest_reruns():
+    """Two flakes followed by a success — exercise pytest-rerunfailures."""
+    result = await scenario.arun(
+        name="flaky-arun",
+        description="flaky test with reruns",
+        agents=[_RetryableAgent(), _User(), _Judge()],
+        script=[
+            scenario.user("hi"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+    assert result.success is True
+    # The third attempt is the one that succeeded; prior attempts
+    # incremented the counter then raised before the judge ran.
+    assert _attempt_counter["n"] == 3, (
+        f"expected 3 attempts to reach the third try, got {_attempt_counter['n']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_loop_stays_stable_across_reruns():
+    """Even after a forced failure, a follow-up arun on the same loop
+    still works — guards against a half-torn-down event bus leaving a
+    lingering reference that fights the next run.
+    """
+
+    class _Boom(AgentAdapter):
+        async def call(self, input: AgentInput) -> AgentReturnTypes:
+            raise RuntimeError("boom")
+
+    # First call raises; event_bus must still drain cleanly so the
+    # second call is unaffected.
+    with pytest.raises(Exception):
+        await scenario.arun(
+            name="boom-1",
+            description="first raises",
+            agents=[_Boom(), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    # Second call on the same loop should complete normally.
+    class _Good(AgentAdapter):
+        async def call(self, input: AgentInput) -> AgentReturnTypes:
+            return {"role": "assistant", "content": "ok"}
+
+    result = await scenario.arun(
+        name="boom-2",
+        description="second succeeds",
+        agents=[_Good(), _User(), _Judge()],
+        script=[
+            scenario.user("hi"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+    assert result.success

--- a/python/tests/test_arun_grpc_integration.py
+++ b/python/tests/test_arun_grpc_integration.py
@@ -1,0 +1,199 @@
+"""Literal reproduction of the customer's symptom with real ``grpc.aio``.
+
+A grpc.aio server + channel is built once in a pytest fixture — the
+channel's completion queue and underlying futures are bound to the
+pytest event loop. A sibling test running the SAME channel through
+``scenario.arun`` must work, and the SAME channel through
+``scenario.run`` must fail with a loop-affinity error. This is the
+customer's exact production setup distilled to a self-contained test.
+
+Skipped if grpc is unavailable (ADK ships it, so normally installed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+try:
+    import grpc  # type: ignore[import-not-found]
+    from grpc import aio as grpc_aio  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+    pytest.skip("grpc not installed", allow_module_level=True)
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+# A no-frills GenericHandler that responds with a fixed byte reply. Using
+# the low-level grpc API keeps the test independent of any generated
+# stubs and keeps it minimal.
+class _EchoHandler(grpc.GenericRpcHandler):
+    def service(self, handler_call_details):
+        if handler_call_details.method == "/echo/Echo":
+            return grpc.unary_unary_rpc_method_handler(
+                lambda request, context: b"ok:" + request,
+            )
+        return None
+
+
+class _RunningEchoServer:
+    """Context manager for a grpc.aio server + channel owned by the
+    caller's current event loop."""
+
+    def __init__(self) -> None:
+        self.server: grpc_aio.Server | None = None
+        self.channel: grpc_aio.Channel | None = None
+
+    async def __aenter__(self) -> grpc_aio.Channel:
+        self.server = grpc_aio.server()
+        self.server.add_generic_rpc_handlers((_EchoHandler(),))
+        port = self.server.add_insecure_port("127.0.0.1:0")
+        await self.server.start()
+        self.channel = grpc_aio.insecure_channel(f"127.0.0.1:{port}")
+        return self.channel
+
+    async def __aexit__(self, *args) -> None:
+        assert self.channel is not None and self.server is not None
+        await self.channel.close()
+        await self.server.stop(None)
+
+
+async def _call_echo(channel: grpc_aio.Channel, payload: bytes) -> bytes:
+    """Single unary round-trip on the given channel."""
+    rpc = channel.unary_unary(
+        "/echo/Echo",
+        request_serializer=lambda x: x,
+        response_deserializer=lambda x: x,
+    )
+    return await rpc(payload)
+
+
+class _GrpcAgent(AgentAdapter):
+    def __init__(self, channel: grpc_aio.Channel, observed: list[dict]):
+        self._channel = channel
+        self._observed = observed
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        reply = await _call_echo(self._channel, b"hello")
+        self._observed.append(
+            {
+                "loop_id": id(asyncio.get_running_loop()),
+                "thread_name": threading.current_thread().name,
+                "reply": reply.decode("utf-8"),
+            }
+        )
+        return {"role": "assistant", "content": reply.decode("utf-8")}
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "ping"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["grpc ok"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_grpc_channel_works_under_arun():
+    """Real grpc.aio channel created on the test's own loop survives
+    arun — exactly the customer's scenario (singleton channel re-used
+    from a scenario adapter)."""
+    observed: list[dict] = []
+
+    async with _RunningEchoServer() as channel:
+        result = await scenario.arun(
+            name="grpc-arun",
+            description="grpc unary RPC from adapter",
+            agents=[_GrpcAgent(channel, observed), _User(), _Judge()],
+            script=[
+                scenario.user("ping"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    assert result.success
+    assert len(observed) == 1
+    assert observed[0]["loop_id"] == id(asyncio.get_running_loop())
+    assert observed[0]["thread_name"] == threading.main_thread().name
+    assert observed[0]["reply"] == "ok:hello"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_arun_shares_one_grpc_channel():
+    """Five concurrent arun invocations all talking to the SAME
+    grpc.aio channel on the same loop — pattern that breaks under
+    the threaded path."""
+    observed: list[dict] = []
+
+    async with _RunningEchoServer() as channel:
+        async def one(i: int):
+            return await scenario.arun(
+                name=f"grpc-arun-{i}",
+                description="shared channel",
+                agents=[_GrpcAgent(channel, observed), _User(), _Judge()],
+                script=[
+                    scenario.user("ping"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+        results = await asyncio.gather(*(one(i) for i in range(5)))
+
+    assert all(r.success for r in results)
+    loop_ids = {o["loop_id"] for o in observed}
+    assert loop_ids == {id(asyncio.get_running_loop())}
+    assert len(observed) == 5
+    assert all(o["reply"] == "ok:hello" for o in observed)
+
+
+@pytest.mark.asyncio
+async def test_grpc_channel_breaks_under_scenario_run():
+    """Characterisation: the SAME real grpc.aio channel raises a
+    loop-affinity error when driven via ``scenario.run`` (threaded).
+
+    This is the customer's exact production bug reduced to a
+    self-contained test.
+    """
+    observed: list[dict] = []
+
+    async with _RunningEchoServer() as channel:
+        with pytest.raises(Exception) as excinfo:
+            await scenario.run(
+                name="grpc-run-negative",
+                description="threaded path must fail on loop-bound grpc channel",
+                agents=[_GrpcAgent(channel, observed), _User(), _Judge()],
+                script=[
+                    scenario.user("ping"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+    message = str(excinfo.value).lower()
+    assert any(
+        keyword in message
+        for keyword in (
+            "different loop",
+            "different event loop",
+            "no running event loop",
+            "event loop is closed",
+            "attached to a different",
+        )
+    ), f"Expected loop-affinity-style error, got: {excinfo.value!r}"

--- a/python/tests/test_arun_grpc_integration.py
+++ b/python/tests/test_arun_grpc_integration.py
@@ -65,12 +65,16 @@ class _RunningEchoServer:
         await self.server.stop(None)
 
 
+def _identity(x: bytes) -> bytes:
+    return x
+
+
 async def _call_echo(channel: grpc_aio.Channel, payload: bytes) -> bytes:
     """Single unary round-trip on the given channel."""
     rpc = channel.unary_unary(
         "/echo/Echo",
-        request_serializer=lambda x: x,
-        response_deserializer=lambda x: x,
+        request_serializer=_identity,
+        response_deserializer=_identity,
     )
     return await rpc(payload)
 

--- a/python/tests/test_arun_multi_turn_traces.py
+++ b/python/tests/test_arun_multi_turn_traces.py
@@ -1,0 +1,213 @@
+"""Multi-turn concurrency test for ``scenario.arun``.
+
+``ScenarioExecutor._new_turn`` creates a new LangWatch trace per turn.
+Under concurrent ``arun``, two scenarios that each cycle through several
+turns must:
+
+- emit one root "Scenario Turn" span per turn per scenario;
+- keep every span within the trace of its own turn;
+- never parent a span under another scenario's turn root, even when
+  turn boundaries interleave in wall-clock time.
+
+The customer's core concern is that shared state (loop-bound
+singletons) survives concurrency; the secondary concern is that the
+telemetry pipeline stays faithful when many scenarios overlap. This
+test covers the second.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import List, Optional
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+@pytest.fixture
+def in_memory_exporter():
+    """Keep every emitted span in memory for the test duration.
+
+    The scenario's own judge span collector is a shared singleton that
+    gets pruned on each scenario's cleanup, so it's unsafe to use
+    across concurrent scenarios. An owned ``InMemorySpanExporter``
+    sees every finished span regardless of per-scenario cleanup.
+    """
+    from opentelemetry import trace
+    from scenario._tracing import ensure_tracing_initialized
+
+    ensure_tracing_initialized(None)
+    provider = trace.get_tracer_provider()
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    if not hasattr(provider, "add_span_processor"):
+        pytest.skip(f"Active tracer provider {type(provider)} is not mutable")
+    provider.add_span_processor(processor)  # type: ignore[attr-defined]
+    try:
+        yield exporter
+    finally:
+        processor.shutdown()
+
+
+class _EchoUser(AgentAdapter):
+    role = AgentRole.USER
+
+    def __init__(self, prompts: List[str]):
+        self._prompts = prompts
+        self._idx = 0
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        prompt = self._prompts[min(self._idx, len(self._prompts) - 1)]
+        self._idx += 1
+        return prompt
+
+
+class _MeetingPoint:
+    """Python 3.10-compatible stand-in for ``asyncio.Barrier(parties)``.
+
+    Each ``wait()`` call bumps the counter and blocks until the
+    expected number of parties have arrived, then releases them all.
+    """
+
+    def __init__(self, parties: int):
+        self._parties = parties
+        self._arrived = 0
+        self._released = asyncio.Event()
+
+    async def wait(self, timeout: float = 5.0) -> None:
+        self._arrived += 1
+        if self._arrived >= self._parties:
+            self._released.set()
+        try:
+            await asyncio.wait_for(self._released.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            # Someone never arrived — release anyway so the already-waiting
+            # tasks can proceed rather than hang the suite.
+            self._released.set()
+
+
+class _TurnTrackingAgent(AgentAdapter):
+    def __init__(self, label: str, barrier: Optional["_MeetingPoint"] = None):
+        self._label = label
+        self._barrier = barrier
+        self._turn = 0
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        self._turn += 1
+        # Synchronise scenarios at every agent turn so they actually
+        # overlap on the event loop rather than running serially.
+        if self._barrier is not None:
+            await self._barrier.wait()
+        return {"role": "assistant", "content": f"{self._label} turn {self._turn}"}
+
+
+class _InstantJudge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True,
+            messages=[],
+            reasoning="ok",
+            passed_criteria=["ran to completion"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_traces_stay_isolated_under_concurrency(in_memory_exporter):
+    """Two multi-turn scenarios launched on the same loop must keep their
+    per-turn trace roots separate. Every non-root span's parent must
+    live in the same trace."""
+    prompts = ["hi first", "still there?", "great, bye"]
+
+    async def one(label: str, barrier: _MeetingPoint):
+        user = _EchoUser(list(prompts))
+        agent = _TurnTrackingAgent(label=label, barrier=barrier)
+        result = await scenario.arun(
+            name=f"multi-turn-{label}",
+            description=f"multi-turn scenario {label}",
+            agents=[agent, user, _InstantJudge()],
+            script=[
+                scenario.user(prompts[0]),
+                scenario.agent(),
+                scenario.user(prompts[1]),
+                scenario.agent(),
+                scenario.user(prompts[2]),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+        return label, result
+
+    barrier = _MeetingPoint(parties=2)
+    results = await asyncio.gather(one("A", barrier), one("B", barrier))
+    assert all(r.success for _, r in results), results
+
+    snapshot = list(in_memory_exporter.get_finished_spans())
+    assert snapshot, "exporter captured nothing from the run"
+
+    by_trace: dict[str, set[str]] = {}
+    parents: list[tuple[str, str, Optional[str]]] = []
+    for span in snapshot:
+        ctx = span.get_span_context()
+        trace_id = format(ctx.trace_id, "032x")
+        span_id = format(ctx.span_id, "016x")
+        parent = span.parent
+        parent_id = format(parent.span_id, "016x") if parent else None
+        by_trace.setdefault(trace_id, set()).add(span_id)
+        parents.append((trace_id, span_id, parent_id))
+
+    for trace_id, span_id, parent_id in parents:
+        if parent_id is None:
+            continue
+        siblings = by_trace.get(trace_id, set())
+        assert parent_id in siblings, (
+            f"Span {span_id} in trace {trace_id} points at parent "
+            f"{parent_id} which lives in a different trace — this is "
+            "the cross-pollination we must prevent."
+        )
+
+
+@pytest.mark.asyncio
+async def test_each_turn_gets_its_own_trace_under_arun(in_memory_exporter):
+    """The scenario executor opens one LangWatch trace per turn. After a
+    3-turn scenario, at least 3 distinct trace_ids appear."""
+    prompts = ["first", "second", "third"]
+
+    await scenario.arun(
+        name="three-turns",
+        description="three turns single-scenario",
+        agents=[_TurnTrackingAgent("solo"), _EchoUser(prompts), _InstantJudge()],
+        script=[
+            scenario.user(prompts[0]),
+            scenario.agent(),
+            scenario.user(prompts[1]),
+            scenario.agent(),
+            scenario.user(prompts[2]),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+
+    snapshot = list(in_memory_exporter.get_finished_spans())
+    turn_roots = {
+        format(s.get_span_context().trace_id, "032x")
+        for s in snapshot
+        if s.name == "Scenario Turn"
+    }
+
+    assert len(turn_roots) >= 3, (
+        f"Expected at least 3 distinct 'Scenario Turn' trace ids from a "
+        f"3-turn scenario, got {len(turn_roots)}: {turn_roots}"
+    )

--- a/python/tests/test_arun_real_llm_integration.py
+++ b/python/tests/test_arun_real_llm_integration.py
@@ -1,0 +1,122 @@
+"""Concurrent ``scenario.arun`` with real LLM-backed simulator + judge.
+
+The customer relies on ``UserSimulatorAgent`` and ``JudgeAgent`` — both
+hit an LLM under the hood via litellm. This test proves they work
+correctly when multiple scenarios run concurrently on the same loop,
+including that their LLM spans end up parented under the correct
+Scenario Turn root and never leak between scenarios.
+
+Requires ``OPENAI_API_KEY``. Uses ``gpt-5-mini`` per CLAUDE.md guidance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+
+
+scenario.configure(default_model="openai/gpt-5-mini")
+
+
+class _EchoAgent(AgentAdapter):
+    """Keeps the test cheap: the agent-under-test is a deterministic echo,
+    so the LLM burn is only the simulator + judge calls."""
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        last = next(
+            (m for m in reversed(input.messages) if m.get("role") == "user"),
+            None,
+        )
+        raw = (last or {}).get("content") or ""
+        text = raw if isinstance(raw, str) else ""
+        return {"role": "assistant", "content": f"I heard you say: {text[:60]}"}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_arun_with_real_simulator_and_judge():
+    """Three concurrent scenarios, each with a full simulator+judge pipeline.
+
+    Success criterion: all three return without raising a loop-affinity
+    error, and every scenario's spans stay in that scenario's trace
+    (invariant checked via the in-process span collector).
+    """
+    from scenario._tracing import judge_span_collector
+
+    before_span_ids = {
+        id(s) for s in (getattr(judge_span_collector, "_spans", []) or [])
+    }
+
+    async def one(i: int):
+        return await scenario.arun(
+            name=f"real-llm-{i}",
+            description=(
+                "User asks a simple question and is mostly happy with the "
+                "echo, then asks one follow-up."
+            ),
+            agents=[
+                _EchoAgent(),
+                scenario.UserSimulatorAgent(),
+                scenario.JudgeAgent(
+                    criteria=[
+                        "The agent responded at least twice",
+                        "The agent's response included something echoed from the user's words",
+                    ],
+                ),
+            ],
+            max_turns=4,
+        )
+
+    results = await asyncio.gather(*(one(i) for i in range(3)))
+
+    # The judge output depends on LLM wording; we don't care whether it
+    # says PASS or FAIL, only that it didn't blow up.
+    for r in results:
+        assert r is not None, "arun returned no result"
+
+    all_spans = [
+        s
+        for s in (getattr(judge_span_collector, "_spans", []) or [])
+        if id(s) not in before_span_ids
+    ]
+    assert all_spans, "expected some spans from the concurrent run"
+
+    by_trace: dict[str, set[str]] = {}
+    parents: list[tuple[str, str, str | None]] = []
+    for span in all_spans:
+        ctx = span.get_span_context()
+        trace_id = format(ctx.trace_id, "032x")
+        span_id = format(ctx.span_id, "016x")
+        parent = span.parent
+        parent_id = format(parent.span_id, "016x") if parent else None
+        by_trace.setdefault(trace_id, set()).add(span_id)
+        parents.append((trace_id, span_id, parent_id))
+
+    for trace_id, span_id, parent_id in parents:
+        if parent_id is None:
+            continue
+        assert parent_id in by_trace[trace_id], (
+            f"Span {span_id} in trace {trace_id} refers to parent "
+            f"{parent_id} which is not in the same trace — spans from "
+            "different concurrent scenarios leaked into each other."
+        )
+
+    # At least one distinct LiteLLM / langwatch span must show up per
+    # scenario — i.e. ≥ 3 distinct trace ids in total from this run.
+    distinct_traces = {t for t, _, _ in parents}
+    assert len(distinct_traces) >= 3, (
+        f"Expected ≥ 3 distinct traces (one per scenario), got "
+        f"{len(distinct_traces)}: {distinct_traces}"
+    )

--- a/python/tests/test_arun_user_spans.py
+++ b/python/tests/test_arun_user_spans.py
@@ -81,6 +81,7 @@ class _InstrumentedAgent(AgentAdapter):
         self._barrier = barrier
 
     async def call(self, input: AgentInput) -> AgentReturnTypes:
+        reply = f"{self._label} done"
         with langwatch.span(name=f"user_work.{self._label}") as s:
             s.set_attributes({"user.label": self._label})
             # Synchronise across sibling scenarios so two user spans
@@ -88,7 +89,7 @@ class _InstrumentedAgent(AgentAdapter):
             # detectable if present.
             if self._barrier is not None:
                 await self._barrier.wait()
-            return {"role": "assistant", "content": f"{self._label} done"}
+        return {"role": "assistant", "content": reply}
 
 
 class _User(AgentAdapter):

--- a/python/tests/test_arun_user_spans.py
+++ b/python/tests/test_arun_user_spans.py
@@ -1,0 +1,175 @@
+"""Adapter-created spans parent under the correct Scenario Turn under
+concurrent ``scenario.arun``.
+
+When users instrument their adapter via ``langwatch.span(...)`` (or by
+an OTel instrumentor) those spans must land inside THEIR scenario's
+trace, not some sibling's. The ADK integration test shows this works
+in practice; this test isolates the invariant without the ADK runtime
+so CI can run it without Gemini.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+import langwatch
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+@pytest.fixture
+def in_memory_exporter():
+    """Attach an in-memory exporter to the active tracer provider for the
+    duration of the test. This keeps captured spans even after the
+    scenario's own cleanup runs.
+
+    Scenario lazily installs its own ``TracerProvider`` when the first
+    ``run``/``arun`` fires, but we need to attach the exporter
+    beforehand. Force the init with ``ensure_tracing_initialized`` so
+    the global provider is concrete before we mutate it.
+    """
+    from opentelemetry import trace
+    from scenario._tracing import ensure_tracing_initialized
+
+    ensure_tracing_initialized(None)
+    provider = trace.get_tracer_provider()
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    if not hasattr(provider, "add_span_processor"):
+        pytest.skip(f"Active tracer provider {type(provider)} is not mutable")
+    provider.add_span_processor(processor)  # type: ignore[attr-defined]
+    try:
+        yield exporter
+    finally:
+        processor.shutdown()
+
+
+class _MeetingPoint:
+    """Python 3.10-compatible stand-in for ``asyncio.Barrier(parties)``."""
+
+    def __init__(self, parties: int):
+        self._parties = parties
+        self._arrived = 0
+        self._released = asyncio.Event()
+
+    async def wait(self, timeout: float = 5.0) -> None:
+        self._arrived += 1
+        if self._arrived >= self._parties:
+            self._released.set()
+        try:
+            await asyncio.wait_for(self._released.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            self._released.set()
+
+
+class _InstrumentedAgent(AgentAdapter):
+    """Emits a nested user-owned span inside its call."""
+
+    def __init__(self, label: str, barrier: "_MeetingPoint | None" = None):
+        self._label = label
+        self._barrier = barrier
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        with langwatch.span(name=f"user_work.{self._label}") as s:
+            s.set_attributes({"user.label": self._label})
+            # Synchronise across sibling scenarios so two user spans
+            # overlap in wall-clock time — makes cross-contamination
+            # detectable if present.
+            if self._barrier is not None:
+                await self._barrier.wait()
+            return {"role": "assistant", "content": f"{self._label} done"}
+
+
+class _User(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class _Judge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True, messages=[], reasoning="ok", passed_criteria=["t"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_adapter_user_span_parents_to_scenario_turn(in_memory_exporter):
+    """Under concurrent arun, each adapter's user span must end up
+    parented inside that adapter's scenario, not its sibling's."""
+    barrier = _MeetingPoint(parties=2)
+
+    async def one(label: str):
+        return await scenario.arun(
+            name=f"user-span-{label}",
+            description=f"instrumented scenario {label}",
+            agents=[_InstrumentedAgent(label, barrier), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+    results = await asyncio.gather(one("A"), one("B"))
+    assert all(r.success for r in results)
+
+    new_spans = list(in_memory_exporter.get_finished_spans())
+
+    user_spans = [s for s in new_spans if s.name.startswith("user_work.")]
+    span_names = [s.name for s in new_spans]
+    assert len(user_spans) == 2, (
+        f"expected 2 user spans, got {len(user_spans)}. "
+        f"Captured span names: {span_names}"
+    )
+
+    # Build trace_id → (span_id → name).
+    by_trace: dict[str, dict[str, str]] = {}
+    for s in new_spans:
+        ctx = s.get_span_context()
+        trace_id = format(ctx.trace_id, "032x")
+        span_id = format(ctx.span_id, "016x")
+        by_trace.setdefault(trace_id, {})[span_id] = s.name
+
+    for s in user_spans:
+        ctx = s.get_span_context()
+        trace_id = format(ctx.trace_id, "032x")
+        assert s.parent is not None, (
+            f"user span {s.name} has no parent — it should be a child "
+            "of the Scenario Turn root"
+        )
+        parent_id = format(s.parent.span_id, "016x")
+        parent_name = by_trace.get(trace_id, {}).get(parent_id)
+        assert parent_name is not None, (
+            f"user span {s.name} (trace {trace_id}) parents at {parent_id} "
+            "which is NOT in its own trace — cross-scenario leak."
+        )
+        # The parent should be the adapter's own _InstrumentedAgent.call
+        # or the Scenario Turn root; never a sibling's user_work.*.
+        assert not parent_name.startswith("user_work."), (
+            f"user span {s.name} parented under ANOTHER user span "
+            f"({parent_name}) — that's leakage between concurrent scenarios."
+        )
+
+    # Each scenario's user span must live in a different trace.
+    user_trace_ids = {
+        format(s.get_span_context().trace_id, "032x") for s in user_spans
+    }
+    assert len(user_trace_ids) == 2, (
+        f"two concurrent scenarios should yield 2 distinct trace ids "
+        f"for user spans, got {user_trace_ids}"
+    )

--- a/python/tests/test_async_native_parallelism.py
+++ b/python/tests/test_async_native_parallelism.py
@@ -1,0 +1,329 @@
+"""Tests for the async-native ``scenario.arun`` entrypoint.
+
+Regression coverage for the ThreadPoolExecutor-per-run design of
+``scenario.run``: loop-bound resources (gRPC channels, ``asyncio.Event``,
+etc.) that were constructed on the caller's loop must survive being
+awaited inside a scenario adapter. See
+``specs/async-native-parallelism.feature``.
+"""
+
+import asyncio
+import os
+import threading
+from typing import List
+
+import pytest
+
+# Disable scenario's "open the run in a browser" behaviour for these
+# tests so that running them locally doesn't spam browser tabs.
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+class _FinishingJudge(AgentAdapter):
+    """Judge that immediately returns a successful result.
+
+    Inherits from the base ``AgentAdapter`` rather than ``JudgeAgent`` so
+    we don't have to configure an LLM just to exercise the executor.
+    """
+
+    role = AgentRole.JUDGE
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True,
+            messages=[],
+            reasoning="ok",
+            passed_criteria=["test criteria"],
+        )
+
+
+class _EchoUser(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        return "hi"
+
+
+class LoopBoundResource:
+    """A resource bound to the event loop it was created on.
+
+    Mirrors what a gRPC channel / Firestore client / ADK ``InMemoryRunner``
+    looks like in practice: ``ping()`` schedules work on the loop it
+    remembers and awaits a future created there. Awaiting that future
+    from a different loop is exactly what the ThreadPoolExecutor path
+    of ``scenario.run`` does and what breaks.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+
+    async def ping(self) -> str:
+        # ``run_coroutine_threadsafe`` schedules the inner coroutine on
+        # the remembered loop and returns a ``concurrent.futures.Future``
+        # — if this method is awaited from a DIFFERENT loop (i.e. the
+        # scenario.run worker-thread loop), the remembered loop's
+        # Future will not be drivable from here and we block/error.
+        if asyncio.get_running_loop() is not self._loop:
+            raise RuntimeError(
+                "Future attached to a different loop: "
+                f"running={id(asyncio.get_running_loop())} "
+                f"resource={id(self._loop)}"
+            )
+        await asyncio.sleep(0)
+        return "pong"
+
+
+class _LoopBoundAgent(AgentAdapter):
+    """Awaits a :class:`LoopBoundResource` created on a specific loop."""
+
+    def __init__(self, resource: LoopBoundResource, observed: List[dict]) -> None:
+        self._resource = resource
+        self._observed = observed
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        reply = await self._resource.ping()
+        self._observed.append(
+            {
+                "loop_id": id(asyncio.get_running_loop()),
+                "thread_name": threading.current_thread().name,
+            }
+        )
+        return {"role": "assistant", "content": reply}
+
+
+async def _build_ready_event() -> LoopBoundResource:
+    """Back-compat alias used by existing tests.
+
+    Returns a resource bound to the currently running loop.
+    """
+    return LoopBoundResource(asyncio.get_running_loop())
+
+
+class TestArun:
+    @pytest.mark.asyncio
+    async def test_runs_on_callers_event_loop(self):
+        ready = await _build_ready_event()
+        observed: List[dict] = []
+
+        result = await scenario.arun(
+            name="loop-bound",
+            description="agent awaits a caller-loop resource",
+            agents=[
+                _LoopBoundAgent(ready, observed),
+                _EchoUser(),
+                _FinishingJudge(),
+            ],
+            script=[
+                scenario.user("ping"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+
+        assert result.success is True
+        assert len(observed) == 1
+        assert observed[0]["loop_id"] == id(asyncio.get_running_loop())
+
+    @pytest.mark.asyncio
+    async def test_loop_bound_singleton_survives_concurrent_runs(self):
+        """Several arun() calls gathered on the same loop share one resource."""
+        ready = await _build_ready_event()
+        observed: List[dict] = []
+
+        async def one(name: str):
+            return await scenario.arun(
+                name=name,
+                description="shared singleton",
+                agents=[
+                    _LoopBoundAgent(ready, observed),
+                    _EchoUser(),
+                    _FinishingJudge(),
+                ],
+                script=[
+                    scenario.user("ping"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+        results = await asyncio.gather(*(one(f"s-{i}") for i in range(5)))
+
+        assert all(r.success for r in results)
+        assert len(observed) == 5
+        loop_id = id(asyncio.get_running_loop())
+        assert all(o["loop_id"] == loop_id for o in observed)
+
+    @pytest.mark.asyncio
+    async def test_sibling_runs_isolate_failures(self):
+        """One failing scenario does not abort sibling scenarios."""
+        ready = await _build_ready_event()
+        observed: List[dict] = []
+
+        class _Boom(AgentAdapter):
+            async def call(self, input: AgentInput) -> AgentReturnTypes:
+                raise RuntimeError("boom")
+
+        async def ok(i: int):
+            return await scenario.arun(
+                name=f"ok-{i}",
+                description="healthy sibling",
+                agents=[
+                    _LoopBoundAgent(ready, observed),
+                    _EchoUser(),
+                    _FinishingJudge(),
+                ],
+                script=[
+                    scenario.user("hi"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+        async def bad():
+            return await scenario.arun(
+                name="bad",
+                description="raises",
+                agents=[_Boom(), _EchoUser(), _FinishingJudge()],
+                script=[
+                    scenario.user("hi"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+        results = await asyncio.gather(ok(0), bad(), ok(1), return_exceptions=True)
+
+        assert isinstance(results[0], ScenarioResult) and results[0].success
+        assert isinstance(results[1], Exception)
+        assert isinstance(results[2], ScenarioResult) and results[2].success
+        assert len(observed) == 2
+
+    @pytest.mark.asyncio
+    async def test_runs_actually_interleave(self):
+        """Two scenarios run concurrently on the same loop must overlap.
+
+        If arun accidentally serialises (e.g. by holding a global lock
+        or re-introducing a per-run thread), the max in-flight count
+        would stay at 1.
+        """
+        in_flight = 0
+        peak = 0
+        lock = asyncio.Lock()
+        gate = asyncio.Event()
+
+        class _Slow(AgentAdapter):
+            async def call(self, input: AgentInput) -> AgentReturnTypes:
+                nonlocal in_flight, peak
+                async with lock:
+                    in_flight += 1
+                    peak = max(peak, in_flight)
+                # Block until both scenarios are in flight, then release.
+                if in_flight >= 2:
+                    gate.set()
+                await asyncio.wait_for(gate.wait(), timeout=2.0)
+                async with lock:
+                    in_flight -= 1
+                return {"role": "assistant", "content": "ok"}
+
+        async def one(i: int):
+            return await scenario.arun(
+                name=f"slow-{i}",
+                description="concurrency proof",
+                agents=[_Slow(), _EchoUser(), _FinishingJudge()],
+                script=[
+                    scenario.user("hi"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+        results = await asyncio.gather(one(0), one(1))
+        assert all(r.success for r in results)
+        assert peak == 2, f"expected concurrent execution, saw peak={peak}"
+
+    @pytest.mark.asyncio
+    async def test_unique_scenario_run_ids(self):
+        ready = await _build_ready_event()
+        observed: List[dict] = []
+
+        async def one():
+            return await scenario.arun(
+                name="dup-check",
+                description="unique ids",
+                agents=[
+                    _LoopBoundAgent(ready, observed),
+                    _EchoUser(),
+                    _FinishingJudge(),
+                ],
+                script=[
+                    scenario.user("hi"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+        await asyncio.gather(*(one() for _ in range(8)))
+
+        # Each arun() builds its own ScenarioExecutor, so even without
+        # exposing the id here the side effect we can assert is the
+        # absence of any cross-run interference: the number of observed
+        # invocations should equal the number of scenarios.
+        assert len(observed) == 8
+
+
+class TestRunStillThreaded:
+    """Guard against accidentally changing ``scenario.run``'s contract."""
+
+    @pytest.mark.asyncio
+    async def test_sync_adapter_style_still_works(self):
+        class _PlainAgent(AgentAdapter):
+            async def call(self, input: AgentInput) -> AgentReturnTypes:
+                return {"role": "assistant", "content": "hi"}
+
+        result = await scenario.run(
+            name="plain",
+            description="no loop-bound resources",
+            agents=[_PlainAgent(), _EchoUser(), _FinishingJudge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_demonstrates_loop_affinity_break_under_run(self):
+        """Characterisation test: ``scenario.run`` DOES break loop-bound
+        awaitables today. This is the exact customer symptom and the
+        reason ``arun`` exists.
+        """
+        ready = await _build_ready_event()
+        observed: List[dict] = []
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await scenario.run(
+                name="expected-broken",
+                description="awaiting on a caller-loop Event",
+                agents=[
+                    _LoopBoundAgent(ready, observed),
+                    _EchoUser(),
+                    _FinishingJudge(),
+                ],
+                script=[
+                    scenario.user("ping"),
+                    scenario.agent(),
+                    scenario.judge(),
+                ],
+            )
+
+        # The same test under scenario.arun succeeds (see
+        # TestArun::test_runs_on_callers_event_loop). The failure mode is
+        # always some form of loop-affinity error coming from asyncio —
+        # pin just the "different loop" signature so any future
+        # regression in the diagnostic message is caught.
+        assert "different loop" in str(excinfo.value).lower()

--- a/specs/async-native-parallelism.feature
+++ b/specs/async-native-parallelism.feature
@@ -1,7 +1,7 @@
 Feature: Async-native parallelism for scenario runs
-  As a scenario test author whose agent harness holds loop-bound singletons
+  As a scenario test author whose adapter relies on loop-bound async state
   I want scenarios to execute on my own event loop instead of a private thread-loop
-  So that gRPC channels, Firestore clients, and async fixtures survive concurrent scenario runs without "Future attached to a different loop"
+  So that my async fixtures and objects survive concurrent scenario runs without "Future attached to a different loop"
 
   Background:
     Given an async-native AgentAdapter implementation
@@ -60,12 +60,12 @@ Feature: Async-native parallelism for scenario runs
     When the scenario turn completes
     Then every agent span parents up to the "Scenario Turn" root of that run
 
-  # --- ADK end-to-end ---
+  # --- End-to-end ---
 
   @e2e
-  Scenario: Shared ADK InMemoryRunner used by many scenarios concurrently
-    Given an ADK InMemoryRunner created once in a pytest fixture
-    And multiple scenarios that call runner.run_async during their adapter
+  Scenario: Shared async singleton used by many scenarios concurrently
+    Given a long-lived async singleton created in a pytest fixture on the caller's loop
+    And multiple scenarios whose adapter awaits on that singleton
     When they are executed concurrently through scenario.arun()
     Then all runs complete without loop-affinity errors
     And each run appears as a distinct trace in ClickHouse

--- a/specs/async-native-parallelism.feature
+++ b/specs/async-native-parallelism.feature
@@ -1,0 +1,72 @@
+Feature: Async-native parallelism for scenario runs
+  As a scenario test author whose agent harness holds loop-bound singletons
+  I want scenarios to execute on my own event loop instead of a private thread-loop
+  So that gRPC channels, Firestore clients, and async fixtures survive concurrent scenario runs without "Future attached to a different loop"
+
+  Background:
+    Given an async-native AgentAdapter implementation
+
+  # --- Loop affinity ---
+
+  @unit
+  Scenario: Async adapter executes on the caller's event loop
+    Given a scenario.arun() call issued from an existing event loop
+    When the agent adapter awaits on a resource created in that same loop
+    Then the resource is awaited successfully
+    And no "Future attached to a different loop" error is raised
+
+  @unit
+  Scenario: Loop-bound singleton survives concurrent scenario runs
+    Given a resource created once outside the scenario and bound to the caller's loop
+    When several scenarios are executed concurrently through scenario.arun()
+    Then every run reuses the same singleton
+    And no loop-affinity error is raised on any run
+
+  @unit
+  Scenario: scenario.run() keeps its private thread-loop behaviour
+    Given an adapter whose body is fully self-contained with no loop-bound dependencies
+    When it is executed through scenario.run()
+    Then it still runs inside a dedicated worker thread and private event loop
+    And existing test suites relying on that behaviour continue to pass
+
+  # --- Concurrency correctness ---
+
+  @unit
+  Scenario: Concurrent runs produce isolated results
+    Given two scenarios launched through scenario.arun() on the same loop
+    When both complete successfully
+    Then each scenario returns its own result object
+    And neither result contains messages from the other scenario
+
+  @unit
+  Scenario: A failing concurrent run does not abort siblings
+    Given three scenarios launched through scenario.arun() where one raises mid-run
+    When the gather completes
+    Then the two sibling scenarios still produce their results
+    And the failing scenario surfaces its error to the caller
+
+  # --- Telemetry ---
+
+  @integration
+  Scenario: Each concurrent scenario owns its own OTel trace
+    Given several scenarios running concurrently through scenario.arun()
+    When spans are exported
+    Then every scenario's spans share a single root trace id unique to that scenario
+    And no span from one scenario is parented under another scenario's span
+
+  @integration
+  Scenario: Agent spans are parented under their scenario turn
+    Given a running scenario where an instrumented agent emits spans
+    When the scenario turn completes
+    Then every agent span parents up to the "Scenario Turn" root of that run
+
+  # --- ADK end-to-end ---
+
+  @e2e
+  Scenario: Shared ADK InMemoryRunner used by many scenarios concurrently
+    Given an ADK InMemoryRunner created once in a pytest fixture
+    And multiple scenarios that call runner.run_async during their adapter
+    When they are executed concurrently through scenario.arun()
+    Then all runs complete without loop-affinity errors
+    And each run appears as a distinct trace in ClickHouse
+    And cost and token counts roll up correctly per scenario


### PR DESCRIPTION
## Summary

- Adds `scenario.arun()` — async-native sibling of `scenario.run()` — that executes the adapter on the caller's event loop instead of a private worker-thread loop. Loop-bound singletons (gRPC channels, Firestore clients, ADK `InMemoryRunner`, async fixtures) now survive parallel scenario runs.
- Keeps `scenario.run()` behaviour unchanged for users on sync-style adapters; docstring gains a pointer to `arun` for the loop-affinity case.
- Mirrors the fix landed for the langwatch SDK experiment loop in [langwatch/langwatch#3273](https://github.com/langwatch/langwatch/pull/3273).

### The bug this fixes

The customer's exact words:

> gRPC channels, Firestore clients, and other connections are bound to the event loop they were created on. Once a channel is created on loop A, it cannot be used from loop B. You get "Future attached to a different loop."

`scenario.run()` wraps each invocation in a `ThreadPoolExecutor` worker that spins up its own event loop via `asyncio.new_event_loop()`. Any resource bound to the caller's loop — gRPC, Firestore, ADK `InMemoryRunner`, an `asyncio.Event` created in a pytest fixture — raises the instant the adapter awaits on it.

`scenario.arun()` runs the adapter directly on the caller's event loop. Parallelism comes from the caller (`asyncio.gather`, `pytest-asyncio-concurrent`, `experiment.aloop` + `experiment.asubmit`).

## Migration

```python
# before
result = await scenario.run(
    name="…",
    agents=[adapter, scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
)

# after — only the call changes
result = await scenario.arun(
    name="…",
    agents=[adapter, scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
)
```

New example under `python/examples/test_running_in_parallel_with_arun.py` shows the recommended `@pytest.mark.asyncio_concurrent(group=…) + scenario.arun` pattern side-by-side with the existing threaded example.

## Test plan

25 new tests across 11 files, all passing. Covering:

- **Loop affinity** — synthetic resource + literal **`grpc.aio` reproduction** of the customer's bug. `arun` succeeds on a shared channel with 5 concurrent runs; `scenario.run` raises `"attached to a different loop"` as a negative control.
- **ADK** — shared `InMemoryRunner` across 4 concurrent scenarios.
- **Real LLM agents** — `UserSimulatorAgent + JudgeAgent` concurrent via gpt-5-mini.
- **Parallel frameworks** — `pytest-asyncio-concurrent`, `pytest-rerunfailures`.
- **Lifecycle** — cancellation propagation + sibling survival, exception chain preservation, event bus drain on adapter error.
- **Telemetry** — per-turn trace isolation, user-span parentage, `batch_run_id` sharing, `@scenario.cache` dedupes under concurrency.
- **True-concurrency proof** — peak in-flight == 2 under a semaphore.

### End-to-end against local langwatch + ClickHouse

- 50-scenario stress: 50 distinct trace IDs, 0 orphan parents, 8.7s wall.
- Mixed `run()` + `arun()` concurrently: 6 isolated traces.
- ADK with priced `gemini-2.5-flash`: `TotalCost=$0.00023` per trace, prompt+completion tokens rolled up.
- **Parity** between `run()` and `arun()` on the same scenario: identical span count (11), same model, same token counts, equivalent cost.
- Parentage integrity: 208 spans audited across paths, 0 orphans.
- Nested `experiment.aloop` + `scenario.arun`: 4 dataset items on a single loop, 4 distinct langwatch traces.

### How to run locally

```bash
cd python
uv sync --all-groups --all-extras
# Unit + integration (no server):
SCENARIO_HEADLESS=true uv run pytest tests/test_arun_*.py tests/test_async_native_parallelism.py
# Existing suite (regression):
SCENARIO_HEADLESS=true uv run pytest tests/
```

## Verification

- [x] Pyright clean
- [x] 25 new tests pass
- [x] Existing suite unaffected (380 pass; 2 pre-existing red-team 401s need `ANTHROPIC_API_KEY` — unrelated)
- [x] Travel-agent, recipe, and running_in_parallel examples still pass
- [x] Thread count stable across 100 sequential arun (no leak)
- [x] Python 3.10+ compatible (avoids `asyncio.Barrier` / 3.11-only features)