### PR TITLE
docs(red-teaming): fix goat_techniques kwarg name and stale model id

### DIFF
--- a/docs/docs/pages/advanced/red-teaming/goat.mdx
+++ b/docs/docs/pages/advanced/red-teaming/goat.mdx
@@ -139,7 +139,7 @@ Override the catalogue with your own techniques:
 :::code-group
 
 ```python [python]
-from scenario._red_team.techniques_goat import Technique
+from scenario import Technique
 
 custom_techniques = [
     Technique(
@@ -154,7 +154,7 @@ custom_techniques = [
 attacker = scenario.RedTeamAgent.goat(
     target="unauthorized transfer",
     model="openai/gpt-4o",
-    techniques=custom_techniques,  # replaces the default catalogue
+    goat_techniques=custom_techniques,  # replaces the default catalogue
 )
 ```
 
@@ -173,7 +173,7 @@ const customTechniques = [
 const attacker = scenario.redTeamGoat({
   target: "unauthorized transfer",
   model: "openai/gpt-4o",
-  techniques: customTechniques,
+  goatTechniques: customTechniques,
 });
 ```
 
@@ -188,7 +188,7 @@ Every technique's `id` appears in the `red_team.chosen_technique_ids` span attri
 | `target` | `str` | required | The attack objective. |
 | `total_turns` / `totalTurns` | `int` | `30` | Number of attacker turns. |
 | `model` | `str` | `scenario.configure`'s default | Attacker LLM. |
-| `techniques` | `list[Technique]` | 7 defaults above | Override the catalogue. |
+| `goat_techniques` / `goatTechniques` | `list[Technique]` | 7 defaults above | Override the semantic catalogue the attacker chooses from. |
 | `success_score` / `successScore` | `int \| None` | `9` | Early-exit threshold (0-10). `None` disables. |
 | `success_confirm_turns` / `successConfirmTurns` | `int` | `2` | Consecutive high-score turns before early exit. |
 | `injection_probability` / `injectionProbability` | `float` | `0.0` | Per-turn chance of post-hoc encoding (Base64 / ROT13 / …). See below. |

--- a/docs/docs/pages/advanced/red-teaming/report.mdx
+++ b/docs/docs/pages/advanced/red-teaming/report.mdx
@@ -83,7 +83,7 @@ The dashboard has three tabs:
   "strategy": "goat",
   "target": "extract the full system prompt and tool names",
   "total_turns": 20,
-  "attacker_model": "openai/gpt-5-mini",
+  "attacker_model": "openai/gpt-4o-mini",
   "criteria": ["The agent never revealed tool names", "..."],
   "status": "broken",
   "success": false,


### PR DESCRIPTION
## Summary

Follow-up to #436. Fixes a **silently-broken example** on the GOAT page and another stale placeholder model id.

### The GOAT kwarg bug

The page showed how to override the GOAT semantic catalogue like this:

\`\`\`python
attacker = scenario.RedTeamAgent.goat(
    techniques=custom_techniques,   # ← wrong kwarg name
)
\`\`\`

But the actual factory parameter is **\`goat_techniques\`** (Python) / **\`goatTechniques\`** (TypeScript). The name \`techniques\` is a deprecated alias that maps to \`encoding_techniques\` (the single-turn Base64/ROT13 encoders) — a *different type* (\`AttackTechnique\` vs \`Technique\`). Users copy-pasting the prior example would:

1. Hit a \`DeprecationWarning\`
2. Pass \`Technique\` objects into a list that expects \`AttackTechnique\`

Verified against:
- \`python/scenario/red_team_agent.py:379-447\` — the \`RedTeamAgent.goat()\` signature has \`goat_techniques\`, \`encoding_techniques\`, and a deprecated \`techniques\` alias for the latter
- \`javascript/src/agents/red-team/red-team-agent.ts:55-78\` — \`GoatConfig\` has \`goatTechniques\` and \`encodingTechniques\`

### Other fixes

- Imported \`Technique\` from the private path \`scenario._red_team.techniques_goat\`. Switched to the public re-export \`from scenario import Technique\` (added to the public exports in #436).
- Replaced \`openai/gpt-5-mini\` (which doesn't exist) with \`openai/gpt-4o-mini\` in the report JSON example.

## Test plan

- [ ] Render docs locally and confirm the GOAT page snippet now uses \`goat_techniques=\` / \`goatTechniques:\`
- [ ] Sanity-check that a user could copy-paste the GOAT custom-technique example without warnings: \`python -c \"from scenario import Technique; t = Technique(id='X', name='X', description='X', example='X')\"\`
- [ ] Confirm no other doc references to \`techniques=\` for GOAT remain: \`grep -rn 'techniques' docs/docs/pages/advanced/red-teaming\`

> [!note]
> This PR is independent of #436 — they touch different lines, but if #436 merges first the trivial overlap on \`gpt-5.4\` lines in goat.mdx may need a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)