### PR TITLE
fix(examples): stabilize vegetarian-agent parallel tests on python-ci

### DIFF
--- a/python/examples/test_running_in_parallel.py
+++ b/python/examples/test_running_in_parallel.py
@@ -28,9 +28,15 @@ class VegetarianRecipeAgentAdapter(AgentAdapter):
             messages=[
                 {
                     "role": "system",
-                    "content": """You are a vegetarian recipe agent.
+                    "content": """You are a strictly vegetarian recipe agent.
                     Given the user request, ask AT MOST ONE follow-up question,
-                    then provide a complete recipe. Keep your responses concise and focused.""",
+                    then provide a complete recipe. Keep your responses concise and focused.
+
+                    HARD RULE: You ONLY produce vegetarian recipes. If the user
+                    asks for a recipe containing meat, poultry, fish, or seafood,
+                    politely decline and offer a vegetarian alternative instead.
+                    Never include meat, poultry, fish, or seafood in any recipe
+                    you generate, even if the user insists.""",
                 },
                 *input.messages,
             ],

--- a/python/examples/test_running_in_parallel_with_arun.py
+++ b/python/examples/test_running_in_parallel_with_arun.py
@@ -40,9 +40,15 @@ class VegetarianRecipeAgentAdapter(AgentAdapter):
             messages=[
                 {
                     "role": "system",
-                    "content": """You are a vegetarian recipe agent.
+                    "content": """You are a strictly vegetarian recipe agent.
                     Given the user request, ask AT MOST ONE follow-up question,
-                    then provide a complete recipe. Keep your responses concise and focused.""",
+                    then provide a complete recipe. Keep your responses concise and focused.
+
+                    HARD RULE: You ONLY produce vegetarian recipes. If the user
+                    asks for a recipe containing meat, poultry, fish, or seafood,
+                    politely decline and offer a vegetarian alternative instead.
+                    Never include meat, poultry, fish, or seafood in any recipe
+                    you generate, even if the user insists.""",
                 },
                 *input.messages,
             ],


### PR DESCRIPTION
## Summary
- python-ci on `main` has been failing intermittently in `examples/test_running_in_parallel.py::test_vegetarian_recipe_agent` and `examples/test_running_in_parallel_with_arun.py::test_vegetarian_recipe_agent_via_arun`. The user-simulator occasionally pivots the conversation toward meat (e.g. "stir-fry with chicken, give me the recipe"), and the agent's weakly-worded "you are a vegetarian recipe agent" prompt complies — the judge correctly flags the meat and the test fails.
- The existing `@pytest.mark.flaky(reruns=2)` was not actually rescuing these runs (likely interaction with `asyncio_concurrent`), so the cleanest fix is to remove the failure mode at its source.
- Strengthen the system prompt with an explicit hard rule that refuses meat / poultry / fish / seafood and offers a vegetarian alternative instead.

## Test plan
- [ ] python-ci `test (3.12) / Test (Examples)` passes on this PR
- [ ] `test_vegetarian_recipe_agent` and `test_vegetarian_recipe_agent_via_arun` both succeed without relying on a rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)