### PR TITLE
fix(deps): bump fast-uri to >=3.1.2 for high severity CVEs

### DIFF
--- a/javascript/examples/openai-realtime-demo/package.json
+++ b/javascript/examples/openai-realtime-demo/package.json
@@ -19,7 +19,8 @@
   },
   "pnpm": {
     "overrides": {
-      "path-to-regexp": ">=8.4.0"
+      "path-to-regexp": ">=8.4.0",
+      "fast-uri@<=3.1.1": ">=3.1.2"
     }
   }
 }

--- a/javascript/examples/openai-realtime-demo/pnpm-lock.yaml
+++ b/javascript/examples/openai-realtime-demo/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.0'
+  path-to-regexp: '>=8.4.0'
+  fast-uri@<=3.1.1: '>=3.1.2'
 
 importers:
 
@@ -188,8 +189,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -554,7 +555,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     optional: true
@@ -702,7 +703,7 @@ snapshots:
   fast-deep-equal@3.1.3:
     optional: true
 
-  fast-uri@3.1.0:
+  fast-uri@3.1.2:
     optional: true
 
   finalhandler@2.1.1:

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -134,7 +134,8 @@
       "picomatch@>=4 <4.0.4": "4.0.4",
       "@langchain/core": "0.3.80",
       "langchain": "0.3.37",
-      "@modelcontextprotocol/sdk": ">=1.29.0"
+      "@modelcontextprotocol/sdk": ">=1.29.0",
+      "fast-uri@<=3.1.1": ">=3.1.2"
     }
   }
 }

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   '@langchain/core': 0.3.80
   langchain: 0.3.37
   '@modelcontextprotocol/sdk': '>=1.29.0'
+  fast-uri@<=3.1.1: '>=3.1.2'
 
 importers:
 
@@ -141,7 +142,7 @@ importers:
     dependencies:
       '@openai/agents':
         specifier: ^0.3.9
-        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -2845,8 +2846,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -7091,7 +7092,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     optional: true
@@ -7946,7 +7947,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0:
+  fast-uri@3.1.2:
     optional: true
 
   fb-watchman@2.0.2:


### PR DESCRIPTION
## Summary
- Adds `pnpm.overrides` for `fast-uri@<=3.1.1` → `>=3.1.2` in both `javascript/package.json` and `javascript/examples/openai-realtime-demo/package.json`
- Regenerates both `pnpm-lock.yaml` files to resolve `fast-uri` to `3.1.2`
- Fixes all 4 high-severity Dependabot alerts (#339, #340, #342, #343)

## Vulnerabilities resolved
| Alert | CVE | Description | Fixed in |
|-------|-----|-------------|----------|
| #339, #340 | Path traversal via percent-encoded dot segments | `fast-uri` did not properly handle percent-encoded dot segments, allowing path traversal | 3.1.1 |
| #342, #343 | Host confusion via percent-encoded authority delimiters | `fast-uri` did not properly handle percent-encoded authority delimiters, allowing host confusion | 3.1.2 |

## Test plan
- [x] `pnpm install` succeeds in both root and demo workspaces
- [x] Both lockfiles resolve `fast-uri` to `3.1.2`
- [ ] CI passes