### PR TITLE
fix(docs): approve esbuild build script for pnpm 11

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+onlyBuiltDependencies:
+  - esbuild
+
 overrides:
   hono: '>=4.12.18'
   lodash-es: '>=4.18.0'


### PR DESCRIPTION
## Summary

Follow-up to #506. After that PR merged, the deploy ran again and failed at the same install step with a *different* pnpm 11 error:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.5
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm 11 (used in CI via setup-pnpm@v4 `version: latest`) promoted ignored-build-scripts from a warning to a fatal error under `--frozen-lockfile`. Declaring esbuild in `docs/pnpm-workspace.yaml` under `onlyBuiltDependencies` (mirroring the same field in `javascript/pnpm-workspace.yaml`) allows its postinstall to run.

## Test plan

- [x] `cd docs && rm -rf node_modules && pnpm install --frozen-lockfile` — succeeds, no ignored-builds error.

Prod (`scenario-docs.langwatch.ai`) is still stuck at the 2026-05-05 snapshot until this lands. Voice docs from #355 / #456 ship to prod the moment this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)