### PR TITLE
fix(voice/#350): post-merge cleanup — capability AC, disconnect logging, doc drift, e2e wedge

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -64,3 +64,37 @@ Edge cases not covered upfront are handled via regression tests. When a bug is f
 3. Fix and verify green
 
 This keeps the suite lean while ensuring real failures never recur.
+
+## Voice `@e2e` suite — isolation requirement
+
+The voice `@e2e` demos under `python/tests/voice/test_*_e2e.py` are auto-marked
+`integration` by `python/tests/voice/conftest.py:pytest_collection_modifyitems`
+and the default `python-ci` job deselects them with `-m "not integration"`.
+They only run via the nightly `voice-integration.yml` dispatch.
+
+Several multi-turn demos additionally carry a `@pytest.mark.skip` marker
+(reason: *"Hangs in full suite (not in isolation) — multi-turn max_turns demos
+wedge pytest process"*). The wedge is reproducible only when the full voice
+e2e suite is run in a single pytest process. Likely contributors (not yet
+isolated):
+
+- Background tasks (`asyncio.create_task`) spawned by adapters
+  (Gemini Live `_session_lifetime`, Twilio webhook server, Cloudflare tunnel
+  subprocess) that aren't fully reaped between function-scoped event loops.
+- The `ffmpeg` playback subprocess in `python/scenario/voice/playback.py`
+  not always exiting cleanly when `.stop()` runs.
+- `max_turns` runaway in demos that should converge in 2-3 turns but spin
+  against a quota when judged in batch.
+
+Until the wedge is diagnosed (tracked in issue #491), run the multi-turn
+demos with one process per cluster:
+
+```bash
+# OK — fresh process per demo cluster.
+pytest -p no:cacheprovider -x python/tests/voice/test_long_hold_e2e.py
+pytest -p no:cacheprovider -x python/tests/voice/test_emotional_escalation_e2e.py
+# …etc.
+
+# NOT OK — runs the whole suite in one process, will wedge.
+pytest -m integration python/tests/voice/
+```

--- a/docs/voice/capability-matrix.md
+++ b/docs/voice/capability-matrix.md
@@ -23,7 +23,7 @@ adapter converts at its send/recv boundary.
 | `TwilioAgentAdapter` | ❌ | ❌ | ✅ | ✅ Twilio Media Streams `clear` | WebSocket (Media Streams) | ✅ |
 | `OpenAIRealtimeAgentAdapter` | ✅ | ✅ | ❌ | ✅ `response.cancel` | WebSocket | ✅ |
 | `ElevenLabsAgentAdapter` | ✅ | ✅ | ❌ | ❌ — server-side VAD barge-in only | WebSocket | ✅ |
-| `GeminiLiveAgentAdapter` | ✅ | ✅ | ❌ | ❌ — server-side VAD barge-in only | WebSocket | ✅ |
+| `GeminiLiveAgentAdapter` | ✅ | ✅ | ❌ | ✅ Activity marker cancel | WebSocket | ✅ |
 | `LiveKitAgentAdapter` | ✅ | ✅ | ❌ | ❌ | WebRTC (planned) | ❌ stub raises `PendingTransportError` |
 | `VapiAgentAdapter` | ✅ | ✅ | ❌ | ❌ | WebSocket (planned) | ❌ stub raises `PendingTransportError` |
 | `WebRTCAgentAdapter` | ❌ | ❌ | ❌ | ❌ | WebRTC | ❌ stub raises `PendingTransportError` |
@@ -188,14 +188,16 @@ class MyCustomAdapter(scenario.VoiceAgentAdapter):
 
 ## Deferred / follow-up items
 
-- **Native interrupt for ElevenLabs and Gemini Live**. Investigated; both
-  providers run server-side VAD and have no client-initiated cancel frame
-  in their public protocols. Setting `interruption=True` on these adapters
-  is incorrect — `interrupt()` would have nothing to send. Barge-in
-  works the moment the executor's next user audio chunk hits the wire;
-  no SDK change required. EL emits a server→client `interruption` event
-  when its VAD fires; surfacing that into the voice timeline is a
-  separate enhancement.
+- **Native interrupt for ElevenLabs**. Investigated; the provider runs
+  server-side VAD and has no client-initiated cancel frame in its public
+  protocol. Setting `interruption=True` would be incorrect — `interrupt()`
+  would have nothing to send. Barge-in works the moment the executor's
+  next user audio chunk hits the wire; no SDK change required. EL emits a
+  server→client `interruption` event when its VAD fires; surfacing that
+  into the voice timeline is a separate enhancement. (Gemini Live also
+  runs server-side VAD but additionally exposes Activity markers — the
+  Gemini Live adapter uses those for explicit cancel, so it does publish
+  `interruption=True`.)
 - **Transport implementations for LiveKit, Vapi, WebRTC**. Stubs raise
   `PendingTransportError` at `send_audio` / `recv_audio`. The capability
   declarations describe what they *will* support.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,8 +15,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -757,14 +757,21 @@ class ScenarioExecutor:
                 continue
             try:
                 await agent.disconnect()
-            except Exception:  # pragma: no cover — defensive cleanup
-                pass
+            except Exception:
+                logger.warning(
+                    "voice adapter %s disconnect failed",
+                    type(agent).__name__,
+                    exc_info=True,
+                )
 
         if self._ffmpeg_playback is not None:
             try:
                 await asyncio.to_thread(self._ffmpeg_playback.stop)
-            except Exception:  # pragma: no cover — best-effort cleanup
-                pass
+            except Exception:
+                logger.warning(
+                    "ffmpeg playback stop failed during voice disconnect",
+                    exc_info=True,
+                )
             self._ffmpeg_playback = None
 
     async def _call_agent(

--- a/python/tests/test_scenario_executor.py
+++ b/python/tests/test_scenario_executor.py
@@ -474,10 +474,12 @@ async def test_voice_disconnect_logs_adapter_failures(caplog):
     from scenario.voice.adapter import VoiceAgentAdapter
 
     class ExplodingVoiceAdapter(VoiceAgentAdapter):
-        async def connect(self) -> None: ...
+        async def connect(self) -> None:
+            pass
         async def disconnect(self) -> None:
             raise RuntimeError("twilio voice_url restore failed")
-        async def send_audio(self, chunk): ...  # type: ignore[override]
+        async def send_audio(self, chunk):  # type: ignore[override]
+            pass
         async def recv_audio(self, timeout):  # type: ignore[override]
             raise NotImplementedError
 

--- a/python/tests/test_scenario_executor.py
+++ b/python/tests/test_scenario_executor.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import scenario
 from scenario import JudgeAgent, UserSimulatorAgent
@@ -456,3 +458,41 @@ async def test_inline_criteria_fail_includes_accumulated():
     assert not result.success, "Expected failure"
     assert "criterion A passes" in result.passed_criteria, "Previously accumulated criteria should be present"
     assert "this will fail" in result.failed_criteria
+
+
+# --------------------------------------------------------------------- #
+# Voice disconnect logging — issue #488                                  #
+# --------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_voice_disconnect_logs_adapter_failures(caplog):
+    """A voice adapter whose disconnect() raises must produce a WARNING
+    record carrying both the adapter name and a traceback, and must not
+    propagate the exception out of _voice_disconnect_all.
+    """
+    from scenario.voice.adapter import VoiceAgentAdapter
+
+    class ExplodingVoiceAdapter(VoiceAgentAdapter):
+        async def connect(self) -> None: ...
+        async def disconnect(self) -> None:
+            raise RuntimeError("twilio voice_url restore failed")
+        async def send_audio(self, chunk): ...  # type: ignore[override]
+        async def recv_audio(self, timeout):  # type: ignore[override]
+            raise NotImplementedError
+
+    executor = ScenarioExecutor(
+        name="voice disconnect logging",
+        description="ensure cleanup failures are surfaced via logging",
+        agents=[ExplodingVoiceAdapter()],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="scenario"):
+        await executor._voice_disconnect_all()
+
+    voice_records = [r for r in caplog.records if "disconnect failed" in r.getMessage()]
+    assert voice_records, "expected a WARNING log when adapter disconnect raises"
+    record = voice_records[0]
+    assert record.levelno == logging.WARNING
+    assert "ExplodingVoiceAdapter" in record.getMessage()
+    assert record.exc_info is not None, "exc_info must be attached so operators see the traceback"

--- a/python/tests/voice/test_adapters.py
+++ b/python/tests/voice/test_adapters.py
@@ -203,7 +203,12 @@ ALL_ADAPTER_CLASSES = [
 def test_every_adapter_publishes_capabilities(cls):
     caps = cls.capabilities
     assert isinstance(caps, AdapterCapabilities)
-    # Every adapter must declare its formats.
+    # Every adapter must declare each capability flag so the capability
+    # matrix doc and feature file stay in lock-step with the runtime.
+    assert isinstance(caps.streaming_transcripts, bool)
+    assert isinstance(caps.native_vad, bool)
+    assert isinstance(caps.dtmf, bool)
+    assert isinstance(caps.interruption, bool)
     assert isinstance(caps.input_formats, list)
     assert isinstance(caps.output_formats, list)
 

--- a/python/tests/voice/test_capabilities.py
+++ b/python/tests/voice/test_capabilities.py
@@ -11,6 +11,7 @@ def test_default_capabilities_are_conservative():
     assert caps.streaming_transcripts is False
     assert caps.native_vad is False
     assert caps.dtmf is False
+    assert caps.interruption is False
     assert caps.input_formats == []
     assert caps.output_formats == []
 
@@ -39,3 +40,28 @@ def test_error_names_adapter_and_capability():
 def test_error_message_points_to_capability_matrix_docs():
     err = UnsupportedCapabilityError("X", "streaming_transcripts")
     assert "capability matrix" in str(err).lower()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_raises_unsupported_when_interruption_false():
+    """An adapter that does not declare ``interruption=True`` must reject
+    ``await adapter.interrupt()`` with ``UnsupportedCapabilityError`` —
+    the contract that lets ``scenario.interrupt()`` fall back to
+    timing-based barge-in instead of silently no-op'ing.
+    """
+    from scenario.voice.adapter import VoiceAgentAdapter
+
+    class BareVoiceAdapter(VoiceAgentAdapter):
+        # Inherits the default AdapterCapabilities() → interruption=False.
+        async def connect(self) -> None: ...
+        async def disconnect(self) -> None: ...
+        async def send_audio(self, chunk) -> None: ...  # type: ignore[override]
+        async def recv_audio(self, timeout):  # type: ignore[override]
+            raise NotImplementedError
+
+    adapter = BareVoiceAdapter()
+    assert adapter.capabilities.interruption is False
+    with pytest.raises(UnsupportedCapabilityError) as exc_info:
+        await adapter.interrupt()
+    assert exc_info.value.capability == "interruption"
+    assert exc_info.value.adapter_name == "BareVoiceAdapter"

--- a/python/tests/voice/test_capabilities.py
+++ b/python/tests/voice/test_capabilities.py
@@ -53,9 +53,12 @@ async def test_interrupt_raises_unsupported_when_interruption_false():
 
     class BareVoiceAdapter(VoiceAgentAdapter):
         # Inherits the default AdapterCapabilities() → interruption=False.
-        async def connect(self) -> None: ...
-        async def disconnect(self) -> None: ...
-        async def send_audio(self, chunk) -> None: ...  # type: ignore[override]
+        async def connect(self) -> None:
+            pass
+        async def disconnect(self) -> None:
+            pass
+        async def send_audio(self, chunk) -> None:  # type: ignore[override]
+            pass
         async def recv_audio(self, timeout):  # type: ignore[override]
             raise NotImplementedError
 

--- a/python/tests/voice/test_vad.py
+++ b/python/tests/voice/test_vad.py
@@ -3,6 +3,7 @@
 import warnings
 
 import numpy as np
+import pytest
 
 from scenario.voice import AudioChunk, WebRTCVadFallback
 
@@ -21,26 +22,46 @@ def _silence_pcm(duration_s: float) -> bytes:
     return b"\x00\x00" * int(duration_s * SR)
 
 
-def test_vad_fallback_emits_userwarning_once_per_adapter():
+def test_vad_fallback_warning_message_names_adapter_and_accuracy_caveat():
+    """Content-shape assertion separate from the rate-limit shape below."""
     WebRTCVadFallback.reset_warnings()
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always")
         WebRTCVadFallback("TwilioAgentAdapter")
-        WebRTCVadFallback("TwilioAgentAdapter")  # second instance must NOT re-warn
     user_warnings = [w for w in captured if issubclass(w.category, UserWarning)]
     assert len(user_warnings) == 1
-    assert "TwilioAgentAdapter" in str(user_warnings[0].message)
-    assert "native VAD" in str(user_warnings[0].message)
-    assert "accuracy" in str(user_warnings[0].message).lower()
+    msg = str(user_warnings[0].message)
+    assert "TwilioAgentAdapter" in msg
+    assert "native VAD" in msg
+    assert "accuracy" in msg.lower()
 
 
-def test_vad_fallback_warns_per_adapter_name():
+@pytest.mark.parametrize(
+    "adapter_names, expected_warning_count",
+    [
+        # Same name twice on same instance pair → one warning. The
+        # ClassVar set memoizes by adapter_name string, not class identity.
+        (["A", "A"], 1),
+        # Two distinct names → two warnings.
+        (["A", "B"], 2),
+        # Cross-instance with the same string → still one warning. Locks
+        # in that the dedupe is across *all* instances of the fallback,
+        # not just within a single instance's lifetime.
+        (["SameName", "SameName"], 1),
+    ],
+)
+def test_vad_fallback_rate_limits_by_adapter_name(adapter_names, expected_warning_count):
+    """``WebRTCVadFallback._warned_adapters`` rate-limits the
+    "no native VAD" UserWarning by the caller-supplied adapter_name
+    string, regardless of how many fallback instances are constructed.
+    """
     WebRTCVadFallback.reset_warnings()
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always")
-        WebRTCVadFallback("AdapterA")
-        WebRTCVadFallback("AdapterB")
-    assert len([w for w in captured if issubclass(w.category, UserWarning)]) == 2
+        for name in adapter_names:
+            WebRTCVadFallback(name)
+    user_warnings = [w for w in captured if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == expected_warning_count
 
 
 def test_vad_detects_silence_to_voice_to_silence_transitions():

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -751,7 +751,7 @@ Feature: Voice agent testing in Scenario SDK
   Scenario: Every adapter publishes a capabilities attribute
     Given any concrete VoiceAgentAdapter subclass
     Then adapter.capabilities is an AdapterCapabilities instance
-    And it declares: streaming_transcripts, native_vad, dtmf, input_formats, output_formats
+    And it declares: streaming_transcripts, native_vad, dtmf, interruption, input_formats, output_formats
 
   @unit
   Scenario: dtmf() raises UnsupportedCapabilityError on non-telephony adapters


### PR DESCRIPTION
## Summary

Bundles four post-merge voice-#350 cleanup issues into one PR by request. Source: fresh-eyes audit of PR #355.

Four atomic commits — one per issue — so any one can be reverted or cherry-picked without losing the others.

Closes #487
Closes #488
Closes #489

`#491` is **partial**: VAD parametrized test + isolation-requirement docs land here; wedge root-cause diagnosis stays open as a follow-up with a comment attached. Refs #491.

`#490` (15 MB recordings) is intentionally **not** in this PR — needs a maintainer policy choice between LFS / golden-per-cluster / manifests-only / CDN.

---

## #489 — doc drift on @unit scenario count + stale Python classifiers

The doc-drift half is moot: `docs/proposals/issue-350-prove-it-report.md` was already deleted in `f423d67` (May 11) as a relocated process artifact. The remaining work is the stale classifier fix.

- `python/pyproject.toml:17-21` — drop `Programming Language :: Python :: 3.8` and `3.9` entries. `requires-python` is `>=3.10`, so those were PyPI search false-positives.

Evidence: `git diff c833990^..c833990 -- python/pyproject.toml` shows two lines removed.

---

## #488 — log disconnect failures in `_voice_disconnect_all`

The docstring at `python/scenario/scenario_executor.py:750-751` promised *"failures are logged but do not mask the primary scenario result"*, but the implementation silently swallowed every `Exception`. That made real operational risks invisible — most notably the Twilio B-leg `voice_url` restore path, where a failure leaves a customer account clobbered with no operator signal.

- `python/scenario/scenario_executor.py:758-768` — add `logger.warning(..., exc_info=True)` in both swallow sites (adapter `disconnect()` and `ffmpeg_playback.stop()`), keying the adapter message on `type(agent).__name__`. Exceptions are still absorbed so cleanup completes — only their visibility changes.
- `python/tests/test_scenario_executor.py::test_voice_disconnect_logs_adapter_failures` — fake `ExplodingVoiceAdapter` whose `disconnect()` raises; asserts a WARNING record with adapter name + `exc_info` is captured.

Evidence:
```
$ uv run pytest tests/test_scenario_executor.py -k voice_disconnect -v
PASSED tests/test_scenario_executor.py::test_voice_disconnect_logs_adapter_failures
```

---

## #487 — `interruption` in published-capabilities AC + parametrized adapter tests

The `interruption` field exists in `AdapterCapabilities` and is set by Pipecat, Twilio, OpenAI Realtime, and Gemini Live adapters, but was not named in the feature file's published-capabilities scenario nor asserted by the parametrized adapter test. TS port (#372) would have inherited the gap.

- `specs/voice-agents.feature:754` — add `interruption` to the declared-capability list.
- `python/tests/voice/test_adapters.py:202-211` — extend `test_every_adapter_publishes_capabilities` to assert each capability flag (`streaming_transcripts`, `native_vad`, `dtmf`, `interruption`) is a bool, alongside the existing format-list checks.
- `python/tests/voice/test_capabilities.py` — cover `interruption=False` default + new `test_interrupt_raises_unsupported_when_interruption_false` (a `BareVoiceAdapter` with default capabilities raises `UnsupportedCapabilityError` from `await adapter.interrupt()`, naming both adapter and capability).
- `docs/voice/capability-matrix.md` — fix Gemini Live cell from ❌ to ✅ (the adapter declares `interruption=True` via Activity markers; the matrix said ❌ — drift caught while scoping this fix). Update the Deferred section to drop Gemini Live from the ElevenLabs-only "no native cancel" note.

Evidence:
```
$ uv run pytest tests/voice/test_capabilities.py tests/voice/test_adapters.py tests/voice/test_feature_file_contract.py -v
64 passed, 210 warnings in 5.70s
```

---

## #491 — partial — VAD rate-limit tests + isolation-requirement docs

**Full delivery on the VAD half:**

- `python/tests/voice/test_vad.py` — replace the two scalar warning-count tests with a single parametrized `test_vad_fallback_rate_limits_by_adapter_name` covering the three documented cases:
  - `["A","A"]` → 1 warning
  - `["A","B"]` → 2 warnings
  - cross-instance same-string → 1 warning (locks in that the dedupe is on the caller-supplied `adapter_name` string in a ClassVar set, across *all* instances)
- Keep one scalar test for the warning *content* (names adapter, mentions native VAD + accuracy caveat) — different assertion shape from rate-limit count.

**Partial delivery on the wedge half:**

- `TESTING.md` — new section documenting the @e2e suite isolation requirement: the multi-turn voice demos wedge when the full suite is run in a single pytest process. Notes that conftest auto-marks `*_e2e.py` as integration (deselected from default CI), the `@pytest.mark.skip` markers are belt-and-suspenders for the nightly `voice-integration.yml` dispatch, and the per-cluster invocation pattern that avoids the wedge.
- Wedge root-cause is **not** isolated in this PR. Diagnosis (static observations + likely contributors + recommended next-step path) posted as a comment on #491. Brief budget cap (`couple hours, ship VAD + docs if stubborn`) hit; LLM credits preserved for demo verification.

Evidence:
```
$ uv run pytest tests/voice/test_vad.py -v
6 passed, 3 warnings in 3.58s
```

---

## Test plan

- [x] `#489` — classifier diff inspected; no runtime tests needed.
- [x] `#488` — `pytest tests/test_scenario_executor.py -k voice_disconnect -v` passes.
- [x] `#487` — `pytest tests/voice/test_capabilities.py tests/voice/test_adapters.py tests/voice/test_feature_file_contract.py -v` passes (64 tests).
- [x] `#491` (partial) — `pytest tests/voice/test_vad.py -v` passes (6 tests). Wedge diagnosis posted on the issue.
- [x] Pre-commit hooks (commitizen, large-file check) pass on all four commits.
- [x] Full voice suite intentionally NOT run (preserves LLM credits for demo verification per project memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
