### PR TITLE
feat(typescript-sdk/#372): voice agent contract surface (types only, PR1 of N)

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -1,2 +1,3 @@
-docs/
+docs/*
+!docs/voice/
 api-reference-docs/

--- a/javascript/docs/voice/capability-matrix.md
+++ b/javascript/docs/voice/capability-matrix.md
@@ -1,0 +1,116 @@
+# Voice Adapter Capability Matrix — TypeScript SDK
+
+> **Status: placeholder.** PR1 of the TS voice parity slice (issue #372)
+> ships the type contract surface only — no concrete adapters land yet.
+> The rows below mirror the Python source-of-truth at
+> `docs/voice/capability-matrix.md`; cells marked `pending` will become
+> ✅ / ❌ as their PRs land. This doc exists in PR1 so error messages
+> (`UnsupportedCapabilityError`) and the planned doc-render test have a
+> stable path to point at.
+
+Every `VoiceAgentAdapter` will publish an `AdapterCapabilities` instance as
+its `capabilities` field. Capability-gated script steps — such as
+`interrupt({ afterWords: N })` (needs streaming transcripts), `dtmf()`
+(needs telephony), or `interrupt(content)` over a native cancel signal
+(needs `interruption=true`) — check this record and either route correctly
+or throw `UnsupportedCapabilityError` when the underlying adapter cannot
+implement the requested behavior.
+
+When `UnsupportedCapabilityError` points users here, this is the page they
+land on.
+
+## Provider × capability matrix
+
+Internal audio format is always PCM16 @ 24 kHz mono (`AudioChunk`); each
+adapter will convert at its send/recv boundary.
+
+| Adapter | Streaming transcripts | Native VAD | DTMF | Interruption (native cancel) | Wire transport | Real I/O? |
+|---|---|---|---|---|---|---|
+| `PipecatAgentAdapter` | pending | pending | pending | pending | WebSocket | pending |
+| `TwilioAgentAdapter` | pending | pending | pending | pending | WebSocket (Media Streams) | pending |
+| `OpenAIRealtimeAgentAdapter` | pending | pending | pending | pending | WebSocket | pending |
+| `ElevenLabsAgentAdapter` | pending | pending | pending | pending | WebSocket | pending |
+| `GeminiLiveAgentAdapter` | pending | pending | pending | pending | WebSocket | pending |
+| `LiveKitAgentAdapter` | pending | pending | pending | pending | WebRTC (planned) | pending |
+| `VapiAgentAdapter` | pending | pending | pending | pending | WebSocket (planned) | pending |
+| `WebRTCAgentAdapter` | pending | pending | pending | pending | WebRTC | pending |
+| `WebSocketAgentAdapter` | pending | pending | pending | pending | user-supplied `WebSocketProtocol` | pending |
+
+**Wire formats** (PCM16 mono at the listed sample rate) will be filled in
+per adapter as the transports land.
+
+## Capability semantics
+
+- **Streaming transcripts** — the adapter emits incremental transcript
+  tokens as the agent speaks. Required for
+  `scenario.interrupt({ afterWords: N })`. Without it, that step raises
+  `UnsupportedCapabilityError` and points here.
+- **Native VAD** — the adapter emits `user_start_speaking` /
+  `user_stop_speaking` events from its own voice-activity-detection
+  pipeline. When `false`, the SDK will fall back to a WASM build of
+  webrtcvad on the incoming audio stream and emit a one-shot warning per
+  adapter ("Adapter X has no native VAD — using SDK-side webrtcvad,
+  accuracy may differ").
+- **DTMF** — the adapter can transmit DTMF tones over a telephony
+  transport. Required for `scenario.dtmf("1234#")`. Without it, that step
+  raises `UnsupportedCapabilityError`.
+- **Interruption (native cancel)** — the adapter can send a transport-level
+  cancel signal that stops the agent under test mid-utterance (Twilio
+  Media Streams `clear`, OpenAI Realtime `response.cancel`, etc.). Required
+  for first-class barge-in. Without it, `scenario.interrupt(content)` will
+  fall back to overlapping user audio with the agent's TTS and relying on
+  the AUT's own VAD-based barge-in (less deterministic).
+
+  Interrupts are inherently a **duplex-channel** capability: the SDK has to
+  send a control frame while the agent is still streaming. HTTP/REST
+  transports cannot support this. WebSocket and WebRTC adapters can.
+
+- **Input formats / Output formats** — wire formats the adapter accepts /
+  emits. The SDK converts internally.
+
+## Errors that reference this page
+
+- `voice.UnsupportedCapabilityError` — raised when a script step requests
+  a capability the adapter does not advertise (e.g. `dtmf()` on a
+  non-telephony adapter, `interrupt({ afterWords: N })` on an adapter
+  without streaming transcripts).
+- `voice.PendingTransportError` (PR2+) — will be raised by adapter stubs
+  whose `sendAudio` / `receiveAudio` implementations have not landed yet.
+
+## Authoring a custom adapter
+
+When subclassing `VoiceAgentAdapter`, declare `capabilities` with accurate
+flags. Inheriting a parent's `AdapterCapabilities` and not re-auditing it
+will silently break capability-gated script steps.
+
+```ts
+import { voice } from "@langwatch/scenario";
+
+class MyCustomAdapter extends voice.VoiceAgentAdapter {
+  readonly capabilities = new voice.AdapterCapabilities({
+    streamingTranscripts: false,
+    nativeVad: false,
+    dtmf: false,
+    interruption: false,
+    inputFormats: ["pcm16/24000"],
+    outputFormats: ["pcm16/24000"],
+  });
+
+  async connect() { /* ... */ }
+  async disconnect() { /* ... */ }
+  async sendAudio(_chunk: voice.AudioChunk) { /* ... */ }
+  async receiveAudio(_timeout: number): Promise<voice.AudioChunk> {
+    throw new Error("not implemented");
+  }
+  async call(_input: any): Promise<any> { /* PR2+ */ }
+}
+```
+
+## Deferred / follow-up items
+
+- Concrete adapter classes (PR2+) — Pipecat WS, Twilio, OpenAI Realtime,
+  ElevenLabs, Gemini Live.
+- VAD fallback (WASM webrtcvad build).
+- Effects module + bundled CC0 noise samples.
+- Voice-aware `UserSimulatorAgent` and `JudgeAgent`.
+- Pluggable STT interface (`scenario.configure({ stt })`).

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -11,6 +11,11 @@ export * from "./execution";
 export * from "./runner";
 export * from "./script";
 
+// Voice subsystem — type contract surface (PR1 of N for issue #372).
+// Runtime (TTS / STT / VAD / transports) lands in subsequent PRs behind
+// this same contract.
+export * as voice from "./voice";
+
 // Tracing public API
 export { setupScenarioTracing } from "./tracing/setup";
 export { scenarioOnly, withCustomScopes } from "./tracing/filters";

--- a/javascript/src/voice/__tests__/voice-contract-surface.test.ts
+++ b/javascript/src/voice/__tests__/voice-contract-surface.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Voice contract surface tests — PR1 of issue #372.
+ *
+ * Binds the five scenarios from `specs/voice-agents.feature` that the PR1
+ * scope is responsible for; concrete adapters and runtime behavior land in
+ * PR2+ and bring their own tests.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { AgentAdapter, AgentRole } from "../../domain/agents";
+import {
+  AdapterCapabilities,
+  AudioChunk,
+  PCM16_CHANNELS,
+  PCM16_SAMPLE_RATE,
+  PCM16_SAMPLE_WIDTH_BYTES,
+  UnsupportedCapabilityError,
+  VoiceAgentAdapter,
+  silentChunk,
+} from "../index";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MATRIX_DOC_PATH = resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "docs",
+  "voice",
+  "capability-matrix.md",
+);
+
+class StubVoiceAdapter extends VoiceAgentAdapter {
+  override role = AgentRole.AGENT;
+  readonly capabilities = new AdapterCapabilities({
+    streamingTranscripts: true,
+    nativeVad: true,
+    dtmf: false,
+    interruption: true,
+    inputFormats: ["pcm16/24000"],
+    outputFormats: ["pcm16/24000"],
+  });
+
+  connectCount = 0;
+  disconnectCount = 0;
+  sent: AudioChunk[] = [];
+
+  async call(): Promise<string> {
+    return "stub";
+  }
+  async connect(): Promise<void> {
+    this.connectCount += 1;
+  }
+  async disconnect(): Promise<void> {
+    this.disconnectCount += 1;
+  }
+  async sendAudio(chunk: AudioChunk): Promise<void> {
+    this.sent.push(chunk);
+  }
+  async receiveAudio(_timeout: number): Promise<AudioChunk> {
+    return silentChunk(0.01);
+  }
+}
+
+describe("specs/voice-agents.feature lines 146-156 — AudioChunk internal format is PCM16 at 24kHz mono", () => {
+  it("normalizes the canonical internal format to PCM16 / 24000 Hz / mono", () => {
+    // "Then the internal AudioChunk is PCM16, 24000 Hz, mono"
+    expect(PCM16_SAMPLE_RATE).toBe(24000);
+    expect(PCM16_CHANNELS).toBe(1);
+    expect(PCM16_SAMPLE_WIDTH_BYTES).toBe(2);
+
+    const chunk = silentChunk(0.5);
+    expect(chunk.sampleRate).toBe(24000);
+    expect(chunk.channels).toBe(1);
+    expect(chunk.durationSeconds).toBeCloseTo(0.5, 3);
+  });
+
+  it("rejects odd-byte buffers — partial PCM16 samples surface at the boundary", () => {
+    // The PCM16 invariant catches partial transport frames at the canonical
+    // boundary instead of letting `frombuffer`/`durationSeconds` silently
+    // truncate and produce off-by-one drift.
+    expect(
+      () => new AudioChunk({ data: new Uint8Array([0x00, 0x00, 0x01]) }),
+    ).toThrowError(/not a multiple of 2/);
+  });
+});
+
+describe("specs/voice-agents.feature lines 698-704 — VoiceAgentAdapter base class is public for custom implementations", () => {
+  it("lets user code subclass it with connect/sendAudio/receiveAudio/disconnect", async () => {
+    const adapter = new StubVoiceAdapter();
+    expect(adapter).toBeInstanceOf(VoiceAgentAdapter);
+    expect(adapter).toBeInstanceOf(AgentAdapter);
+
+    // Public surface — every method exposed by the contract is callable on
+    // the subclass instance.
+    await adapter.connect();
+    await adapter.sendAudio(silentChunk(0.02));
+    const received = await adapter.receiveAudio(1);
+    await adapter.disconnect();
+
+    expect(adapter.connectCount).toBe(1);
+    expect(adapter.disconnectCount).toBe(1);
+    expect(adapter.sent).toHaveLength(1);
+    expect(received).toBeInstanceOf(AudioChunk);
+  });
+});
+
+describe("specs/voice-agents.feature lines 751-756 — Every adapter publishes a capabilities attribute", () => {
+  it("declares streamingTranscripts / nativeVad / dtmf / inputFormats / outputFormats", () => {
+    const adapter = new StubVoiceAdapter();
+    expect(adapter.capabilities).toBeInstanceOf(AdapterCapabilities);
+
+    // Field-name parity with the spec — the AC enumerates the five
+    // capabilities every adapter must publish.
+    const caps = adapter.capabilities;
+    expect(typeof caps.streamingTranscripts).toBe("boolean");
+    expect(typeof caps.nativeVad).toBe("boolean");
+    expect(typeof caps.dtmf).toBe("boolean");
+    expect(Array.isArray(caps.inputFormats)).toBe(true);
+    expect(Array.isArray(caps.outputFormats)).toBe(true);
+  });
+
+  it("defaults to the safest possible declaration when no flags are set", () => {
+    // An adapter author who forgets to declare anything must NOT silently
+    // claim every capability. Default is "supports nothing".
+    const empty = new AdapterCapabilities();
+    expect(empty.streamingTranscripts).toBe(false);
+    expect(empty.nativeVad).toBe(false);
+    expect(empty.dtmf).toBe(false);
+    expect(empty.interruption).toBe(false);
+    expect(empty.inputFormats).toEqual([]);
+    expect(empty.outputFormats).toEqual([]);
+  });
+});
+
+describe("specs/voice-agents.feature lines 757-762 — UnsupportedCapabilityError naming", () => {
+  it("names the adapter and the missing capability in the error message", () => {
+    // The spec's example fires when `scenario.dtmf("1")` runs on a
+    // non-telephony adapter; we exercise the raise-only stub shape here —
+    // adapter name + capability both surfaced for downstream UX.
+    const err = new UnsupportedCapabilityError("StubVoiceAdapter", "dtmf");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.adapterName).toBe("StubVoiceAdapter");
+    expect(err.capability).toBe("dtmf");
+    expect(err.message).toContain("StubVoiceAdapter");
+    expect(err.message).toContain("dtmf");
+    expect(err.message).toContain("docs/voice/capability-matrix.md");
+  });
+
+  it("the base interrupt() throws UnsupportedCapabilityError on adapters without override", () => {
+    class NoInterruptAdapter extends VoiceAgentAdapter {
+      readonly capabilities = new AdapterCapabilities();
+      async call(): Promise<string> {
+        return "stub";
+      }
+      async connect(): Promise<void> {}
+      async disconnect(): Promise<void> {}
+      async sendAudio(_chunk: AudioChunk): Promise<void> {}
+      async receiveAudio(_timeout: number): Promise<AudioChunk> {
+        return silentChunk(0);
+      }
+    }
+
+    const adapter = new NoInterruptAdapter();
+    expect(() => adapter.interrupt()).toThrow(UnsupportedCapabilityError);
+  });
+});
+
+describe("specs/voice-agents.feature lines 763-771 — Capability matrix is rendered into adapter docs", () => {
+  const doc = readFileSync(MATRIX_DOC_PATH, "utf8");
+
+  it("renders a table that lists every shipped + planned adapter", () => {
+    // Same adapter set as the Python source-of-truth at
+    // docs/voice/capability-matrix.md — PR1 placeholder, real flags land
+    // alongside each adapter PR (#372 PR2+).
+    const adapters = [
+      "PipecatAgentAdapter",
+      "TwilioAgentAdapter",
+      "OpenAIRealtimeAgentAdapter",
+      "ElevenLabsAgentAdapter",
+      "GeminiLiveAgentAdapter",
+      "LiveKitAgentAdapter",
+      "VapiAgentAdapter",
+      "WebRTCAgentAdapter",
+      "WebSocketAgentAdapter",
+    ];
+    for (const adapter of adapters) {
+      expect(doc).toContain(adapter);
+    }
+  });
+
+  it("table header lists streaming_transcripts, native_vad, dtmf, and input/output formats", () => {
+    // The AC enumerates the columns the doc must surface — the column
+    // headers are in human prose in the table header row.
+    expect(doc.toLowerCase()).toContain("streaming transcripts");
+    expect(doc.toLowerCase()).toContain("native vad");
+    expect(doc.toLowerCase()).toContain("dtmf");
+    expect(doc.toLowerCase()).toContain("wire formats");
+  });
+});

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -1,0 +1,92 @@
+/**
+ * VoiceAgentAdapter — base class for voice-capable agents (SIGNATURE ONLY).
+ *
+ * PR1 surface: types + abstract signatures only. Runtime (default `call()`
+ * implementation, executor recording bridge, drain-on-tail-silence loop)
+ * lands in PR2+. See `python/scenario/voice/adapter.py` for the eventual
+ * behavior; this file pins the contract.
+ *
+ * Extends {@link AgentAdapter} (text-based) with audio send/receive
+ * primitives and a capability matrix. Concrete subclasses will live under
+ * `scenario.voice.adapters` once the transports ship (Pipecat, Twilio,
+ * OpenAI Realtime, Gemini Live, ElevenLabs).
+ */
+
+import { AgentAdapter } from "../domain/agents";
+import { AudioChunk } from "./audio-chunk";
+import { AdapterCapabilities, UnsupportedCapabilityError } from "./capabilities";
+
+/**
+ * Abstract base for voice agents that exchange audio with the agent under
+ * test.
+ *
+ * Subclasses must implement {@link connect}, {@link disconnect},
+ * {@link sendAudio}, and {@link receiveAudio}. They must also publish an
+ * {@link AdapterCapabilities} instance as the {@link capabilities} field —
+ * declared once per concrete adapter, not per instance.
+ *
+ * The {@link AgentAdapter.call} method from the parent class remains
+ * abstract on this base in PR1; PR2 will introduce the shared `call()`
+ * implementation that threads audio extracted from the latest user message
+ * through the transport and records segments into the executor state. PR1
+ * intentionally leaves it unimplemented so no executor coupling lands with
+ * the contract surface.
+ */
+export abstract class VoiceAgentAdapter extends AgentAdapter {
+  /**
+   * Declaration of what this adapter can and cannot do. Concrete subclasses
+   * MUST publish a non-default value; the base instance defaults to "nothing
+   * supported" so capability-gated steps fail safely when an adapter forgets
+   * to declare.
+   */
+  abstract readonly capabilities: AdapterCapabilities;
+
+  /** Seconds to wait for agent audio after sending user audio. */
+  responseTimeout = 30.0;
+
+  /**
+   * Tail silence: once the first agent chunk arrives, keep draining
+   * {@link receiveAudio} until no chunk shows up within this many seconds
+   * — that's how we detect the agent finished talking.
+   */
+  responseTailSilence = 0.6;
+
+  /**
+   * Hard cap on a single agent turn's audio. Prevents runaway loops if a
+   * transport never signals end-of-stream. 30s = a long sentence.
+   */
+  responseMaxDuration = 30.0;
+
+  /** Open the transport and prepare to exchange audio. */
+  abstract connect(): Promise<void>;
+
+  /** Close the transport and release resources. */
+  abstract disconnect(): Promise<void>;
+
+  /** Transmit an {@link AudioChunk} to the agent under test. */
+  abstract sendAudio(chunk: AudioChunk): Promise<void>;
+
+  /** Receive the next {@link AudioChunk} from the agent. */
+  abstract receiveAudio(timeout: number): Promise<AudioChunk>;
+
+  /**
+   * Send a first-class interrupt signal to the agent under test.
+   *
+   * Adapters that advertise `capabilities.interruption === true` override
+   * this to send the transport-native interrupt (e.g. Twilio `clear`,
+   * OpenAI Realtime `response.cancel`). The default raises
+   * {@link UnsupportedCapabilityError}; callers (`scenario.interrupt()`)
+   * check `capabilities.interruption` and fall back to timing-based
+   * barge-in when this returns false.
+   */
+  interrupt(): Promise<void> {
+    throw new UnsupportedCapabilityError(
+      this.constructor.name,
+      "interruption",
+      "This adapter has no native interrupt signal. Use the timing-based " +
+        "barge-in pattern instead: agent({ wait: false }) + sleep(N) + " +
+        "user(content), where the user audio overlaps with the agent's TTS " +
+        "and the SUT's VAD detects it.",
+    );
+  }
+}

--- a/javascript/src/voice/audio-chunk.ts
+++ b/javascript/src/voice/audio-chunk.ts
@@ -1,0 +1,77 @@
+/**
+ * AudioChunk — the canonical internal audio representation.
+ *
+ * Per the AudioChunk normalization locked decision (Python parity: see
+ * `python/scenario/voice/audio_chunk.py`), every piece of audio flowing
+ * through the SDK is PCM16 @ 24kHz mono at the framework boundary. Adapters
+ * convert to/from their transport-native format at the send/recv edge.
+ *
+ * This keeps the combinatorial complexity of N adapters x M formats
+ * collapsed to N conversions at the adapter edge.
+ */
+
+export const PCM16_SAMPLE_RATE = 24000;
+export const PCM16_CHANNELS = 1;
+export const PCM16_SAMPLE_WIDTH_BYTES = 2;
+
+export interface AudioChunkInit {
+  /** Raw PCM16 little-endian bytes, mono, sample rate = 24000 Hz. */
+  data: Uint8Array;
+  /** Optional transcript text (may be populated by streaming STT). */
+  transcript?: string;
+  /** Optional wall-clock offset from scenario start, in seconds. */
+  startTime?: number;
+  /** Optional wall-clock offset from scenario start, in seconds. */
+  endTime?: number;
+}
+
+/**
+ * A chunk of audio in the canonical internal format: PCM16, 24kHz, mono.
+ *
+ * Enforces the PCM16 odd-byte invariant at construction — partial-sample
+ * buffers (length not a multiple of 2) cause silent off-by-one drift in
+ * downstream consumers, so we catch them at the canonical boundary.
+ */
+export class AudioChunk {
+  readonly data: Uint8Array;
+  readonly transcript?: string;
+  readonly startTime?: number;
+  readonly endTime?: number;
+
+  constructor(init: AudioChunkInit) {
+    if (init.data.length % PCM16_SAMPLE_WIDTH_BYTES !== 0) {
+      throw new Error(
+        `AudioChunk.data length (${init.data.length} bytes) is not a ` +
+          `multiple of ${PCM16_SAMPLE_WIDTH_BYTES} — not valid PCM16. ` +
+          "This usually indicates a partial transport frame; adapters " +
+          "must buffer until a complete sample is available.",
+      );
+    }
+    this.data = init.data;
+    this.transcript = init.transcript;
+    this.startTime = init.startTime;
+    this.endTime = init.endTime;
+  }
+
+  get sampleRate(): number {
+    return PCM16_SAMPLE_RATE;
+  }
+
+  get channels(): number {
+    return PCM16_CHANNELS;
+  }
+
+  /** Length of the chunk in seconds (from bytes, assuming PCM16 mono). */
+  get durationSeconds(): number {
+    if (this.data.length === 0) return 0;
+    const numSamples = Math.floor(this.data.length / PCM16_SAMPLE_WIDTH_BYTES);
+    return numSamples / PCM16_SAMPLE_RATE;
+  }
+}
+
+/** Generate a PCM16 silent AudioChunk of the given duration. */
+export function silentChunk(durationSeconds: number): AudioChunk {
+  const numSamples = Math.floor(durationSeconds * PCM16_SAMPLE_RATE);
+  const data = new Uint8Array(numSamples * PCM16_SAMPLE_WIDTH_BYTES);
+  return new AudioChunk({ data });
+}

--- a/javascript/src/voice/capabilities.ts
+++ b/javascript/src/voice/capabilities.ts
@@ -1,0 +1,97 @@
+/**
+ * Adapter capability matrix.
+ *
+ * Every {@link VoiceAgentAdapter} publishes an {@link AdapterCapabilities}
+ * instance as `adapter.capabilities`. Capability-gated script steps check
+ * it and raise {@link UnsupportedCapabilityError} when the underlying
+ * adapter cannot implement the requested behavior (e.g. `interrupt(after_words=N)`
+ * needs streaming transcripts; `dtmf()` needs telephony; etc.).
+ *
+ * Python parity: `python/scenario/voice/capabilities.py`.
+ */
+
+export interface AdapterCapabilitiesInit {
+  streamingTranscripts?: boolean;
+  nativeVad?: boolean;
+  dtmf?: boolean;
+  interruption?: boolean;
+  inputFormats?: readonly string[];
+  outputFormats?: readonly string[];
+}
+
+/**
+ * Declaration of what a voice adapter can and cannot do.
+ *
+ * `readonly` everywhere — the Python `@dataclass(frozen=True)` analogue in
+ * TS. Concrete adapters declare this once as a class-level constant.
+ */
+export class AdapterCapabilities {
+  /**
+   * True if the adapter emits incremental transcript updates as the agent
+   * speaks. Required for `interrupt(afterWords: N)`.
+   */
+  readonly streamingTranscripts: boolean;
+
+  /**
+   * True if the adapter itself provides voice-activity-detection events
+   * (`user_start_speaking` / `user_stop_speaking`). When False, the SDK
+   * falls back to webrtcvad on the incoming audio stream.
+   */
+  readonly nativeVad: boolean;
+
+  /** True if the adapter can transmit DTMF tones (telephony). */
+  readonly dtmf: boolean;
+
+  /**
+   * True if the adapter can send a first-class interrupt signal to the
+   * agent under test (e.g. Twilio `clear`, OpenAI Realtime
+   * `response.cancel`). When True, `scenario.interrupt()` uses the signal
+   * path; when False, it falls back to timing-based barge-in (audio sent
+   * over the wire while the agent is speaking, which the SUT detects via
+   * VAD).
+   */
+  readonly interruption: boolean;
+
+  /**
+   * Wire formats the adapter accepts from the SDK for outgoing user audio
+   * (e.g. `["pcm16/24000", "mulaw/8000"]`).
+   */
+  readonly inputFormats: readonly string[];
+
+  /**
+   * Wire formats the adapter emits for incoming agent audio. The SDK
+   * converts these to internal PCM16/24000 mono.
+   */
+  readonly outputFormats: readonly string[];
+
+  constructor(init: AdapterCapabilitiesInit = {}) {
+    this.streamingTranscripts = init.streamingTranscripts ?? false;
+    this.nativeVad = init.nativeVad ?? false;
+    this.dtmf = init.dtmf ?? false;
+    this.interruption = init.interruption ?? false;
+    this.inputFormats = init.inputFormats ?? [];
+    this.outputFormats = init.outputFormats ?? [];
+  }
+}
+
+/**
+ * Raised when a script step requests a capability the adapter does not
+ * advertise. The message names the adapter and the missing capability so
+ * users can pick a different adapter or fall back to a capability-free
+ * alternative (e.g. `interrupt({ after: seconds })` instead of `afterWords`).
+ */
+export class UnsupportedCapabilityError extends Error {
+  readonly adapterName: string;
+  readonly capability: string;
+
+  constructor(adapterName: string, capability: string, hint = "") {
+    const suffix = hint ? ` ${hint}` : "";
+    super(
+      `Adapter '${adapterName}' does not support capability '${capability}'. ` +
+        `See the adapter capability matrix at docs/voice/capability-matrix.md.${suffix}`,
+    );
+    this.name = "UnsupportedCapabilityError";
+    this.adapterName = adapterName;
+    this.capability = capability;
+  }
+}

--- a/javascript/src/voice/index.ts
+++ b/javascript/src/voice/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Voice subsystem barrel — type contract surface for the TS voice port.
+ *
+ * PR1 ships types + the {@link UnsupportedCapabilityError} class only.
+ * Runtime (TTS, STT, VAD, recording, transports) lands in PR2+ behind this
+ * same contract.
+ */
+
+export {
+  AudioChunk,
+  silentChunk,
+  PCM16_SAMPLE_RATE,
+  PCM16_CHANNELS,
+  PCM16_SAMPLE_WIDTH_BYTES,
+  type AudioChunkInit,
+} from "./audio-chunk";
+
+export {
+  AdapterCapabilities,
+  UnsupportedCapabilityError,
+  type AdapterCapabilitiesInit,
+} from "./capabilities";
+
+export { VoiceAgentAdapter } from "./adapter";
+
+export type {
+  AudioSegment,
+  LatencyMetrics,
+  SpeakerRole,
+  VoiceEvent,
+  VoiceRecording,
+} from "./recording.types";
+
+export type { VoiceExecutorState } from "./voice-executor-state";
+
+export type {
+  AudioContentPart,
+  AudioMessageContentPart,
+  AudioMessageParam,
+  AudioMessageRole,
+  InputAudioContentPart,
+  TextContentPart,
+} from "./messages.types";
+
+export {
+  GEMINI_LIVE_MODEL,
+  OPENAI_REALTIME_MODEL,
+  OPENAI_STT_MODEL,
+  OPENAI_TTS_MODEL,
+} from "./voice-models";

--- a/javascript/src/voice/messages.types.ts
+++ b/javascript/src/voice/messages.types.ts
@@ -1,0 +1,77 @@
+/**
+ * Audio message type surface (Decision 2(b) — see issue #372).
+ *
+ * Python `python/scenario/voice/messages.py:17` imports
+ * `ChatCompletionMessageParam` from `openai.types.chat` at module load,
+ * committing the canonical message bus to OpenAI's schema. The TS port
+ * locks Decision 2(b): define a local {@link AudioMessageParam} superset
+ * that is structurally compatible with OpenAI's shape but does NOT import
+ * from `openai`.
+ *
+ * Rationale (from the locked AC at `specs/voice-agents.feature:819-824`):
+ * audio works cleanly in any message role — user, assistant, or tool — so
+ * the type bus must not bake in OpenAI's awkward assistant-role split that
+ * led to the JS `forceUserRole` workaround we are NOT porting.
+ *
+ * NOTE: this file MUST NOT import from `openai`. CI / AC #3 enforces.
+ */
+
+/** A plain text content part (transcript or instruction). */
+export interface TextContentPart {
+  type: "text";
+  text: string;
+}
+
+/**
+ * Audio carried in the OpenAI "input_audio" content convention — base64
+ * payload + format hint (`wav`, `mp3`, etc.). Accepted on incoming
+ * messages regardless of role.
+ */
+export interface InputAudioContentPart {
+  type: "input_audio";
+  input_audio: {
+    data: string;
+    format: string;
+  };
+}
+
+/**
+ * Audio carried in the alternate "audio" content convention used by some
+ * providers (e.g. assistant-role audio replies). Same payload shape as
+ * `input_audio` — kept structurally distinct so consumers can switch on
+ * the `type` discriminator without losing information.
+ */
+export interface AudioContentPart {
+  type: "audio";
+  audio: {
+    data: string;
+    format: string;
+    transcript?: string;
+  };
+}
+
+/** All content-part shapes an {@link AudioMessageParam} may carry. */
+export type AudioMessageContentPart =
+  | TextContentPart
+  | InputAudioContentPart
+  | AudioContentPart;
+
+/** Roles audio messages may flow under — every role, no forceUserRole. */
+export type AudioMessageRole = "system" | "user" | "assistant" | "tool";
+
+/**
+ * Locally-defined message shape carrying optional audio content parts.
+ *
+ * Structurally compatible with OpenAI's `ChatCompletionMessageParam` for
+ * the cases the voice subsystem produces, but does not depend on the
+ * `openai` package's type surface. Branded providers (OpenAI, Anthropic,
+ * etc.) can map to/from this shape at their adapter boundary.
+ */
+export interface AudioMessageParam {
+  role: AudioMessageRole;
+  content: AudioMessageContentPart[];
+  /** Optional tool call id, when `role === "tool"`. */
+  tool_call_id?: string;
+  /** Optional sender name; matches OpenAI convention. */
+  name?: string;
+}

--- a/javascript/src/voice/recording.types.ts
+++ b/javascript/src/voice/recording.types.ts
@@ -1,0 +1,82 @@
+/**
+ * Voice recording, timeline events, and latency metrics — type contracts only.
+ *
+ * PR1 ships the type surface; PR2+ adds the runtime that populates these
+ * (writing segments + events on each adapter turn, computing latencies,
+ * saving WAV/MP3 via ffmpeg). Python parity: `python/scenario/voice/recording.py`.
+ *
+ * These are the output-side types attached to a `ScenarioResult` for voice
+ * runs: `result.audio` (a {@link VoiceRecording}), `result.timeline` (a
+ * `VoiceEvent[]`), and `result.latency` (a {@link LatencyMetrics}).
+ */
+
+export type SpeakerRole = "user" | "agent";
+
+/**
+ * A contiguous span of audio attributed to one speaker.
+ *
+ * `transcriptTruncated` is true when an agent segment was cut short by a
+ * `user_interrupt` event during the run — the audio bytes are
+ * authoritative; the transcript may reflect what the agent INTENDED to say,
+ * not what the user actually heard.
+ */
+export interface AudioSegment {
+  speaker: SpeakerRole;
+  startTime: number;
+  endTime: number;
+  /** PCM16 little-endian bytes, mono, 24kHz. */
+  audio: Uint8Array;
+  transcript?: string;
+  transcriptTruncated?: boolean;
+}
+
+/**
+ * One timestamped event on the voice conversation timeline.
+ *
+ * Types include: `user_start_speaking`, `user_stop_speaking`,
+ * `agent_start_speaking`, `agent_stop_speaking`, `tool_call`, `tool_result`,
+ * `user_interrupt`.
+ *
+ * `latency` is populated for `agent_start_speaking` events and measures the
+ * response time from the preceding `user_stop_speaking` event.
+ *
+ * `metadata` is a free-form dict for type-specific context. Examples:
+ * - `user_interrupt`: `{ adapter: "PipecatAgentAdapter", native: true }`
+ * - `tool_call`: `{ call_id: "..." }`
+ */
+export interface VoiceEvent {
+  time: number;
+  type: string;
+  name?: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  latency?: number;
+  metadata?: Record<string, unknown>;
+}
+
+/** Summary of agent response timing across the conversation. */
+export interface LatencyMetrics {
+  measurements: number[];
+  timeToFirstByte?: number;
+  interruptResponseTime?: number;
+  /** Mean of `measurements`; undefined when no measurements recorded. */
+  avgResponseTime?: number;
+  /** Median of `measurements`. */
+  p50ResponseTime?: number;
+  /** 95th percentile of `measurements` (ceiling-style index). */
+  p95ResponseTime?: number;
+}
+
+/**
+ * The full audio record of a voice scenario, segmented by speaker.
+ *
+ * PR1 defines the contract; PR2+ adds the WAV/MP3 save methods, segment
+ * directory layout, and JSON manifest schema (see Python `VoiceRecording`
+ * for the eventual API).
+ */
+export interface VoiceRecording {
+  segments: AudioSegment[];
+  timeline: VoiceEvent[];
+  /** Total duration (max segment endTime) in seconds. */
+  duration?: number;
+}

--- a/javascript/src/voice/voice-executor-state.ts
+++ b/javascript/src/voice/voice-executor-state.ts
@@ -1,0 +1,30 @@
+/**
+ * Voice executor state contract (Decision 1(b) — see issue #372).
+ *
+ * Python `python/scenario/voice/adapter.py` reaches into the executor via
+ * 6 untyped `getattr(executor, "_voice_*", None)` indirections. Duck-typing
+ * collapses in TS, so we commit explicitly to the shape that the executor
+ * must expose to the voice subsystem.
+ *
+ * Concrete `ScenarioExecutor` implementations satisfy this interface
+ * structurally — no nominal `implements`, no inheritance change required.
+ * The voice adapter and recorder read these properties through this typed
+ * surface instead of `(executor as any)._voiceRecording`.
+ */
+
+import type { AudioChunk } from "./audio-chunk";
+import type {
+  LatencyMetrics,
+  VoiceEvent,
+  VoiceRecording,
+} from "./recording.types";
+
+export interface VoiceExecutorState {
+  voiceRecording: VoiceRecording | null;
+  voiceTimeline: VoiceEvent[] | null;
+  voiceLatency: LatencyMetrics | null;
+  /** `performance.now()` (or equivalent monotonic clock) anchor in seconds. */
+  voiceRecordingStartedAt: number | null;
+  onVoiceEvent?: (event: VoiceEvent) => void;
+  onAudioChunk?: (chunk: AudioChunk) => void;
+}

--- a/javascript/src/voice/voice-models.ts
+++ b/javascript/src/voice/voice-models.ts
@@ -1,0 +1,23 @@
+/**
+ * Default model identifiers for voice paths.
+ *
+ * Single source of truth so demos, adapters, and any stub bot don't drift.
+ * Anything outside this module that needs a model name should import from
+ * here.
+ *
+ * Mirror of `python/scenario/config/voice_models.py`. When OpenAI / Google /
+ * ElevenLabs ship a new generation, update this file and re-test once.
+ * Avoid sprinkling magic strings.
+ */
+
+/** OpenAI Realtime — bidirectional streaming audio API. */
+export const OPENAI_REALTIME_MODEL = "gpt-realtime-mini";
+
+/** OpenAI STT — speech-to-text default for the judge / transcript path. */
+export const OPENAI_STT_MODEL = "gpt-4o-transcribe";
+
+/** OpenAI TTS — text-to-speech endpoint default. */
+export const OPENAI_TTS_MODEL = "gpt-4o-mini-tts";
+
+/** Gemini Live — bidirectional audio (Google's realtime model). */
+export const GEMINI_LIVE_MODEL = "gemini-2.5-flash-native-audio-latest";


### PR DESCRIPTION
## Summary

PR1 of N for **issue #372 — TS voice agent parity** (full Python port).
Ships the **type contract surface only**: types, an abstract adapter
class, an error class, a placeholder capability matrix doc, and the two
port-only design decisions locked in the issue body. No runtime, no
transport, no network, no Python changes.

Concrete adapters and runtime behavior (TTS / STT / VAD / drain loop /
executor recording bridge) land in PR2+ behind this same contract.

### Files in this PR

| File | What |
|---|---|
| `javascript/src/voice/audio-chunk.ts` | `AudioChunk` + PCM16 odd-byte invariant + `silentChunk` helper |
| `javascript/src/voice/capabilities.ts` | `AdapterCapabilities` (readonly) + `UnsupportedCapabilityError` |
| `javascript/src/voice/adapter.ts` | `abstract class VoiceAgentAdapter` — signatures only |
| `javascript/src/voice/recording.types.ts` | `VoiceRecording` / `AudioSegment` / `VoiceEvent` / `LatencyMetrics` interfaces |
| `javascript/src/voice/voice-models.ts` | 4 string constants (OpenAI Realtime / STT / TTS / Gemini Live) |
| `javascript/src/voice/voice-executor-state.ts` | **Decision 1(b)** — explicit `VoiceExecutorState` interface |
| `javascript/src/voice/messages.types.ts` | **Decision 2(b)** — local `AudioMessageParam` superset, NO `openai` types import |
| `javascript/src/voice/index.ts` | barrel |
| `javascript/src/index.ts` | re-exports `voice` namespace |
| `javascript/docs/voice/capability-matrix.md` | placeholder copy of Python doc with same adapter rows |
| `javascript/src/voice/__tests__/voice-contract-surface.test.ts` | vitest binding 5 scenarios from `specs/voice-agents.feature` |

### Locked decisions implemented

- **Decision 1(b)** — explicit `VoiceExecutorState` interface in
  `voice-executor-state.ts` (replaces Python's 6 `getattr(executor, "_voice_*", None)` indirections).
- **Decision 2(b)** — local `AudioMessageParam` superset in
  `messages.types.ts`; **no** `import` from `openai`.

### Out of scope (deferred to PR2+)

- No adapter runtime (`call()` stays abstract).
- No transport / WebSocket / WebRTC.
- No TTS / STT / VAD / interruption / barge-in.
- No executor coupling (the executor doesn't read the new interface yet).
- No effects module, no recordings, no script step changes, no judge changes.
- No Python changes.

## Acceptance checks (PR1)

- [x] **AC1** — `pnpm -C javascript build` green.
  ```
  ESM dist/index.mjs   215.31 KB
  CJS dist/index.js    220.24 KB
  DTS dist/index.d.ts  127.50 KB
  ESM ⚡️ Build success in 190ms
  CJS ⚡️ Build success in 191ms
  DTS ⚡️ Build success in 7017ms
  ```
- [x] **AC2** — `pnpm -C javascript test` green (full suite + new file).
  ```
  Test Files  21 passed (21)
       Tests  369 passed (369)
    Duration  2.94s
  ```
  Targeted run of the new file:
  ```
  Test Files  1 passed (1)
       Tests  9 passed (9)
    Duration  246ms
  ```
- [x] **AC3** — No imports from `openai` types in `messages.types.ts`.
  ```
  $ grep -E "^(import|from).*openai" javascript/src/voice/messages.types.ts; echo "EXIT=$?"
  EXIT=1
  ```
- [x] **AC4** — Capability matrix doc lists the same adapters as
  `docs/voice/capability-matrix.md` in Python.
  ```
  $ diff <(grep -oE "[A-Z][a-zA-Z]+Adapter\b" docs/voice/capability-matrix.md | sort -u) \
         <(grep -oE "[A-Z][a-zA-Z]+Adapter\b" javascript/docs/voice/capability-matrix.md | sort -u)
  (no diff)
  ```

## Test plan

Each test maps to one or more lines in `specs/voice-agents.feature`:

- [x] L146-156 — AudioChunk PCM16 @ 24kHz mono internal format + odd-byte invariant
- [x] L698-704 — `VoiceAgentAdapter` base class is public; user subclasses can implement `connect` / `sendAudio` / `receiveAudio` / `disconnect`
- [x] L751-756 — Every adapter publishes a `capabilities` attribute carrying `streamingTranscripts` / `nativeVad` / `dtmf` / `inputFormats` / `outputFormats` (+ defaults to "supports nothing" so a forgetful adapter author fails closed)
- [x] L757-762 — `UnsupportedCapabilityError` names the adapter + capability + points at the capability matrix doc
- [x] L763-771 — Capability matrix doc renders the same adapter row set as the Python doc

## Notes for reviewers

- **Draft** — kept open early per the grinder workflow; incremental commits coming if I need to iterate. Don't mark ready-for-review yet.
- The `interruption` capability is included on `AdapterCapabilities` matching the Python source-of-truth, but the AC at lines 751-756 of `specs/voice-agents.feature` only enumerates 5 columns. That feature-file gap is tracked in #487 (Python-side); the TS interface is the superset.
- `javascript/.gitignore` was tweaked from `docs/` to `docs/*` + `!docs/voice/` so the new doc tree is tracked while typedoc output (`docs/...`) remains ignored — no other doc tree is currently impacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
