### PR TITLE
docs(voice): document LatencyMetrics.avg_response_time

### DIFF
--- a/docs/docs/pages/voice/recipes/observability.mdx
+++ b/docs/docs/pages/voice/recipes/observability.mdx
@@ -62,6 +62,7 @@ before any exchange). Always guard with `if result.audio is not None`.
 | Field | Description |
 |---|---|
 | `time_to_first_byte` | Wall-clock seconds from when the user turn ended to when the first byte of agent audio arrived. |
+| `avg_response_time` | Mean agent response time across all turns. |
 | `p50_response_time` | Median agent response time across all turns. |
 | `p95_response_time` | 95th-percentile agent response time across all turns. |
 | `interrupt_response_time` | Time from interrupt signal to agent resume (populated only when `scenario.interrupt()` was used). |
@@ -69,6 +70,7 @@ before any exchange). Always guard with `if result.audio is not None`.
 ```python
 if result.latency is not None:
     print(f"TTFB: {result.latency.time_to_first_byte:.3f}s")
+    print(f"avg:  {result.latency.avg_response_time:.3f}s")
     print(f"p50:  {result.latency.p50_response_time:.3f}s")
     print(f"p95:  {result.latency.p95_response_time:.3f}s")
 ```


### PR DESCRIPTION
## Summary

Follow-up to the audit in #512. \`LatencyMetrics\` in 0.7.27 also exposes \`avg_response_time\`, which the observability recipe didn't mention. Add it to the field table and the example print snippet.

## Verification

Against the installed \`langwatch-scenario==0.7.27\` wheel:

\`\`\`
>>> from scenario.voice.recording import LatencyMetrics
>>> [f for f in dir(LatencyMetrics) if not f.startswith('_')]
['avg_response_time', 'interrupt_response_time', 'p50_response_time',
 'p95_response_time', 'time_to_first_byte']
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)