### PR TITLE
fix(deps): bump filelock to >=3.20.3 for TOCTOU/symlink CVEs

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -82,6 +82,7 @@ markers = ["agent_test: marks tests as agent scenario tests"]
 constraint-dependencies = [
     "urllib3>=2.7.0",
     "python-liquid>=2.2.0",
+    "filelock>=3.20.3",
 ]
 
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -13,6 +13,7 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "filelock", specifier = ">=3.20.3" },
     { name = "python-liquid", specifier = ">=2.2.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
@@ -591,11 +592,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.18.0"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add uv constraint to pin filelock to `>=3.20.3` to fix CVE-2026-22701 (TOCTOU symlink in SoftFileLock) and CVE-2025-68146 (TOCTOU race condition during lock file creation)

## Production impact
Low. filelock is a transitive dependency. The vulnerabilities involve time-of-check-time-of-use race conditions that require local attacker access to exploit.

Fixes #128, #118