### PR TITLE
fix(examples): stabilize custom LLM judge criteria matching

### DIFF
--- a/javascript/examples/vitest/tests/custom-judge-llm.test.ts
+++ b/javascript/examples/vitest/tests/custom-judge-llm.test.ts
@@ -49,7 +49,6 @@ class CustomLLMJudge extends AgentAdapter {
         reasoning: z.string(),
         results: z.array(
           z.object({
-            criterion: z.string(),
             met: z.boolean(),
           })
         ),
@@ -62,14 +61,11 @@ ${criteria.map((c, i) => `${i + 1}. ${c}`).join("\n")}
 Conversation:
 ${transcript}
 
-Return a result for each criterion using the exact criterion text.`,
+Return one result per criterion, in the same order as listed above.`,
     });
 
-    const resultsMap = new Map(
-      result.results.map((r) => [r.criterion, r.met])
-    );
-    const passed = criteria.filter((c) => resultsMap.get(c));
-    const failed = criteria.filter((c) => !resultsMap.get(c));
+    const passed = criteria.filter((_, i) => result.results[i]?.met);
+    const failed = criteria.filter((_, i) => !result.results[i]?.met);
 
     return {
       success: result.pass,

--- a/python/examples/test_custom_judge_llm.py
+++ b/python/examples/test_custom_judge_llm.py
@@ -55,7 +55,7 @@ class CustomLLMJudge(scenario.AgentAdapter):
 Criteria:
 {criteria_numbered}
 
-Return a result for each criterion using the exact criterion text.""",
+Return one result per criterion, in the same order as listed above.""",
                 },
                 {"role": "user", "content": transcript},
             ],
@@ -73,10 +73,9 @@ Return a result for each criterion using the exact criterion text.""",
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "criterion": {"type": "string"},
                                         "met": {"type": "boolean"},
                                     },
-                                    "required": ["criterion", "met"],
+                                    "required": ["met"],
                                     "additionalProperties": False,
                                 },
                             },
@@ -90,9 +89,8 @@ Return a result for each criterion using the exact criterion text.""",
 
         result = json.loads(response.choices[0].message.content)  # type: ignore[union-attr]
 
-        results_map = {r["criterion"]: r["met"] for r in result["results"]}
-        passed = [c for c in effective_criteria if results_map.get(c, False)]
-        failed = [c for c in effective_criteria if not results_map.get(c, True)]
+        passed = [c for i, c in enumerate(effective_criteria) if result["results"][i]["met"]]
+        failed = [c for i, c in enumerate(effective_criteria) if not result["results"][i]["met"]]
 
         return ScenarioResult(
             success=result["pass"],
@@ -111,7 +109,6 @@ class PoliteAgent(scenario.AgentAdapter):
 
 
 @pytest.mark.agent_test
-@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio
 async def test_custom_llm_judge():
     """Custom LLM judge evaluates a polite agent response."""


### PR DESCRIPTION
## Summary

- Custom judge examples (JS + Python) used exact text matching (`Map.get(c)` / `dict.get(c)`) to map LLM-returned criterion strings back to the original criteria. When the LLM paraphrased the criterion text, the lookup returned `undefined`/`None`, causing `metCriteria` to be empty and the test to fail.
- Switched to **positional index matching** — the same pattern the built-in `JudgeAgent` uses — eliminating the text-matching fragility entirely.
- Removed `@pytest.mark.flaky(reruns=2)` band-aid from the Python example since the root cause is now fixed.

Fixes the flaky `custom-judge-llm.test.ts` failure seen in CI: https://github.com/langwatch/scenario/actions/runs/25236483645/job/74003686585

## Test plan

- [ ] CI passes `tests/custom-judge-llm.test.ts` (JS) without flaky reruns
- [ ] CI passes `test_custom_judge_llm.py` (Python) without `@pytest.mark.flaky`