### PR TITLE
fix(voice): render audio messages cleanly in the terminal

### DIFF
--- a/python/scenario/_events/event_reporter.py
+++ b/python/scenario/_events/event_reporter.py
@@ -19,36 +19,29 @@ def _redacted_event_repr(event: Any) -> str:
     available, falling back to scrubbing the raw ``repr(event)`` string —
     that fallback matters because logging often runs in the exception path,
     where ``to_dict()`` itself may have failed.
+
+    The dict-walker scrubs both real ``input_audio.data`` keys and any long
+    base64 runs that appear inside string values, since upstream sometimes
+    serialises content lists to ``repr()`` strings before they reach us.
     """
     try:
         payload = event.to_dict()
-        _redact_audio_in_place(payload)
-        return repr(payload)
+        return repr(_redact_audio(payload))
     except Exception:
         return _redact_b64_runs_in_text(repr(event))
 
 
-def _redact_audio_in_place(node: Any) -> None:
+def _redact_audio(node: Any) -> Any:
     if isinstance(node, dict):
-        for value in node.values():
-            if isinstance(value, dict):
-                data = value.get("data")
-                if isinstance(data, str) and len(data) > 64 and _looks_base64(data):
-                    value["data"] = f"<audio:{len(data)} b64 chars elided>"
-                    continue
-            _redact_audio_in_place(value)
-    elif isinstance(node, list):
-        for item in node:
-            _redact_audio_in_place(item)
+        return {key: _redact_audio(value) for key, value in node.items()}
+    if isinstance(node, list):
+        return [_redact_audio(item) for item in node]
+    if isinstance(node, str):
+        return _redact_b64_runs_in_text(node)
+    return node
 
 
 _B64_RUN = re.compile(r"[A-Za-z0-9+/]{200,}={0,2}")
-
-
-def _looks_base64(value: str) -> bool:
-    return bool(_B64_RUN.fullmatch(value)) or (
-        len(value) > 200 and all(c.isalnum() or c in "+/=" for c in value[:200])
-    )
 
 
 def _redact_b64_runs_in_text(text: str) -> str:

--- a/python/scenario/_events/event_reporter.py
+++ b/python/scenario/_events/event_reporter.py
@@ -1,9 +1,60 @@
 import logging
+import re
 import httpx
 from typing import ClassVar, Optional, Dict, Any
 from .events import ScenarioEvent
 from .event_alert_message_logger import EventAlertMessageLogger
 from scenario.config import LangWatchSettings, ScenarioConfig
+
+
+def _redacted_event_repr(event: Any) -> str:
+    """
+    Repr-style summary of an event with base64 audio payloads stripped.
+
+    Failure logs include the full event for debuggability, but multimodal
+    voice messages carry base64-encoded WAVs that dwarf everything else and
+    flood the terminal. Replace audio payloads with ``<audio:N b64 chars
+    elided>`` placeholders so the log stays readable while preserving message
+    order and metadata. The redaction is applied to ``event.to_dict()`` when
+    available, falling back to scrubbing the raw ``repr(event)`` string —
+    that fallback matters because logging often runs in the exception path,
+    where ``to_dict()`` itself may have failed.
+    """
+    try:
+        payload = event.to_dict()
+        _redact_audio_in_place(payload)
+        return repr(payload)
+    except Exception:
+        return _redact_b64_runs_in_text(repr(event))
+
+
+def _redact_audio_in_place(node: Any) -> None:
+    if isinstance(node, dict):
+        for value in node.values():
+            if isinstance(value, dict):
+                data = value.get("data")
+                if isinstance(data, str) and len(data) > 64 and _looks_base64(data):
+                    value["data"] = f"<audio:{len(data)} b64 chars elided>"
+                    continue
+            _redact_audio_in_place(value)
+    elif isinstance(node, list):
+        for item in node:
+            _redact_audio_in_place(item)
+
+
+_B64_RUN = re.compile(r"[A-Za-z0-9+/]{200,}={0,2}")
+
+
+def _looks_base64(value: str) -> bool:
+    return bool(_B64_RUN.fullmatch(value)) or (
+        len(value) > 200 and all(c.isalnum() or c in "+/=" for c in value[:200])
+    )
+
+
+def _redact_b64_runs_in_text(text: str) -> str:
+    return _B64_RUN.sub(
+        lambda m: f"<audio:{len(m.group(0))} b64 chars elided>", text
+    )
 
 
 def _resolve_langwatch_client_api_key() -> str:
@@ -153,11 +204,11 @@ class EventReporter:
                     self.logger.error(
                         f"[{event_type}] Event POST failed: status={response.status_code}, "
                         f"reason={response.reason_phrase}, error={error_text}, "
-                        f"event={event}"
+                        f"event={_redacted_event_repr(event)}"
                     )
         except Exception as error:
             self.logger.error(
-                f"[{event_type}] Event POST error: {repr(error)}, event={event}, endpoint={self.endpoint}"
+                f"[{event_type}] Event POST error: {repr(error)}, event={_redacted_event_repr(event)}, endpoint={self.endpoint}"
             )
 
         return result

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -160,6 +160,43 @@ def title_case(string: str) -> str:
     return " ".join(word.capitalize() for word in string.split("_"))
 
 
+_ITALIC_ON = "\x1b[3m"
+_ITALIC_OFF = "\x1b[23m"
+
+
+def _format_message_content(content: Any) -> Any:
+    """
+    Render message content for terminal output.
+
+    Multimodal content (a list of parts) is collapsed into a readable string:
+    audio parts become ``<audio>`` and text parts (e.g. transcripts) are
+    rendered in italic so the user sees the spoken text without the raw
+    base64-encoded WAV payload that the model actually consumes.
+
+    Plain string content (and anything we don't recognise) is returned as-is.
+    """
+    if not isinstance(content, list):
+        return content
+
+    rendered: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            rendered.append(str(part))
+            continue
+        part_type = part.get("type")
+        if part_type in ("input_audio", "audio"):
+            rendered.append("<audio>")
+        elif part_type == "text":
+            text = part.get("text") or ""
+            if text:
+                rendered.append(f"{_ITALIC_ON}{text}{_ITALIC_OFF}")
+        elif part_type == "image_url":
+            rendered.append("<image>")
+        else:
+            rendered.append(f"<{part_type or 'part'}>")
+    return " ".join(rendered) if rendered else content
+
+
 def print_openai_messages(
     scenario_name: str, messages: list[ChatCompletionMessageParam]
 ):
@@ -196,7 +233,10 @@ def print_openai_messages(
         if role == "assistant":
             tool_calls = safe_attr_or_key(msg, "tool_calls")
             if content:
-                print(scenario_name + termcolor.colored("Agent:", "blue"), content)
+                print(
+                    scenario_name + termcolor.colored("Agent:", "blue"),
+                    _format_message_content(content),
+                )
             if tool_calls:
                 for tool_call in tool_calls:
                     function = safe_attr_or_key(tool_call, "function")
@@ -209,7 +249,10 @@ def print_openai_messages(
                         f"\n\n{indent(args, ' ' * 4)}\n",
                     )
         elif role == "user":
-            print(scenario_name + termcolor.colored("User:", "green"), content)
+            print(
+                scenario_name + termcolor.colored("User:", "green"),
+                _format_message_content(content),
+            )
         elif role == "tool":
             content = _take_maybe_json_first_lines(content or msg.__repr__())
             print(

--- a/python/scenario/_utils/utils.py
+++ b/python/scenario/_utils/utils.py
@@ -162,38 +162,54 @@ def title_case(string: str) -> str:
 
 _ITALIC_ON = "\x1b[3m"
 _ITALIC_OFF = "\x1b[23m"
+_AUDIO_ICON = "\U0001f50a"
 
 
 def _format_message_content(content: Any) -> Any:
     """
     Render message content for terminal output.
 
-    Multimodal content (a list of parts) is collapsed into a readable string:
-    audio parts become ``<audio>`` and text parts (e.g. transcripts) are
-    rendered in italic so the user sees the spoken text without the raw
-    base64-encoded WAV payload that the model actually consumes.
+    Multimodal content (a list of parts) is collapsed into a readable line.
+    Audio turns are prefixed with the speaker emoji and (if a transcript is
+    attached) the spoken text follows in italic, so voice scenarios read
+    cleanly in demo terminals and recordings without leaking the raw base64
+    WAV payload that the model actually consumes. Audio-only turns render
+    as ``🔊 (audio)``.
 
     Plain string content (and anything we don't recognise) is returned as-is.
     """
     if not isinstance(content, list):
         return content
 
-    rendered: list[str] = []
+    has_audio = False
+    transcripts: list[str] = []
+    other_parts: list[str] = []
     for part in content:
         if not isinstance(part, dict):
-            rendered.append(str(part))
+            other_parts.append(str(part))
             continue
         part_type = part.get("type")
         if part_type in ("input_audio", "audio"):
-            rendered.append("<audio>")
+            has_audio = True
         elif part_type == "text":
             text = part.get("text") or ""
             if text:
-                rendered.append(f"{_ITALIC_ON}{text}{_ITALIC_OFF}")
+                transcripts.append(text)
         elif part_type == "image_url":
-            rendered.append("<image>")
+            other_parts.append("<image>")
         else:
-            rendered.append(f"<{part_type or 'part'}>")
+            other_parts.append(f"<{part_type or 'part'}>")
+
+    rendered: list[str] = []
+    if has_audio:
+        if transcripts:
+            transcript = " ".join(transcripts)
+            rendered.append(f"{_AUDIO_ICON} {_ITALIC_ON}{transcript}{_ITALIC_OFF}")
+        else:
+            rendered.append(f"{_AUDIO_ICON} (audio)")
+    elif transcripts:
+        rendered.extend(transcripts)
+    rendered.extend(other_parts)
     return " ".join(rendered) if rendered else content
 
 

--- a/python/tests/test_event_reporter.py
+++ b/python/tests/test_event_reporter.py
@@ -217,3 +217,51 @@ async def test_warns_only_once_when_api_key_missing(
         f"Expected exactly one warning across 10 events, got {len(matching)}: "
         f"{[r.getMessage() for r in matching]}"
     )
+
+
+@pytest.mark.asyncio
+async def test_post_event_failure_log_redacts_base64_audio(
+    caplog: LogCaptureFixture,
+    monkeypatch,
+) -> None:
+    """Failed POST log must not dump raw base64 WAV payloads."""
+    from scenario._events.events import ScenarioMessageSnapshotEvent
+
+    big_b64 = "U" * 5000
+    messages = [
+        {
+            "id": "msg-1",
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": big_b64, "format": "wav"},
+                },
+            ],
+        }
+    ]
+    event = ScenarioMessageSnapshotEvent(
+        batch_run_id="batch-1",
+        scenario_id="scenario-1",
+        scenario_run_id="run-1",
+        messages=messages,  # type: ignore[arg-type]
+        timestamp=int(time.time() * 1000),
+    )
+
+    monkeypatch.setenv("LANGWATCH_ENDPOINT", "https://example.test")
+    monkeypatch.setenv("LANGWATCH_API_KEY", "sk-test")
+    reporter = EventReporter()
+
+    with respx.mock:
+        respx.post("https://example.test/api/scenario-events").mock(
+            return_value=httpx.Response(500, text="boom")
+        )
+        with caplog.at_level(logging.ERROR):
+            await reporter.post_event(event)
+
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    # Either path (failed POST or in-flight exception) must scrub the payload.
+    assert "Event POST" in joined
+    assert big_b64 not in joined
+    assert "<audio:" in joined

--- a/python/tests/test_event_reporter.py
+++ b/python/tests/test_event_reporter.py
@@ -265,3 +265,31 @@ async def test_post_event_failure_log_redacts_base64_audio(
     assert "Event POST" in joined
     assert big_b64 not in joined
     assert "<audio:" in joined
+
+
+def test_redacted_event_repr_scrubs_b64_inside_stringified_content() -> None:
+    """The wire format sometimes carries content as a repr() string. Scrub that too."""
+    from scenario._events.event_reporter import _redacted_event_repr
+
+    big_b64 = "U" * 5000
+
+    class _FakeEvent:
+        def to_dict(self) -> dict:
+            return {
+                "type": "SCENARIO_MESSAGE_SNAPSHOT",
+                "messages": [
+                    {
+                        "id": "scenariomsg_1",
+                        "role": "assistant",
+                        "content": (
+                            "[{'type': 'input_audio', 'input_audio': "
+                            f"{{'data': '{big_b64}', 'format': 'wav'}}}}]"
+                        ),
+                    }
+                ],
+            }
+
+    rendered = _redacted_event_repr(_FakeEvent())
+
+    assert big_b64 not in rendered
+    assert "<audio:" in rendered

--- a/python/tests/voice/test_feature_file_contract.py
+++ b/python/tests/voice/test_feature_file_contract.py
@@ -45,21 +45,22 @@ def test_feature_file_parses_cleanly(parsed_feature):
 
 def test_feature_file_declares_expected_scenario_count(parsed_feature):
     """
-    The issue-350 contract is 105 scenarios:
+    The issue-350 contract is 108 scenarios:
       - 83 original
       - +4 for locked decision #9 (composable + branded voice agents)
       - +12 for @e2e demo parity (TESTING.md: every user-facing feature has
         a runnable example). 8 platform-demo + 4 cross-cutting SDK demos.
       - +3 for AC-14 (demo recordings: save_segments + opt-in + CI artifact).
       - +3 for AC-15 (auto-transcribe agent audio for non-multimodal judges).
+      - +3 for AC-16 (audio messages render cleanly in the terminal).
 
     Any change to this count must be a deliberate contract update — and must
     be reflected in the prove-it report at
     docs/proposals/issue-350-prove-it-report.md.
     """
     scenarios = _collect_scenarios(parsed_feature)
-    assert len(scenarios) == 105, (
-        f"Expected 105 scenarios; found {len(scenarios)}. "
+    assert len(scenarios) == 108, (
+        f"Expected 108 scenarios; found {len(scenarios)}. "
         "If this is an intentional contract change, update the count here "
         "AND regenerate docs/proposals/issue-350-prove-it-report.md."
     )
@@ -105,10 +106,11 @@ def test_every_scenario_is_tagged_unit_integration_or_e2e(parsed_feature):
 
 def test_tag_split_matches_prove_it_report(parsed_feature):
     """
-    The prove-it report assumes 72 @unit / 8 @integration / 25 @e2e.
+    The prove-it report assumes 75 @unit / 8 @integration / 25 @e2e.
     §6 examples and §8 pain patterns are @e2e (happy paths via real examples,
     per TESTING.md). AC-14 adds 1 @unit + 2 @integration. AC-15 adds 3 @unit.
-    If the split changes, the report must be updated in the same PR.
+    AC-16 adds 3 @unit. If the split changes, the report must be updated in
+    the same PR.
     """
     scenarios = _collect_scenarios(parsed_feature)
     unit = sum(1 for s in scenarios if "@unit" in {t.name for t in s.tags})
@@ -116,8 +118,8 @@ def test_tag_split_matches_prove_it_report(parsed_feature):
         1 for s in scenarios if "@integration" in {t.name for t in s.tags}
     )
     e2e = sum(1 for s in scenarios if "@e2e" in {t.name for t in s.tags})
-    assert (unit, integration, e2e) == (72, 8, 25), (
-        f"Expected 72 @unit / 8 @integration / 25 @e2e; found "
+    assert (unit, integration, e2e) == (75, 8, 25), (
+        f"Expected 75 @unit / 8 @integration / 25 @e2e; found "
         f"{unit} / {integration} / {e2e}. "
         "Update docs/proposals/issue-350-prove-it-report.md alongside this change."
     )

--- a/python/tests/voice/test_print_audio_messages.py
+++ b/python/tests/voice/test_print_audio_messages.py
@@ -1,0 +1,62 @@
+"""
+Tests that print_openai_messages renders audio content cleanly.
+
+AC: specs/voice-agents.feature "AC-16 — Audio messages render cleanly in the terminal"
+
+Without this guarantee the terminal fills with base64-encoded WAV data on every
+voice turn, which buries the actual scenario flow in noise.
+"""
+
+from __future__ import annotations
+
+import re
+
+from scenario.voice import AudioChunk, create_audio_message
+from scenario._utils.utils import print_openai_messages, _format_message_content
+
+
+_BASE64_RUN = re.compile(r"[A-Za-z0-9+/]{40,}={0,2}")
+
+
+def _voice_chunk(transcript: str | None = "hello world") -> AudioChunk:
+    return AudioChunk(data=b"\x00\x00" * 2400, transcript=transcript)
+
+
+def test_audio_with_transcript_renders_as_audio_marker_plus_italic_text(capsys):
+    msg = create_audio_message(_voice_chunk("hello world"), role="assistant")
+
+    print_openai_messages("", [msg])
+    out = capsys.readouterr().out
+
+    assert "<audio>" in out
+    assert "hello world" in out
+    assert "\x1b[3m" in out and "\x1b[23m" in out
+    assert not _BASE64_RUN.search(out), (
+        "raw base64 WAV payload leaked into terminal output"
+    )
+
+
+def test_audio_without_transcript_renders_only_audio_marker(capsys):
+    msg = create_audio_message(_voice_chunk(transcript=None), role="user")
+
+    print_openai_messages("", [msg])
+    out = capsys.readouterr().out
+
+    assert "<audio>" in out
+    assert not _BASE64_RUN.search(out)
+
+
+def test_plain_string_content_is_unchanged():
+    assert _format_message_content("just text") == "just text"
+
+
+def test_text_only_multimodal_content_renders_as_italic_text():
+    content = [{"type": "text", "text": "just text"}]
+    rendered = _format_message_content(content)
+    assert "just text" in rendered
+    assert "\x1b[3m" in rendered
+
+
+def test_unknown_part_types_render_as_typed_placeholder():
+    content = [{"type": "image_url", "image_url": {"url": "http://x"}}]
+    assert _format_message_content(content) == "<image>"

--- a/python/tests/voice/test_print_audio_messages.py
+++ b/python/tests/voice/test_print_audio_messages.py
@@ -22,13 +22,16 @@ def _voice_chunk(transcript: str | None = "hello world") -> AudioChunk:
     return AudioChunk(data=b"\x00\x00" * 2400, transcript=transcript)
 
 
-def test_audio_with_transcript_renders_as_audio_marker_plus_italic_text(capsys):
+_SPEAKER_ICON = "\U0001f50a"
+
+
+def test_audio_with_transcript_renders_as_speaker_icon_plus_italic_text(capsys):
     msg = create_audio_message(_voice_chunk("hello world"), role="assistant")
 
     print_openai_messages("", [msg])
     out = capsys.readouterr().out
 
-    assert "<audio>" in out
+    assert _SPEAKER_ICON in out
     assert "hello world" in out
     assert "\x1b[3m" in out and "\x1b[23m" in out
     assert not _BASE64_RUN.search(out), (
@@ -36,13 +39,13 @@ def test_audio_with_transcript_renders_as_audio_marker_plus_italic_text(capsys):
     )
 
 
-def test_audio_without_transcript_renders_only_audio_marker(capsys):
+def test_audio_without_transcript_renders_as_speaker_icon_audio_placeholder(capsys):
     msg = create_audio_message(_voice_chunk(transcript=None), role="user")
 
     print_openai_messages("", [msg])
     out = capsys.readouterr().out
 
-    assert "<audio>" in out
+    assert f"{_SPEAKER_ICON} (audio)" in out
     assert not _BASE64_RUN.search(out)
 
 
@@ -50,11 +53,11 @@ def test_plain_string_content_is_unchanged():
     assert _format_message_content("just text") == "just text"
 
 
-def test_text_only_multimodal_content_renders_as_italic_text():
+def test_text_only_multimodal_content_renders_without_speaker_icon():
     content = [{"type": "text", "text": "just text"}]
     rendered = _format_message_content(content)
-    assert "just text" in rendered
-    assert "\x1b[3m" in rendered
+    assert rendered == "just text"
+    assert _SPEAKER_ICON not in rendered
 
 
 def test_unknown_part_types_render_as_typed_placeholder():

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -873,3 +873,29 @@ Feature: Voice agent testing in Scenario SDK
     Given transcribe_segments is called with no configured STT provider
     Then it logs a warning and returns without raising
     And segment transcripts remain null
+
+  # ======================================================================
+  # AC-16 — Audio messages render cleanly in the terminal
+  # ======================================================================
+
+  @unit
+  Scenario: print_openai_messages renders audio parts without base64 payloads
+    Given a message with multimodal content containing an input_audio part
+    And the message also includes a text transcript part
+    When print_openai_messages is called for the message
+    Then the printed output contains "<audio>"
+    And the transcript is rendered in italic
+    And no base64-encoded WAV data appears in the output
+
+  @unit
+  Scenario: print_openai_messages renders audio-only parts as <audio>
+    Given a message with multimodal content containing only an input_audio part
+    When print_openai_messages is called for the message
+    Then the printed output contains "<audio>"
+    And no base64-encoded WAV data appears in the output
+
+  @unit
+  Scenario: text-only multimodal content still prints normally
+    Given a message with multimodal content containing only a text part
+    When print_openai_messages is called for the message
+    Then the printed output contains the text without italics or audio markers

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -879,23 +879,23 @@ Feature: Voice agent testing in Scenario SDK
   # ======================================================================
 
   @unit
-  Scenario: print_openai_messages renders audio parts without base64 payloads
+  Scenario: print_openai_messages renders audio with transcript as speaker icon plus italic text
     Given a message with multimodal content containing an input_audio part
     And the message also includes a text transcript part
     When print_openai_messages is called for the message
-    Then the printed output contains "<audio>"
+    Then the printed output starts the audio with the 🔊 speaker icon
     And the transcript is rendered in italic
     And no base64-encoded WAV data appears in the output
 
   @unit
-  Scenario: print_openai_messages renders audio-only parts as <audio>
+  Scenario: print_openai_messages renders audio-only parts as "🔊 (audio)"
     Given a message with multimodal content containing only an input_audio part
     When print_openai_messages is called for the message
-    Then the printed output contains "<audio>"
+    Then the printed output contains "🔊 (audio)"
     And no base64-encoded WAV data appears in the output
 
   @unit
   Scenario: text-only multimodal content still prints normally
     Given a message with multimodal content containing only a text part
     When print_openai_messages is called for the message
-    Then the printed output contains the text without italics or audio markers
+    Then the printed output contains the text without the speaker icon or italics


### PR DESCRIPTION
Related to #494 (the SDK-side root cause: multimodal `content` is serialised to a Python-repr string by `scenario/_events/utils.py`, so even structured `input_audio` parts arrive at the server as a string). This PR does NOT close #494 — it only makes the symptoms (terminal noise + base64 in error logs) survive that bug so voice scenarios are usable today. The real fix lives in #494's plan.

## Summary

When a voice scenario runs (e.g. `examples/voice/angry_customer.py`), every agent and user turn was dumping the raw multimodal message content to stdout, so each audio turn produced several KB of base64-encoded WAV like:

```
Agent: [{'type': 'input_audio', 'input_audio': {'data': 'UklGRlC1AgBXQVZFZm10I...
```

This made the actual scenario flow unreadable in the terminal. The audio payload also leaked into `event_reporter` error logs on every failed POST, since the log line did `event={event}` and the full `repr(event)` contained the same base64 blob — including the #494 case where the content has already been stringified upstream.

After the fix:

```
[scn] Agent: 🔊 Hello, this is the assistant speaking.
[scn] User:  🔊 [shouting] You charged me the wrong amount!
[scn] Agent: 🔊 (audio)
```

(transcripts print in italic ANSI; only ASCII shown above)

## Changes

- New `_format_message_content` helper in `scenario/_utils/utils.py` collapses multimodal content lists into a readable line: audio parts add a 🔊 speaker-icon prefix, transcript text renders in italic, audio-only turns become `🔊 (audio)`, unknown parts get a `<type>` placeholder, image parts become `<image>`. Plain string content is left untouched. `print_openai_messages` uses it for both `assistant` and `user` roles.
- New `_redacted_event_repr` in `scenario/_events/event_reporter.py`, used on both the failed-POST and in-flight-exception log paths. It walks `event.to_dict()` and scrubs any string longer than 200 base64-alphabet chars (handles real `input_audio.data` keys and the #494 stringified-content case), falling back to a regex sweep of `repr(event)` when `to_dict()` itself raises. Long blobs become `<audio:N b64 chars elided>`.
- Specs in `specs/voice-agents.feature` (AC-16) describe the new behaviour. Contract counts bumped 105 → 108 / 72 → 75 @unit.
- Unit tests cover: audio+transcript, audio-only, text-only multimodal, unknown part type, plain-string passthrough, event-log redaction via dict walker, event-log redaction via stringified content, and event-log redaction on the in-flight exception path.

## Side note

If you also want to silence the `[SCENARIO_MESSAGE_SNAPSHOT] Event POST failed` lines themselves (the underlying `getaddrinfo ENOTFOUND sts.auto.amazonaws.com` 500 is a server-side issue), add this near scenario startup:

```python
import logging
logging.getLogger("scenario._events").setLevel(logging.CRITICAL)
```

## Test plan

- [x] `uv run pytest tests/voice/test_print_audio_messages.py tests/test_event_reporter.py -v` — 13 passed
- [x] `uv run pytest tests/voice/test_feature_file_contract.py -v` — 5 passed
- [x] `uv run pytest tests/ -k 'print or message'` — 45 passed
- [ ] CI green
- [ ] CodeRabbit review addressed
