### PR TITLE
fix(docs): exclude scenario.report.app from pdoc to unblock Publish Docs

### DIFF
--- a/python/scenario/report/__init__.py
+++ b/python/scenario/report/__init__.py
@@ -12,6 +12,12 @@ from such a directory.
 from ._save import save_redteam_report, set_batch_dir, current_batch_dir
 from ._aggregate import aggregate_fixes, load_or_generate as load_or_generate_fixes
 
+# Skip the Streamlit dashboard entry point during pdoc API doc generation.
+# `app` is launched via `streamlit run`, not imported, and `streamlit` is an
+# optional extra (`pip install langwatch-scenario[report]`) so the docs build
+# environment can't import it.
+__pdoc__ = {"app": False}
+
 __all__ = [
     "save_redteam_report",
     "set_batch_dir",


### PR DESCRIPTION
## Summary
- `Publish Docs` has been failing on `main` since #346 merged (commit `2896c97`)
- pdoc crashes with `ModuleNotFoundError: No module named 'streamlit'` while walking submodules of `scenario.report`
- `scenario.report.app` is the Streamlit dashboard launched via `streamlit run` for the new `scenario redteam-report` CLI — not a public Python API, and `streamlit` is an optional `[report]` extra
- Fix: add `__pdoc__ = {"app": False}` to `scenario.report.__init__` so pdoc skips the submodule entirely. No runtime behavior change

## Failing run
https://github.com/langwatch/scenario/actions/runs/25102940755 (deploy step → `make pdocs`)

## Verification
Reproduced pdoc's submodule traversal locally:

- Without the filter: `scenario.report.app` is included → would import → crash on missing `streamlit`
- With the filter: pdoc lists `scenario.report` only and never imports `app`

## Test plan
- [x] `Publish Docs` workflow passes on this PR
- [x] `scenario redteam-report` CLI still works for users who installed `langwatch-scenario[report]` (no runtime change — only affects pdoc introspection)

## Notes on the other two failing checks on `main`
Not addressed here — both are flaky LLM tests, not regressions from #346:
- `python-ci`: `test_vegetarian_recipe_agent_via_arun` — agent returned a chicken recipe, judge correctly failed
- `javascript-ci`: `multiturn-10-scripted` (180s timeout) and `scenario-expert-realtime` voice test — LLM/network-dependent

🤖 Generated with [Claude Code](https://claude.com/claude-code)