### PR TITLE
fix(ci/python-publish): skip integration tests during release sanity check

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,10 +40,14 @@ jobs:
         run: uv run python -m build
         working-directory: python
 
-      # Sanity check
+      # Sanity check.
+      # `-m "not integration"` deselects voice e2e tests (auto-marked by
+      # tests/voice/conftest.py). Those hit live providers, require API
+      # key secrets we don't expose to the publish workflow, and run
+      # nightly via voice-integration.yml. Mirrors python-ci.yml.
       - name: Run tests
         run: |
-          uv run pytest tests
+          uv run pytest tests -m "not integration"
         working-directory: python
 
       - name: Publish package


### PR DESCRIPTION
## Summary

The \`python-publish.yml\` sanity step runs \`pytest tests\` against the full python suite — including \`tests/voice/*_e2e.py\`. After voice agents landed in #355, those e2e files are auto-marked \`integration\` (by \`tests/voice/conftest.py\`) and fail-fast when API keys are missing. The publish workflow has only \`PYPI_API_TOKEN\`, **no OpenAI / ElevenLabs / Twilio / Gemini secrets**, so the 0.7.27 release (currently in release-please PR #387) would be blocked at the sanity step before reaching the publish step.

Apply the same \`-m "not integration"\` deselect that \`python-ci.yml\` already uses. Nightly voice e2e remains in \`voice-integration.yml\`.

## Why now

PR #387 (\`chore(main): release python 0.7.27\`) is mergeable and ready to ship; this is the first release after voice landed. Without this fix, merging #387 would create the \`python/v0.7.27\` tag, fire the publish workflow, and crash at the test step.

## Test plan

- [x] Mirrors the existing \`-m "not integration"\` invocation in \`python-ci.yml\` line 86 (verified).
- [ ] Post-merge: rebase #387 onto main so the next release tag fires with the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)