### PR TITLE
fix(deps): bump protobufjs to >=8.0.2 for 4 high severity CVEs

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -118,7 +118,7 @@
   },
   "pnpm": {
     "overrides": {
-      "protobufjs@>=8.0.0 <8.0.1": "8.0.1",
+      "protobufjs@>=8.0.0 <8.0.2": "8.0.2",
       "protobufjs@<7.5.5": "7.5.5",
       "handlebars@>=4.0.0 <=4.7.8": "4.7.9",
       "minimatch@<3.1.3": "3.1.3",

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  protobufjs@>=8.0.0 <8.0.1: 8.0.1
+  protobufjs@>=8.0.0 <8.0.2: 8.0.2
   protobufjs@<7.5.5: 7.5.5
   handlebars@>=4.0.0 <=4.7.8: 4.7.9
   minimatch@<3.1.3: 3.1.3
@@ -4161,8 +4161,8 @@ packages:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@8.0.2:
+    resolution: {integrity: sha512-TNF0rhMsp+g21us9R2aj3iA7JY9pG7G/3zyRiULl6NS+AurvgQ7iWA203QcykDGSosHxMsV+K6GTR15RBWw1bA==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -6187,7 +6187,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.1
+      protobufjs: 8.0.2
 
   '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9354,18 +9354,8 @@ snapshots:
       '@types/node': 24.12.2
       long: 5.3.2
 
-  protobufjs@8.0.1:
+  protobufjs@8.0.2:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
       '@types/node': 24.12.2
       long: 5.3.2
 


### PR DESCRIPTION
## Summary

- Bumps the `protobufjs` pnpm override from `8.0.1` to `8.0.2` to fix 4 high severity CVEs in the v8 series
- The previous override (`protobufjs@>=8.0.0 <8.0.1 → 8.0.1`, from PR #390) is itself now vulnerable — these are newly published advisories affecting `8.0.1`
- Override range widened to `protobufjs@>=8.0.0 <8.0.2 → 8.0.2` so any transitive resolution in that range is caught

### CVEs addressed

| Alert | GHSA | Summary |
|---|---|---|
| #365 | GHSA-685m-2w69-288q | DoS through unbounded protobuf recursion |
| #366 | GHSA-jvwf-75h9-cwgg | DoS through unsafe option paths |
| #367 | GHSA-75px-5xx7-5xc7 | Code generation gadget after prototype pollution |
| #369 | GHSA-66ff-xgx4-vchm | Code injection through bytes field defaults |

### Why pnpm overrides

`protobufjs` is a transitive dependency (via `@grpc/proto-loader`, `@opentelemetry/otlp-transformer`). We can't bump the direct parents to pull in the fix, so the pnpm override is the correct mechanism — it persists in `package.json` and will enforce the minimum safe version even after lockfile regeneration.

Closes Dependabot alerts #365, #366, #367, #369

## Test plan

- [x] `pnpm install` succeeds
- [x] Lockfile resolves `protobufjs@8.0.2`
- [ ] CI passes