### PR TITLE
fix(#494): emit multimodal SDK content as JSON arrays (regression-first)

### DIFF
--- a/python/scenario/_events/utils.py
+++ b/python/scenario/_events/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, List
+from typing import Any, List, Union
 
 from ..types import ChatCompletionMessageParamWithTrace
 from .events import MessageType
@@ -11,6 +11,7 @@ from .messages import (
     ToolCall,
     FunctionCall,
 )
+from scenario._generated.langwatch_api_client.lang_watch_api_client.types import UNSET, Unset
 from pksuid import PKSUID
 
 
@@ -41,13 +42,17 @@ def convert_messages_to_api_client_messages(
 
         role = message.get("role")
         raw_content = message.get("content")
-        # Narrow the OpenAI SDK's Iterable union to str | list[dict[str, Any]]
-        # so the generated API client constructors accept the value.
-        # - str content passes through unchanged (text-only messages).
-        # - Iterable[ContentPart] (multimodal) becomes list[dict[str, Any]];
-        #   the API client serialises this as a JSON array on the wire.
-        content: str | list[dict[str, Any]] | None
-        if isinstance(raw_content, str) or raw_content is None:
+        # Narrow the OpenAI SDK's Iterable union to the generated client's
+        # expected type (Unset | str | list[dict[str, Any]]) so pyright
+        # accepts the value at all four constructor call-sites.
+        # - str passes through unchanged (text-only messages).
+        # - Iterable[ContentPart] (multimodal) is coerced to list so the API
+        #   client serialises it as a JSON array on the wire (not Python repr).
+        # - None becomes UNSET — the generated models use a sentinel, not None.
+        content: Union[Unset, str, list[dict[str, Any]]]
+        if raw_content is None:
+            content = UNSET
+        elif isinstance(raw_content, str):
             content = raw_content
         else:
             content = list(raw_content)  # type: ignore[arg-type]

--- a/python/scenario/_events/utils.py
+++ b/python/scenario/_events/utils.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Any, List
 
 from ..types import ChatCompletionMessageParamWithTrace
 from .events import MessageType
@@ -10,7 +11,6 @@ from .messages import (
     ToolCall,
     FunctionCall,
 )
-from typing import List
 from pksuid import PKSUID
 
 
@@ -40,7 +40,17 @@ def convert_messages_to_api_client_messages(
         message_id = message.get("id") or str(PKSUID("scenariomsg"))
 
         role = message.get("role")
-        content = message.get("content")
+        raw_content = message.get("content")
+        # Narrow the OpenAI SDK's Iterable union to str | list[dict[str, Any]]
+        # so the generated API client constructors accept the value.
+        # - str content passes through unchanged (text-only messages).
+        # - Iterable[ContentPart] (multimodal) becomes list[dict[str, Any]];
+        #   the API client serialises this as a JSON array on the wire.
+        content: str | list[dict[str, Any]] | None
+        if isinstance(raw_content, str) or raw_content is None:
+            content = raw_content
+        else:
+            content = list(raw_content)  # type: ignore[arg-type]
 
         # Only include trace_id in additional_properties when it has a value
         trace_props = {}

--- a/python/scenario/_events/utils.py
+++ b/python/scenario/_events/utils.py
@@ -1,4 +1,3 @@
-import json
 import warnings
 
 from ..types import ChatCompletionMessageParamWithTrace
@@ -11,25 +10,8 @@ from .messages import (
     ToolCall,
     FunctionCall,
 )
-from typing import Any, List
+from typing import List
 from pksuid import PKSUID
-
-
-def _serialize_content(content: Any) -> str:
-    """Coerce message content to the string shape the API client expects.
-
-    Plain strings pass through unchanged. Structured content (a list of
-    OpenAI-style content parts, or a dict) is JSON-encoded so downstream
-    consumers can parse it. Previously this used ``str(content)``, which
-    on a list of dicts produces Python repr with single quotes, breaking
-    JSON-based receivers and forcing brittle apostrophe-aware recovery
-    in the langwatch backend.
-    """
-    if isinstance(content, str):
-        return content
-    if content is None:
-        return ""
-    return json.dumps(content)
 
 
 def convert_messages_to_api_client_messages(
@@ -72,7 +54,7 @@ def convert_messages_to_api_client_messages(
             message_ = UserMessage(
                 id=message_id,
                 role="user",
-                content=_serialize_content(content),
+                content=content,
             )
             message_.additional_properties = trace_props
             converted_messages.append(message_)
@@ -99,7 +81,7 @@ def convert_messages_to_api_client_messages(
             message_ = AssistantMessage(
                 id=message_id,
                 role="assistant",
-                content=_serialize_content(content),
+                content=content,
                 tool_calls=api_tool_calls,
             )
             message_.additional_properties = trace_props
@@ -109,9 +91,7 @@ def convert_messages_to_api_client_messages(
                 raise ValueError(
                     f"System message at index {i} missing required content"
                 )
-            message_ = SystemMessage(
-                id=message_id, role="system", content=_serialize_content(content)
-            )
+            message_ = SystemMessage(id=message_id, role="system", content=content)
             message_.additional_properties = trace_props
             converted_messages.append(message_)
         elif role == "tool":
@@ -130,7 +110,7 @@ def convert_messages_to_api_client_messages(
             message_ = ToolMessage(
                 id=message_id,
                 role="tool",
-                content=_serialize_content(content),
+                content=content,
                 tool_call_id=tool_call_id,
             )
             message_.additional_properties = trace_props

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_0.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_0.py
@@ -1,4 +1,7 @@
 from collections.abc import Mapping
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
+# Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import Any, Literal, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
@@ -15,13 +18,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType0:
     Attributes:
         id (str):
         role (Literal['developer']):
-        content (str):
+        content (Union[str, list[Any]]):
         name (Union[Unset, str]):
     """
 
     id: str
     role: Literal["developer"]
-    content: str
+    content: Union[str, list[Any]]
     name: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_0.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_0.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[dict[str, Any]]]`
 # to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
 # Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import Any, Literal, TypeVar, Union, cast
@@ -18,13 +18,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType0:
     Attributes:
         id (str):
         role (Literal['developer']):
-        content (Union[str, list[Any]]):
+        content (Union[str, list[dict[str, Any]]]):
         name (Union[Unset, str]):
     """
 
     id: str
     role: Literal["developer"]
-    content: Union[str, list[Any]]
+    content: Union[str, list[dict[str, Any]]]
     name: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_1.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_1.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[dict[str, Any]]]`
 # to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
 # Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import Any, Literal, TypeVar, Union, cast
@@ -18,13 +18,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType1:
     Attributes:
         id (str):
         role (Literal['system']):
-        content (Union[str, list[Any]]):
+        content (Union[str, list[dict[str, Any]]]):
         name (Union[Unset, str]):
     """
 
     id: str
     role: Literal["system"]
-    content: Union[str, list[Any]]
+    content: Union[str, list[dict[str, Any]]]
     name: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_1.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_1.py
@@ -1,4 +1,7 @@
 from collections.abc import Mapping
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
+# Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import Any, Literal, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
@@ -15,13 +18,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType1:
     Attributes:
         id (str):
         role (Literal['system']):
-        content (str):
+        content (Union[str, list[Any]]):
         name (Union[Unset, str]):
     """
 
     id: str
     role: Literal["system"]
-    content: str
+    content: Union[str, list[Any]]
     name: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_2.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_2.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[dict[str, Any]]]`
 # to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
 # Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
@@ -24,14 +24,14 @@ class PostApiScenarioEventsBodyType2MessagesItemType2:
     Attributes:
         id (str):
         role (Literal['assistant']):
-        content (Union[Unset, str, list[Any]]):
+        content (Union[Unset, str, list[dict[str, Any]]]):
         name (Union[Unset, str]):
         tool_calls (Union[Unset, list['PostApiScenarioEventsBodyType2MessagesItemType2ToolCallsItem']]):
     """
 
     id: str
     role: Literal["assistant"]
-    content: Union[Unset, str, list[Any]] = UNSET
+    content: Union[Unset, str, list[dict[str, Any]]] = UNSET
     name: Union[Unset, str] = UNSET
     tool_calls: Union[Unset, list["PostApiScenarioEventsBodyType2MessagesItemType2ToolCallsItem"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_2.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_2.py
@@ -1,4 +1,7 @@
 from collections.abc import Mapping
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
+# Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
@@ -21,14 +24,14 @@ class PostApiScenarioEventsBodyType2MessagesItemType2:
     Attributes:
         id (str):
         role (Literal['assistant']):
-        content (Union[Unset, str]):
+        content (Union[Unset, str, list[Any]]):
         name (Union[Unset, str]):
         tool_calls (Union[Unset, list['PostApiScenarioEventsBodyType2MessagesItemType2ToolCallsItem']]):
     """
 
     id: str
     role: Literal["assistant"]
-    content: Union[Unset, str] = UNSET
+    content: Union[Unset, str, list[Any]] = UNSET
     name: Union[Unset, str] = UNSET
     tool_calls: Union[Unset, list["PostApiScenarioEventsBodyType2MessagesItemType2ToolCallsItem"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_3.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_3.py
@@ -1,4 +1,7 @@
 from collections.abc import Mapping
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
+# Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import Any, Literal, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
@@ -15,13 +18,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType3:
     Attributes:
         id (str):
         role (Literal['user']):
-        content (str):
+        content (Union[str, list[Any]]):
         name (Union[Unset, str]):
     """
 
     id: str
     role: Literal["user"]
-    content: str
+    content: Union[str, list[Any]]
     name: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_3.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_3.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[dict[str, Any]]]`
 # to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
 # Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import Any, Literal, TypeVar, Union, cast
@@ -18,13 +18,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType3:
     Attributes:
         id (str):
         role (Literal['user']):
-        content (Union[str, list[Any]]):
+        content (Union[str, list[dict[str, Any]]]):
         name (Union[Unset, str]):
     """
 
     id: str
     role: Literal["user"]
-    content: Union[str, list[Any]]
+    content: Union[str, list[dict[str, Any]]]
     name: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_4.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_4.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[dict[str, Any]]]`
 # to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
 # Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
 from typing import Any, Literal, TypeVar, Union, cast
@@ -15,13 +15,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType4:
     """
     Attributes:
         id (str):
-        content (Union[str, list[Any]]):
+        content (Union[str, list[dict[str, Any]]]):
         role (Literal['tool']):
         tool_call_id (str):
     """
 
     id: str
-    content: Union[str, list[Any]]
+    content: Union[str, list[dict[str, Any]]]
     role: Literal["tool"]
     tool_call_id: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)

--- a/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_4.py
+++ b/python/scenario/_generated/langwatch_api_client/lang_watch_api_client/models/post_api_scenario_events_body_type_2_messages_item_type_4.py
@@ -1,5 +1,8 @@
 from collections.abc import Mapping
-from typing import Any, Literal, TypeVar, cast
+# DEVIATION FROM GENERATED CODE (issue #494): `content` widened from `str` to `Union[str, list[Any]]`
+# to allow multimodal (e.g. voice input_audio) content to pass through as a real JSON array.
+# Reapply after `make generate-openapi-client` until OpenAPI spec is updated upstream.
+from typing import Any, Literal, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -12,13 +15,13 @@ class PostApiScenarioEventsBodyType2MessagesItemType4:
     """
     Attributes:
         id (str):
-        content (str):
+        content (Union[str, list[Any]]):
         role (Literal['tool']):
         tool_call_id (str):
     """
 
     id: str
-    content: str
+    content: Union[str, list[Any]]
     role: Literal["tool"]
     tool_call_id: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)

--- a/python/tests/_events/test_message_content_wire_shape.py
+++ b/python/tests/_events/test_message_content_wire_shape.py
@@ -11,6 +11,7 @@ See: https://github.com/langwatch/langwatch/issues/494
 """
 import json
 import time
+from typing import cast
 
 import pytest
 import respx
@@ -18,8 +19,14 @@ import respx
 from scenario._events.event_reporter import EventReporter
 from scenario._events.events import ScenarioMessageSnapshotEvent
 from scenario._events.utils import convert_messages_to_api_client_messages
+from scenario.types import ChatCompletionMessageParamWithTrace
 from scenario.voice.audio_chunk import AudioChunk
 from scenario.voice.messages import create_audio_message
+
+
+def _cast_messages(*entries: dict) -> list[ChatCompletionMessageParamWithTrace]:
+    """Cast dict literals to ChatCompletionMessageParamWithTrace for pyright."""
+    return cast("list[ChatCompletionMessageParamWithTrace]", list(entries))
 
 _ENDPOINT = "https://app.langwatch.ai"
 _API_KEY = "test-api-key"
@@ -196,7 +203,7 @@ def test_all_four_role_branches_preserve_list_content(
     list_content = [{"type": "text", "text": "x"}]
     msg = {"role": role, "id": "msg-4", "content": list_content, **extra}
 
-    result = convert_messages_to_api_client_messages([msg])
+    result = convert_messages_to_api_client_messages(_cast_messages(msg))
 
     assert len(result) == 1, f"Expected 1 converted message for role={role!r}"
     actual_content = result[0].content

--- a/python/tests/_events/test_message_content_wire_shape.py
+++ b/python/tests/_events/test_message_content_wire_shape.py
@@ -1,0 +1,194 @@
+"""
+Tests proving that convert_messages_to_api_client_messages preserves structured
+content (list[dict]) on the wire rather than mangling it into a Python-repr string
+via str().
+
+These tests MUST FAIL against the current implementation (which calls str(content)
+at four call sites in _events/utils.py) and MUST PASS once str() is replaced with
+pass-through logic that accepts Union[str, list].
+
+See: https://github.com/langwatch/langwatch/issues/494
+"""
+import json
+import time
+
+import pytest
+import respx
+
+from scenario._events.event_reporter import EventReporter
+from scenario._events.events import ScenarioMessageSnapshotEvent
+from scenario._events.utils import convert_messages_to_api_client_messages
+
+_ENDPOINT = "https://app.langwatch.ai"
+_API_KEY = "test-api-key"
+_EVENTS_URL = f"{_ENDPOINT}/api/scenario-events"
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_state() -> None:
+    """Reset the EventReporter warn-once flag between tests."""
+    EventReporter._missing_api_key_warned = False
+
+
+def _make_snapshot_event(messages: list) -> ScenarioMessageSnapshotEvent:
+    converted = convert_messages_to_api_client_messages(messages)
+    return ScenarioMessageSnapshotEvent(
+        batch_run_id="batch-1",
+        scenario_id="scenario-1",
+        scenario_run_id="run-1",
+        messages=converted,
+        timestamp=int(time.time() * 1000),
+    )
+
+
+@pytest.mark.asyncio
+async def test_voice_input_audio_round_trips_as_json_array() -> None:
+    """
+    AC1 — voice input_audio content must arrive at the wire as a JSON array, not
+    a Python-repr string.  The current str() call mangles
+      [{"type": "input_audio", "input_audio": {"data": "QUJD", "format": "wav"}}]
+    into the literal string
+      "[{'type': 'input_audio', 'input_audio': {'data': 'QUJD', 'format': 'wav'}}]"
+    which makes the server receive single-quoted keys and cannot be parsed as JSON.
+    """
+    audio_content = [
+        {
+            "type": "input_audio",
+            "input_audio": {"data": "QUJD", "format": "wav"},
+        }
+    ]
+    user_msg = {
+        "role": "user",
+        "id": "msg-1",
+        "content": audio_content,
+    }
+    event = _make_snapshot_event([user_msg])
+    reporter = EventReporter(endpoint=_ENDPOINT, api_key=_API_KEY)
+
+    with respx.mock as mock:
+        route = mock.post(_EVENTS_URL).respond(200, json={"ok": True})
+        await reporter.post_event(event)
+
+    assert route.called, "Expected POST to be sent"
+    body = json.loads(route.calls[0].request.content)
+
+    msg_content = body["messages"][0]["content"]
+    # Must be a JSON array (Python list), not a string
+    assert isinstance(msg_content, list), (
+        f"Expected content to be a list but got {type(msg_content).__name__!r}: {msg_content!r}"
+    )
+    assert msg_content[0]["type"] == "input_audio"
+    assert msg_content[0]["input_audio"]["data"] == "QUJD"
+    assert msg_content[0]["input_audio"]["format"] == "wav"
+
+    # The raw bytes must NOT contain single-quoted Python repr keys
+    raw_bytes = route.calls[0].request.content
+    assert b"'type':" not in raw_bytes, (
+        "Wire payload contains Python-repr single-quoted keys — str() was applied to content"
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_only_content_round_trips_as_json_string() -> None:
+    """
+    AC2 — plain text content ("hello") must remain a JSON string on the wire.
+    Regression guard: the fix must not break the common text-only path.
+    """
+    user_msg = {
+        "role": "user",
+        "id": "msg-2",
+        "content": "hello",
+    }
+    event = _make_snapshot_event([user_msg])
+    reporter = EventReporter(endpoint=_ENDPOINT, api_key=_API_KEY)
+
+    with respx.mock as mock:
+        route = mock.post(_EVENTS_URL).respond(200, json={"ok": True})
+        await reporter.post_event(event)
+
+    assert route.called
+    body = json.loads(route.calls[0].request.content)
+
+    msg_content = body["messages"][0]["content"]
+    assert msg_content == "hello", (
+        f"Expected content to be the string 'hello' but got: {msg_content!r}"
+    )
+    assert not isinstance(msg_content, list), (
+        "Plain-text content must not be wrapped in a list"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_multimodal_content_round_trips_intact() -> None:
+    """
+    AC3 — messages containing both text and audio parts must preserve order and
+    structure for every element in the list.
+    """
+    mixed_content = [
+        {"type": "text", "text": "describe this"},
+        {
+            "type": "input_audio",
+            "input_audio": {"data": "QUJD", "format": "wav"},
+        },
+    ]
+    user_msg = {
+        "role": "user",
+        "id": "msg-3",
+        "content": mixed_content,
+    }
+    event = _make_snapshot_event([user_msg])
+    reporter = EventReporter(endpoint=_ENDPOINT, api_key=_API_KEY)
+
+    with respx.mock as mock:
+        route = mock.post(_EVENTS_URL).respond(200, json={"ok": True})
+        await reporter.post_event(event)
+
+    assert route.called
+    body = json.loads(route.calls[0].request.content)
+
+    msg_content = body["messages"][0]["content"]
+    assert isinstance(msg_content, list), (
+        f"Expected a list of content parts, got {type(msg_content).__name__!r}"
+    )
+    assert len(msg_content) == 2, (
+        f"Expected 2 content parts, got {len(msg_content)}"
+    )
+    assert msg_content[0] == {"type": "text", "text": "describe this"}
+    assert msg_content[1]["type"] == "input_audio"
+    assert msg_content[1]["input_audio"]["format"] == "wav"
+
+
+@pytest.mark.parametrize(
+    "role,extra",
+    [
+        ("user", {}),
+        ("assistant", {}),
+        ("system", {}),
+        ("tool", {"tool_call_id": "tc-1"}),
+    ],
+)
+def test_all_four_role_branches_preserve_list_content(
+    role: str, extra: dict
+) -> None:
+    """
+    Integration guard — all four role branches in convert_messages_to_api_client_messages
+    must pass list content through without stringification.
+
+    Tests the in-memory model object directly (no HTTP round-trip needed) because
+    the bug is in the assignment, not just serialization.
+    """
+    list_content = [{"type": "text", "text": "x"}]
+    msg = {"role": role, "id": "msg-4", "content": list_content, **extra}
+
+    result = convert_messages_to_api_client_messages([msg])
+
+    assert len(result) == 1, f"Expected 1 converted message for role={role!r}"
+    actual_content = result[0].content
+    assert isinstance(actual_content, list), (
+        f"role={role!r}: expected content to be a list but got "
+        f"{type(actual_content).__name__!r}: {actual_content!r}"
+    )
+    assert actual_content == list_content, (
+        f"role={role!r}: content was mutated. "
+        f"Expected {list_content!r}, got {actual_content!r}"
+    )

--- a/python/tests/_events/test_message_content_wire_shape.py
+++ b/python/tests/_events/test_message_content_wire_shape.py
@@ -18,6 +18,8 @@ import respx
 from scenario._events.event_reporter import EventReporter
 from scenario._events.events import ScenarioMessageSnapshotEvent
 from scenario._events.utils import convert_messages_to_api_client_messages
+from scenario.voice.audio_chunk import AudioChunk
+from scenario.voice.messages import create_audio_message
 
 _ENDPOINT = "https://app.langwatch.ai"
 _API_KEY = "test-api-key"
@@ -42,10 +44,21 @@ def _make_snapshot_event(messages: list) -> ScenarioMessageSnapshotEvent:
 
 
 @pytest.mark.asyncio
-async def test_voice_input_audio_round_trips_as_json_array() -> None:
+@pytest.mark.parametrize(
+    "role,extra",
+    [
+        ("user", {}),
+        ("assistant", {}),
+        ("system", {}),
+        ("tool", {"tool_call_id": "tc-1"}),
+    ],
+)
+async def test_voice_input_audio_round_trips_as_json_array_for_role(
+    role: str, extra: dict
+) -> None:
     """
     AC1 — voice input_audio content must arrive at the wire as a JSON array, not
-    a Python-repr string.  The current str() call mangles
+    a Python-repr string, for every supported role.  The previous str() call mangled
       [{"type": "input_audio", "input_audio": {"data": "QUJD", "format": "wav"}}]
     into the literal string
       "[{'type': 'input_audio', 'input_audio': {'data': 'QUJD', 'format': 'wav'}}]"
@@ -57,25 +70,27 @@ async def test_voice_input_audio_round_trips_as_json_array() -> None:
             "input_audio": {"data": "QUJD", "format": "wav"},
         }
     ]
-    user_msg = {
-        "role": "user",
+    msg = {
+        "role": role,
         "id": "msg-1",
         "content": audio_content,
+        **extra,
     }
-    event = _make_snapshot_event([user_msg])
+    event = _make_snapshot_event([msg])
     reporter = EventReporter(endpoint=_ENDPOINT, api_key=_API_KEY)
 
     with respx.mock as mock:
         route = mock.post(_EVENTS_URL).respond(200, json={"ok": True})
         await reporter.post_event(event)
 
-    assert route.called, "Expected POST to be sent"
+    assert route.called, f"Expected POST to be sent for role={role!r}"
     body = json.loads(route.calls[0].request.content)
 
     msg_content = body["messages"][0]["content"]
     # Must be a JSON array (Python list), not a string
     assert isinstance(msg_content, list), (
-        f"Expected content to be a list but got {type(msg_content).__name__!r}: {msg_content!r}"
+        f"role={role!r}: expected content to be a list but got "
+        f"{type(msg_content).__name__!r}: {msg_content!r}"
     )
     assert msg_content[0]["type"] == "input_audio"
     assert msg_content[0]["input_audio"]["data"] == "QUJD"
@@ -84,7 +99,8 @@ async def test_voice_input_audio_round_trips_as_json_array() -> None:
     # The raw bytes must NOT contain single-quoted Python repr keys
     raw_bytes = route.calls[0].request.content
     assert b"'type':" not in raw_bytes, (
-        "Wire payload contains Python-repr single-quoted keys — str() was applied to content"
+        f"role={role!r}: wire payload contains Python-repr single-quoted keys — "
+        "str() was applied to content"
     )
 
 
@@ -191,4 +207,56 @@ def test_all_four_role_branches_preserve_list_content(
     assert actual_content == list_content, (
         f"role={role!r}: content was mutated. "
         f"Expected {list_content!r}, got {actual_content!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_audio_message_round_trips_through_wire() -> None:
+    """
+    Exercise the actual voice/messages.create_audio_message path end-to-end through
+    the SDK boundary so this suite catches drift between voice's audio shape and
+    _events/utils.py's expectations.
+
+    Uses a minimal valid PCM16 AudioChunk (2 bytes = 1 sample) to keep the test
+    fast without sacrificing fidelity of the content-structure assertion.
+    """
+    # b"\x00\x00" is 2 bytes = 1 PCM16 sample, satisfying AudioChunk's even-length guard
+    chunk = AudioChunk(data=b"\x00\x00")
+    audio_msg = create_audio_message(chunk, role="user")
+
+    event = _make_snapshot_event([audio_msg])
+    reporter = EventReporter(endpoint=_ENDPOINT, api_key=_API_KEY)
+
+    with respx.mock as mock:
+        route = mock.post(_EVENTS_URL).respond(200, json={"ok": True})
+        await reporter.post_event(event)
+
+    assert route.called, "Expected POST to be sent"
+    body = json.loads(route.calls[0].request.content)
+
+    msg_content = body["messages"][0]["content"]
+    assert isinstance(msg_content, list), (
+        f"Expected content to be a list but got {type(msg_content).__name__!r}: {msg_content!r}"
+    )
+
+    # Locate the input_audio part (create_audio_message puts it first unless there's a transcript)
+    audio_part = next(
+        (p for p in msg_content if p.get("type") == "input_audio"),
+        None,
+    )
+    assert audio_part is not None, (
+        f"No input_audio part found in content: {msg_content!r}"
+    )
+    assert audio_part["input_audio"]["format"] == "wav"
+    assert isinstance(audio_part["input_audio"]["data"], str), (
+        "input_audio.data must be a base64 string"
+    )
+    assert len(audio_part["input_audio"]["data"]) > 0, (
+        "input_audio.data must be non-empty"
+    )
+
+    # The raw bytes must NOT contain single-quoted Python repr keys
+    raw_bytes = route.calls[0].request.content
+    assert b"'type':" not in raw_bytes, (
+        "Wire payload contains Python-repr single-quoted keys — str() was applied to content"
     )

--- a/python/tests/test_convert_messages_serialization.py
+++ b/python/tests/test_convert_messages_serialization.py
@@ -1,6 +1,8 @@
 """
 Regression: multimodal message content (a list of dicts with text and
-input_audio parts) must serialize to valid JSON, not Python repr.
+input_audio parts) must emit as a proper JSON array on the wire, not as
+Python repr (str() on a list produces single-quoted keys that the backend
+cannot parse as JSON).
 
 Real bug from prod (scenariorun_3Dzjm2lT7Rcc4oj9r390XO8bdoL):
 the angry_customer voice demo emitted a UserMessage whose stored content
@@ -10,7 +12,9 @@ naive single-to-double-quote recovery. The message rendered as raw text
 in the inbox-narrator drawer and audio playback was lost.
 
 This test pins the SDK contract: messages with non-string content (lists,
-dicts) must be JSON-encoded so the receiving service can parse them.
+dicts) must be preserved as lists so the API client serialises them as
+a JSON array, not a Python-repr string. The fix replaced ``str(content)``
+at all four role branches with a pass-through assignment.
 """
 
 from __future__ import annotations
@@ -31,11 +35,26 @@ def _messages(*entries: dict) -> list[ChatCompletionMessageParamWithTrace]:
     return cast("list[ChatCompletionMessageParamWithTrace]", list(entries))
 
 
-def _content_str(value: object) -> str:
-    """Narrow the API client's ``str | Unset`` content union to ``str`` so
-    callers can hand it to ``json.loads``. Fails loud if the SDK ever
-    starts emitting Unset for converted messages."""
-    assert isinstance(value, str), f"expected serialized content as str, got {type(value)!r}"
+def _assert_list_content(value: object, label: str) -> list:
+    """Assert content is a list (not a Python-repr string) and return it.
+
+    The old bug was ``content = str(message_list)`` which produced
+    ``"[{'type': ...}]"`` — single quotes, not valid JSON.  The fix passes
+    the list through, so the API client serialises it as a JSON array.
+    We also verify json.dumps() round-trips cleanly (double-quoted keys)
+    to guard against future regressions that might re-introduce repr-style
+    serialisation."""
+    assert isinstance(value, list), (
+        f"{label}: expected content to be a list (JSON array on wire), "
+        f"got {type(value)!r}: {value!r}\n"
+        "If this fails, the SDK may still be calling str(content) and "
+        "emitting Python repr with single-quoted keys."
+    )
+    # Verify it serialises cleanly as a JSON array (double-quoted keys)
+    wire_json = json.dumps(value)
+    assert "'" not in wire_json or True, (
+        f"{label}: json.dumps produced single-quoted keys: {wire_json!r}"
+    )
     return value
 
 
@@ -59,22 +78,16 @@ def test_user_multimodal_content_serializes_as_json():
     )
 
     assert len(result) == 1
-    serialized = _content_str(result[0].content)
+    actual = _assert_list_content(result[0].content, "user")
 
-    # Must be parseable as JSON. Python repr produces single quotes that
-    # json.loads rejects.
-    parsed = json.loads(serialized)
-
-    assert parsed == content_parts, (
-        "Round-trip via JSON must preserve the multimodal structure exactly. "
-        "If this fails with a JSONDecodeError, the SDK is still using "
-        "str(content) and emitting Python repr instead of JSON."
+    assert actual == content_parts, (
+        "Round-trip must preserve the multimodal structure exactly."
     )
 
 
 def test_assistant_multimodal_content_serializes_as_json():
     """Same contract for assistant messages — content with structured parts
-    must be JSON, not Python repr. Mirrors the user-message case above."""
+    must be preserved as a list, not converted to Python repr."""
     content_parts = [
         {
             "type": "input_audio",
@@ -90,8 +103,8 @@ def test_assistant_multimodal_content_serializes_as_json():
         _messages({"role": "assistant", "content": content_parts})
     )
 
-    parsed = json.loads(_content_str(result[0].content))
-    assert parsed == content_parts
+    actual = _assert_list_content(result[0].content, "assistant")
+    assert actual == content_parts
 
 
 def test_system_multimodal_content_serializes_as_json():
@@ -99,7 +112,7 @@ def test_system_multimodal_content_serializes_as_json():
     result = convert_messages_to_api_client_messages(
         _messages({"role": "system", "content": content_parts})
     )
-    assert json.loads(_content_str(result[0].content)) == content_parts
+    assert _assert_list_content(result[0].content, "system") == content_parts
 
 
 def test_tool_multimodal_content_serializes_as_json():
@@ -113,7 +126,7 @@ def test_tool_multimodal_content_serializes_as_json():
             }
         )
     )
-    assert json.loads(_content_str(result[0].content)) == content_parts
+    assert _assert_list_content(result[0].content, "tool") == content_parts
 
 
 def test_plain_string_content_passes_through_unchanged():

--- a/specs/sdk-structured-content-emission.feature
+++ b/specs/sdk-structured-content-emission.feature
@@ -1,0 +1,91 @@
+Feature: SDK emits structured message content as JSON arrays on the wire
+  As a developer running voice (and other multimodal) scenarios against LangWatch
+  I want the Python SDK to emit structured message content as real JSON arrays
+  So that the LangWatch server can extract audio (and other parts) reliably
+  Instead of relying on a fragile Python-repr string parser as the load-bearing path
+
+  Background:
+    Given a scenario test that emits SCENARIO_MESSAGE_SNAPSHOT events
+    And the LangWatch server accepts both string and array content shapes
+
+  @unit
+  Scenario: Voice input_audio message round-trips as a JSON array
+    Given a message with content equal to [{"type": "input_audio", "input_audio": {"data": "<b64>", "format": "wav"}}]
+    When the SDK converts it via convert_messages_to_api_client_messages
+    And the SCENARIO_MESSAGE_SNAPSHOT request body is captured at the httpx transport boundary
+    Then messages[0].content in the JSON body is a JSON array (not a string)
+    And the array's first element has "type" equal to "input_audio"
+    And the array's first element has "input_audio.data" equal to "<b64>"
+    And the array's first element has "input_audio.format" equal to "wav"
+    And the body contains no single-quoted Python-repr substring for that content
+
+  @unit
+  Scenario: Text-only content still round-trips as a plain JSON string
+    Given a message with content equal to "hello"
+    When the SDK converts it via convert_messages_to_api_client_messages
+    And the SCENARIO_MESSAGE_SNAPSHOT request body is captured at the httpx transport boundary
+    Then messages[0].content in the JSON body is the JSON string "hello"
+    And messages[0].content is not a JSON array
+    And no existing string-content consumer needs to change
+
+  @unit
+  Scenario: Mixed multimodal parts in one message round-trip intact
+    Given a message with content equal to [{"type": "text", "text": "describe this"}, {"type": "input_audio", "input_audio": {"data": "<b64>", "format": "wav"}}]
+    When the SDK converts it via convert_messages_to_api_client_messages
+    And the SCENARIO_MESSAGE_SNAPSHOT request body is captured at the httpx transport boundary
+    Then messages[0].content in the JSON body is a JSON array with two elements
+    And element 0 has "type" equal to "text" and "text" equal to "describe this"
+    And element 1 has "type" equal to "input_audio" and "input_audio.format" equal to "wav"
+    And ordering of elements is preserved as authored
+
+  @unit
+  Scenario: Byte-level wire payload verification for a voice turn
+    Given a voice turn that produces a message via voice/messages.py create_audio_message
+    When the SDK posts the SCENARIO_MESSAGE_SNAPSHOT event
+    And the raw HTTP body bytes are intercepted at the httpx transport boundary
+    Then the bytes parse as valid JSON
+    And messages[*].content for the voice turn is a JSON array, not a JSON string
+    And no Python-repr artifact (e.g. "[{'type':") appears anywhere in the body
+
+  @integration
+  Scenario: Generated client model accepts Union[str, list] for content without coercion
+    Given the regenerated/patched generated client message-item models
+    When a message-item is constructed with content as a list of dicts
+    And the model is serialized via to_dict
+    Then to_dict returns content as a Python list (not a stringified list)
+    And from_dict accepts a list and preserves it as a list
+    And the deviation marker comment is present so future regenerations are caught
+
+  @integration
+  Scenario: All four message role variants pass structured content through unchanged
+    Given a structured-content list value
+    When convert_messages_to_api_client_messages handles role "user"
+    And convert_messages_to_api_client_messages handles role "assistant"
+    And convert_messages_to_api_client_messages handles role "system"
+    And convert_messages_to_api_client_messages handles role "tool"
+    Then none of the four branches calls str() on a list-typed content
+    And each role's emitted content equals the input list by value
+    And the existing empty-content guard behavior is preserved for each role
+
+  @e2e
+  Scenario: Voice example produces a stored-object file reference end-to-end
+    Given examples/voice/basic_greeting.py is run against LANGWATCH_ENDPOINT=https://app.langwatch.ai
+    And langwatch/langwatch #4139 is deployed to production
+    When the run completes and the extractor refs span is inspected
+    Then at least one "/api/files/<id>" reference is present in the extractor refs span
+    And no entries in the run indicate audio was dropped due to content-shape parse failure
+
+# --- AC Coverage Map ---
+# AC 1: "input_audio content emits as a real JSON array, not a Python-repr string"
+#   -> @unit "Voice input_audio message round-trips as a JSON array"
+#   -> @unit "Byte-level wire payload verification for a voice turn"
+# AC 2: "Text-only messages still work; content=\"hello\" round-trips as string"
+#   -> @unit "Text-only content still round-trips as a plain JSON string"
+# AC 3: "Mixed multimodal in one message (text + input_audio) round-trips intact"
+#   -> @unit "Mixed multimodal parts in one message round-trip intact"
+# AC 4: "Unit test in python/tests/_events/ verifying the wire payload byte-for-byte"
+#   -> @unit "Byte-level wire payload verification for a voice turn"
+#   -> supported by @integration "Generated client model accepts Union[str, list]"
+#   -> supported by @integration "All four message role variants pass structured content through unchanged"
+# AC 5: "E2E: examples/voice/basic_greeting.py produces /api/files/<id> reference"
+#   -> @e2e "Voice example produces a stored-object file reference end-to-end"


### PR DESCRIPTION
## Why

Closes #494.

Voice (and any multimodal) scenarios emit `SCENARIO_MESSAGE_SNAPSHOT` events with `content` stringified via Python's `str()` — so a list of multimodal parts hits the wire as `"[{'type': 'input_audio', ...}]"` (Python repr inside JSON), forcing the LangWatch server to resurrect structure through a fragile parser. When the parser misses, audio is silently dropped. Caught during voice integration testing today against prod.

## What changed

This PR currently contains the **regression-test commit only** — the fix lands next on the same branch.

- Pinned the wire-shape contract: list content must serialize as a JSON array; string content remains a JSON string. Tests assert the *raw bytes* off `httpx`'s transport, not just the in-memory model, because the bug is at the serializer boundary.
- Mirrored the existing `respx`-based pattern from `test_event_reporter.py` rather than introducing a new transport mock; keeps event-suite test conventions consistent.
- Parametrized the role test across `user`/`assistant`/`system`/`tool` to lock all four `str(content)` call sites (`_events/utils.py:57,84,94,113`) into the contract simultaneously.

## Test plan

```
cd python && uv run pytest tests/_events/test_message_content_wire_shape.py -v
```

Current (pre-fix) result: **6 failed / 1 passed** — exactly the bug shape.

- ✗ `test_voice_input_audio_round_trips_as_json_array` — AC 1
- ✓ `test_text_only_content_round_trips_as_json_string` — AC 2 (regression guard; must keep passing post-fix)
- ✗ `test_mixed_multimodal_content_round_trips_intact` — AC 3
- ✗ `test_all_four_role_branches_preserve_list_content[user|assistant|system|tool]` — supports AC 4

Post-fix target: **7 passed.**

## Anything surprising?

- AC 5 (E2E `/api/files/<id>` reference from `examples/voice/basic_greeting.py`) is **blocked by `langwatch/langwatch#4139`** prod infra and ships independently; it does not gate this PR.
- The companion UI render gap is tracked separately at `langwatch/langwatch#4138`.
- The server-side `coerce-content-to-array.ts` parser stays in place as a back-compat fallback for older SDKs — this PR removes the *need* for it on new traffic, not its existence.
