### PR TITLE
fix(ci/docs): set PNPM_CONFIG_ONLY_BUILT_DEPENDENCIES for docs install

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -83,6 +83,13 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "docs/pnpm-lock.yaml"
       - name: Install dependencies
+        # PNPM_CONFIG_ONLY_BUILT_DEPENDENCIES tells pnpm 10.22+ to permit
+        # esbuild's postinstall under --frozen-lockfile in CI mode, where
+        # ignored-build-scripts is otherwise fatal. The same field exists in
+        # docs/pnpm-workspace.yaml for local dev but is not honored in CI's
+        # single-project install context, so we set it explicitly here.
+        env:
+          PNPM_CONFIG_ONLY_BUILT_DEPENDENCIES: esbuild
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
## Summary

Third follow-up to the docs deploy fix chain (#506, #507). Even after declaring \`onlyBuiltDependencies: [esbuild]\` in \`docs/pnpm-workspace.yaml\`, the deploy still failed with \`ERR_PNPM_IGNORED_BUILDS: esbuild@0.25.5\`.

Pass the same value via the \`PNPM_CONFIG_ONLY_BUILT_DEPENDENCIES\` env var on the docs install step. pnpm reads all settings from \`PNPM_CONFIG_*\` unconditionally — works regardless of workspace mode.

The workspace file is kept for local dev parity and any future migration to workspace mode.

## Test plan

- [x] Local install still succeeds (pnpm 10.22.0 + 10.24.0).
- [ ] Post-merge: deploy run reaches "Build" and "Deploy to GitHub Pages" steps; \`scenario-docs.langwatch.ai\` shows voice docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)