### PR TITLE
docs(voice): fix broken github links and stale ctor docs

### DIFF
--- a/docs/docs/pages/voice/adapters/twilio.mdx
+++ b/docs/docs/pages/voice/adapters/twilio.mdx
@@ -25,9 +25,11 @@ adapter = scenario.TwilioAgentAdapter(
 )
 ```
 
-All arguments after the first three are keyword-only:
+All arguments are keyword-only. Beyond the three above:
 `public_base_url`, `allowed_callers`, `on_dtmf`, `http_port` (default `8765`),
-`role` (default `AgentRole.AGENT`).
+`role` (default `AgentRole.AGENT`), `validate_signature` (default `True` — set
+to `False` only when running against a local test harness that can't sign
+webhook requests).
 
 ## Test harness (recommended)
 

--- a/docs/docs/pages/voice/recipes/effects.mdx
+++ b/docs/docs/pages/voice/recipes/effects.mdx
@@ -44,16 +44,13 @@ scenario.UserSimulatorAgent(
 <Callout type="tip">
 Accents are handled via TTS voice selection (e.g. `voice="elevenlabs/raj_indian_english"`),
 not via post-processing. There is no `accent` effect by design — see the
-[effects module source](https://github.com/langwatch/scenario/blob/main/python/scenario/voice/effects.py).
+[effects module source](https://github.com/langwatch/scenario/tree/main/python/scenario/voice/effects).
 </Callout>
 
 ### Per-step overrides
 
 The `audio_effects` list on `UserSimulatorAgent` applies to every user turn in the
-scenario. To apply effects only to a specific turn, use `scenario.user()` with an
-explicit `audio_effects` override (if supported by your script executor version).
-For finer control, inject audio directly with `scenario.audio(path)` on a pre-processed
-WAV file.
+scenario.
 
 <Callout type="warning">
 Per-step effect overrides via `scenario.user(audio_effects=[...])` are on the roadmap

--- a/docs/docs/pages/voice/troubleshooting.mdx
+++ b/docs/docs/pages/voice/troubleshooting.mdx
@@ -11,9 +11,7 @@ This page covers the failure modes that show up most often when running voice
 scenarios. Each entry states the symptom, what is actually going wrong, and the
 minimum steps to fix it. If your failure is not listed here, check the
 [voice agents feature file](https://github.com/langwatch/scenario/blob/main/specs/voice-agents.feature)
-for the behavioral contract and the
-[voice agents proposal](https://github.com/langwatch/scenario/blob/main/docs/proposals/issue-350-voice-agents-source.md)
-for adapter internals.
+for the full behavioral contract.
 
 ---
 


### PR DESCRIPTION
## Summary

Audit of the new voice docs against the published \`langwatch-scenario==0.7.27\` wheel surfaced 3 user-facing issues.

| # | File | Problem | Fix |
|---|---|---|---|
| 1 | \`recipes/effects.mdx\` | "effects module source" link 404'd (effects is a package, not a single file) | Relink to \`tree/main/python/scenario/voice/effects\`. Also drop a hedged sentence about per-step \`audio_effects\` on \`scenario.user()\` — the kwarg is not accepted in 0.7.27; the following Callout already says so |
| 2 | \`troubleshooting.mdx\` | "voice agents proposal" link 404'd | Drop the proposal link. The adjacent \`specs/voice-agents.feature\` link remains as the canonical contract |
| 3 | \`adapters/twilio.mdx\` | "All arguments after the first three are keyword-only" was wrong — every arg is keyword-only. Also missing \`validate_signature\` in the option list | Correct the wording and document \`validate_signature: bool = True\` |

## What I verified

Against the installed wheel (clean venv, \`pip install langwatch-scenario==0.7.27\`):
- All 23 \`scenario.X\` symbols + 6 from-imports across the 19 voice pages resolve.
- All 10 adapter capability tables match \`AdapterCapabilities\` declarations verbatim.
- All 10 \`scenario.effects.*\` functions exist; \`UserSimulatorAgent(audio_effects=...)\` accepts them.
- \`scenario.run(on_audio_chunk, on_voice_event, audio_playback, …)\` signature matches the observability recipe.
- \`ScenarioResult\` has \`.audio: Optional[Any]\` and \`.latency: Optional[Any]\`; \`LatencyMetrics\` exposes the 4 fields the doc documents.
- \`getting_started.py\` from the repo compiles cleanly against the wheel.
- Remaining 27/29 external github links resolve; both 404s are the ones this PR fixes.
- All 4 anchor targets on \`/voice/troubleshooting\` exist in the rendered HTML.
- All 19 voice URLs are live on prod with content (HTTP 200, real titles).

## Test plan

- [x] \`cd docs && pnpm run build\` — vocs build green, 311s, prerendered pages.
- [x] \`curl -sL\` on both new github links returns 200.
- [ ] Post-merge: \`scenario-docs.langwatch.ai\` deploy reflects the new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)