### PR TITLE
fix(security): patch lodash-es code injection via _.template

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -44,6 +44,7 @@
   "pnpm": {
     "overrides": {
       "hono": ">=4.12.4",
+      "lodash-es": ">=4.17.21",
       "minimatch@<3.1.3": "3.1.3",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7"
     }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   hono: '>=4.12.4'
+  lodash-es: '>=4.17.21'
   minimatch@<3.1.3: 3.1.3
   minimatch@>=9.0.0 <9.0.7: 9.0.7
 


### PR DESCRIPTION
## Summary

Adds pnpm.overrides for lodash-es in docs/ to fix:

- **#262**: Code Injection via _.template imports key names

Part of #400

## Test plan

- [ ] `pnpm install --lockfile-only` succeeds
- [ ] CI passes