### PR TITLE
ci: skip example tests on Dependabot PRs

### DIFF
--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -63,8 +63,9 @@ jobs:
         run: pnpm run test:ci
         working-directory: javascript
 
-      # Examples
+      # Examples — skipped for Dependabot PRs since they don't have access to repo secrets
       - name: Test (Examples)
+        if: github.actor != 'dependabot[bot]'
         run: pnpm -F vitest-examples test
         env:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -62,7 +62,9 @@ jobs:
         run: uv run pyright .
         working-directory: python
 
+      # Examples — skipped for Dependabot PRs since they don't have access to repo secrets
       - name: Test (Examples)
+        if: github.actor != 'dependabot[bot]'
         run: uv run pytest examples/ -v --tb=short
         env:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}


### PR DESCRIPTION
## Summary
- Skip `Test (Examples)` in `javascript-ci.yml` and `python-ci.yml` when `github.actor == 'dependabot[bot]'`
- Dependabot PRs don't get repo secrets (OPENAI/LANGWATCH/GEMINI keys), so the step was failing with `Incorrect API key provided: ''` on PRs like #300 and #302
- Build, lint, typecheck, and unit tests still run on Dependabot PRs

## Test plan
- [ ] Re-run CI on #300 / #302 after merge and confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)