### PR TITLE
feat(typescript-sdk/#372): voice adapter runtime + executor wiring + VAD fallback (PR3 of N)

### DIFF
--- a/javascript/src/domain/scenarios/index.ts
+++ b/javascript/src/domain/scenarios/index.ts
@@ -1,6 +1,8 @@
 import { ModelMessage } from "ai";
 import { AgentAdapter } from "../agents/index";
 import { ScenarioExecutionStateLike, ScenarioResult } from "../core/execution";
+import type { AudioChunk } from "../../voice/audio-chunk";
+import type { VoiceEvent } from "../../voice/recording.types";
 
 export const DEFAULT_MAX_TURNS = 10;
 export const DEFAULT_VERBOSE = false;
@@ -68,6 +70,24 @@ export interface ScenarioConfig {
    * The `langwatch` key is reserved for platform-internal use.
    */
   metadata?: Record<string, unknown>;
+
+  /**
+   * Optional callback invoked for every audio chunk that flows through
+   * a voice adapter (both user-side and agent-side).
+   *
+   * Mirrors Python `scenario.run(on_audio_chunk=...)`. Best-effort — if
+   * the hook throws, the scenario continues uninterrupted.
+   */
+  onAudioChunk?: (chunk: AudioChunk) => void;
+
+  /**
+   * Optional callback invoked for every {@link VoiceEvent} appended to
+   * the timeline (`user_start_speaking`, `agent_stop_speaking`, etc.).
+   *
+   * Mirrors Python `scenario.run(on_voice_event=...)`. Best-effort — if
+   * the hook throws, the scenario continues uninterrupted.
+   */
+  onVoiceEvent?: (event: VoiceEvent) => void;
 }
 
 /**

--- a/javascript/src/execution/scenario-execution-state.ts
+++ b/javascript/src/execution/scenario-execution-state.ts
@@ -27,6 +27,26 @@ export class ScenarioExecutionState implements ScenarioExecutionStateLike {
   private _threadId: string = "";
   private _onRollback?: (removedSet: Set<object>) => void;
 
+  /**
+   * Back-reference to the {@link ScenarioExecution} that owns this state.
+   *
+   * The voice adapter runtime (see `voice/adapter.runtime.ts`) reads this
+   * to reach the executor's {@link
+   * import("../voice/voice-executor-state").VoiceExecutorState} surface
+   * (`voiceRecording`, `voiceTimeline`, `voiceLatency`, etc.). Mirrors
+   * Python `ScenarioState._executor`.
+   *
+   * Underscored to keep callers out of the internal coupling — only the
+   * voice subsystem reaches in. Set once by the constructor of
+   * {@link ScenarioExecution} via {@link setExecutor}.
+   */
+  _executor: object | null = null;
+
+  /** Set the back-reference; called once by the executor's constructor. */
+  setExecutor(executor: object): void {
+    this._executor = executor;
+  }
+
   /** Event stream for message additions */
   private eventSubject = new Subject<StateChangeEvent>();
   public readonly events$: Observable<StateChangeEvent> =

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -33,6 +33,20 @@ import {
   ScenarioRunStatus,
   Verdict,
 } from "../events/schema";
+import type { AudioChunk } from "../voice/audio-chunk";
+import type {
+  LatencyMetrics,
+  VoiceEvent,
+  VoiceRecording,
+} from "../voice/recording.types";
+import type { VoiceAgentAdapter } from "../voice/adapter";
+import type { VoiceExecutorState } from "../voice/voice-executor-state";
+import {
+  initVoiceExecutorState,
+  pickVoiceAdapters,
+  startVoiceAdapters,
+  stopVoiceAdapters,
+} from "../voice/adapter.runtime";
 import convertModelMessagesToAguiMessages from "../utils/convert-core-messages-to-agui-messages";
 import {
   generateScenarioId,
@@ -125,12 +139,39 @@ import { Logger } from "../utils/logger";
  * console.log("Scenario result:", result.success);
  * ```
  */
-export class ScenarioExecution implements ScenarioExecutionLike {
+export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorState {
   /** LangWatch tracer for scenario execution */
   private tracer = getLangWatchTracer("@langwatch/scenario");
 
   /** The current state of the scenario execution */
   private state: ScenarioExecutionState;
+
+  // ----- VoiceExecutorState surface (issue #372 Decision 1(b)). ----------
+  // These are public fields rather than getters because the voice adapter
+  // runtime writes to them through the typed surface — see
+  // `voice/voice-executor-state.ts` for the contract. They default to
+  // `null` and only get populated when at least one VoiceAgentAdapter
+  // participates in the scenario.
+
+  /** PCM16 segments + timeline accumulated during the run. */
+  voiceRecording: VoiceRecording | null = null;
+  /** Mirror of `voiceRecording.timeline` for direct subscribers. */
+  voiceTimeline: VoiceEvent[] | null = null;
+  /** Response-time measurements from agent_start_speaking events. */
+  voiceLatency: LatencyMetrics | null = null;
+  /** Monotonic clock anchor (`performance.now() / 1000`) for offsets. */
+  voiceRecordingStartedAt: number | null = null;
+  /** Per-event hook from {@link ScenarioConfig.onVoiceEvent}. */
+  onVoiceEvent?: (event: VoiceEvent) => void;
+  /** Per-chunk hook from {@link ScenarioConfig.onAudioChunk}. */
+  onAudioChunk?: (chunk: AudioChunk) => void;
+
+  /**
+   * Snapshot of voice adapters for the in-flight execution. Captured at
+   * the top of {@link execute} so the matching `disconnect()` always
+   * fires in the finally block, even when the for-loop bails early.
+   */
+  private voiceAdapters: readonly VoiceAgentAdapter[] = [];
 
   /** The final result of the scenario execution, set when a conclusion is reached */
   private _result?: ScenarioResult;
@@ -224,7 +265,17 @@ export class ScenarioExecution implements ScenarioExecutionLike {
     } satisfies ScenarioConfigFinal;
 
     this.state = new ScenarioExecutionState(this.config);
+    // The voice adapter runtime reaches into `state._executor` to read the
+    // VoiceExecutorState surface (Python parity: `ScenarioState._executor`).
+    // Set once here so adapters fetched via AgentInput.scenarioState can
+    // find their voice fields.
+    this.state.setExecutor(this);
     this.preAssignedRunId = runId;
+
+    // Pull voice-side hooks off the user-supplied config. They fan out
+    // through the VoiceExecutorState surface during the run.
+    this.onAudioChunk = config.onAudioChunk;
+    this.onVoiceEvent = config.onVoiceEvent;
 
     // Wire up rollback handler so the state can clean pending queues
     this.state.setOnRollback((removedSet: Set<object>) => {
@@ -375,9 +426,22 @@ export class ScenarioExecution implements ScenarioExecutionLike {
         this.emitMessageSnapshot({ scenarioRunId });
       });
 
+    // Voice adapter lifecycle (issue #372 spec lines 138-145):
+    // `connect()` is awaited exactly once before the first script step;
+    // the matching `disconnect()` lives in the finally block so it fires
+    // regardless of pass / fail / exception. Connect runs inside the try
+    // so a partial connect still pairs with disconnect on the cleanup path
+    // — matches Python `scenario_executor.py:642-678`.
+    this.voiceAdapters = pickVoiceAdapters(this.agents);
+
     let checkFailure: Error | null = null;
 
     try {
+      if (this.voiceAdapters.length > 0) {
+        initVoiceExecutorState(this);
+        await startVoiceAdapters(this.voiceAdapters, this);
+      }
+
       // Execute script steps - pass the execution context (this), not just state
       for (let i = 0; i < this.config.script.length; i++) {
         const scriptStep = this.config.script[i];
@@ -490,6 +554,12 @@ export class ScenarioExecution implements ScenarioExecutionLike {
       if (this.currentTurnSpan) {
         this.currentTurnSpan.end();
         this.currentTurnSpan = undefined;
+      }
+      // Voice adapter lifecycle close — matches the connect at the top of
+      // execute(). Errors swallowed inside stopVoiceAdapters so cleanup
+      // never masks the primary scenario result.
+      if (this.voiceAdapters.length > 0) {
+        await stopVoiceAdapters(this.voiceAdapters);
       }
       // Clean up the subscription when execution is done
       subscription.unsubscribe();

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -1256,6 +1256,11 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     }
 
     this.state = new ScenarioExecutionState(this.config);
+    // Re-establish the voice runtime's back-reference — the new state
+    // object loses the linkage from the constructor's setExecutor call,
+    // so adapters reaching `input.scenarioState._executor` would see
+    // `null` for the rest of the run otherwise.
+    this.state.setExecutor(this);
     this.state.threadId = this.config.threadId || generateThreadId();
     this.setAgents(this.config.agents);
     // Initialize turn state without creating a span yet. execute() calls

--- a/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
+++ b/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Voice adapter lifecycle tests — binds `specs/voice-agents.feature`
+ * lines 138-145 (`Executor calls connect() before and disconnect() after
+ * every scenario`).
+ *
+ * The PR3 scope of issue #372 promises the executor wraps every voice
+ * adapter in a `connect()` → script → `disconnect()` sandwich, and that
+ * the disconnect fires regardless of pass / fail / exception. These
+ * tests exercise the runtime built in `adapter.runtime.ts` + the
+ * executor patch in `execution/scenario-execution.ts`.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentRole,
+  AgentAdapter,
+  type AgentInput,
+  type AgentReturnTypes,
+  UserSimulatorAgentAdapter,
+} from "../../domain";
+import { agent, fail, succeed, user } from "../../script";
+import { ScenarioExecution } from "../../execution/scenario-execution";
+import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+
+class TextUserSimulator extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return "Hi, this is a user turn.";
+  }
+}
+
+describe("specs/voice-agents.feature lines 138-145 — Executor calls connect() before and disconnect() after every scenario", () => {
+  it("connect() is awaited exactly once before the first script step", async () => {
+    const adapter = new FakeVoiceAdapter();
+    const execution = new ScenarioExecution(
+      {
+        name: "lifecycle / happy path",
+        description: "verifies connect-before-step + disconnect-after",
+        agents: [adapter, new TextUserSimulator()],
+      },
+      [user("hello"), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    await execution.execute();
+
+    expect(adapter.connectCount).toBe(1);
+    // The fake adapter snapshots (connectCount === 1 && disconnectCount === 0)
+    // inside its first call() invocation — proves connect was awaited
+    // before the agent step, not after.
+    expect(adapter.wasConnectedAtFirstCall).toBe(true);
+  });
+
+  it("disconnect() is awaited exactly once on the happy path", async () => {
+    const adapter = new FakeVoiceAdapter();
+    const execution = new ScenarioExecution(
+      {
+        name: "lifecycle / happy path / disconnect once",
+        description: "verifies disconnect runs after success",
+        agents: [adapter, new TextUserSimulator()],
+      },
+      [user("hello"), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    const result = await execution.execute();
+    expect(result.success).toBe(true);
+    expect(adapter.disconnectCount).toBe(1);
+  });
+
+  it("disconnect() is awaited even when the scenario fails", async () => {
+    const adapter = new FakeVoiceAdapter();
+    const execution = new ScenarioExecution(
+      {
+        name: "lifecycle / fail() still disconnects",
+        description: "verifies disconnect runs after explicit fail()",
+        agents: [adapter, new TextUserSimulator()],
+      },
+      [user("hello"), agent(), fail("test-driven failure")],
+      "test-batch-id",
+    );
+
+    const result = await execution.execute();
+    expect(result.success).toBe(false);
+    expect(adapter.disconnectCount).toBe(1);
+  });
+
+  it("disconnect() is awaited even when a script step throws", async () => {
+    // The AC says "regardless of pass/fail/exception". Throwing AGENT
+    // simulates an adapter raising mid-call — the executor must still
+    // unwind through the finally and disconnect.
+    class ThrowingAgent extends AgentAdapter {
+      role = AgentRole.AGENT;
+      async call(_input: AgentInput): Promise<AgentReturnTypes> {
+        throw new Error("simulated agent failure");
+      }
+    }
+
+    const adapter = new FakeVoiceAdapter();
+    const execution = new ScenarioExecution(
+      {
+        name: "lifecycle / exception",
+        description: "verifies disconnect runs after thrown error",
+        agents: [adapter, new ThrowingAgent(), new TextUserSimulator()],
+      },
+      // The executor picks the AGENT-role agent for `agent()` — the
+      // ThrowingAgent will run before the FakeVoiceAdapter; the test
+      // only cares that disconnect runs on the voice adapter when the
+      // execution loop blows up.
+      [user("hello"), agent(), succeed("never reached")],
+      "test-batch-id",
+    );
+
+    await expect(execution.execute()).rejects.toThrow(
+      /simulated agent failure/,
+    );
+    expect(adapter.connectCount).toBe(1);
+    expect(adapter.disconnectCount).toBe(1);
+  });
+
+  it("multiple voice adapters each get exactly one connect + one disconnect", async () => {
+    const adapterA = new FakeVoiceAdapter();
+    const adapterB = new FakeVoiceAdapter();
+
+    const execution = new ScenarioExecution(
+      {
+        name: "lifecycle / multi-adapter",
+        description: "verifies lifecycle fans out across all voice adapters",
+        agents: [adapterA, adapterB, new TextUserSimulator()],
+      },
+      [user("hello"), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    await execution.execute();
+
+    expect(adapterA.connectCount).toBe(1);
+    expect(adapterA.disconnectCount).toBe(1);
+    expect(adapterB.connectCount).toBe(1);
+    expect(adapterB.disconnectCount).toBe(1);
+  });
+
+  it("disconnect errors are swallowed so cleanup never masks the scenario result", async () => {
+    // Mirrors the Python contract at scenario_executor.py:747-759 — a
+    // failed disconnect must not poison the result we return to the user.
+    const adapter = new FakeVoiceAdapter({ failOnDisconnect: true });
+    const execution = new ScenarioExecution(
+      {
+        name: "lifecycle / disconnect error swallowed",
+        description: "verifies disconnect failure does not propagate",
+        agents: [adapter, new TextUserSimulator()],
+      },
+      [user("hello"), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    const result = await execution.execute();
+    expect(result.success).toBe(true);
+  });
+});

--- a/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
+++ b/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
@@ -11,13 +11,20 @@
  *
  * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
  * the suite if any bound scenario is missing a step binding.
+ *
+ * The bound Scenario covers only the happy-path contract named in the spec
+ * (connect before step, disconnect after). Sub-cases for fail/throw/multi-
+ * adapter/disconnect-swallow are implementation-level guarantees; they live
+ * as plain it() blocks below. Option (b) chosen — specs/voice-agents.feature
+ * does not name those sub-cases (confirmed via grep: no "fail", "throw",
+ * "multi-adapter", or "disconnect error" scenario near line 138).
  */
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
-import { expect } from "vitest";
+import { expect, it } from "vitest";
 
 import {
   AgentRole,
@@ -47,6 +54,90 @@ class TextUserSimulator extends UserSimulatorAgentAdapter {
   }
 }
 
+// -------------------------------------------------------------------------
+// Plain unit tests: implementation-level guarantees for disconnect() invariant.
+//
+// These sub-cases are not named in specs/voice-agents.feature (the spec's And
+// step says "regardless of pass/fail/exception" as a single AC). Each case
+// is a separate it() so vitest can pinpoint exactly which sub-case breaks.
+// Option (b) chosen.
+// -------------------------------------------------------------------------
+
+it("disconnect() fires even on explicit fail()", async () => {
+  const adapter = new FakeVoiceAdapter();
+  const execution = new ScenarioExecution(
+    {
+      name: "lifecycle / fail() still disconnects",
+      description: "verifies disconnect runs after explicit fail()",
+      agents: [adapter, new TextUserSimulator()],
+    },
+    [user("hello"), agent(), fail("test-driven failure")],
+    "test-batch-id",
+  );
+  const result = await execution.execute();
+  expect(result.success).toBe(false);
+  expect(adapter.disconnectCount).toBe(1);
+});
+
+it("disconnect() fires even when a script step throws", async () => {
+  // `failOnCall` causes the FakeVoiceAdapter's `call()` to throw — the
+  // executor must unwind through the finally and still disconnect.
+  const adapter = new FakeVoiceAdapter({ failOnCall: true });
+  const execution = new ScenarioExecution(
+    {
+      name: "lifecycle / exception",
+      description: "verifies disconnect runs after thrown error",
+      agents: [adapter, new TextUserSimulator()],
+    },
+    [user("hello"), agent(), succeed("never reached")],
+    "test-batch-id",
+  );
+  await expect(execution.execute()).rejects.toThrow(
+    /FakeVoiceAdapter\.call failure/,
+  );
+  expect(adapter.connectCount).toBe(1);
+  expect(adapter.disconnectCount).toBe(1);
+});
+
+it("multiple voice adapters each get exactly one connect + one disconnect", async () => {
+  const adapterA = new FakeVoiceAdapter();
+  const adapterB = new FakeVoiceAdapter();
+  const execution = new ScenarioExecution(
+    {
+      name: "lifecycle / multi-adapter",
+      description: "verifies lifecycle fans out across all voice adapters",
+      agents: [adapterA, adapterB, new TextUserSimulator()],
+    },
+    [user("hello"), agent(), succeed("done")],
+    "test-batch-id",
+  );
+  await execution.execute();
+  expect(adapterA.connectCount).toBe(1);
+  expect(adapterA.disconnectCount).toBe(1);
+  expect(adapterB.connectCount).toBe(1);
+  expect(adapterB.disconnectCount).toBe(1);
+});
+
+it("disconnect errors are swallowed so cleanup never masks the scenario result", async () => {
+  // Mirrors the Python contract at scenario_executor.py:747-759.
+  const adapter = new FakeVoiceAdapter({ failOnDisconnect: true });
+  const execution = new ScenarioExecution(
+    {
+      name: "lifecycle / disconnect error swallowed",
+      description: "verifies disconnect failure does not propagate",
+      agents: [adapter, new TextUserSimulator()],
+    },
+    [user("hello"), agent(), succeed("done")],
+    "test-batch-id",
+  );
+  const result = await execution.execute();
+  expect(result.success).toBe(true);
+});
+
+// -------------------------------------------------------------------------
+// Bound scenario — the spec-named happy-path contract.
+// -------------------------------------------------------------------------
+
 const feature = await loadFeature(FEATURE_PATH);
 
 describeFeature(
@@ -69,8 +160,8 @@ describeFeature(
         });
 
         When("scenario.run() starts and completes (success or error)", () => {
-          // The run happens inside each Then/And assertion below, so we can
-          // capture per-run observables without cross-contamination.
+          // The run happens inside Then/And so we can capture per-run
+          // observables without cross-contamination.
         });
 
         Then(
@@ -101,100 +192,20 @@ describeFeature(
         And(
           "disconnect() was awaited exactly once regardless of pass/fail/exception",
           async () => {
-            // Sub-case 1: happy path disconnect fires once.
-            {
-              const adapter = new FakeVoiceAdapter();
-              const execution = new ScenarioExecution(
-                {
-                  name: "lifecycle / happy path / disconnect once",
-                  description: "verifies disconnect runs after success",
-                  agents: [adapter, new TextUserSimulator()],
-                },
-                [user("hello"), agent(), succeed("done")],
-                "test-batch-id",
-              );
-              const result = await execution.execute();
-              expect(result.success).toBe(true);
-              expect(adapter.disconnectCount).toBe(1);
-            }
-
-            // Sub-case 2: disconnect fires even on explicit fail().
-            {
-              const adapter = new FakeVoiceAdapter();
-              const execution = new ScenarioExecution(
-                {
-                  name: "lifecycle / fail() still disconnects",
-                  description: "verifies disconnect runs after explicit fail()",
-                  agents: [adapter, new TextUserSimulator()],
-                },
-                [user("hello"), agent(), fail("test-driven failure")],
-                "test-batch-id",
-              );
-              const result = await execution.execute();
-              expect(result.success).toBe(false);
-              expect(adapter.disconnectCount).toBe(1);
-            }
-
-            // Sub-case 3: disconnect fires even when a script step throws.
-            // `failOnCall` causes the FakeVoiceAdapter's `call()` to throw —
-            // the executor must unwind through the finally and still disconnect.
-            {
-              const adapter = new FakeVoiceAdapter({ failOnCall: true });
-              const execution = new ScenarioExecution(
-                {
-                  name: "lifecycle / exception",
-                  description: "verifies disconnect runs after thrown error",
-                  agents: [adapter, new TextUserSimulator()],
-                },
-                [user("hello"), agent(), succeed("never reached")],
-                "test-batch-id",
-              );
-              await expect(execution.execute()).rejects.toThrow(
-                /FakeVoiceAdapter\.call failure/,
-              );
-              expect(adapter.connectCount).toBe(1);
-              expect(adapter.disconnectCount).toBe(1);
-            }
-
-            // Sub-case 4: multiple voice adapters each get exactly one
-            // connect + one disconnect.
-            {
-              const adapterA = new FakeVoiceAdapter();
-              const adapterB = new FakeVoiceAdapter();
-              const execution = new ScenarioExecution(
-                {
-                  name: "lifecycle / multi-adapter",
-                  description:
-                    "verifies lifecycle fans out across all voice adapters",
-                  agents: [adapterA, adapterB, new TextUserSimulator()],
-                },
-                [user("hello"), agent(), succeed("done")],
-                "test-batch-id",
-              );
-              await execution.execute();
-              expect(adapterA.connectCount).toBe(1);
-              expect(adapterA.disconnectCount).toBe(1);
-              expect(adapterB.connectCount).toBe(1);
-              expect(adapterB.disconnectCount).toBe(1);
-            }
-
-            // Sub-case 5: disconnect errors are swallowed so cleanup never
-            // masks the scenario result (mirrors the Python contract at
-            // scenario_executor.py:747-759).
-            {
-              const adapter = new FakeVoiceAdapter({ failOnDisconnect: true });
-              const execution = new ScenarioExecution(
-                {
-                  name: "lifecycle / disconnect error swallowed",
-                  description: "verifies disconnect failure does not propagate",
-                  agents: [adapter, new TextUserSimulator()],
-                },
-                [user("hello"), agent(), succeed("done")],
-                "test-batch-id",
-              );
-              const result = await execution.execute();
-              expect(result.success).toBe(true);
-            }
+            // Happy path: disconnect fires once after success.
+            const adapter = new FakeVoiceAdapter();
+            const execution = new ScenarioExecution(
+              {
+                name: "lifecycle / happy path / disconnect once",
+                description: "verifies disconnect runs after success",
+                agents: [adapter, new TextUserSimulator()],
+              },
+              [user("hello"), agent(), succeed("done")],
+              "test-batch-id",
+            );
+            const result = await execution.execute();
+            expect(result.success).toBe(true);
+            expect(adapter.disconnectCount).toBe(1);
           },
         );
       },

--- a/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
+++ b/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
@@ -13,7 +13,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   AgentRole,
-  AgentAdapter,
   type AgentInput,
   type AgentReturnTypes,
   UserSimulatorAgentAdapter,
@@ -86,33 +85,22 @@ describe("specs/voice-agents.feature lines 138-145 — Executor calls connect() 
   });
 
   it("disconnect() is awaited even when a script step throws", async () => {
-    // The AC says "regardless of pass/fail/exception". Throwing AGENT
-    // simulates an adapter raising mid-call — the executor must still
-    // unwind through the finally and disconnect.
-    class ThrowingAgent extends AgentAdapter {
-      role = AgentRole.AGENT;
-      async call(_input: AgentInput): Promise<AgentReturnTypes> {
-        throw new Error("simulated agent failure");
-      }
-    }
-
-    const adapter = new FakeVoiceAdapter();
+    // The AC says "regardless of pass/fail/exception". `failOnCall`
+    // causes the FakeVoiceAdapter's `call()` to throw — the executor
+    // must unwind through the finally and still disconnect.
+    const adapter = new FakeVoiceAdapter({ failOnCall: true });
     const execution = new ScenarioExecution(
       {
         name: "lifecycle / exception",
         description: "verifies disconnect runs after thrown error",
-        agents: [adapter, new ThrowingAgent(), new TextUserSimulator()],
+        agents: [adapter, new TextUserSimulator()],
       },
-      // The executor picks the AGENT-role agent for `agent()` — the
-      // ThrowingAgent will run before the FakeVoiceAdapter; the test
-      // only cares that disconnect runs on the voice adapter when the
-      // execution loop blows up.
       [user("hello"), agent(), succeed("never reached")],
       "test-batch-id",
     );
 
     await expect(execution.execute()).rejects.toThrow(
-      /simulated agent failure/,
+      /FakeVoiceAdapter\.call failure/,
     );
     expect(adapter.connectCount).toBe(1);
     expect(adapter.disconnectCount).toBe(1);

--- a/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
+++ b/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
@@ -1,15 +1,23 @@
 /**
- * Voice adapter lifecycle tests — binds `specs/voice-agents.feature`
- * lines 138-145 (`Executor calls connect() before and disconnect() after
- * every scenario`).
+ * Voice adapter lifecycle tests — binds `specs/voice-agents.feature` scenario
+ * tagged `@ts-adapter`: "Executor calls connect() before and disconnect() after
+ * every scenario".
  *
  * The PR3 scope of issue #372 promises the executor wraps every voice
  * adapter in a `connect()` → script → `disconnect()` sandwich, and that
  * the disconnect fires regardless of pass / fail / exception. These
  * tests exercise the runtime built in `adapter.runtime.ts` + the
  * executor patch in `execution/scenario-execution.ts`.
+ *
+ * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
+ * the suite if any bound scenario is missing a step binding.
  */
-import { describe, expect, it } from "vitest";
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
 
 import {
   AgentRole,
@@ -21,6 +29,17 @@ import { agent, fail, succeed, user } from "../../script";
 import { ScenarioExecution } from "../../execution/scenario-execution";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
 
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "specs",
+  "voice-agents.feature",
+);
+
 class TextUserSimulator extends UserSimulatorAgentAdapter {
   role = AgentRole.USER;
   async call(_input: AgentInput): Promise<AgentReturnTypes> {
@@ -28,121 +47,158 @@ class TextUserSimulator extends UserSimulatorAgentAdapter {
   }
 }
 
-describe("specs/voice-agents.feature lines 138-145 — Executor calls connect() before and disconnect() after every scenario", () => {
-  it("connect() is awaited exactly once before the first script step", async () => {
-    const adapter = new FakeVoiceAdapter();
-    const execution = new ScenarioExecution(
-      {
-        name: "lifecycle / happy path",
-        description: "verifies connect-before-step + disconnect-after",
-        agents: [adapter, new TextUserSimulator()],
+const feature = await loadFeature(FEATURE_PATH);
+
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    // -----------------------------------------------------------------------
+    // Scenario: Executor calls connect() before and disconnect() after every
+    // scenario (lines 138-143)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "Executor calls connect() before and disconnect() after every scenario",
+      ({ Given, When, Then, And }) => {
+        // Adapters are set up fresh inside each step so the assertions are
+        // independent. The Given/When/Then structure maps to the spec's
+        // stated precondition / trigger / observable outcomes.
+
+        Given("any VoiceAgentAdapter subclass", () => {
+          // FakeVoiceAdapter is the test-double VoiceAgentAdapter subclass.
+          // No persistent state needed at Given — adapters are built per assertion.
+        });
+
+        When("scenario.run() starts and completes (success or error)", () => {
+          // The run happens inside each Then/And assertion below, so we can
+          // capture per-run observables without cross-contamination.
+        });
+
+        Then(
+          "connect() was awaited exactly once before the first script step",
+          async () => {
+            // Happy path: connect before step, verified via wasConnectedAtFirstCall.
+            const adapter = new FakeVoiceAdapter();
+            const execution = new ScenarioExecution(
+              {
+                name: "lifecycle / happy path",
+                description: "verifies connect-before-step + disconnect-after",
+                agents: [adapter, new TextUserSimulator()],
+              },
+              [user("hello"), agent(), succeed("done")],
+              "test-batch-id",
+            );
+
+            await execution.execute();
+
+            expect(adapter.connectCount).toBe(1);
+            // The fake adapter snapshots (connectCount === 1 && disconnectCount === 0)
+            // inside its first call() invocation — proves connect was awaited
+            // before the agent step, not after.
+            expect(adapter.wasConnectedAtFirstCall).toBe(true);
+          },
+        );
+
+        And(
+          "disconnect() was awaited exactly once regardless of pass/fail/exception",
+          async () => {
+            // Sub-case 1: happy path disconnect fires once.
+            {
+              const adapter = new FakeVoiceAdapter();
+              const execution = new ScenarioExecution(
+                {
+                  name: "lifecycle / happy path / disconnect once",
+                  description: "verifies disconnect runs after success",
+                  agents: [adapter, new TextUserSimulator()],
+                },
+                [user("hello"), agent(), succeed("done")],
+                "test-batch-id",
+              );
+              const result = await execution.execute();
+              expect(result.success).toBe(true);
+              expect(adapter.disconnectCount).toBe(1);
+            }
+
+            // Sub-case 2: disconnect fires even on explicit fail().
+            {
+              const adapter = new FakeVoiceAdapter();
+              const execution = new ScenarioExecution(
+                {
+                  name: "lifecycle / fail() still disconnects",
+                  description: "verifies disconnect runs after explicit fail()",
+                  agents: [adapter, new TextUserSimulator()],
+                },
+                [user("hello"), agent(), fail("test-driven failure")],
+                "test-batch-id",
+              );
+              const result = await execution.execute();
+              expect(result.success).toBe(false);
+              expect(adapter.disconnectCount).toBe(1);
+            }
+
+            // Sub-case 3: disconnect fires even when a script step throws.
+            // `failOnCall` causes the FakeVoiceAdapter's `call()` to throw —
+            // the executor must unwind through the finally and still disconnect.
+            {
+              const adapter = new FakeVoiceAdapter({ failOnCall: true });
+              const execution = new ScenarioExecution(
+                {
+                  name: "lifecycle / exception",
+                  description: "verifies disconnect runs after thrown error",
+                  agents: [adapter, new TextUserSimulator()],
+                },
+                [user("hello"), agent(), succeed("never reached")],
+                "test-batch-id",
+              );
+              await expect(execution.execute()).rejects.toThrow(
+                /FakeVoiceAdapter\.call failure/,
+              );
+              expect(adapter.connectCount).toBe(1);
+              expect(adapter.disconnectCount).toBe(1);
+            }
+
+            // Sub-case 4: multiple voice adapters each get exactly one
+            // connect + one disconnect.
+            {
+              const adapterA = new FakeVoiceAdapter();
+              const adapterB = new FakeVoiceAdapter();
+              const execution = new ScenarioExecution(
+                {
+                  name: "lifecycle / multi-adapter",
+                  description:
+                    "verifies lifecycle fans out across all voice adapters",
+                  agents: [adapterA, adapterB, new TextUserSimulator()],
+                },
+                [user("hello"), agent(), succeed("done")],
+                "test-batch-id",
+              );
+              await execution.execute();
+              expect(adapterA.connectCount).toBe(1);
+              expect(adapterA.disconnectCount).toBe(1);
+              expect(adapterB.connectCount).toBe(1);
+              expect(adapterB.disconnectCount).toBe(1);
+            }
+
+            // Sub-case 5: disconnect errors are swallowed so cleanup never
+            // masks the scenario result (mirrors the Python contract at
+            // scenario_executor.py:747-759).
+            {
+              const adapter = new FakeVoiceAdapter({ failOnDisconnect: true });
+              const execution = new ScenarioExecution(
+                {
+                  name: "lifecycle / disconnect error swallowed",
+                  description: "verifies disconnect failure does not propagate",
+                  agents: [adapter, new TextUserSimulator()],
+                },
+                [user("hello"), agent(), succeed("done")],
+                "test-batch-id",
+              );
+              const result = await execution.execute();
+              expect(result.success).toBe(true);
+            }
+          },
+        );
       },
-      [user("hello"), agent(), succeed("done")],
-      "test-batch-id",
     );
-
-    await execution.execute();
-
-    expect(adapter.connectCount).toBe(1);
-    // The fake adapter snapshots (connectCount === 1 && disconnectCount === 0)
-    // inside its first call() invocation — proves connect was awaited
-    // before the agent step, not after.
-    expect(adapter.wasConnectedAtFirstCall).toBe(true);
-  });
-
-  it("disconnect() is awaited exactly once on the happy path", async () => {
-    const adapter = new FakeVoiceAdapter();
-    const execution = new ScenarioExecution(
-      {
-        name: "lifecycle / happy path / disconnect once",
-        description: "verifies disconnect runs after success",
-        agents: [adapter, new TextUserSimulator()],
-      },
-      [user("hello"), agent(), succeed("done")],
-      "test-batch-id",
-    );
-
-    const result = await execution.execute();
-    expect(result.success).toBe(true);
-    expect(adapter.disconnectCount).toBe(1);
-  });
-
-  it("disconnect() is awaited even when the scenario fails", async () => {
-    const adapter = new FakeVoiceAdapter();
-    const execution = new ScenarioExecution(
-      {
-        name: "lifecycle / fail() still disconnects",
-        description: "verifies disconnect runs after explicit fail()",
-        agents: [adapter, new TextUserSimulator()],
-      },
-      [user("hello"), agent(), fail("test-driven failure")],
-      "test-batch-id",
-    );
-
-    const result = await execution.execute();
-    expect(result.success).toBe(false);
-    expect(adapter.disconnectCount).toBe(1);
-  });
-
-  it("disconnect() is awaited even when a script step throws", async () => {
-    // The AC says "regardless of pass/fail/exception". `failOnCall`
-    // causes the FakeVoiceAdapter's `call()` to throw — the executor
-    // must unwind through the finally and still disconnect.
-    const adapter = new FakeVoiceAdapter({ failOnCall: true });
-    const execution = new ScenarioExecution(
-      {
-        name: "lifecycle / exception",
-        description: "verifies disconnect runs after thrown error",
-        agents: [adapter, new TextUserSimulator()],
-      },
-      [user("hello"), agent(), succeed("never reached")],
-      "test-batch-id",
-    );
-
-    await expect(execution.execute()).rejects.toThrow(
-      /FakeVoiceAdapter\.call failure/,
-    );
-    expect(adapter.connectCount).toBe(1);
-    expect(adapter.disconnectCount).toBe(1);
-  });
-
-  it("multiple voice adapters each get exactly one connect + one disconnect", async () => {
-    const adapterA = new FakeVoiceAdapter();
-    const adapterB = new FakeVoiceAdapter();
-
-    const execution = new ScenarioExecution(
-      {
-        name: "lifecycle / multi-adapter",
-        description: "verifies lifecycle fans out across all voice adapters",
-        agents: [adapterA, adapterB, new TextUserSimulator()],
-      },
-      [user("hello"), agent(), succeed("done")],
-      "test-batch-id",
-    );
-
-    await execution.execute();
-
-    expect(adapterA.connectCount).toBe(1);
-    expect(adapterA.disconnectCount).toBe(1);
-    expect(adapterB.connectCount).toBe(1);
-    expect(adapterB.disconnectCount).toBe(1);
-  });
-
-  it("disconnect errors are swallowed so cleanup never masks the scenario result", async () => {
-    // Mirrors the Python contract at scenario_executor.py:747-759 — a
-    // failed disconnect must not poison the result we return to the user.
-    const adapter = new FakeVoiceAdapter({ failOnDisconnect: true });
-    const execution = new ScenarioExecution(
-      {
-        name: "lifecycle / disconnect error swallowed",
-        description: "verifies disconnect failure does not propagate",
-        agents: [adapter, new TextUserSimulator()],
-      },
-      [user("hello"), agent(), succeed("done")],
-      "test-batch-id",
-    );
-
-    const result = await execution.execute();
-    expect(result.success).toBe(true);
-  });
-});
+  },
+  { includeTags: ["ts-adapter"] },
+);

--- a/javascript/src/voice/__tests__/fixtures/fake-adapter.ts
+++ b/javascript/src/voice/__tests__/fixtures/fake-adapter.ts
@@ -1,0 +1,125 @@
+/**
+ * In-memory voice adapter for PR3 runtime tests.
+ *
+ * Carries no transport — `sendAudio` and `receiveAudio` move bytes
+ * through in-memory queues. The adapter publishes a configurable
+ * {@link AdapterCapabilities} so individual tests can flip
+ * `nativeVad` on or off and the VAD-fallback contract becomes
+ * observable without touching a real audio stack.
+ *
+ * Lifecycle bookkeeping:
+ *   - `connectCount` / `disconnectCount` — counters, asserted by the
+ *     lifecycle test.
+ *   - `wasConnectedAtFirstCall` — `true` if `connectCount === 1` and
+ *     `disconnectCount === 0` at the moment of the first `call()`,
+ *     binding the "connect before first script step" half of the AC.
+ *   - `sentAudio` / `responses` — visible audio queues for assertions.
+ */
+import { AgentRole } from "../../../domain/agents";
+import {
+  AdapterCapabilities,
+  type AdapterCapabilitiesInit,
+} from "../../capabilities";
+import { AudioChunk, silentChunk } from "../../audio-chunk";
+import { VoiceAgentAdapter } from "../../adapter";
+
+export interface FakeAdapterOptions {
+  /** Override the default capability matrix (defaults to nativeVad=true). */
+  capabilities?: AdapterCapabilitiesInit;
+  /**
+   * Sequence of agent-side responses the fake adapter will yield via
+   * `receiveAudio` in order. Once exhausted, it returns
+   * `silentChunk(0)` to signal end-of-stream and let the drain loop
+   * exit cleanly.
+   */
+  responses?: AudioChunk[];
+  /**
+   * If true, `connect()` rejects on first call. Used to exercise the
+   * "disconnect still fires when connect throws" code path.
+   */
+  failOnConnect?: boolean;
+  /**
+   * If true, `disconnect()` rejects on first call. Used to exercise
+   * the swallow-on-cleanup behaviour.
+   */
+  failOnDisconnect?: boolean;
+}
+
+export class FakeVoiceAdapter extends VoiceAgentAdapter {
+  override role = AgentRole.AGENT;
+  readonly capabilities: AdapterCapabilities;
+
+  /** Counter incremented every time {@link connect} resolves. */
+  connectCount = 0;
+  /** Counter incremented every time {@link disconnect} resolves. */
+  disconnectCount = 0;
+  /** Counter incremented every time {@link call} is entered. */
+  callCount = 0;
+  /**
+   * Frozen snapshot of `(connectCount === 1 && disconnectCount === 0)`
+   * at the moment of the first `call()`. Tests assert this to bind the
+   * "connect before the first script step" half of the AC.
+   */
+  wasConnectedAtFirstCall = false;
+  /** Audio chunks captured via {@link sendAudio} in order. */
+  readonly sentAudio: AudioChunk[] = [];
+
+  private readonly responses: AudioChunk[];
+  private nextResponseIndex = 0;
+  private readonly failOnConnect: boolean;
+  private readonly failOnDisconnect: boolean;
+
+  constructor(options: FakeAdapterOptions = {}) {
+    super();
+    this.capabilities = new AdapterCapabilities({
+      streamingTranscripts: false,
+      nativeVad: true,
+      dtmf: false,
+      interruption: false,
+      inputFormats: ["pcm16/24000"],
+      outputFormats: ["pcm16/24000"],
+      ...options.capabilities,
+    });
+    this.responses = options.responses ?? [silentChunk(0.05)];
+    this.failOnConnect = options.failOnConnect ?? false;
+    this.failOnDisconnect = options.failOnDisconnect ?? false;
+  }
+
+  async connect(): Promise<void> {
+    if (this.failOnConnect) {
+      throw new Error("FakeVoiceAdapter.connect failure (test fixture)");
+    }
+    this.connectCount += 1;
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.failOnDisconnect) {
+      throw new Error("FakeVoiceAdapter.disconnect failure (test fixture)");
+    }
+    this.disconnectCount += 1;
+  }
+
+  async sendAudio(chunk: AudioChunk): Promise<void> {
+    this.sentAudio.push(chunk);
+  }
+
+  async receiveAudio(_timeout: number): Promise<AudioChunk> {
+    if (this.nextResponseIndex < this.responses.length) {
+      return this.responses[this.nextResponseIndex++]!;
+    }
+    // After draining all responses, return an empty chunk so the
+    // tail-silence loop in the runtime exits without timing out.
+    return silentChunk(0);
+  }
+
+  override async call(input: import("../../../domain/agents").AgentInput) {
+    this.callCount += 1;
+    if (this.callCount === 1) {
+      this.wasConnectedAtFirstCall =
+        this.connectCount === 1 && this.disconnectCount === 0;
+    }
+    // Delegate to the default voice runtime so this fixture exercises
+    // the adapter.runtime.ts code paths under test.
+    return super.call(input);
+  }
+}

--- a/javascript/src/voice/__tests__/fixtures/fake-adapter.ts
+++ b/javascript/src/voice/__tests__/fixtures/fake-adapter.ts
@@ -43,6 +43,13 @@ export interface FakeAdapterOptions {
    * the swallow-on-cleanup behaviour.
    */
   failOnDisconnect?: boolean;
+  /**
+   * If true, `call()` rejects on first invocation — used to verify the
+   * "disconnect fires even when the script throws" half of the
+   * lifecycle AC without needing a second AGENT-role agent that would
+   * compete for the `agent()` step.
+   */
+  failOnCall?: boolean;
 }
 
 export class FakeVoiceAdapter extends VoiceAgentAdapter {
@@ -68,6 +75,7 @@ export class FakeVoiceAdapter extends VoiceAgentAdapter {
   private nextResponseIndex = 0;
   private readonly failOnConnect: boolean;
   private readonly failOnDisconnect: boolean;
+  private readonly failOnCall: boolean;
 
   constructor(options: FakeAdapterOptions = {}) {
     super();
@@ -83,6 +91,7 @@ export class FakeVoiceAdapter extends VoiceAgentAdapter {
     this.responses = options.responses ?? [silentChunk(0.05)];
     this.failOnConnect = options.failOnConnect ?? false;
     this.failOnDisconnect = options.failOnDisconnect ?? false;
+    this.failOnCall = options.failOnCall ?? false;
   }
 
   async connect(): Promise<void> {
@@ -117,6 +126,9 @@ export class FakeVoiceAdapter extends VoiceAgentAdapter {
     if (this.callCount === 1) {
       this.wasConnectedAtFirstCall =
         this.connectCount === 1 && this.disconnectCount === 0;
+    }
+    if (this.failOnCall) {
+      throw new Error("FakeVoiceAdapter.call failure (test fixture)");
     }
     // Delegate to the default voice runtime so this fixture exercises
     // the adapter.runtime.ts code paths under test.

--- a/javascript/src/voice/__tests__/hooks.test.ts
+++ b/javascript/src/voice/__tests__/hooks.test.ts
@@ -10,12 +10,16 @@
  *
  * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
  * the suite if any bound scenario is missing a step binding.
+ *
+ * The "throwing hook doesn't break scenario" behavior is tested as a plain
+ * it() below — it is an implementation-level guarantee, not a named feature
+ * scenario. Option (a) chosen: no spec scenario exists for this behavior.
  */
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
-import { expect } from "vitest";
+import { expect, it } from "vitest";
 
 import {
   AgentRole,
@@ -83,6 +87,37 @@ class AudioUserSimulator extends UserSimulatorAgentAdapter {
     } as unknown as AgentReturnTypes;
   }
 }
+
+// -------------------------------------------------------------------------
+// Plain unit test: a throwing on_voice_event hook does not break the scenario.
+//
+// This is an implementation-level guarantee (the runtime swallows hook errors
+// so a buggy observability callback can never break a scenario run). It is NOT
+// a named scenario in specs/voice-agents.feature, so it lives here as a plain
+// it() rather than inside a describeFeature binding. Option (a) chosen.
+// -------------------------------------------------------------------------
+it("throwing on_voice_event hook does not break the scenario", async () => {
+  const adapter = new FakeVoiceAdapter({
+    responses: [pcm16Chunk(0.05)],
+  });
+  let voiceEventCalls = 0;
+  const throwingExecution = new ScenarioExecution(
+    {
+      name: "hooks / throwing hook does not break scenario",
+      description: "binds the swallow-on-hook-error contract",
+      agents: [adapter, new AudioUserSimulator(silentChunk(0.05))],
+      onVoiceEvent: () => {
+        voiceEventCalls += 1;
+        throw new Error("simulated observability bug");
+      },
+    },
+    [user(), agent(), succeed("done")],
+    "test-batch-id",
+  );
+  const result = await throwingExecution.execute();
+  expect(result.success).toBe(true);
+  expect(voiceEventCalls).toBeGreaterThan(0);
+});
 
 const feature = await loadFeature(FEATURE_PATH);
 
@@ -163,30 +198,6 @@ describeFeature(
 
         When("VAD/interrupt/tool events occur", async () => {
           await execution.execute();
-
-          // Also verify: hook errors don't break the scenario. A throwing
-          // hook must not interrupt the run — the runtime swallows hook errors
-          // so a buggy observability callback can never break the scenario.
-          const adapterB = new FakeVoiceAdapter({
-            responses: [pcm16Chunk(0.05)],
-          });
-          let voiceEventCalls = 0;
-          const throwingExecution = new ScenarioExecution(
-            {
-              name: "hooks / throwing hook does not break scenario",
-              description: "binds the swallow-on-hook-error contract",
-              agents: [adapterB, new AudioUserSimulator(silentChunk(0.05))],
-              onVoiceEvent: () => {
-                voiceEventCalls += 1;
-                throw new Error("simulated observability bug");
-              },
-            },
-            [user(), agent(), succeed("done")],
-            "test-batch-id",
-          );
-          const result = await throwingExecution.execute();
-          expect(result.success).toBe(true);
-          expect(voiceEventCalls).toBeGreaterThan(0);
         });
 
         Then("cb is invoked with each VoiceEvent", () => {

--- a/javascript/src/voice/__tests__/hooks.test.ts
+++ b/javascript/src/voice/__tests__/hooks.test.ts
@@ -1,13 +1,21 @@
 /**
- * Voice hook fan-out tests — binds `specs/voice-agents.feature` lines
- * 449-461 (`on_audio_chunk` and `on_voice_event` hooks).
+ * Voice hook fan-out tests — binds `specs/voice-agents.feature` scenarios
+ * tagged `@ts-hooks`:
+ *   - "on_audio_chunk hook fires for each chunk" (lines 450-454)
+ *   - "on_voice_event hook fires for each VoiceEvent" (lines 457-461)
  *
  * The PR3 runtime fans `on_audio_chunk` out to every audio chunk that
- * crosses the recorder (user-side via `writeUserSegment`, agent-side
- * via the merged drain output) and fans `on_voice_event` out to every
- * `VoiceEvent` appended to the timeline.
+ * crosses the recorder and fans `on_voice_event` out to every `VoiceEvent`
+ * appended to the timeline.
+ *
+ * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
+ * the suite if any bound scenario is missing a step binding.
  */
-import { describe, expect, it } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
 
 import {
   AgentRole,
@@ -20,6 +28,17 @@ import { ScenarioExecution } from "../../execution/scenario-execution";
 import { AudioChunk, silentChunk } from "../audio-chunk";
 import type { VoiceEvent } from "../recording.types";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "specs",
+  "voice-agents.feature",
+);
 
 /**
  * Build a synthetic-but-non-silent PCM16 chunk so the recorder treats it
@@ -65,93 +84,122 @@ class AudioUserSimulator extends UserSimulatorAgentAdapter {
   }
 }
 
-describe("specs/voice-agents.feature lines 449-454 — on_audio_chunk hook fires for each chunk", () => {
-  it("invokes the hook for every audio chunk that crosses the recorder", async () => {
-    const userChunk = pcm16Chunk(0.05, 0x1234);
-    const agentChunk = pcm16Chunk(0.06, 0x5678);
-    const adapter = new FakeVoiceAdapter({ responses: [agentChunk] });
-    const captured: AudioChunk[] = [];
+const feature = await loadFeature(FEATURE_PATH);
 
-    const execution = new ScenarioExecution(
-      {
-        name: "hooks / on_audio_chunk fires",
-        description: "covers the bound feature scenario lines 449-454",
-        agents: [adapter, new AudioUserSimulator(userChunk)],
-        onAudioChunk: (chunk) => captured.push(chunk),
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    // -----------------------------------------------------------------------
+    // Scenario: on_audio_chunk hook fires for each chunk (lines 450-454)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "on_audio_chunk hook fires for each chunk",
+      ({ Given, When, Then }) => {
+        let userChunk: AudioChunk;
+        let agentChunk: AudioChunk;
+        let captured: AudioChunk[];
+
+        Given("scenario.run(..., on_audio_chunk=cb)", () => {
+          userChunk = pcm16Chunk(0.05, 0x1234);
+          agentChunk = pcm16Chunk(0.06, 0x5678);
+          captured = [];
+        });
+
+        When("audio flows", async () => {
+          const adapter = new FakeVoiceAdapter({ responses: [agentChunk] });
+          const execution = new ScenarioExecution(
+            {
+              name: "hooks / on_audio_chunk fires",
+              description: "covers the bound feature scenario lines 449-454",
+              agents: [adapter, new AudioUserSimulator(userChunk)],
+              onAudioChunk: (chunk) => captured.push(chunk),
+            },
+            [user(), agent(), succeed("done")],
+            "test-batch-id",
+          );
+          const result = await execution.execute();
+          expect(result.success).toBe(true);
+        });
+
+        Then("cb is invoked with each AudioChunk", () => {
+          // The default call() flow records one user chunk (the sent audio)
+          // and one agent chunk (the drained response) — both fan out to
+          // on_audio_chunk in `fireAudioChunk`.
+          expect(captured.length).toBeGreaterThanOrEqual(2);
+          // The bytes round-trip through the hook intact (no normalisation
+          // side-effects from the recorder boundary).
+          const firstByte = captured[0]!.data[0];
+          expect(typeof firstByte).toBe("number");
+        });
       },
-      [user(), agent(), succeed("done")],
-      "test-batch-id",
     );
 
-    const result = await execution.execute();
-    expect(result.success).toBe(true);
-    // The default call() flow records one user chunk (the sent audio)
-    // and one agent chunk (the drained response) — both fan out to
-    // on_audio_chunk in `_fire_audio_chunk` / `fireAudioChunk`.
-    expect(captured.length).toBeGreaterThanOrEqual(2);
-    // The bytes round-trip through the hook intact (no normalisation
-    // side-effects from the recorder boundary).
-    const firstByte = captured[0]!.data[0];
-    expect(typeof firstByte).toBe("number");
-  });
-});
+    // -----------------------------------------------------------------------
+    // Scenario: on_voice_event hook fires for each VoiceEvent (lines 457-461)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "on_voice_event hook fires for each VoiceEvent",
+      ({ Given, When, Then }) => {
+        let events: VoiceEvent[];
+        let execution: ScenarioExecution;
 
-describe("specs/voice-agents.feature lines 456-461 — on_voice_event hook fires for each VoiceEvent", () => {
-  it("invokes the hook for every VoiceEvent appended to the timeline", async () => {
-    const userChunk = pcm16Chunk(0.05);
-    const agentChunk = pcm16Chunk(0.06);
-    const adapter = new FakeVoiceAdapter({ responses: [agentChunk] });
-    const events: VoiceEvent[] = [];
+        Given("scenario.run(..., on_voice_event=cb)", () => {
+          const userChunk = pcm16Chunk(0.05);
+          const agentChunk = pcm16Chunk(0.06);
+          const adapter = new FakeVoiceAdapter({ responses: [agentChunk] });
+          events = [];
 
-    const execution = new ScenarioExecution(
-      {
-        name: "hooks / on_voice_event fires",
-        description: "covers the bound feature scenario lines 456-461",
-        agents: [adapter, new AudioUserSimulator(userChunk)],
-        onVoiceEvent: (event) => events.push(event),
+          execution = new ScenarioExecution(
+            {
+              name: "hooks / on_voice_event fires",
+              description: "covers the bound feature scenario lines 456-461",
+              agents: [adapter, new AudioUserSimulator(userChunk)],
+              onVoiceEvent: (event) => events.push(event),
+            },
+            [user(), agent(), succeed("done")],
+            "test-batch-id",
+          );
+        });
+
+        When("VAD/interrupt/tool events occur", async () => {
+          await execution.execute();
+
+          // Also verify: hook errors don't break the scenario. A throwing
+          // hook must not interrupt the run — the runtime swallows hook errors
+          // so a buggy observability callback can never break the scenario.
+          const adapterB = new FakeVoiceAdapter({
+            responses: [pcm16Chunk(0.05)],
+          });
+          let voiceEventCalls = 0;
+          const throwingExecution = new ScenarioExecution(
+            {
+              name: "hooks / throwing hook does not break scenario",
+              description: "binds the swallow-on-hook-error contract",
+              agents: [adapterB, new AudioUserSimulator(silentChunk(0.05))],
+              onVoiceEvent: () => {
+                voiceEventCalls += 1;
+                throw new Error("simulated observability bug");
+              },
+            },
+            [user(), agent(), succeed("done")],
+            "test-batch-id",
+          );
+          const result = await throwingExecution.execute();
+          expect(result.success).toBe(true);
+          expect(voiceEventCalls).toBeGreaterThan(0);
+        });
+
+        Then("cb is invoked with each VoiceEvent", () => {
+          // Default call() emits: user_start, user_stop, agent_start,
+          // agent_stop — 4 events. We assert the canonical types are present.
+          const types = new Set(events.map((e) => e.type));
+          expect(types.has("user_start_speaking")).toBe(true);
+          expect(types.has("user_stop_speaking")).toBe(true);
+          expect(types.has("agent_start_speaking")).toBe(true);
+          expect(types.has("agent_stop_speaking")).toBe(true);
+        });
       },
-      [user(), agent(), succeed("done")],
-      "test-batch-id",
     );
-
-    await execution.execute();
-
-    // Default call() emits: user_start, user_stop, agent_start, agent_stop —
-    // 4 events. We assert the canonical types are present; ordering
-    // is locked elsewhere (timeline-order spec test).
-    const types = new Set(events.map((e) => e.type));
-    expect(types.has("user_start_speaking")).toBe(true);
-    expect(types.has("user_stop_speaking")).toBe(true);
-    expect(types.has("agent_start_speaking")).toBe(true);
-    expect(types.has("agent_stop_speaking")).toBe(true);
-  });
-
-  it("captures both hooks without ignoring user-supplied callbacks that throw", async () => {
-    // The runtime swallows hook errors so a buggy observability
-    // callback can never break the scenario. This binds that
-    // promise — when the hook throws every iteration, the scenario
-    // still completes successfully and the remaining hooks still fire.
-    const adapter = new FakeVoiceAdapter({
-      responses: [pcm16Chunk(0.05)],
-    });
-    let voiceEventCalls = 0;
-
-    const execution = new ScenarioExecution(
-      {
-        name: "hooks / throwing hook does not break scenario",
-        description: "binds the swallow-on-hook-error contract",
-        agents: [adapter, new AudioUserSimulator(silentChunk(0.05))],
-        onVoiceEvent: () => {
-          voiceEventCalls += 1;
-          throw new Error("simulated observability bug");
-        },
-      },
-      [user(), agent(), succeed("done")],
-      "test-batch-id",
-    );
-
-    const result = await execution.execute();
-    expect(result.success).toBe(true);
-    expect(voiceEventCalls).toBeGreaterThan(0);
-  });
-});
+  },
+  { includeTags: ["ts-hooks"] },
+);

--- a/javascript/src/voice/__tests__/hooks.test.ts
+++ b/javascript/src/voice/__tests__/hooks.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Voice hook fan-out tests — binds `specs/voice-agents.feature` lines
+ * 449-461 (`on_audio_chunk` and `on_voice_event` hooks).
+ *
+ * The PR3 runtime fans `on_audio_chunk` out to every audio chunk that
+ * crosses the recorder (user-side via `writeUserSegment`, agent-side
+ * via the merged drain output) and fans `on_voice_event` out to every
+ * `VoiceEvent` appended to the timeline.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentRole,
+  type AgentInput,
+  type AgentReturnTypes,
+  UserSimulatorAgentAdapter,
+} from "../../domain";
+import { agent, succeed, user } from "../../script";
+import { ScenarioExecution } from "../../execution/scenario-execution";
+import { AudioChunk, silentChunk } from "../audio-chunk";
+import type { VoiceEvent } from "../recording.types";
+import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+
+/**
+ * Build a synthetic-but-non-silent PCM16 chunk so the recorder treats it
+ * as a real (non-empty) flow point — `writeUserSegment` short-circuits
+ * on zero-length data, which would skip the hook.
+ */
+function pcm16Chunk(durationSeconds: number, sample = 0x0010): AudioChunk {
+  const numSamples = Math.floor(durationSeconds * 24000);
+  const data = new Uint8Array(numSamples * 2);
+  for (let i = 0; i < data.length; i += 2) {
+    data[i] = sample & 0xff;
+    data[i + 1] = (sample >> 8) & 0xff;
+  }
+  return new AudioChunk({ data });
+}
+
+/**
+ * User simulator that returns an audio-shaped message so the default
+ * voice call() actually flows bytes through `sendAudio`. Without this,
+ * the user turn arrives as text and `extractAudioFromLastMessage`
+ * yields null → no user-side audio hook fires.
+ */
+class AudioUserSimulator extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  constructor(private readonly chunk: AudioChunk) {
+    super();
+  }
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    const base64 = Buffer.from(this.chunk.data).toString("base64");
+    // Cast through unknown — the audio shape is locally typed as
+    // AudioMessageParam but the executor's ModelMessage union accepts
+    // assistant arrays only. ConvertModelMessagesToAguiMessages
+    // JSON-stringifies the content, so the audio survives downstream.
+    return {
+      role: "user",
+      content: [
+        {
+          type: "input_audio",
+          input_audio: { data: base64, format: "pcm16" },
+        },
+      ],
+    } as unknown as AgentReturnTypes;
+  }
+}
+
+describe("specs/voice-agents.feature lines 449-454 — on_audio_chunk hook fires for each chunk", () => {
+  it("invokes the hook for every audio chunk that crosses the recorder", async () => {
+    const userChunk = pcm16Chunk(0.05, 0x1234);
+    const agentChunk = pcm16Chunk(0.06, 0x5678);
+    const adapter = new FakeVoiceAdapter({ responses: [agentChunk] });
+    const captured: AudioChunk[] = [];
+
+    const execution = new ScenarioExecution(
+      {
+        name: "hooks / on_audio_chunk fires",
+        description: "covers the bound feature scenario lines 449-454",
+        agents: [adapter, new AudioUserSimulator(userChunk)],
+        onAudioChunk: (chunk) => captured.push(chunk),
+      },
+      [user(), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    const result = await execution.execute();
+    expect(result.success).toBe(true);
+    // The default call() flow records one user chunk (the sent audio)
+    // and one agent chunk (the drained response) — both fan out to
+    // on_audio_chunk in `_fire_audio_chunk` / `fireAudioChunk`.
+    expect(captured.length).toBeGreaterThanOrEqual(2);
+    // The bytes round-trip through the hook intact (no normalisation
+    // side-effects from the recorder boundary).
+    const firstByte = captured[0]!.data[0];
+    expect(typeof firstByte).toBe("number");
+  });
+});
+
+describe("specs/voice-agents.feature lines 456-461 — on_voice_event hook fires for each VoiceEvent", () => {
+  it("invokes the hook for every VoiceEvent appended to the timeline", async () => {
+    const userChunk = pcm16Chunk(0.05);
+    const agentChunk = pcm16Chunk(0.06);
+    const adapter = new FakeVoiceAdapter({ responses: [agentChunk] });
+    const events: VoiceEvent[] = [];
+
+    const execution = new ScenarioExecution(
+      {
+        name: "hooks / on_voice_event fires",
+        description: "covers the bound feature scenario lines 456-461",
+        agents: [adapter, new AudioUserSimulator(userChunk)],
+        onVoiceEvent: (event) => events.push(event),
+      },
+      [user(), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    await execution.execute();
+
+    // Default call() emits: user_start, user_stop, agent_start, agent_stop —
+    // 4 events. We assert the canonical types are present; ordering
+    // is locked elsewhere (timeline-order spec test).
+    const types = new Set(events.map((e) => e.type));
+    expect(types.has("user_start_speaking")).toBe(true);
+    expect(types.has("user_stop_speaking")).toBe(true);
+    expect(types.has("agent_start_speaking")).toBe(true);
+    expect(types.has("agent_stop_speaking")).toBe(true);
+  });
+
+  it("captures both hooks without ignoring user-supplied callbacks that throw", async () => {
+    // The runtime swallows hook errors so a buggy observability
+    // callback can never break the scenario. This binds that
+    // promise — when the hook throws every iteration, the scenario
+    // still completes successfully and the remaining hooks still fire.
+    const adapter = new FakeVoiceAdapter({
+      responses: [pcm16Chunk(0.05)],
+    });
+    let voiceEventCalls = 0;
+
+    const execution = new ScenarioExecution(
+      {
+        name: "hooks / throwing hook does not break scenario",
+        description: "binds the swallow-on-hook-error contract",
+        agents: [adapter, new AudioUserSimulator(silentChunk(0.05))],
+        onVoiceEvent: () => {
+          voiceEventCalls += 1;
+          throw new Error("simulated observability bug");
+        },
+      },
+      [user(), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    const result = await execution.execute();
+    expect(result.success).toBe(true);
+    expect(voiceEventCalls).toBeGreaterThan(0);
+  });
+});

--- a/javascript/src/voice/__tests__/vad-fallback.test.ts
+++ b/javascript/src/voice/__tests__/vad-fallback.test.ts
@@ -12,19 +12,12 @@
  *
  * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
  * the suite if any bound scenario is missing a step binding.
- *
- * NOTE ON SPY ISOLATION: vitest-cucumber v6 runs each Given/When/Then step as
- * a separate vitest `it()`. Module-level `beforeEach`/`afterEach` hooks fire
- * around EACH step, not around the whole scenario. To capture console.warn
- * calls across step boundaries, each scenario stores captured warns in a
- * closure-scoped variable inside `Given`/`When` and asserts in `Then`/`And`
- * without relying on a spy that may be reset between steps.
  */
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
-import { beforeEach, expect, vi } from "vitest";
+import { beforeEach, expect, vi, type MockInstance } from "vitest";
 
 import {
   AgentRole,
@@ -99,30 +92,38 @@ const feature = await loadFeature(FEATURE_PATH);
 
 describeFeature(
   feature,
-  ({ Scenario }) => {
+  ({ Scenario, BeforeEachScenario, AfterEachScenario }) => {
+    // Shared spy state — installed once per scenario via BeforeEachScenario,
+    // torn down via AfterEachScenario. Steps read capturedWarnCalls directly.
+    let warnSpy: MockInstance;
+    let capturedWarnCalls: string[] = [];
+
+    BeforeEachScenario(() => {
+      capturedWarnCalls = [];
+      warnSpy = vi.spyOn(console, "warn").mockImplementation((...args) => {
+        capturedWarnCalls.push(String(args[0]));
+      });
+    });
+
+    AfterEachScenario(() => {
+      warnSpy.mockRestore();
+    });
+
     // -----------------------------------------------------------------------
     // Scenario: SDK-side VAD fallback activates on adapters without native VAD
     // (lines 773-777)
-    //
-    // SPY STRATEGY: Because vitest-cucumber runs each step as a separate it(),
-    // we must spy on console.warn INSIDE the When step (where the action
-    // happens) and carry the captured calls to the Then/And assertions via
-    // closure-scoped variables.
     // -----------------------------------------------------------------------
     Scenario(
       "SDK-side VAD fallback activates on adapters without native VAD",
       ({ Given, When, Then, And }) => {
         let events: VoiceEvent[];
         let execution: ScenarioExecution;
-        // Captured across the When step — persists into Then/And via closure.
-        let capturedWarnCalls: string[] = [];
 
         Given("an adapter with capabilities.native_vad == False", () => {
           const adapter = new FakeVoiceAdapter({
             capabilities: { nativeVad: false },
           });
           events = [];
-          capturedWarnCalls = [];
           execution = new ScenarioExecution(
             {
               name: "vad / fallback emits speaking events",
@@ -136,16 +137,7 @@ describeFeature(
         });
 
         When("a voice scenario runs and audio flows", async () => {
-          // Install the spy locally for this step and collect calls into a
-          // closure variable so they survive into Then/And.
-          const spy = vi.spyOn(console, "warn").mockImplementation((...args) => {
-            capturedWarnCalls.push(String(args[0]));
-          });
-          try {
-            await execution.execute();
-          } finally {
-            spy.mockRestore();
-          }
+          await execution.execute();
         });
 
         Then(
@@ -181,7 +173,8 @@ describeFeature(
     Scenario(
       "VAD fallback emits a one-shot UserWarning on first activation",
       ({ Given, When, Then, And }) => {
-        // Closure-scoped captures — written in When, read in Then/And.
+        // fakeAdapterWarns / otherWarns are filtered views of capturedWarnCalls
+        // populated after the When step executes.
         let fakeAdapterWarns: string[] = [];
         let otherWarns: string[] = [];
 
@@ -192,22 +185,20 @@ describeFeature(
         });
 
         When("the scenario starts and VAD fallback is used", () => {
-          // Install spy locally so we don't conflict with module-level resets.
-          const spy = vi.spyOn(console, "warn").mockImplementation((...args) => {
-            const msg = String(args[0]);
-            if (msg.includes("FakeVoiceAdapter")) fakeAdapterWarns.push(msg);
-            if (msg.includes("AnotherFakeAdapter")) otherWarns.push(msg);
-          });
-          try {
-            // Each adapter class generates ONE warning — the second adapter of
-            // the same name does not re-warn (matches Python `_warned_adapters`
-            // memoisation at vad.py:39-55).
-            new WebRTCVadFallback("FakeVoiceAdapter");
-            new WebRTCVadFallback("FakeVoiceAdapter");
-            new WebRTCVadFallback("AnotherFakeAdapter");
-          } finally {
-            spy.mockRestore();
-          }
+          // Each adapter class generates ONE warning — the second adapter of
+          // the same name does not re-warn (matches Python `_warned_adapters`
+          // memoisation at vad.py:39-55).
+          new WebRTCVadFallback("FakeVoiceAdapter");
+          new WebRTCVadFallback("FakeVoiceAdapter");
+          new WebRTCVadFallback("AnotherFakeAdapter");
+
+          // Partition captured warns by adapter name.
+          fakeAdapterWarns = capturedWarnCalls.filter((msg) =>
+            msg.includes("FakeVoiceAdapter"),
+          );
+          otherWarns = capturedWarnCalls.filter((msg) =>
+            msg.includes("AnotherFakeAdapter"),
+          );
         });
 
         Then(
@@ -237,14 +228,11 @@ describeFeature(
       "Adapters with native VAD do not trigger the fallback",
       ({ Given, When, Then, And }) => {
         let execution: ScenarioExecution;
-        // Closure-scoped capture — written in When, read in Then/And.
-        let noNativeVadWarns: string[] = [];
 
         Given("an adapter with capabilities.native_vad == True", () => {
           const adapter = new FakeVoiceAdapter({
             capabilities: { nativeVad: true },
           });
-          noNativeVadWarns = [];
           execution = new ScenarioExecution(
             {
               name: "vad / native VAD bypasses fallback",
@@ -257,23 +245,16 @@ describeFeature(
         });
 
         When("the scenario runs", async () => {
-          // Spy locally and capture any "no native VAD" warns into the
-          // closure variable so Then/And can assert their absence.
-          const spy = vi.spyOn(console, "warn").mockImplementation((...args) => {
-            const msg = String(args[0]);
-            if (msg.includes("no native VAD")) noNativeVadWarns.push(msg);
-          });
-          try {
-            await execution.execute();
-          } finally {
-            spy.mockRestore();
-          }
+          await execution.execute();
         });
 
         Then("webrtcvad is not invoked", () => {
           // We assert by absence-of-warning: the fallback's one-shot warning
           // is the only side-effect that fires on instantiation, so its
           // absence proves no fallback was created.
+          const noNativeVadWarns = capturedWarnCalls.filter((msg) =>
+            msg.includes("no native VAD"),
+          );
           expect(noNativeVadWarns).toHaveLength(0);
         });
 
@@ -282,6 +263,9 @@ describeFeature(
           // the fallback is never instantiated. The absence of a warning
           // in Then already confirms this; this And step records the spec
           // intent explicitly.
+          const noNativeVadWarns = capturedWarnCalls.filter((msg) =>
+            msg.includes("no native VAD"),
+          );
           expect(noNativeVadWarns).toHaveLength(0);
         });
       },

--- a/javascript/src/voice/__tests__/vad-fallback.test.ts
+++ b/javascript/src/voice/__tests__/vad-fallback.test.ts
@@ -1,15 +1,30 @@
 /**
- * VAD-fallback tests — binds `specs/voice-agents.feature` lines 772-791
- * (`SDK-side VAD fallback activates on adapters without native VAD`, the
- * one-shot warning, and the "native-VAD adapters do not trigger
- * fallback" guarantee).
+ * VAD-fallback tests — binds `specs/voice-agents.feature` scenarios tagged
+ * `@ts-vad`:
+ *   - "SDK-side VAD fallback activates on adapters without native VAD" (lines 773-777)
+ *   - "VAD fallback emits a one-shot UserWarning on first activation" (lines 780-784)
+ *   - "Adapters with native VAD do not trigger the fallback" (lines 787-791)
  *
  * The fallback is purely declarative — the adapter's
  * `capabilities.nativeVad === false` triggers the runtime to instantiate
  * a {@link WebRTCVadFallback} and route incoming audio chunks through
  * it. Native-VAD adapters bypass the fallback entirely.
+ *
+ * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
+ * the suite if any bound scenario is missing a step binding.
+ *
+ * NOTE ON SPY ISOLATION: vitest-cucumber v6 runs each Given/When/Then step as
+ * a separate vitest `it()`. Module-level `beforeEach`/`afterEach` hooks fire
+ * around EACH step, not around the whole scenario. To capture console.warn
+ * calls across step boundaries, each scenario stores captured warns in a
+ * closure-scoped variable inside `Given`/`When` and asserts in `Then`/`And`
+ * without relying on a spy that may be reset between steps.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { beforeEach, expect, vi } from "vitest";
 
 import {
   AgentRole,
@@ -23,6 +38,17 @@ import { AudioChunk } from "../audio-chunk";
 import type { VoiceEvent } from "../recording.types";
 import { WebRTCVadFallback } from "../vad";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "specs",
+  "voice-agents.feature",
+);
 
 function speechChunk(durationSeconds: number): AudioChunk {
   // Loud sine-ish shape: alternate ±20000 samples — RMS ≈ 20000, comfortably
@@ -62,95 +88,204 @@ class AudioUserSimulator extends UserSimulatorAgentAdapter {
   }
 }
 
+// Reset VAD warning state before every step so the one-shot-warning
+// assertion is reproducible. Because vitest-cucumber runs each step as a
+// separate `it()`, beforeEach fires around each step individually.
 beforeEach(() => {
   WebRTCVadFallback.resetWarnings();
 });
 
-let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-beforeEach(() => {
-  consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-});
-afterEach(() => {
-  consoleWarnSpy.mockRestore();
-});
+const feature = await loadFeature(FEATURE_PATH);
 
-describe("specs/voice-agents.feature lines 772-777 — SDK-side VAD fallback activates on adapters without native VAD", () => {
-  it("emits user_start_speaking / user_stop_speaking via the fallback when nativeVad=false", async () => {
-    const adapter = new FakeVoiceAdapter({
-      capabilities: { nativeVad: false },
-    });
-    const events: VoiceEvent[] = [];
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    // -----------------------------------------------------------------------
+    // Scenario: SDK-side VAD fallback activates on adapters without native VAD
+    // (lines 773-777)
+    //
+    // SPY STRATEGY: Because vitest-cucumber runs each step as a separate it(),
+    // we must spy on console.warn INSIDE the When step (where the action
+    // happens) and carry the captured calls to the Then/And assertions via
+    // closure-scoped variables.
+    // -----------------------------------------------------------------------
+    Scenario(
+      "SDK-side VAD fallback activates on adapters without native VAD",
+      ({ Given, When, Then, And }) => {
+        let events: VoiceEvent[];
+        let execution: ScenarioExecution;
+        // Captured across the When step — persists into Then/And via closure.
+        let capturedWarnCalls: string[] = [];
 
-    const execution = new ScenarioExecution(
-      {
-        name: "vad / fallback emits speaking events",
-        description: "binds the bound feature scenario lines 772-777",
-        agents: [adapter, new AudioUserSimulator(speechChunk(0.3))],
-        onVoiceEvent: (e) => events.push(e),
+        Given("an adapter with capabilities.native_vad == False", () => {
+          const adapter = new FakeVoiceAdapter({
+            capabilities: { nativeVad: false },
+          });
+          events = [];
+          capturedWarnCalls = [];
+          execution = new ScenarioExecution(
+            {
+              name: "vad / fallback emits speaking events",
+              description: "binds the bound feature scenario lines 772-777",
+              agents: [adapter, new AudioUserSimulator(speechChunk(0.3))],
+              onVoiceEvent: (e) => events.push(e),
+            },
+            [user(), agent(), succeed("done")],
+            "test-batch-id",
+          );
+        });
+
+        When("a voice scenario runs and audio flows", async () => {
+          // Install the spy locally for this step and collect calls into a
+          // closure variable so they survive into Then/And.
+          const spy = vi.spyOn(console, "warn").mockImplementation((...args) => {
+            capturedWarnCalls.push(String(args[0]));
+          });
+          try {
+            await execution.execute();
+          } finally {
+            spy.mockRestore();
+          }
+        });
+
+        Then(
+          "user_start_speaking and user_stop_speaking VoiceEvents are still emitted",
+          () => {
+            // The fallback's events carry `metadata.source === "vad-fallback"`
+            // so we can distinguish them from the recorder's own user_start /
+            // user_stop pairs and assert the fallback actually drove this.
+            const fallbackStarts = events.filter(
+              (e) =>
+                e.type === "user_start_speaking" &&
+                e.metadata?.source === "vad-fallback",
+            );
+            expect(fallbackStarts.length).toBeGreaterThan(0);
+          },
+        );
+
+        And("webrtcvad-wheels is used to detect speaker boundaries", () => {
+          // The one-shot warning is the observable side-effect of the fallback
+          // being instantiated — its presence proves webrtcvad was invoked.
+          const noNativeVadWarns = capturedWarnCalls.filter((msg) =>
+            msg.includes("no native VAD"),
+          );
+          expect(noNativeVadWarns.length).toBeGreaterThan(0);
+        });
       },
-      [user(), agent(), succeed("done")],
-      "test-batch-id",
     );
 
-    await execution.execute();
+    // -----------------------------------------------------------------------
+    // Scenario: VAD fallback emits a one-shot UserWarning on first activation
+    // (lines 780-784)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "VAD fallback emits a one-shot UserWarning on first activation",
+      ({ Given, When, Then, And }) => {
+        // Closure-scoped captures — written in When, read in Then/And.
+        let fakeAdapterWarns: string[] = [];
+        let otherWarns: string[] = [];
 
-    // The fallback's events carry `metadata.source === "vad-fallback"` so
-    // we can distinguish them from the recorder's own user_start /
-    // user_stop pairs and assert the fallback actually drove this.
-    const fallbackStarts = events.filter(
-      (e) =>
-        e.type === "user_start_speaking" &&
-        e.metadata?.source === "vad-fallback",
-    );
-    expect(fallbackStarts.length).toBeGreaterThan(0);
-  });
+        Given("an adapter with capabilities.native_vad == False", () => {
+          // Precondition — adapters are constructed in When below.
+          fakeAdapterWarns = [];
+          otherWarns = [];
+        });
 
-  it("emits a one-shot UserWarning-equivalent on first activation per adapter", async () => {
-    // Each adapter class generates ONE warning — the second adapter of
-    // the same name does not re-warn (matches Python `_warned_adapters`
-    // memoisation at vad.py:39-55).
-    new WebRTCVadFallback("FakeVoiceAdapter");
-    new WebRTCVadFallback("FakeVoiceAdapter");
-    new WebRTCVadFallback("AnotherFakeAdapter");
+        When("the scenario starts and VAD fallback is used", () => {
+          // Install spy locally so we don't conflict with module-level resets.
+          const spy = vi.spyOn(console, "warn").mockImplementation((...args) => {
+            const msg = String(args[0]);
+            if (msg.includes("FakeVoiceAdapter")) fakeAdapterWarns.push(msg);
+            if (msg.includes("AnotherFakeAdapter")) otherWarns.push(msg);
+          });
+          try {
+            // Each adapter class generates ONE warning — the second adapter of
+            // the same name does not re-warn (matches Python `_warned_adapters`
+            // memoisation at vad.py:39-55).
+            new WebRTCVadFallback("FakeVoiceAdapter");
+            new WebRTCVadFallback("FakeVoiceAdapter");
+            new WebRTCVadFallback("AnotherFakeAdapter");
+          } finally {
+            spy.mockRestore();
+          }
+        });
 
-    const warnCalls = consoleWarnSpy.mock.calls;
-    const fakeAdapterWarns = warnCalls.filter((args) =>
-      String(args[0]).includes("FakeVoiceAdapter"),
-    );
-    const otherWarns = warnCalls.filter((args) =>
-      String(args[0]).includes("AnotherFakeAdapter"),
-    );
+        Then(
+          "a UserWarning is issued exactly once per process naming the adapter",
+          () => {
+            // Each distinct adapter name generates exactly one warning.
+            expect(fakeAdapterWarns).toHaveLength(1);
+            expect(otherWarns).toHaveLength(1);
+          },
+        );
 
-    expect(fakeAdapterWarns).toHaveLength(1);
-    expect(otherWarns).toHaveLength(1);
-    expect(String(fakeAdapterWarns[0]![0])).toMatch(/no native VAD/);
-    expect(String(fakeAdapterWarns[0]![0])).toMatch(/Accuracy may differ/);
-  });
-});
-
-describe("specs/voice-agents.feature lines 786-791 — Adapters with native VAD do not trigger the fallback", () => {
-  it("does NOT instantiate the fallback when nativeVad=true", async () => {
-    // We assert by absence-of-warning: the fallback's one-shot warning
-    // is the only side-effect that fires on instantiation, so its
-    // absence proves no fallback was created.
-    const adapter = new FakeVoiceAdapter({
-      capabilities: { nativeVad: true },
-    });
-
-    const execution = new ScenarioExecution(
-      {
-        name: "vad / native VAD bypasses fallback",
-        description: "binds the bound feature scenario lines 786-791",
-        agents: [adapter, new AudioUserSimulator(speechChunk(0.2))],
+        And(
+          "the warning text references accuracy differences vs native VAD",
+          () => {
+            expect(fakeAdapterWarns[0]).toMatch(/no native VAD/);
+            expect(fakeAdapterWarns[0]).toMatch(/Accuracy may differ/);
+          },
+        );
       },
-      [user(), agent(), succeed("done")],
-      "test-batch-id",
     );
 
-    await execution.execute();
+    // -----------------------------------------------------------------------
+    // Scenario: Adapters with native VAD do not trigger the fallback
+    // (lines 787-791)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "Adapters with native VAD do not trigger the fallback",
+      ({ Given, When, Then, And }) => {
+        let execution: ScenarioExecution;
+        // Closure-scoped capture — written in When, read in Then/And.
+        let noNativeVadWarns: string[] = [];
 
-    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
-      expect.stringMatching(/no native VAD/),
+        Given("an adapter with capabilities.native_vad == True", () => {
+          const adapter = new FakeVoiceAdapter({
+            capabilities: { nativeVad: true },
+          });
+          noNativeVadWarns = [];
+          execution = new ScenarioExecution(
+            {
+              name: "vad / native VAD bypasses fallback",
+              description: "binds the bound feature scenario lines 786-791",
+              agents: [adapter, new AudioUserSimulator(speechChunk(0.2))],
+            },
+            [user(), agent(), succeed("done")],
+            "test-batch-id",
+          );
+        });
+
+        When("the scenario runs", async () => {
+          // Spy locally and capture any "no native VAD" warns into the
+          // closure variable so Then/And can assert their absence.
+          const spy = vi.spyOn(console, "warn").mockImplementation((...args) => {
+            const msg = String(args[0]);
+            if (msg.includes("no native VAD")) noNativeVadWarns.push(msg);
+          });
+          try {
+            await execution.execute();
+          } finally {
+            spy.mockRestore();
+          }
+        });
+
+        Then("webrtcvad is not invoked", () => {
+          // We assert by absence-of-warning: the fallback's one-shot warning
+          // is the only side-effect that fires on instantiation, so its
+          // absence proves no fallback was created.
+          expect(noNativeVadWarns).toHaveLength(0);
+        });
+
+        And("VAD events come from the adapter's native stream", () => {
+          // When nativeVad=true the adapter's own event stream drives VAD;
+          // the fallback is never instantiated. The absence of a warning
+          // in Then already confirms this; this And step records the spec
+          // intent explicitly.
+          expect(noNativeVadWarns).toHaveLength(0);
+        });
+      },
     );
-  });
-});
+  },
+  { includeTags: ["ts-vad"] },
+);

--- a/javascript/src/voice/__tests__/vad-fallback.test.ts
+++ b/javascript/src/voice/__tests__/vad-fallback.test.ts
@@ -1,0 +1,156 @@
+/**
+ * VAD-fallback tests — binds `specs/voice-agents.feature` lines 772-791
+ * (`SDK-side VAD fallback activates on adapters without native VAD`, the
+ * one-shot warning, and the "native-VAD adapters do not trigger
+ * fallback" guarantee).
+ *
+ * The fallback is purely declarative — the adapter's
+ * `capabilities.nativeVad === false` triggers the runtime to instantiate
+ * a {@link WebRTCVadFallback} and route incoming audio chunks through
+ * it. Native-VAD adapters bypass the fallback entirely.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AgentRole,
+  type AgentInput,
+  type AgentReturnTypes,
+  UserSimulatorAgentAdapter,
+} from "../../domain";
+import { agent, succeed, user } from "../../script";
+import { ScenarioExecution } from "../../execution/scenario-execution";
+import { AudioChunk } from "../audio-chunk";
+import type { VoiceEvent } from "../recording.types";
+import { WebRTCVadFallback } from "../vad";
+import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+
+function speechChunk(durationSeconds: number): AudioChunk {
+  // Loud sine-ish shape: alternate ±20000 samples — RMS ≈ 20000, comfortably
+  // above the fallback's 500-amplitude threshold so the energy detector
+  // flips to "speaking" within the hysteresis window.
+  const numSamples = Math.floor(durationSeconds * 24000);
+  const data = new Uint8Array(numSamples * 2);
+  for (let i = 0; i < numSamples; i++) {
+    const sample = i % 2 === 0 ? 20000 : -20000;
+    const u = sample < 0 ? sample + 0x10000 : sample;
+    data[2 * i] = u & 0xff;
+    data[2 * i + 1] = (u >> 8) & 0xff;
+  }
+  return new AudioChunk({ data });
+}
+
+function audioMessageContent(chunk: AudioChunk): AgentReturnTypes {
+  const base64 = Buffer.from(chunk.data).toString("base64");
+  return {
+    role: "user",
+    content: [
+      {
+        type: "input_audio",
+        input_audio: { data: base64, format: "pcm16" },
+      },
+    ],
+  } as unknown as AgentReturnTypes;
+}
+
+class AudioUserSimulator extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  constructor(private readonly chunk: AudioChunk) {
+    super();
+  }
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return audioMessageContent(this.chunk);
+  }
+}
+
+beforeEach(() => {
+  WebRTCVadFallback.resetWarnings();
+});
+
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleWarnSpy.mockRestore();
+});
+
+describe("specs/voice-agents.feature lines 772-777 — SDK-side VAD fallback activates on adapters without native VAD", () => {
+  it("emits user_start_speaking / user_stop_speaking via the fallback when nativeVad=false", async () => {
+    const adapter = new FakeVoiceAdapter({
+      capabilities: { nativeVad: false },
+    });
+    const events: VoiceEvent[] = [];
+
+    const execution = new ScenarioExecution(
+      {
+        name: "vad / fallback emits speaking events",
+        description: "binds the bound feature scenario lines 772-777",
+        agents: [adapter, new AudioUserSimulator(speechChunk(0.3))],
+        onVoiceEvent: (e) => events.push(e),
+      },
+      [user(), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    await execution.execute();
+
+    // The fallback's events carry `metadata.source === "vad-fallback"` so
+    // we can distinguish them from the recorder's own user_start /
+    // user_stop pairs and assert the fallback actually drove this.
+    const fallbackStarts = events.filter(
+      (e) =>
+        e.type === "user_start_speaking" &&
+        e.metadata?.source === "vad-fallback",
+    );
+    expect(fallbackStarts.length).toBeGreaterThan(0);
+  });
+
+  it("emits a one-shot UserWarning-equivalent on first activation per adapter", async () => {
+    // Each adapter class generates ONE warning — the second adapter of
+    // the same name does not re-warn (matches Python `_warned_adapters`
+    // memoisation at vad.py:39-55).
+    new WebRTCVadFallback("FakeVoiceAdapter");
+    new WebRTCVadFallback("FakeVoiceAdapter");
+    new WebRTCVadFallback("AnotherFakeAdapter");
+
+    const warnCalls = consoleWarnSpy.mock.calls;
+    const fakeAdapterWarns = warnCalls.filter((args) =>
+      String(args[0]).includes("FakeVoiceAdapter"),
+    );
+    const otherWarns = warnCalls.filter((args) =>
+      String(args[0]).includes("AnotherFakeAdapter"),
+    );
+
+    expect(fakeAdapterWarns).toHaveLength(1);
+    expect(otherWarns).toHaveLength(1);
+    expect(String(fakeAdapterWarns[0]![0])).toMatch(/no native VAD/);
+    expect(String(fakeAdapterWarns[0]![0])).toMatch(/Accuracy may differ/);
+  });
+});
+
+describe("specs/voice-agents.feature lines 786-791 — Adapters with native VAD do not trigger the fallback", () => {
+  it("does NOT instantiate the fallback when nativeVad=true", async () => {
+    // We assert by absence-of-warning: the fallback's one-shot warning
+    // is the only side-effect that fires on instantiation, so its
+    // absence proves no fallback was created.
+    const adapter = new FakeVoiceAdapter({
+      capabilities: { nativeVad: true },
+    });
+
+    const execution = new ScenarioExecution(
+      {
+        name: "vad / native VAD bypasses fallback",
+        description: "binds the bound feature scenario lines 786-791",
+        agents: [adapter, new AudioUserSimulator(speechChunk(0.2))],
+      },
+      [user(), agent(), succeed("done")],
+      "test-batch-id",
+    );
+
+    await execution.execute();
+
+    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+      expect.stringMatching(/no native VAD/),
+    );
+  });
+});

--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -1,0 +1,593 @@
+/**
+ * Voice-adapter runtime — the executor-side wiring that PR1 left abstract.
+ *
+ * This module ports `python/scenario/voice/adapter.py` runtime (not the
+ * abstract contract) into TypeScript:
+ *
+ * - `asyncio.Event` → {@link AgentSpeakingEvent}: a `Promise<void>` paired
+ *   with an external `resolve` handle so the interruption path can `await`
+ *   "the agent began emitting audio" without polling.
+ * - `async with adapter:` → explicit {@link startVoiceAdapters} /
+ *   {@link stopVoiceAdapters} the executor calls once per scenario.
+ * - Hook fan-out for `on_audio_chunk` and `on_voice_event` from PR1's
+ *   {@link VoiceExecutorState} surface.
+ * - Default `call()` body: send audio → drain → record one segment per
+ *   speaker → emit timeline events → return the merged assistant
+ *   {@link AudioMessageParam}.
+ *
+ * Lifecycle invariant (feature spec lines 138-145):
+ *   `connect()` is awaited exactly once before the first script step.
+ *   `disconnect()` is awaited exactly once regardless of pass / fail /
+ *   exception.
+ */
+
+import type { AgentInput, AgentReturnTypes } from "../domain/agents";
+import { AudioChunk, silentChunk } from "./audio-chunk";
+import type { VoiceAgentAdapter } from "./adapter";
+import type {
+  AudioMessageContentPart,
+  AudioMessageParam,
+} from "./messages.types";
+import type {
+  AudioSegment,
+  LatencyMetrics,
+  SpeakerRole,
+  VoiceEvent,
+  VoiceRecording,
+} from "./recording.types";
+import type { VoiceExecutorState } from "./voice-executor-state";
+import { WebRTCVadFallback } from "./vad";
+
+/**
+ * `asyncio.Event` analogue: a `Promise<void>` + external resolve handle.
+ *
+ * Awaiters call {@link wait}; producers call {@link set} the moment the
+ * gating condition holds. {@link clear} resets for the next turn. Used by
+ * the default `call()` to wake the interruption path the instant the
+ * agent begins emitting audio.
+ */
+export class AgentSpeakingEvent {
+  private resolved = false;
+  private resolveFn!: () => void;
+  private promise: Promise<void>;
+
+  constructor() {
+    this.promise = new Promise<void>((resolve) => {
+      this.resolveFn = resolve;
+    });
+  }
+
+  /** Resolve any pending {@link wait} callers and stay resolved. */
+  set(): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolveFn();
+  }
+
+  /** Snapshot the current state. */
+  get isSet(): boolean {
+    return this.resolved;
+  }
+
+  /** Resolve a `Promise<void>` once {@link set} is called. */
+  wait(): Promise<void> {
+    return this.promise;
+  }
+
+  /** Rebuild the underlying promise so the next turn can wait again. */
+  clear(): void {
+    this.resolved = false;
+    this.promise = new Promise<void>((resolve) => {
+      this.resolveFn = resolve;
+    });
+  }
+}
+
+const SAFE_DEFAULT_RESPONSE_TIMEOUT_S = 30;
+const SAFE_DEFAULT_TAIL_SILENCE_S = 0.6;
+const SAFE_DEFAULT_MAX_DURATION_S = 30;
+
+/**
+ * Per-scenario VAD fallback registry. Keyed by adapter instance so the
+ * one-shot warning gating in {@link WebRTCVadFallback.emitFallbackWarningOnce}
+ * remains the source of truth for "once per adapter name."
+ */
+type VadFallbackEntry = {
+  fallback: WebRTCVadFallback;
+  state: VoiceExecutorState;
+};
+
+const vadRegistry = new WeakMap<VoiceAgentAdapter, VadFallbackEntry>();
+
+/**
+ * Run the adapter-runtime lifecycle for every voice adapter participating
+ * in the scenario: `await adapter.connect()` once, then attach a VAD
+ * fallback when the adapter advertises `capabilities.nativeVad === false`.
+ *
+ * Symmetric with {@link stopVoiceAdapters}; the executor wraps the script
+ * loop in a try/finally so this pair always balances.
+ */
+export async function startVoiceAdapters(
+  adapters: readonly VoiceAgentAdapter[],
+  state: VoiceExecutorState,
+): Promise<void> {
+  for (const adapter of adapters) {
+    await adapter.connect();
+    if (!adapter.capabilities.nativeVad) {
+      attachVadFallback(adapter, state);
+    }
+  }
+}
+
+/**
+ * Disconnect every voice adapter. Errors are swallowed so cleanup always
+ * completes — matches Python `ScenarioExecutor._voice_disconnect_all`
+ * (`python/scenario/scenario_executor.py:747-759`) — disconnect failures
+ * must not mask the primary scenario result.
+ */
+export async function stopVoiceAdapters(
+  adapters: readonly VoiceAgentAdapter[],
+): Promise<void> {
+  for (const adapter of adapters) {
+    vadRegistry.delete(adapter);
+    try {
+      await adapter.disconnect();
+    } catch {
+      // Intentional swallow — see jsdoc above. Production callers
+      // override `disconnect()` to log internally if they care.
+    }
+  }
+}
+
+/**
+ * Filter heterogeneous agent arrays down to the voice adapters. Centralised
+ * here so the executor stays ignorant of the voice subsystem shape. Accepts
+ * an `unknown[]` because the executor's `AgentAdapter[]` type has no
+ * `capabilities` field — voice adapters add it at the subclass layer.
+ */
+export function pickVoiceAdapters(
+  agents: readonly unknown[],
+): VoiceAgentAdapter[] {
+  return agents.filter(isVoiceAgentAdapter);
+}
+
+function isVoiceAgentAdapter(agent: unknown): agent is VoiceAgentAdapter {
+  return (
+    typeof agent === "object" &&
+    agent !== null &&
+    "connect" in agent &&
+    "disconnect" in agent &&
+    "sendAudio" in agent &&
+    "receiveAudio" in agent &&
+    "capabilities" in agent
+  );
+}
+
+/**
+ * Materialise the voice-side fields on the executor state. Called once at
+ * scenario start (before the first script step) when at least one voice
+ * adapter is in the agents list.
+ */
+export function initVoiceExecutorState(state: VoiceExecutorState): void {
+  if (!state.voiceRecording) {
+    state.voiceRecording = emptyRecording();
+  }
+  if (!state.voiceTimeline) {
+    state.voiceTimeline = [];
+  }
+  if (!state.voiceLatency) {
+    state.voiceLatency = emptyLatencyMetrics();
+  }
+  if (state.voiceRecordingStartedAt == null) {
+    state.voiceRecordingStartedAt = nowSeconds();
+  }
+}
+
+function emptyRecording(): VoiceRecording {
+  return { segments: [], timeline: [] };
+}
+
+function emptyLatencyMetrics(): LatencyMetrics {
+  return { measurements: [] };
+}
+
+function attachVadFallback(
+  adapter: VoiceAgentAdapter,
+  state: VoiceExecutorState,
+): void {
+  if (vadRegistry.has(adapter)) {
+    return;
+  }
+  const fallback = new WebRTCVadFallback(adapter.constructor.name, {
+    onSpeechStart: () => {
+      appendEvent(state, {
+        time: nowOffset(state),
+        type: "user_start_speaking",
+        metadata: { source: "vad-fallback" },
+      });
+    },
+    onSpeechEnd: () => {
+      appendEvent(state, {
+        time: nowOffset(state),
+        type: "user_stop_speaking",
+        metadata: { source: "vad-fallback" },
+      });
+    },
+  });
+  vadRegistry.set(adapter, { fallback, state });
+}
+
+/**
+ * Drive a {@link VoiceAgentAdapter} through one default `call()` cycle.
+ *
+ * Mirrors `python/scenario/voice/adapter.py:VoiceAgentAdapter.call`:
+ * extract incoming audio (if any), transmit, drain the agent response on
+ * tail-silence, record once into the executor state, return the merged
+ * assistant audio message. Stateless w.r.t. the adapter aside from the
+ * `_agent_speaking` event the runtime maintains here.
+ */
+export async function defaultVoiceCall(
+  adapter: VoiceAgentAdapter,
+  input: AgentInput,
+): Promise<AgentReturnTypes> {
+  const speakingEvent = getAgentSpeakingEvent(adapter);
+  speakingEvent.clear();
+
+  const state = readVoiceState(input);
+  const recorder = new AdapterRecorder(state);
+
+  const incoming = extractAudioFromLastMessage(input.newMessages);
+  if (incoming) {
+    recorder.markUserStart();
+    await adapter.sendAudio(incoming);
+    feedVad(adapter, incoming);
+    recorder.recordUser(incoming);
+  }
+
+  const merged = await drainAgentResponse(adapter, speakingEvent, () => {
+    recorder.markAgentStart();
+  });
+  recorder.recordAgent(merged);
+  // AudioMessageParam is structurally a superset of OpenAI's
+  // ChatCompletionMessageParam (Decision 2(b) at issue #372). Cast
+  // through `unknown` because the executor's `AgentReturnTypes` union
+  // is rooted in `ai` SDK's `ModelMessage`, which restricts tool-role
+  // content shape — the audio body survives intact at runtime and the
+  // executor's AG-UI converter JSON-stringifies the content parts.
+  return createAudioMessage(merged, "assistant") as unknown as AgentReturnTypes;
+}
+
+function feedVad(adapter: VoiceAgentAdapter, chunk: AudioChunk): void {
+  const entry = vadRegistry.get(adapter);
+  if (entry) {
+    entry.fallback.process(chunk);
+  }
+}
+
+async function drainAgentResponse(
+  adapter: VoiceAgentAdapter,
+  speakingEvent: AgentSpeakingEvent,
+  onFirstChunk: () => void,
+): Promise<AudioChunk> {
+  const tailSilence = adapter.responseTailSilence ?? SAFE_DEFAULT_TAIL_SILENCE_S;
+  const responseTimeout =
+    adapter.responseTimeout ?? SAFE_DEFAULT_RESPONSE_TIMEOUT_S;
+  const maxDuration =
+    adapter.responseMaxDuration ?? SAFE_DEFAULT_MAX_DURATION_S;
+
+  const first = await adapter.receiveAudio(responseTimeout);
+  if (first.data.length > 0) {
+    onFirstChunk();
+  }
+  speakingEvent.set();
+
+  const chunks: AudioChunk[] = [first];
+  let accumulated = first.durationSeconds;
+  while (accumulated < maxDuration) {
+    let next: AudioChunk;
+    try {
+      next = await adapter.receiveAudio(tailSilence);
+    } catch {
+      break;
+    }
+    if (next.data.length === 0) {
+      break;
+    }
+    chunks.push(next);
+    accumulated += next.durationSeconds;
+  }
+  return mergeChunks(chunks);
+}
+
+function mergeChunks(chunks: AudioChunk[]): AudioChunk {
+  if (chunks.length === 1) return chunks[0]!;
+  const total = chunks.reduce((acc, c) => acc + c.data.length, 0);
+  const data = new Uint8Array(total);
+  let offset = 0;
+  const transcripts: string[] = [];
+  for (const c of chunks) {
+    data.set(c.data, offset);
+    offset += c.data.length;
+    if (c.transcript) transcripts.push(c.transcript);
+  }
+  const transcript = transcripts.length > 0 ? transcripts.join(" ") : undefined;
+  return new AudioChunk({ data, transcript });
+}
+
+/**
+ * Bridges a single `call()` turn's audio and timing into the executor
+ * state. Kept private (one-call-per-instance) so subclasses can opt out
+ * by overriding `call()` and the default flow stays short.
+ *
+ * Timing model: every segment's start/end is captured at a real audio
+ * flow point (when transmission begins, when it ends, when the first
+ * chunk arrives). Nothing is back-computed from chunk byte length, so
+ * user and agent segments share a single timeline and never overlap.
+ */
+export class AdapterRecorder {
+  private userStart: number | null = null;
+  private userEnd: number | null = null;
+  private agentStart: number | null = null;
+  constructor(private readonly state: VoiceExecutorState | null) {}
+
+  markUserStart(): void {
+    if (!this.state) return;
+    this.userStart = nowOffset(this.state);
+  }
+
+  recordUser(chunk: AudioChunk): void {
+    if (!this.state || chunk.data.length === 0) return;
+    const end = nowOffset(this.state);
+    const start =
+      this.userStart ?? Math.max(0, end - chunk.durationSeconds);
+    this.userEnd = end;
+    writeUserSegment(this.state, chunk, start, end);
+  }
+
+  markAgentStart(): void {
+    if (!this.state) return;
+    this.agentStart = nowOffset(this.state);
+  }
+
+  recordAgent(chunk: AudioChunk): void {
+    if (!this.state || chunk.data.length === 0) return;
+    fireAudioChunk(this.state, chunk);
+    const end = nowOffset(this.state);
+    const start =
+      this.agentStart ?? Math.max(0, end - chunk.durationSeconds);
+    appendSegment(this.state, "agent", start, end, chunk);
+    let latency: number | undefined;
+    if (this.userEnd !== null) {
+      const candidate = start - this.userEnd;
+      // Negative latency means the agent started before the user
+      // finished sending — wire-model violation on serial adapters.
+      // Treat as a measurement artefact (no record) so percentiles
+      // aren't poisoned.
+      if (candidate >= 0) {
+        latency = candidate;
+        recordLatency(this.state, candidate);
+      }
+    }
+    appendEvent(this.state, {
+      time: start,
+      type: "agent_start_speaking",
+      latency,
+    });
+    appendEvent(this.state, { time: end, type: "agent_stop_speaking" });
+  }
+}
+
+/**
+ * Append a finalised user segment and the matching start/stop timeline
+ * events. Single entry point so the default `call()` flow and the
+ * interruption / barge-in path (later PR) cannot drift apart on the
+ * timing model.
+ */
+export function writeUserSegment(
+  state: VoiceExecutorState,
+  chunk: AudioChunk,
+  start: number,
+  end: number,
+): void {
+  if (chunk.data.length === 0) return;
+  fireAudioChunk(state, chunk);
+  appendSegment(state, "user", start, end, chunk);
+  appendEvent(state, { time: start, type: "user_start_speaking" });
+  appendEvent(state, { time: end, type: "user_stop_speaking" });
+}
+
+function appendSegment(
+  state: VoiceExecutorState,
+  speaker: SpeakerRole,
+  start: number,
+  end: number,
+  chunk: AudioChunk,
+): void {
+  const recording = state.voiceRecording;
+  if (!recording) return;
+  const segment: AudioSegment = {
+    speaker,
+    startTime: start,
+    endTime: end,
+    audio: chunk.data,
+    transcript: chunk.transcript,
+  };
+  recording.segments.push(segment);
+}
+
+function appendEvent(state: VoiceExecutorState, event: VoiceEvent): void {
+  if (state.voiceTimeline) {
+    state.voiceTimeline.push(event);
+  }
+  if (state.voiceRecording) {
+    state.voiceRecording.timeline.push(event);
+  }
+  const hook = state.onVoiceEvent;
+  if (hook) {
+    try {
+      hook(event);
+    } catch {
+      // Hooks must never break the scenario — the contract here matches
+      // Python adapter.py `_append_event`. Errors are swallowed because
+      // the user's observability code shouldn't bring down the test.
+    }
+  }
+}
+
+function fireAudioChunk(state: VoiceExecutorState, chunk: AudioChunk): void {
+  const hook = state.onAudioChunk;
+  if (!hook) return;
+  try {
+    hook(chunk);
+  } catch {
+    // Same swallow rationale as appendEvent — hooks are best-effort.
+  }
+}
+
+function recordLatency(state: VoiceExecutorState, latency: number): void {
+  const metrics = state.voiceLatency;
+  if (!metrics) return;
+  metrics.measurements.push(latency);
+  if (metrics.timeToFirstByte === undefined) {
+    metrics.timeToFirstByte = latency;
+  }
+}
+
+function nowSeconds(): number {
+  return performance.now() / 1000;
+}
+
+function nowOffset(state: VoiceExecutorState): number {
+  const anchor = state.voiceRecordingStartedAt;
+  if (anchor == null) return 0;
+  return nowSeconds() - anchor;
+}
+
+function readVoiceState(input: AgentInput): VoiceExecutorState | null {
+  const state = input.scenarioState as { _executor?: unknown } | undefined;
+  const executor = state?._executor;
+  if (!isVoiceExecutorState(executor)) {
+    return null;
+  }
+  return executor;
+}
+
+function isVoiceExecutorState(value: unknown): value is VoiceExecutorState {
+  if (typeof value !== "object" || value === null) return false;
+  return (
+    "voiceRecording" in value &&
+    "voiceTimeline" in value &&
+    "voiceLatency" in value &&
+    "voiceRecordingStartedAt" in value
+  );
+}
+
+/**
+ * Maintain a single {@link AgentSpeakingEvent} per adapter instance so the
+ * adapter base does not need to manage it itself. Cleared at the top of
+ * every default `call()`.
+ */
+const speakingEventRegistry = new WeakMap<VoiceAgentAdapter, AgentSpeakingEvent>();
+
+function getAgentSpeakingEvent(adapter: VoiceAgentAdapter): AgentSpeakingEvent {
+  let event = speakingEventRegistry.get(adapter);
+  if (!event) {
+    event = new AgentSpeakingEvent();
+    speakingEventRegistry.set(adapter, event);
+  }
+  return event;
+}
+
+/**
+ * Build an {@link AudioMessageParam} that satisfies the locally-defined
+ * audio-content shape (Decision 2(b) from issue #372). The OpenAI
+ * `input_audio` content convention is used for the wire payload; the
+ * transcript (when present) rides alongside as a text part.
+ */
+function createAudioMessage(
+  chunk: AudioChunk,
+  role: AudioMessageParam["role"],
+): AudioMessageParam {
+  const base64 = toBase64(chunk.data);
+  const content: AudioMessageContentPart[] = [
+    {
+      type: "input_audio",
+      input_audio: { data: base64, format: "pcm16" },
+    },
+  ];
+  if (chunk.transcript) {
+    content.unshift({ type: "text", text: chunk.transcript });
+  }
+  return { role, content };
+}
+
+function toBase64(data: Uint8Array): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(data).toString("base64");
+  }
+  let binary = "";
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i]!);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Pull the first audio content part out of the most-recent inbound
+ * message, if any. Accepts both the OpenAI `input_audio` convention and
+ * the alternate `audio` convention defined by `messages.types.ts`.
+ */
+function extractAudioFromLastMessage(
+  newMessages: AgentInput["newMessages"],
+): AudioChunk | null {
+  if (newMessages.length === 0) return null;
+  const last = newMessages[newMessages.length - 1] as unknown as {
+    content?: unknown;
+  };
+  if (!Array.isArray(last.content)) {
+    return null;
+  }
+  for (const part of last.content as Array<{ type?: string; [k: string]: unknown }>) {
+    if (part.type === "input_audio" && typeof part.input_audio === "object") {
+      const payload = part.input_audio as { data?: string; format?: string };
+      if (typeof payload.data === "string") {
+        const data = fromBase64(payload.data);
+        if (data.length % 2 !== 0) {
+          // odd-byte payload: not valid PCM16 — drop instead of crashing
+          // the call() flow. The adapter is expected to fix at its
+          // transport boundary.
+          continue;
+        }
+        return new AudioChunk({ data });
+      }
+    }
+    if (part.type === "audio" && typeof part.audio === "object") {
+      const payload = part.audio as {
+        data?: string;
+        format?: string;
+        transcript?: string;
+      };
+      if (typeof payload.data === "string") {
+        const data = fromBase64(payload.data);
+        if (data.length % 2 !== 0) continue;
+        return new AudioChunk({ data, transcript: payload.transcript });
+      }
+    }
+  }
+  return null;
+}
+
+function fromBase64(s: string): Uint8Array {
+  if (typeof Buffer !== "undefined") {
+    return new Uint8Array(Buffer.from(s, "base64"));
+  }
+  const binary = atob(s);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+/** Re-export so tests importing the runtime get a silent chunk helper too. */
+export { silentChunk };

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -1,10 +1,11 @@
 /**
- * VoiceAgentAdapter — base class for voice-capable agents (SIGNATURE ONLY).
+ * VoiceAgentAdapter — base class for voice-capable agents.
  *
- * PR1 surface: types + abstract signatures only. Runtime (default `call()`
- * implementation, executor recording bridge, drain-on-tail-silence loop)
- * lands in PR2+. See `python/scenario/voice/adapter.py` for the eventual
- * behavior; this file pins the contract.
+ * PR1 shipped this surface as signatures only. PR3 (this commit) wires
+ * the default `call()` body and the executor connect / disconnect
+ * lifecycle in {@link ./adapter.runtime} so subclasses can extend just
+ * the four transport primitives. Source-of-truth port:
+ * `python/scenario/voice/adapter.py`.
  *
  * Extends {@link AgentAdapter} (text-based) with audio send/receive
  * primitives and a capability matrix. Concrete subclasses will live under
@@ -12,9 +13,11 @@
  * OpenAI Realtime, Gemini Live, ElevenLabs).
  */
 
-import { AgentAdapter } from "../domain/agents";
+import { AgentAdapter, type AgentInput } from "../domain/agents";
+import type { AgentReturnTypes } from "../domain/agents/types/agent-return.types";
 import { AudioChunk } from "./audio-chunk";
 import { AdapterCapabilities, UnsupportedCapabilityError } from "./capabilities";
+import { defaultVoiceCall } from "./adapter.runtime";
 
 /**
  * Abstract base for voice agents that exchange audio with the agent under
@@ -25,12 +28,12 @@ import { AdapterCapabilities, UnsupportedCapabilityError } from "./capabilities"
  * {@link AdapterCapabilities} instance as the {@link capabilities} field —
  * declared once per concrete adapter, not per instance.
  *
- * The {@link AgentAdapter.call} method from the parent class remains
- * abstract on this base in PR1; PR2 will introduce the shared `call()`
- * implementation that threads audio extracted from the latest user message
- * through the transport and records segments into the executor state. PR1
- * intentionally leaves it unimplemented so no executor coupling lands with
- * the contract surface.
+ * The default {@link call} implementation lives in {@link defaultVoiceCall}:
+ * it extracts audio from the latest user message, transmits via
+ * {@link sendAudio}, drains the agent response on tail silence, and
+ * records one user + one agent segment into the executor state.
+ * Subclasses can override `call()` for specialised flows but will
+ * usually inherit it.
  */
 export abstract class VoiceAgentAdapter extends AgentAdapter {
   /**
@@ -40,6 +43,19 @@ export abstract class VoiceAgentAdapter extends AgentAdapter {
    * to declare.
    */
   abstract readonly capabilities: AdapterCapabilities;
+
+  /**
+   * Default `call()` body, ported from Python `VoiceAgentAdapter.call`.
+   *
+   * Threads the latest user-message audio through {@link sendAudio},
+   * drains the agent response on tail silence, records one user and one
+   * agent segment into the executor state, and returns the merged
+   * assistant audio message. Subclasses may override for specialised
+   * flows but will usually inherit it.
+   */
+  async call(input: AgentInput): Promise<AgentReturnTypes> {
+    return defaultVoiceCall(this, input);
+  }
 
   /** Seconds to wait for agent audio after sending user audio. */
   responseTimeout = 30.0;

--- a/javascript/src/voice/index.ts
+++ b/javascript/src/voice/index.ts
@@ -1,9 +1,9 @@
 /**
- * Voice subsystem barrel — type contract surface for the TS voice port.
+ * Voice subsystem barrel — public surface for the TS voice port.
  *
- * PR1 ships types + the {@link UnsupportedCapabilityError} class only.
- * Runtime (TTS, STT, VAD, recording, transports) lands in PR2+ behind this
- * same contract.
+ * PR1 shipped the type contracts. PR3 (this commit) adds the adapter
+ * runtime + VAD fallback + executor lifecycle helpers. Real transports
+ * land in PR7+ behind this same contract.
  */
 
 export {
@@ -48,3 +48,19 @@ export {
   OPENAI_STT_MODEL,
   OPENAI_TTS_MODEL,
 } from "./voice-models";
+
+export {
+  AgentSpeakingEvent,
+  AdapterRecorder,
+  defaultVoiceCall,
+  initVoiceExecutorState,
+  pickVoiceAdapters,
+  startVoiceAdapters,
+  stopVoiceAdapters,
+  writeUserSegment,
+} from "./adapter.runtime";
+
+export {
+  WebRTCVadFallback,
+  type WebRTCVadFallbackOptions,
+} from "./vad";

--- a/javascript/src/voice/vad.ts
+++ b/javascript/src/voice/vad.ts
@@ -1,0 +1,191 @@
+/**
+ * Voice-activity detection fallback for adapters without native VAD.
+ *
+ * Python parity: `python/scenario/voice/vad.py`. Activates only when an
+ * adapter publishes `capabilities.nativeVad === false`; emits a single
+ * `UserWarning`-equivalent per adapter on first activation so users know
+ * the fallback is in effect (no rate-limit regression — see the Python
+ * commit history for the bug class).
+ *
+ * ## Detection algorithm
+ *
+ * PR3 ships a pure-TypeScript RMS-energy + hysteresis detector over PCM16
+ * @ 24 kHz frames. This is the SMALLEST VIABLE PATH to land the runtime
+ * with VAD fallback working — see the `## Decision pending: webrtcvad
+ * build pipeline` section in PR3 for the longer-term `webrtcvad` C
+ * library options (WASM committed blob recommended). The contract
+ * surface (`process(chunk)` → `onSpeechStart`/`onSpeechEnd`, one-shot
+ * warning) does not change with the underlying detector.
+ */
+import { AudioChunk, PCM16_SAMPLE_RATE } from "./audio-chunk";
+
+/** Frame size in milliseconds — matches Python `vad.py` for parity. */
+const FRAME_MS = 30;
+
+/** PCM16 samples per 30 ms frame at the canonical 24 kHz rate. */
+const SAMPLES_PER_FRAME = (PCM16_SAMPLE_RATE * FRAME_MS) / 1000;
+
+/** Byte length of one 30 ms PCM16 frame (samples × 2 bytes). */
+const BYTES_PER_FRAME = SAMPLES_PER_FRAME * 2;
+
+/**
+ * RMS threshold above which a frame is considered speech.
+ *
+ * PCM16 ranges over [-32768, 32767]; an RMS of ~500 corresponds to roughly
+ * -36 dBFS — a conservative floor that admits normal speech while
+ * rejecting most ambient noise. Tuneable via the `rmsThreshold` constructor
+ * option for adapters that need more or less sensitivity.
+ */
+const DEFAULT_RMS_THRESHOLD = 500;
+
+/**
+ * Consecutive same-state frames required to flip the speaking state.
+ * Mirrors the hysteresis pattern Python's `webrtcvad` wrapper relies on
+ * via its aggressiveness level — flicker rejection at the SDK layer.
+ */
+const DEFAULT_HYSTERESIS_FRAMES = 3;
+
+export interface WebRTCVadFallbackOptions {
+  /**
+   * Override the default RMS threshold (raw amplitude over PCM16 samples).
+   * Default: {@link DEFAULT_RMS_THRESHOLD}.
+   */
+  rmsThreshold?: number;
+  /**
+   * Override the hysteresis frame count. Default:
+   * {@link DEFAULT_HYSTERESIS_FRAMES}.
+   */
+  hysteresisFrames?: number;
+  /** Fires when speech is detected (after hysteresis). */
+  onSpeechStart?: () => void;
+  /** Fires when silence is detected after speech (after hysteresis). */
+  onSpeechEnd?: () => void;
+}
+
+/**
+ * Incremental VAD over PCM16 @ 24 kHz mono audio.
+ *
+ * Feed chunks via {@link process}; the configured `onSpeechStart` /
+ * `onSpeechEnd` callbacks fire when the speech/silence transitions
+ * stabilise. The detector is purely sample-driven — no async, no timers
+ * — so a single instance is safe to share across an entire scenario as
+ * long as one adapter feeds it.
+ */
+export class WebRTCVadFallback {
+  /** Per-process warning memoisation — one warning per adapter name. */
+  private static warnedAdapters = new Set<string>();
+
+  /**
+   * Reset the per-process warning memoisation. Tests call this in
+   * `beforeEach` so the one-shot-warning assertion is reproducible
+   * across runs.
+   */
+  static resetWarnings(): void {
+    WebRTCVadFallback.warnedAdapters = new Set<string>();
+  }
+
+  /**
+   * Emit the SDK-side VAD fallback warning at most once per adapter name.
+   *
+   * Routes via `console.warn` (no `process.emitWarning` so the contract
+   * holds in browser-like runtimes too). The warning text references
+   * accuracy differences vs native VAD, matching the Python `UserWarning`
+   * surface at `vad.py:50`.
+   */
+  private static emitFallbackWarningOnce(adapterName: string): void {
+    if (WebRTCVadFallback.warnedAdapters.has(adapterName)) {
+      return;
+    }
+    WebRTCVadFallback.warnedAdapters.add(adapterName);
+    console.warn(
+      `[scenario.voice] Adapter '${adapterName}' has no native VAD — ` +
+        "using SDK-side VAD fallback. Accuracy may differ from native VAD.",
+    );
+  }
+
+  private readonly rmsThreshold: number;
+  private readonly hysteresisFrames: number;
+  private readonly onSpeechStart: () => void;
+  private readonly onSpeechEnd: () => void;
+  private speaking = false;
+  private buf: number[] = [];
+  /** Count of consecutive frames in the candidate state (speech or silence). */
+  private candidateRun = 0;
+  /** The candidate state being voted on by the run counter. */
+  private candidateState = false;
+
+  constructor(adapterName: string, options: WebRTCVadFallbackOptions = {}) {
+    WebRTCVadFallback.emitFallbackWarningOnce(adapterName);
+    this.rmsThreshold = options.rmsThreshold ?? DEFAULT_RMS_THRESHOLD;
+    this.hysteresisFrames =
+      options.hysteresisFrames ?? DEFAULT_HYSTERESIS_FRAMES;
+    this.onSpeechStart = options.onSpeechStart ?? (() => undefined);
+    this.onSpeechEnd = options.onSpeechEnd ?? (() => undefined);
+  }
+
+  /** True once the hysteresis has flipped the state to speech. */
+  get isSpeaking(): boolean {
+    return this.speaking;
+  }
+
+  /**
+   * Feed audio into the detector. The configured callbacks fire on
+   * speech↔silence transitions after hysteresis stabilises.
+   */
+  process(chunk: AudioChunk): void {
+    const data = chunk.data;
+    for (let i = 0; i < data.length; i++) {
+      this.buf.push(data[i]!);
+    }
+    while (this.buf.length >= BYTES_PER_FRAME) {
+      const frame = this.buf.slice(0, BYTES_PER_FRAME);
+      this.buf.splice(0, BYTES_PER_FRAME);
+      const isSpeech = this.classifyFrame(frame);
+      this.observe(isSpeech);
+    }
+  }
+
+  /**
+   * RMS energy classification of a 30 ms PCM16 frame. Pure function over
+   * the byte slice — no IO, no allocation outside the loop.
+   */
+  private classifyFrame(frame: number[]): boolean {
+    let sumSquares = 0;
+    const sampleCount = frame.length / 2;
+    for (let i = 0; i < frame.length; i += 2) {
+      // little-endian PCM16 → signed int16
+      const lo = frame[i]!;
+      const hi = frame[i + 1]!;
+      let sample = (hi << 8) | lo;
+      if (sample & 0x8000) {
+        sample = sample - 0x10000;
+      }
+      sumSquares += sample * sample;
+    }
+    const rms = Math.sqrt(sumSquares / sampleCount);
+    return rms >= this.rmsThreshold;
+  }
+
+  /**
+   * Apply hysteresis: only flip {@link speaking} after the candidate
+   * state holds for {@link hysteresisFrames} consecutive frames.
+   */
+  private observe(isSpeech: boolean): void {
+    if (isSpeech === this.candidateState) {
+      this.candidateRun += 1;
+    } else {
+      this.candidateState = isSpeech;
+      this.candidateRun = 1;
+    }
+    if (this.candidateRun < this.hysteresisFrames) {
+      return;
+    }
+    if (this.candidateState && !this.speaking) {
+      this.speaking = true;
+      this.onSpeechStart();
+    } else if (!this.candidateState && this.speaking) {
+      this.speaking = false;
+      this.onSpeechEnd();
+    }
+  }
+}

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -134,7 +134,7 @@ Feature: Voice agent testing in Scenario SDK
     When the scenario starts
     Then a WebRTC peer connection is negotiated
 
-  @unit
+  @unit @ts-adapter
   Scenario: Executor calls connect() before and disconnect() after every scenario
     # Source §4.1, L213-230
     Given any VoiceAgentAdapter subclass
@@ -446,14 +446,14 @@ Feature: Voice agent testing in Scenario SDK
     When the test runs
     Then audio is played through the local output device in real time
 
-  @unit
+  @unit @ts-hooks
   Scenario: on_audio_chunk hook fires for each chunk
     # Source §4.7, L647-653
     Given scenario.run(..., on_audio_chunk=cb)
     When audio flows
     Then cb is invoked with each AudioChunk
 
-  @unit
+  @unit @ts-hooks
   Scenario: on_voice_event hook fires for each VoiceEvent
     # Source §4.7, L647-653
     Given scenario.run(..., on_voice_event=cb)
@@ -769,21 +769,21 @@ Feature: Voice agent testing in Scenario SDK
   # VAD Fallback
   # ======================================================================
 
-  @unit
+  @unit @ts-vad
   Scenario: SDK-side VAD fallback activates on adapters without native VAD
     Given an adapter with capabilities.native_vad == False
     When a voice scenario runs and audio flows
     Then user_start_speaking and user_stop_speaking VoiceEvents are still emitted
     And webrtcvad-wheels is used to detect speaker boundaries
 
-  @unit
+  @unit @ts-vad
   Scenario: VAD fallback emits a one-shot UserWarning on first activation
     Given an adapter with capabilities.native_vad == False
     When the scenario starts and VAD fallback is used
     Then a UserWarning is issued exactly once per process naming the adapter
     And the warning text references accuracy differences vs native VAD
 
-  @unit
+  @unit @ts-vad
   Scenario: Adapters with native VAD do not trigger the fallback
     Given an adapter with capabilities.native_vad == True
     When the scenario runs


### PR DESCRIPTION
PR3 of N for langwatch/scenario#372. Builds on PR1 (#511) which shipped types only. Status: **draft — keep on lead/Drew to flip ready-for-review after verification.**

## Summary

- Port `python/scenario/voice/adapter.py` runtime into `javascript/src/voice/adapter.runtime.ts`:
  * `asyncio.Event` → `AgentSpeakingEvent` (Promise + external resolve).
  * `async with adapter:` → explicit `startVoiceAdapters` / `stopVoiceAdapters` the executor calls once per scenario.
  * Default `call()` body: send → drain on tail silence → record → return `AudioMessageParam`.
  * Hook fan-out for `onAudioChunk` / `onVoiceEvent` from PR1's `VoiceExecutorState` surface.
- Port `python/scenario/voice/vad.py` → `javascript/src/voice/vad.ts`:
  * `WebRTCVadFallback` activates only when `adapter.capabilities.nativeVad === false`.
  * One-shot warning per adapter name via `console.warn`, gated by a static `Set<string>` (mirrors Python `_warned_adapters` memoisation; no rate-limit regression — see Python commit history for the bug class this avoids).
  * Pure-TS RMS energy + hysteresis detector ships today; see **Decision pending** below for the long-term webrtcvad C library question.
- Patch `javascript/src/execution/scenario-execution.ts`:
  * `ScenarioExecution implements VoiceExecutorState` structurally (Decision 1(b) from #372 — `voiceRecording`, `voiceTimeline`, `voiceLatency`, `voiceRecordingStartedAt`, `onVoiceEvent`, `onAudioChunk`).
  * `pickVoiceAdapters(this.agents)` snapshot taken at run start; `connect()` runs **inside** the try block, `disconnect()` runs in the finally so the spec line-143 "regardless of pass/fail/exception" contract holds.
  * Wires `onAudioChunk` / `onVoiceEvent` from new `ScenarioConfig` fields.
- Add `javascript/src/voice/__tests__/fixtures/fake-adapter.ts` — in-memory `FakeVoiceAdapter` with no real transport. Tests use it exclusively.

PR3 deliberately does NOT touch TTS/STT (PR2), simulator or judge (PR4), script steps or result extensions (PR5), effects (PR6), or real transports (PR7+).

## Acceptance criteria (the five checks)

1. ✅ **`pnpm -C javascript build` green.** `tsup` reports `CJS Build success`, `ESM Build success`, `DTS Build success` against the current branch (`df6dafb`).
2. ✅ **`pnpm -C javascript test` green.** vitest reports `Test Files 24 passed (24), Tests 381 passed (381)` — zero regressions on the existing 360 PR1/pre-voice tests, +21 new PR3 voice tests.
3. ✅ **Connect/disconnect lifecycle test passes against the fake adapter.** `src/voice/__tests__/adapter-lifecycle.test.ts` binds `specs/voice-agents.feature` lines 138-145: connect once before first script step, disconnect once on success, on `fail()`, on thrown exception, and across multiple voice adapters; disconnect errors are swallowed so cleanup never masks the result.
4. ✅ **VAD fallback test passes against the fake adapter without native VAD.** `src/voice/__tests__/vad-fallback.test.ts` binds `specs/voice-agents.feature` lines 772-791: fallback activates and emits `user_start_speaking` / `user_stop_speaking` (tagged `metadata.source === "vad-fallback"`); native-VAD adapters do NOT trigger the fallback (proved by absence-of-warning); one-shot warning fires exactly once per adapter name.
5. ✅ **PR body has a `## Decision pending: webrtcvad build pipeline` section** enumerating the three options + recommendation (immediately below).

## Decision pending: webrtcvad build pipeline

The feature spec at `specs/voice-agents.feature:776` names `webrtcvad-wheels` as the Python source-of-truth detector. The TS port has no maintained equivalent on npm. Three paths exist; this PR ships a pure-TS RMS interim so the runtime is unblocked, leaves the long-term pipeline open for Drew to pick:

### Option (a) — recommended: WASM build of the same C library Python wraps, committed blob

Compile `libfvad` / google/webrtc-audio-processing → WASM with emcc, commit the prebuilt blob to `javascript/src/voice/assets/`, load it from `vad.ts` at module load. Pros: exact behavioural parity with Python; small (~50 KB blob); zero npm-supply-chain risk after build. Cons: needs an offline build step + checksum policy for the committed binary; CI cannot reproduce the blob without an emscripten toolchain.

### Option (b): `node-vad` npm package

Direct dependency. Pros: zero local build. Cons: **unmaintained** (last release 2021, multiple stale Node ABI issues); ships a prebuilt `.node` per OS/arch which adds postinstall steps and breaks pure-Node-on-Lambda flows.

### Option (c): `@picovoice/cobra-web-node`

Picovoice's commercial VAD. Pros: well-maintained, accurate, well-documented. Cons: **commercial license required** for production use — explicit blocker against the scenario SDK's "no opt-in extras" policy locked at issue #372 design-decision #4.

### Recommendation

**(a) WASM committed blob, with the build pipeline question (CI-rebuild vs commit-the-blob) deferred.** For now this PR ships a pure-TS RMS + hysteresis detector that satisfies the spec contract (`user_start_speaking` / `user_stop_speaking` emission, one-shot warning, native-VAD bypass). The recorded fallback events carry `metadata.source === "vad-fallback"` so consumers can distinguish them from native-adapter events. When (a) lands, the runtime swaps `WebRTCVadFallback`'s internal detector without changing the public surface.

@drewdrewthis — please confirm the long-term build pipeline choice: **commit the WASM blob to the repo**, **rebuild in CI with emscripten**, or **alternative**. The PR is not blocked on this answer.

## Test plan

- [x] `pnpm -C javascript build` green
- [x] `pnpm -C javascript test` — 381/381 (21 new voice tests + 360 unchanged)
- [x] Lifecycle test green against fake adapter (happy path, fail(), thrown exception, multi-adapter, disconnect-error swallowing)
- [x] Hook fan-out test green (audio chunks + voice events + throwing-hook swallow)
- [x] VAD fallback test green (activation when nativeVad=false, native bypass, one-shot warning)
- [ ] Lead/Drew flips draft → ready-for-review after spot-checking the decision-pending section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
