### PR TITLE
fix(judge): harden forceVerdict so discovery tools cannot leak (JS + Python)

### DIFF
--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -565,6 +565,180 @@ describe("JudgeAgent", () => {
       expect(result!.unmetCriteria).toContain("Agent uses tools");
     });
 
+    it("strips discovery tools and rewrites history before forced verdict", async () => {
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent works correctly"],
+        spanCollector: collector,
+        maxDiscoverySteps: 2,
+      };
+
+      const agent = judgeAgent(config);
+
+      let forcedParams: InvokeLLMParams | undefined;
+      let callCount = 0;
+      agent.invokeLLM = async (params) => {
+        callCount++;
+        if (callCount === 1) {
+          // Simulate a real multi-step loop: last step emits a discovery tool
+          // and the accumulated history carries the matching tool_use /
+          // tool_result pair that would normally trip up a stripped call.
+          const prevMessages = params.messages ?? [];
+          params.messages = [
+            ...prevMessages,
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "tool-call" as const,
+                  toolCallId: "tc-1",
+                  toolName: "expand_trace",
+                  input: { span_ids: ["deadbeef00000000"] },
+                },
+              ],
+            },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result" as const,
+                  toolCallId: "tc-1",
+                  toolName: "expand_trace",
+                  output: { type: "text", value: "span details here" },
+                },
+              ],
+            },
+          ] as any;
+          return {
+            text: "",
+            content: [],
+            toolCalls: [
+              {
+                toolName: "grep_trace",
+                input: { pattern: "error" },
+                type: "tool-call" as const,
+                toolCallId: "tc-2",
+              },
+            ],
+            toolResults: [],
+          } as unknown as InvokeLLMResult;
+        }
+        forcedParams = params;
+        return mockLLMResult("finish_test", {
+          criteria: { agent_works_correctly: "true" },
+          reasoning: "ok",
+          verdict: "success",
+        });
+      };
+
+      const result = await agent.call(createBaseInput());
+
+      expect(callCount).toBe(2);
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(true);
+
+      // forceVerdict must have stripped expand_trace and grep_trace from the
+      // tool set, leaving only the terminal tools.
+      const toolNames = Object.keys(forcedParams!.tools ?? {});
+      expect(toolNames).not.toContain("expand_trace");
+      expect(toolNames).not.toContain("grep_trace");
+      expect(toolNames).toContain("finish_test");
+
+      // Message history must have been rewritten: no assistant message
+      // should still contain a tool-call part for a discovery tool, and no
+      // tool-role message should remain.
+      const msgs = forcedParams!.messages ?? [];
+      for (const m of msgs) {
+        expect(m.role).not.toBe("tool");
+        if (m.role === "assistant" && Array.isArray(m.content)) {
+          for (const part of m.content as Array<Record<string, unknown>>) {
+            expect(part.type).not.toBe("tool-call");
+          }
+        }
+      }
+
+      // The recap text should carry forward what the discovery tool returned
+      // so the model can still reason about it.
+      const recapHit = msgs.some(
+        (m) =>
+          m.role === "assistant" &&
+          typeof m.content === "string" &&
+          m.content.includes("expand_trace") &&
+          m.content.includes("span details here")
+      );
+      expect(recapHit).toBe(true);
+    });
+
+    it("skips forceVerdict when an earlier step already emitted finish_test", async () => {
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent works correctly"],
+        spanCollector: collector,
+        maxDiscoverySteps: 3,
+      };
+
+      const agent = judgeAgent(config);
+
+      let callCount = 0;
+      agent.invokeLLM = async () => {
+        callCount++;
+        // AI SDK v6 surfaces only the last step in `toolCalls`, but an
+        // earlier step did emit finish_test. discoveryExhausted should
+        // spot it via `steps` and skip the force path.
+        return {
+          text: "",
+          content: [],
+          toolCalls: [
+            {
+              toolName: "expand_trace",
+              input: { span_ids: ["0000000000000000"] },
+              type: "tool-call" as const,
+              toolCallId: "tc-last",
+            },
+          ],
+          toolResults: [],
+          steps: [
+            {
+              toolCalls: [
+                {
+                  toolName: "expand_trace",
+                  input: { span_ids: ["0000000000000000"] },
+                  type: "tool-call" as const,
+                  toolCallId: "tc-first",
+                },
+              ],
+            },
+            {
+              toolCalls: [
+                {
+                  toolName: "finish_test",
+                  input: {
+                    criteria: { agent_works_correctly: "true" },
+                    reasoning: "converged early",
+                    verdict: "success",
+                  },
+                  type: "tool-call" as const,
+                  toolCallId: "tc-finish",
+                },
+              ],
+            },
+            {
+              toolCalls: [
+                {
+                  toolName: "expand_trace",
+                  input: { span_ids: ["0000000000000000"] },
+                  type: "tool-call" as const,
+                  toolCallId: "tc-last",
+                },
+              ],
+            },
+          ],
+        } as unknown as InvokeLLMResult;
+      };
+
+      await agent.call(createBaseInput());
+      // Only one LLM call — forceVerdict must not have fired.
+      expect(callCount).toBe(1);
+    });
+
     it("returns inconclusive when forceVerdict still leaks a discovery tool", async () => {
       const config: JudgeAgentConfig = {
         criteria: ["Agent works correctly"],

--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -564,5 +564,42 @@ describe("JudgeAgent", () => {
       expect(result!.metCriteria).toContain("Agent responds politely");
       expect(result!.unmetCriteria).toContain("Agent uses tools");
     });
+
+    it("returns inconclusive when forceVerdict still leaks a discovery tool", async () => {
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent works correctly"],
+        spanCollector: collector,
+        maxDiscoverySteps: 2,
+      };
+
+      const agent = judgeAgent(config);
+
+      agent.invokeLLM = async () => {
+        // Simulate both the exhausted discovery loop and a forceVerdict
+        // response where the model ignored tool_choice and still returned
+        // only a discovery tool.
+        return {
+          text: "",
+          content: [],
+          toolCalls: [
+            {
+              toolName: "grep_trace",
+              input: { pattern: "anything" },
+              type: "tool-call" as const,
+              toolCallId: "tc-leak",
+            },
+          ],
+          toolResults: [],
+        } as unknown as InvokeLLMResult;
+      };
+
+      const result = await agent.call(createBaseInput());
+
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+      expect(result!.reasoning).not.toContain("Unknown tool call");
+      expect(result!.reasoning).toContain("did not converge");
+      expect(result!.unmetCriteria).toContain("Agent works correctly");
+    });
   });
 });

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -436,6 +436,21 @@ class JudgeAgent extends JudgeAgentAdapter {
           return null;
 
         default:
+          if (
+            toolCall.toolName === "expand_trace" ||
+            toolCall.toolName === "grep_trace"
+          ) {
+            this.logger.warn(
+              `Discovery tool ${toolCall.toolName} leaked past discovery loop without reaching a terminal verdict`
+            );
+            return {
+              success: false,
+              reasoning:
+                "JudgeAgent: trace discovery did not converge on a verdict within the step budget",
+              metCriteria: [],
+              unmetCriteria: criteria,
+            };
+          }
           return {
             success: false,
             reasoning: `JudgeAgent: Unknown tool call: ${toolCall.toolName}`,

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -8,6 +8,115 @@ import {
   stepCountIs,
   hasToolCall,
 } from "ai";
+
+const DISCOVERY_TOOL_NAMES = new Set(["expand_trace", "grep_trace"]);
+
+/**
+ * Stringifies a tool result's `output` field into something safe to embed in
+ * a plain-text assistant message.
+ */
+function stringifyToolOutput(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (output && typeof output === "object") {
+    const maybeValue = (output as { value?: unknown }).value;
+    if (typeof maybeValue === "string") return maybeValue;
+    try {
+      return JSON.stringify(output);
+    } catch {
+      return String(output);
+    }
+  }
+  return String(output);
+}
+
+/**
+ * Rewrites the message history so every discovery cycle
+ * (assistant tool-call for expand_trace/grep_trace → tool-result) is
+ * collapsed into a single plain-text assistant message recounting what
+ * the judge called and what came back.
+ *
+ * Two reasons this matters before a forced verdict:
+ *  1. Anthropic rejects calls whose history references tools that aren't
+ *     in the current `tools` array. Plain-text history lets us safely strip
+ *     expand_trace/grep_trace from the tool set.
+ *  2. With the discovery tools gone from both history and tool set, the
+ *     model physically cannot emit them in the forced response — no more
+ *     leaks past `parseToolCalls`.
+ *
+ * Messages without discovery tool content pass through unchanged, so
+ * nothing else (criteria, transcripts, non-discovery tool calls) is
+ * affected.
+ */
+function collapseDiscoveryHistory(
+  messages: readonly ModelMessage[]
+): ModelMessage[] {
+  const out: ModelMessage[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      const parts = msg.content as Array<Record<string, unknown>>;
+      const discoveryCalls = parts.filter(
+        (p) =>
+          p?.type === "tool-call" &&
+          typeof p.toolName === "string" &&
+          DISCOVERY_TOOL_NAMES.has(p.toolName)
+      );
+
+      if (discoveryCalls.length > 0) {
+        const nextMsg = messages[i + 1];
+        const resultParts: Array<Record<string, unknown>> =
+          nextMsg?.role === "tool" && Array.isArray(nextMsg.content)
+            ? (nextMsg.content as Array<Record<string, unknown>>).filter(
+                (p) => p?.type === "tool-result"
+              )
+            : [];
+
+        const lines: string[] = [];
+        for (const p of parts) {
+          if (p?.type === "text" && typeof p.text === "string") {
+            lines.push(p.text);
+          } else if (
+            p?.type === "tool-call" &&
+            typeof p.toolName === "string" &&
+            DISCOVERY_TOOL_NAMES.has(p.toolName)
+          ) {
+            const match = resultParts.find(
+              (r) => r.toolCallId === p.toolCallId
+            );
+            let input: string;
+            try {
+              input = JSON.stringify(p.input);
+            } catch {
+              input = String(p.input);
+            }
+            const body = match
+              ? stringifyToolOutput(match.output)
+              : "(no result captured)";
+            lines.push(
+              `[Called ${String(p.toolName)} with ${input}]\n${body}`
+            );
+          }
+        }
+
+        out.push({
+          role: "assistant",
+          content: lines.join("\n\n"),
+        });
+
+        if (nextMsg?.role === "tool") {
+          i++;
+        }
+        continue;
+      }
+    }
+
+    out.push(msg);
+  }
+
+  return out;
+}
 import { z } from "zod/v4";
 
 import { JudgeUtils } from "./judge-utils";
@@ -351,8 +460,24 @@ class JudgeAgent extends JudgeAgentAdapter {
   /**
    * Checks whether the discovery loop ran out of steps without the judge
    * calling finish_test or continue_test.
+   *
+   * AI SDK v6 surfaces only the final step in `completion.toolCalls`; if a
+   * terminal call happened earlier in the loop, it would be invisible here.
+   * Inspect the aggregate `steps` array when present so we don't force a
+   * verdict on a run that already resolved.
    */
   private discoveryExhausted(completion: InvokeLLMResult): boolean {
+    const steps = completion.steps;
+    if (steps && steps.length > 0) {
+      const anyTerminal = steps.some((step) =>
+        step.toolCalls?.some(
+          (tc) =>
+            tc.toolName === "finish_test" || tc.toolName === "continue_test"
+        )
+      );
+      return !anyTerminal;
+    }
+
     if (!completion.toolCalls?.length) return false;
     return !completion.toolCalls.some(
       (tc) =>
@@ -361,9 +486,16 @@ class JudgeAgent extends JudgeAgentAdapter {
   }
 
   /**
-   * Makes one final LLM call with tool_choice forced to finish_test,
-   * so the judge renders a verdict with whatever context it accumulated
-   * during discovery instead of hard-failing.
+   * Makes one final LLM call with `tool_choice` forced to `finish_test`.
+   *
+   * Hardening (vs. a naive re-invocation with the same tool set):
+   *  - Prior discovery tool_use/tool_result pairs are rewritten in the
+   *    message history as plain-text assistant recaps. This lets us drop
+   *    `expand_trace`/`grep_trace` from the tool set without Anthropic
+   *    rejecting the call for referencing undefined tools.
+   *  - Discovery tools are then stripped so the model physically cannot
+   *    emit them, closing the leak path where `tool_choice` wasn't
+   *    honored and a discovery tool reached `parseToolCalls`.
    */
   private async forceVerdict(
     params: InvokeLLMParams
@@ -376,12 +508,24 @@ class JudgeAgent extends JudgeAgentAdapter {
       prompt: _p,
       messages: prevMessages,
       toolChoice: _tc,
+      tools: prevTools,
       ...rest
     } = params;
+
+    const rewrittenMessages = collapseDiscoveryHistory(prevMessages ?? []);
+    const finishOnlyTools: ToolSet | undefined = prevTools
+      ? (Object.fromEntries(
+          Object.entries(prevTools).filter(
+            ([name]) => !DISCOVERY_TOOL_NAMES.has(name)
+          )
+        ) as ToolSet)
+      : undefined;
+
     return this.invokeLLM({
       ...rest,
+      tools: finishOnlyTools,
       messages: [
-        ...(prevMessages ?? []),
+        ...rewrittenMessages,
         {
           role: "user" as const,
           content:

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -65,13 +65,21 @@ function collapseDiscoveryHistory(
       );
 
       if (discoveryCalls.length > 0) {
-        const nextMsg = messages[i + 1];
-        const resultParts: Array<Record<string, unknown>> =
-          nextMsg?.role === "tool" && Array.isArray(nextMsg.content)
-            ? (nextMsg.content as Array<Record<string, unknown>>).filter(
-                (p) => p?.type === "tool-result"
-              )
-            : [];
+        // Collect all consecutive tool-role messages so we catch results even
+        // when the AI SDK emits them across multiple separate messages.
+        const resultParts: Array<Record<string, unknown>> = [];
+        let toolMsgCount = 0;
+        for (let k = i + 1; k < messages.length; k++) {
+          const next = messages[k];
+          if (next.role === "tool" && Array.isArray(next.content)) {
+            for (const p of next.content as Array<Record<string, unknown>>) {
+              if (p?.type === "tool-result") resultParts.push(p);
+            }
+            toolMsgCount++;
+          } else {
+            break;
+          }
+        }
 
         const lines: string[] = [];
         for (const p of parts) {
@@ -105,9 +113,7 @@ function collapseDiscoveryHistory(
           content: lines.join("\n\n"),
         });
 
-        if (nextMsg?.role === "tool") {
-          i++;
-        }
+        i += toolMsgCount;
         continue;
       }
     }
@@ -465,6 +471,9 @@ class JudgeAgent extends JudgeAgentAdapter {
    * terminal call happened earlier in the loop, it would be invisible here.
    * Inspect the aggregate `steps` array when present so we don't force a
    * verdict on a run that already resolved.
+   *
+   * `continue_test` counts as non-exhausted: the judge explicitly asked to
+   * keep going, so the loop is progressing — forcing a verdict would be wrong.
    */
   private discoveryExhausted(completion: InvokeLLMResult): boolean {
     const steps = completion.steps;

--- a/javascript/src/agents/types.ts
+++ b/javascript/src/agents/types.ts
@@ -13,7 +13,7 @@ export type InvokeLLMParams = Parameters<typeof generateText>[0];
  */
 export type InvokeLLMResult = Pick<
   Awaited<ReturnType<typeof generateText>>,
-  "text" | "content" | "toolCalls" | "toolResults"
+  "text" | "content" | "toolCalls" | "toolResults" | "steps"
 >;
 
 /**

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -64,25 +64,29 @@ def _collapse_discovery_history(messages: List[dict]) -> List[dict]:
     for referencing undefined tools, and so the model physically cannot
     emit a discovery tool again.
 
-    Messages without discovery content pass through unchanged.
+    If an assistant message mixes discovery and non-discovery tool calls,
+    only the discovery calls are collapsed to text; non-discovery calls
+    and their corresponding tool results are preserved unchanged.
+
+    Messages without any discovery content pass through unchanged.
     """
     out: List[dict] = []
     i = 0
     while i < len(messages):
         msg = messages[i]
         tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
-        is_discovery_assistant = (
+        has_discovery_call = (
             msg.get("role") == "assistant"
             and isinstance(tool_calls, list)
-            and len(tool_calls) > 0
-            and all(
+            and any(
                 tc.get("function", {}).get("name") in _DISCOVERY_TOOL_NAMES
                 for tc in tool_calls
             )
         )
 
-        if is_discovery_assistant:
-            # Gather the matching tool result messages that immediately follow.
+        if has_discovery_call:
+            # Gather ALL consecutive following tool result messages (covers
+            # both discovery and non-discovery results).
             result_by_id: dict = {}
             j = i + 1
             while (
@@ -95,12 +99,22 @@ def _collapse_discovery_history(messages: List[dict]) -> List[dict]:
                 )
                 j += 1
 
+            discovery_calls = [
+                tc for tc in tool_calls
+                if tc.get("function", {}).get("name") in _DISCOVERY_TOOL_NAMES
+            ]
+            non_discovery_calls = [
+                tc for tc in tool_calls
+                if tc.get("function", {}).get("name") not in _DISCOVERY_TOOL_NAMES
+            ]
+            discovery_ids = {tc.get("id") for tc in discovery_calls}
+
             lines: List[str] = []
             leading_text = msg.get("content") or ""
             if leading_text:
                 lines.append(str(leading_text))
 
-            for tc in tool_calls:
+            for tc in discovery_calls:
                 name = tc.get("function", {}).get("name", "unknown_tool")
                 raw_args = tc.get("function", {}).get("arguments", "")
                 try:
@@ -111,7 +125,18 @@ def _collapse_discovery_history(messages: List[dict]) -> List[dict]:
                 body = _stringify_tool_output(result_by_id.get(tc.get("id")))
                 lines.append(f"[Called {name} with {args_str}]\n{body}")
 
-            out.append({"role": "assistant", "content": "\n\n".join(lines)})
+            new_msg: dict = {"role": "assistant", "content": "\n\n".join(lines)}
+            if non_discovery_calls:
+                new_msg["tool_calls"] = non_discovery_calls
+            out.append(new_msg)
+
+            # Re-emit tool result messages only for non-discovery calls so
+            # their tool references remain valid in the stripped tool set.
+            for k in range(i + 1, j):
+                result_msg = messages[k]
+                if result_msg.get("tool_call_id") not in discovery_ids:
+                    out.append(result_msg)
+
             i = j
             continue
 

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -85,6 +85,7 @@ def _collapse_discovery_history(messages: List[dict]) -> List[dict]:
         )
 
         if has_discovery_call:
+            assert isinstance(tool_calls, list)
             # Gather ALL consecutive following tool result messages (covers
             # both discovery and non-discovery results).
             result_by_id: dict = {}

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -31,6 +31,96 @@ from .types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
 logger = logging.getLogger("scenario")
 
 
+_DISCOVERY_TOOL_NAMES = frozenset({"expand_trace", "grep_trace"})
+
+
+def _stringify_tool_output(output: Any) -> str:
+    """Best-effort stringify of a tool result for a plain-text recap."""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        value = output.get("value")
+        if isinstance(value, str):
+            return value
+        try:
+            return json.dumps(output)
+        except (TypeError, ValueError):
+            return str(output)
+    try:
+        return json.dumps(output)
+    except (TypeError, ValueError):
+        return str(output)
+
+
+def _collapse_discovery_history(messages: List[dict]) -> List[dict]:
+    """
+    Rewrites message history so every discovery cycle
+    (assistant tool_call for expand_trace/grep_trace → tool result)
+    collapses into a single plain-text assistant message recounting what
+    the judge called and what came back.
+
+    Required before a forced verdict so we can strip expand_trace /
+    grep_trace from the tool set without Anthropic rejecting the call
+    for referencing undefined tools, and so the model physically cannot
+    emit a discovery tool again.
+
+    Messages without discovery content pass through unchanged.
+    """
+    out: List[dict] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
+        is_discovery_assistant = (
+            msg.get("role") == "assistant"
+            and isinstance(tool_calls, list)
+            and len(tool_calls) > 0
+            and all(
+                tc.get("function", {}).get("name") in _DISCOVERY_TOOL_NAMES
+                for tc in tool_calls
+            )
+        )
+
+        if is_discovery_assistant:
+            # Gather the matching tool result messages that immediately follow.
+            result_by_id: dict = {}
+            j = i + 1
+            while (
+                j < len(messages)
+                and messages[j].get("role") == "tool"
+                and messages[j].get("tool_call_id")
+            ):
+                result_by_id[messages[j]["tool_call_id"]] = messages[j].get(
+                    "content", ""
+                )
+                j += 1
+
+            lines: List[str] = []
+            leading_text = msg.get("content") or ""
+            if leading_text:
+                lines.append(str(leading_text))
+
+            for tc in tool_calls:
+                name = tc.get("function", {}).get("name", "unknown_tool")
+                raw_args = tc.get("function", {}).get("arguments", "")
+                try:
+                    parsed = json.loads(raw_args) if raw_args else {}
+                    args_str = json.dumps(parsed)
+                except (TypeError, ValueError):
+                    args_str = str(raw_args)
+                body = _stringify_tool_output(result_by_id.get(tc.get("id")))
+                lines.append(f"[Called {name} with {args_str}]\n{body}")
+
+            out.append({"role": "assistant", "content": "\n\n".join(lines)})
+            i = j
+            continue
+
+        out.append(msg)
+        i += 1
+
+    return out
+
+
 class JudgeAgent(AgentAdapter):
     """
     Agent that evaluates conversations against success criteria.
@@ -656,36 +746,53 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         effective_criteria: List[str],
     ) -> AgentReturnTypes:
         """
-        Makes one final LLM call with tool_choice forced to finish_test,
-        so the judge renders a verdict with whatever context it accumulated
-        during discovery instead of hard-failing.
+        Makes one final LLM call with tool_choice forced to finish_test.
+
+        Hardening (vs. a naive re-invocation with the same tool set):
+          - Prior discovery tool_call/tool_result pairs are rewritten in the
+            message history as plain-text assistant recaps. This lets us
+            drop expand_trace/grep_trace from the tool set without
+            Anthropic rejecting the call for referencing undefined tools.
+          - Discovery tools are then stripped so the model physically
+            cannot emit them, closing the leak path where tool_choice
+            wasn't honored and a discovery tool reached _parse_response.
         """
         logger.warning(
             f"Progressive discovery hit max steps ({self._max_discovery_steps}), "
             "forcing verdict"
         )
-        messages.append({
+
+        rewritten_messages = _collapse_discovery_history(messages)
+        rewritten_messages.append({
             "role": "user",
             "content": (
                 "You have reached the maximum number of trace exploration steps. "
                 "Based on the information you have gathered so far, give your final verdict now."
             ),
         })
+
+        finish_only_tools = [
+            t for t in tools
+            if t.get("function", {}).get("name") not in _DISCOVERY_TOOL_NAMES
+        ]
+
         forced_response = cast(
             ModelResponse,
             litellm.completion(
                 model=self.model,
-                messages=messages,
+                messages=rewritten_messages,
                 temperature=self.temperature,
                 api_key=self.api_key,
                 api_base=self.api_base,
                 max_tokens=self.max_tokens,
-                tools=tools,
+                tools=finish_only_tools,
                 tool_choice={"type": "function", "function": {"name": "finish_test"}},
                 **self._extra_params,
             ),
         )
-        return self._parse_response(forced_response, effective_criteria, messages)
+        return self._parse_response(
+            forced_response, effective_criteria, rewritten_messages
+        )
 
     def _execute_discovery_tool(self, tool_call: Any, spans: Sequence[Any]) -> str:
         """
@@ -784,6 +891,22 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 raise Exception(
                     f"Failed to parse tool call arguments from judge agent: {tool_call.function.arguments}"
                 )
+
+        if tool_call.function.name in _DISCOVERY_TOOL_NAMES:
+            logger.warning(
+                f"Discovery tool {tool_call.function.name} leaked past "
+                "discovery loop without reaching a terminal verdict"
+            )
+            return ScenarioResult(
+                success=False,
+                messages=cast(Any, messages),
+                reasoning=(
+                    "JudgeAgent: trace discovery did not converge on a "
+                    "verdict within the step budget"
+                ),
+                passed_criteria=[],
+                failed_criteria=list(effective_criteria),
+            )
 
         raise Exception(
             f"Invalid tool call from judge agent: {tool_call.function.name}"

--- a/python/tests/test_judge_force_verdict_hardening.py
+++ b/python/tests/test_judge_force_verdict_hardening.py
@@ -1,0 +1,185 @@
+"""Tests for the hardening applied to JudgeAgent's force-verdict path.
+
+The force-verdict path must:
+  - Collapse prior expand_trace/grep_trace tool_call/tool_result pairs into
+    plain-text assistant recaps so Anthropic does not reject the call for
+    referencing tools that are being stripped.
+  - Strip expand_trace/grep_trace from the tool set on the forced call so
+    the model physically cannot leak a discovery tool back.
+  - Degrade a leaked discovery tool to an inconclusive ScenarioResult
+    instead of raising, as a last line of defense.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scenario import JudgeAgent
+from scenario.judge_agent import (
+    _DISCOVERY_TOOL_NAMES,
+    _collapse_discovery_history,
+)
+from scenario.types import ScenarioResult
+
+
+def _make_tool_call(call_id: str, name: str, args: dict) -> dict:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(args)},
+    }
+
+
+def _mock_llm_response(tool_name: str, args: dict, call_id: str = "tc-final"):
+    tc = SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=tool_name, arguments=json.dumps(args)),
+    )
+    message = SimpleNamespace(tool_calls=[tc], content=None)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+class TestCollapseDiscoveryHistory:
+    def test_rewrites_discovery_cycles_into_plain_text(self):
+        messages = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "evaluate this"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    _make_tool_call(
+                        "tc-1", "expand_trace", {"span_ids": ["deadbeef"]}
+                    )
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "tc-1",
+                "content": "span details body",
+            },
+        ]
+
+        out = _collapse_discovery_history(messages)
+
+        assert len(out) == 3  # system, user, single recap assistant
+        assert out[0]["role"] == "system"
+        assert out[1]["role"] == "user"
+        assert out[2]["role"] == "assistant"
+        assert isinstance(out[2]["content"], str)
+        assert "expand_trace" in out[2]["content"]
+        assert "span details body" in out[2]["content"]
+        # No tool_calls and no tool-role messages remain.
+        assert "tool_calls" not in out[2]
+        assert not any(m.get("role") == "tool" for m in out)
+
+    def test_non_discovery_messages_pass_through(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert _collapse_discovery_history(messages) == messages
+
+
+class TestForceVerdictHardening:
+    def test_strips_discovery_tools_and_rewrites_history(self):
+        agent = JudgeAgent(
+            criteria=["Agent works"],
+            model="openai/gpt-5-mini",
+            max_discovery_steps=2,
+        )
+
+        tools = [
+            {"type": "function", "function": {"name": "expand_trace"}},
+            {"type": "function", "function": {"name": "grep_trace"}},
+            {"type": "function", "function": {"name": "continue_test"}},
+            {"type": "function", "function": {"name": "finish_test"}},
+        ]
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "judge"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    _make_tool_call(
+                        "tc-d1", "expand_trace", {"span_ids": ["aa"]}
+                    )
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "tc-d1",
+                "content": "discovery result",
+            },
+        ]
+
+        captured: dict = {}
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            return _mock_llm_response(
+                "finish_test",
+                {
+                    "criteria": {"agent_works": "true"},
+                    "reasoning": "ok",
+                    "verdict": "success",
+                },
+            )
+
+        with patch("scenario.judge_agent.litellm.completion", side_effect=fake_completion):
+            result = agent._force_verdict(
+                messages=messages,
+                tools=tools,
+                effective_criteria=["Agent works"],
+            )
+
+        assert isinstance(result, ScenarioResult)
+        assert result.success is True
+
+        # Discovery tools must not be passed on the forced call.
+        forced_tool_names = {
+            t["function"]["name"] for t in captured["tools"]
+        }
+        assert _DISCOVERY_TOOL_NAMES.isdisjoint(forced_tool_names)
+        assert "finish_test" in forced_tool_names
+
+        # Message history must be rewritten: no tool role, no tool_calls on
+        # assistant messages, and the discovery output must survive as text.
+        forced_messages = captured["messages"]
+        assert all(m.get("role") != "tool" for m in forced_messages)
+        assert all(
+            "tool_calls" not in m for m in forced_messages
+            if m.get("role") == "assistant"
+        )
+        recap_hit = any(
+            m.get("role") == "assistant"
+            and "expand_trace" in (m.get("content") or "")
+            and "discovery result" in (m.get("content") or "")
+            for m in forced_messages
+        )
+        assert recap_hit
+
+        # tool_choice forces finish_test.
+        assert captured["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "finish_test"},
+        }
+
+
+class TestParseResponseSafetyNet:
+    def test_leaked_discovery_tool_returns_inconclusive_not_exception(self):
+        agent = JudgeAgent(criteria=["A", "B"], model="openai/gpt-5-mini")
+        leaked = _mock_llm_response(
+            "expand_trace", {"span_ids": ["xx"]}, call_id="tc-leak"
+        )
+
+        result = agent._parse_response(leaked, ["A", "B"], messages=[])
+
+        assert isinstance(result, ScenarioResult)
+        assert result.success is False
+        assert "did not converge" in result.reasoning
+        assert set(result.failed_criteria) == {"A", "B"}
+        assert result.passed_criteria == []

--- a/python/tests/test_judge_force_verdict_hardening.py
+++ b/python/tests/test_judge_force_verdict_hardening.py
@@ -82,6 +82,40 @@ class TestCollapseDiscoveryHistory:
         ]
         assert _collapse_discovery_history(messages) == messages
 
+    def test_mixed_discovery_and_non_discovery_tool_calls(self):
+        """Discovery calls are collapsed to text; non-discovery calls and their
+        tool results are preserved so their references stay valid in the stripped
+        tool set."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    _make_tool_call("tc-grep", "grep_trace", {"pattern": "error"}),
+                    _make_tool_call("tc-ct", "continue_test", {}),
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc-grep", "content": "grep result"},
+            {"role": "tool", "tool_call_id": "tc-ct", "content": ""},
+        ]
+
+        out = _collapse_discovery_history(messages)
+
+        # assistant message + tool result for continue_test only
+        assert len(out) == 2
+        assert out[0]["role"] == "assistant"
+        # grep_trace recapped as text
+        assert "grep_trace" in (out[0].get("content") or "")
+        assert "grep result" in (out[0].get("content") or "")
+        # continue_test preserved as a tool_call
+        remaining_calls = out[0].get("tool_calls", [])
+        assert len(remaining_calls) == 1
+        assert remaining_calls[0]["function"]["name"] == "continue_test"
+        # tool result for continue_test kept, tool result for grep_trace dropped
+        assert out[1]["role"] == "tool"
+        assert out[1]["tool_call_id"] == "tc-ct"
+        assert not any(m.get("tool_call_id") == "tc-grep" for m in out)
+
 
 class TestForceVerdictHardening:
     def test_strips_discovery_tools_and_rewrites_history(self):

--- a/python/tests/test_judge_force_verdict_hardening.py
+++ b/python/tests/test_judge_force_verdict_hardening.py
@@ -180,6 +180,7 @@ class TestParseResponseSafetyNet:
 
         assert isinstance(result, ScenarioResult)
         assert result.success is False
+        assert result.reasoning is not None
         assert "did not converge" in result.reasoning
         assert set(result.failed_criteria) == {"A", "B"}
         assert result.passed_criteria == []


### PR DESCRIPTION
Fixes #376.

## What this PR does

Hardens the judge's large-trace discovery path with three layered defenses so `JudgeAgent: Unknown tool call: grep_trace/expand_trace` cannot surface. Applied identically (within SDK conventions) to the JavaScript and Python SDKs.

See #376 for the problem statement and root-cause analysis.

## The three layers

| Layer | File (JS / Python) | What it does |
| --- | --- | --- |
| **1. Aggregate-steps exhaustion check** *(JS only — Python's loop already walks steps)* | `judge-agent.ts::discoveryExhausted` | Inspects `completion.steps` when present so an earlier `finish_test` isn't hidden by AI SDK v6's last-step-only `toolCalls`. Skips `forceVerdict` entirely when the loop already converged. |
| **2. `forceVerdict` cannot leak a discovery tool** | `judge-agent.ts::forceVerdict` / `judge_agent.py::_force_verdict` | Collapses prior `expand_trace` / `grep_trace` `tool_use`+`tool_result` pairs into plain-text assistant recaps (via `collapseDiscoveryHistory` / `_collapse_discovery_history`), then strips discovery tools from the forced call's tool set. Model physically cannot emit them; Anthropic doesn't reject the call for dangling tool references in history. |
| **3. Safety net at the parser** | `judge-agent.ts::parseToolCalls` / `judge_agent.py::_parse_response` | Any residual leak degrades to an `inconclusive` verdict with reasoning `\"JudgeAgent: trace discovery did not converge on a verdict within the step budget\"`, instead of hard-failing with `Unknown tool call` (JS) or raising (Python). |

For each layer to be bypassed, the two other layers have to fail simultaneously — the symptom in #376 required all three to fail.

## Files touched

- `javascript/src/agents/judge/judge-agent.ts` — helper + three methods.
- `javascript/src/agents/types.ts` — `InvokeLLMResult` now includes `steps`.
- `javascript/src/agents/judge/__tests__/judge-agent.test.ts` — three new cases.
- `python/scenario/judge_agent.py` — helper + two methods.
- `python/tests/test_judge_force_verdict_hardening.py` — four new cases.

## Test plan

- [x] **JS unit:** `pnpm test` → **306/306 pass** (3 new cases directly covering the three layers).
- [x] **Python unit:** `uv run pytest tests/test_judge_*.py` → **35/35 pass** (4 new cases; 2 pre-existing skips unrelated).
- [x] **CI:** `javascript-ci` green. `python-ci` reports 384 passed / 7 skipped, with a single flaky failure in `test_arun_cancellation.py::test_cancellation_does_not_affect_sibling_arun` (`TimeoutError`) that also fails on other branches — unrelated to this change.
- [ ] **Manual end-to-end:** run a scenario on the LangWatch platform with a Claude Opus 4.6 judge and an 8192+ token trace, 10–20 iterations. Expectation: zero `Unknown tool call` failures; runs either finish cleanly or return `inconclusive` with the `did not converge` reason.

## Trade-offs / things worth knowing

- **History rewrite is lossy at the protocol level** (tool_use/tool_result → plain text), but preserves the discovery tool *output* as text so the model can still reason about what was found. No regression in verdict quality in the tests.
- **Discovery tool names are hardcoded** (`{\"expand_trace\", \"grep_trace\"}`) in a `DISCOVERY_TOOL_NAMES` constant per SDK. A first-class registry would be cleaner; deliberately skipped to keep this PR narrow. Anyone adding a new discovery tool must update the constant in both SDKs.
- **This makes `forceVerdict` robust, not rare.** Opus 4.6 still regularly hits the force path because `maxDiscoverySteps = 10` is tuned for `gpt-5-mini`. Provider-aware defaults would reduce how often we enter the force path; tracked as a follow-up, not in scope here.

## Follow-ups (not this PR)

- Provider-aware `maxDiscoverySteps` (higher default for Anthropic).
- Promote `DISCOVERY_TOOL_NAMES` to a shared registry so future discovery tools don't require hunting through three code paths.
- Contract test fixture shared between JS and Python collapse helpers so the two implementations can't drift.
- Metric on `forceVerdict invoked` so we can verify empirically that the fix moved the failure-rate to zero rather than just renaming the failure.