### PR TITLE
fix(deps): bump requests to >=2.33.0 for CVE-2026-25645

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -84,6 +84,7 @@ constraint-dependencies = [
     "python-liquid>=2.2.0",
     "filelock>=3.20.3",
     "virtualenv>=20.36.1",
+    "requests>=2.33.0",
 ]
 
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -15,6 +15,7 @@ resolution-markers = [
 constraints = [
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "python-liquid", specifier = ">=2.2.0" },
+    { name = "requests", specifier = ">=2.33.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "virtualenv", specifier = ">=20.36.1" },
 ]
@@ -2883,7 +2884,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2891,9 +2892,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add uv constraint to pin requests to `>=2.33.0` to fix CVE-2026-25645 (insecure temp file reuse in extract_zipped_paths)

## Production impact
Low. requests is a transitive dependency. The vulnerability involves insecure temporary file reuse which requires specific conditions to exploit.

Fixes #227