### PR TITLE
feat(test/#516): bind PR #511 voice scenarios via vitest-cucumber (retrofit PR-A)

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -65,6 +65,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@amiceli/vitest-cucumber": "^6.5.0",
     "@eslint/js": "^9.39.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@amiceli/vitest-cucumber':
+        specifier: ^6.5.0
+        version: 6.5.0(vitest@4.1.5)
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.4
@@ -145,7 +148,7 @@ importers:
     dependencies:
       '@openai/agents':
         specifier: ^0.3.9
-        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
+        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -360,6 +363,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@amiceli/vitest-cucumber@6.5.0':
+    resolution: {integrity: sha512-1883MTz+PsfTcR5C2wYlHh8rQzOEYOogdDhAikGWsx5UfTzIusP4HLH32kpcAPOBvHUpguYcA8Zmw5JxEydbzg==}
+    hasBin: true
+    peerDependencies:
+      vitest: ^4.0.4
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1736,6 +1745,9 @@ packages:
     peerDependencies:
       vite: '>=7.3.2'
 
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
@@ -1935,6 +1947,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2326,6 +2339,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  callsites@4.2.0:
+    resolution: {integrity: sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==}
+    engines: {node: '>=12.20'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -2396,6 +2413,9 @@ packages:
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
@@ -4054,9 +4074,15 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parsecurrency@1.1.1:
+    resolution: {integrity: sha512-IAw/8PSFgiko70KfZGv63rbEXhmVu+zpb42PvEtgHAm83Mze3eQJHWV1ZoOhPnrYeOyufvv0GS6hZDuQOdBH4Q==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4649,6 +4675,9 @@ packages:
       jest-util:
         optional: true
 
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -5119,6 +5148,14 @@ snapshots:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
       zod: 4.4.3
+
+  '@amiceli/vitest-cucumber@6.5.0(vitest@4.1.5)':
+    dependencies:
+      callsites: 4.2.0
+      minimist: 1.2.8
+      parsecurrency: 1.1.1
+      ts-morph: 28.0.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.0.14)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6656,6 +6693,12 @@ snapshots:
       tailwindcss: 4.1.17
       vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
 
+  '@ts-morph/common@0.29.0':
+    dependencies:
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.16
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@tybys/wasm-util@0.10.2':
@@ -7343,6 +7386,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  callsites@4.2.0: {}
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -7393,6 +7438,8 @@ snapshots:
   clsx@2.1.1: {}
 
   co@4.6.0: {}
+
+  code-block-writer@13.0.3: {}
 
   collect-v8-coverage@1.0.3: {}
 
@@ -9248,7 +9295,11 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parsecurrency@1.1.1: {}
+
   parseurl@1.3.3: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -9880,6 +9931,11 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       esbuild: 0.27.7
       jest-util: 30.3.0
+
+  ts-morph@28.0.0:
+    dependencies:
+      '@ts-morph/common': 0.29.0
+      code-block-writer: 13.0.3
 
   tsconfig-paths@3.15.0:
     dependencies:

--- a/javascript/src/voice/__tests__/voice-contract-surface.test.ts
+++ b/javascript/src/voice/__tests__/voice-contract-surface.test.ts
@@ -4,13 +4,17 @@
  * Binds the five scenarios from `specs/voice-agents.feature` that the PR1
  * scope is responsible for; concrete adapters and runtime behavior land in
  * PR2+ and bring their own tests.
+ *
+ * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
+ * the suite if any bound scenario is missing a step binding.
  */
 
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
 
 import { AgentAdapter, AgentRole } from "../../domain/agents";
 import {
@@ -25,6 +29,7 @@ import {
 } from "../index";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
 const MATRIX_DOC_PATH = resolve(
   HERE,
   "..",
@@ -35,6 +40,10 @@ const MATRIX_DOC_PATH = resolve(
   "capability-matrix.md",
 );
 
+/**
+ * Stub adapter used by several scenarios. Keeps the same shape as the
+ * original hand-written tests so assertions are equivalent.
+ */
 class StubVoiceAdapter extends VoiceAgentAdapter {
   override role = AgentRole.AGENT;
   readonly capabilities = new AdapterCapabilities({
@@ -67,139 +76,213 @@ class StubVoiceAdapter extends VoiceAgentAdapter {
   }
 }
 
-describe("specs/voice-agents.feature lines 146-156 — AudioChunk internal format is PCM16 at 24kHz mono", () => {
-  it("normalizes the canonical internal format to PCM16 / 24000 Hz / mono", () => {
-    // "Then the internal AudioChunk is PCM16, 24000 Hz, mono"
-    expect(PCM16_SAMPLE_RATE).toBe(24000);
-    expect(PCM16_CHANNELS).toBe(1);
-    expect(PCM16_SAMPLE_WIDTH_BYTES).toBe(2);
+const feature = await loadFeature(FEATURE_PATH);
 
-    const chunk = silentChunk(0.5);
-    expect(chunk.sampleRate).toBe(24000);
-    expect(chunk.channels).toBe(1);
-    expect(chunk.durationSeconds).toBeCloseTo(0.5, 3);
-  });
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    // -----------------------------------------------------------------------
+    // Scenario: AudioChunk internal format is PCM16 at 24kHz mono (lines 146-156)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "AudioChunk internal format is PCM16 at 24kHz mono",
+      ({ Given, When, Then, And }) => {
+        Given("any adapter receives or sends audio", () => {
+          // Precondition — constants are module-level exports; nothing to set up.
+        });
 
-  it("rejects odd-byte buffers — partial PCM16 samples surface at the boundary", () => {
-    // The PCM16 invariant catches partial transport frames at the canonical
-    // boundary instead of letting `frombuffer`/`durationSeconds` silently
-    // truncate and produce off-by-one drift.
-    expect(
-      () => new AudioChunk({ data: new Uint8Array([0x00, 0x00, 0x01]) }),
-    ).toThrowError(/not a multiple of 2/);
-  });
-});
+        When("the framework normalizes the chunk", () => {
+          // Normalization is a compile-time invariant expressed in constants;
+          // the assertion is in Then.
+        });
 
-describe("specs/voice-agents.feature lines 698-704 — VoiceAgentAdapter base class is public for custom implementations", () => {
-  it("lets user code subclass it with connect/sendAudio/receiveAudio/disconnect", async () => {
-    const adapter = new StubVoiceAdapter();
-    expect(adapter).toBeInstanceOf(VoiceAgentAdapter);
-    expect(adapter).toBeInstanceOf(AgentAdapter);
+        Then("the internal AudioChunk is PCM16, 24000 Hz, mono", () => {
+          expect(PCM16_SAMPLE_RATE).toBe(24000);
+          expect(PCM16_CHANNELS).toBe(1);
+          expect(PCM16_SAMPLE_WIDTH_BYTES).toBe(2);
 
-    // Public surface — every method exposed by the contract is callable on
-    // the subclass instance.
-    await adapter.connect();
-    await adapter.sendAudio(silentChunk(0.02));
-    const received = await adapter.receiveAudio(1);
-    await adapter.disconnect();
+          const chunk = silentChunk(0.5);
+          expect(chunk.sampleRate).toBe(24000);
+          expect(chunk.channels).toBe(1);
+          expect(chunk.durationSeconds).toBeCloseTo(0.5, 3);
+        });
 
-    expect(adapter.connectCount).toBe(1);
-    expect(adapter.disconnectCount).toBe(1);
-    expect(adapter.sent).toHaveLength(1);
-    expect(received).toBeInstanceOf(AudioChunk);
-  });
-});
+        And(
+          "each adapter converts to/from its transport-native format at the send/recv boundary",
+          () => {
+            // PCM16 invariant: odd-byte buffers (partial samples) are rejected
+            // at the canonical boundary rather than silently truncated.
+            expect(
+              () => new AudioChunk({ data: new Uint8Array([0x00, 0x00, 0x01]) }),
+            ).toThrowError(/not a multiple of 2/);
+          },
+        );
+      },
+    );
 
-describe("specs/voice-agents.feature lines 751-756 — Every adapter publishes a capabilities attribute", () => {
-  it("declares streamingTranscripts / nativeVad / dtmf / inputFormats / outputFormats", () => {
-    const adapter = new StubVoiceAdapter();
-    expect(adapter.capabilities).toBeInstanceOf(AdapterCapabilities);
+    // -----------------------------------------------------------------------
+    // Scenario: VoiceAgentAdapter base class is public (lines 698-704)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "VoiceAgentAdapter base class is public for custom implementations",
+      ({ Given, When, Then }) => {
+        let adapter: StubVoiceAdapter;
 
-    // Field-name parity with the spec — the AC enumerates the five
-    // capabilities every adapter must publish.
-    const caps = adapter.capabilities;
-    expect(typeof caps.streamingTranscripts).toBe("boolean");
-    expect(typeof caps.nativeVad).toBe("boolean");
-    expect(typeof caps.dtmf).toBe("boolean");
-    expect(Array.isArray(caps.inputFormats)).toBe(true);
-    expect(Array.isArray(caps.outputFormats)).toBe(true);
-  });
+        Given(
+          "a user subclass of VoiceAgentAdapter implementing connect/send_audio/recv_audio/disconnect",
+          () => {
+            adapter = new StubVoiceAdapter();
+            expect(adapter).toBeInstanceOf(VoiceAgentAdapter);
+            expect(adapter).toBeInstanceOf(AgentAdapter);
+          },
+        );
 
-  it("defaults to the safest possible declaration when no flags are set", () => {
-    // An adapter author who forgets to declare anything must NOT silently
-    // claim every capability. Default is "supports nothing".
-    const empty = new AdapterCapabilities();
-    expect(empty.streamingTranscripts).toBe(false);
-    expect(empty.nativeVad).toBe(false);
-    expect(empty.dtmf).toBe(false);
-    expect(empty.interruption).toBe(false);
-    expect(empty.inputFormats).toEqual([]);
-    expect(empty.outputFormats).toEqual([]);
-  });
-});
+        When("plugged into scenario.run()", async () => {
+          await adapter.connect();
+          await adapter.sendAudio(silentChunk(0.02));
+          await adapter.receiveAudio(1);
+          await adapter.disconnect();
+        });
 
-describe("specs/voice-agents.feature lines 757-762 — UnsupportedCapabilityError naming", () => {
-  it("names the adapter and the missing capability in the error message", () => {
-    // The spec's example fires when `scenario.dtmf("1")` runs on a
-    // non-telephony adapter; we exercise the raise-only stub shape here —
-    // adapter name + capability both surfaced for downstream UX.
-    const err = new UnsupportedCapabilityError("StubVoiceAdapter", "dtmf");
-    expect(err).toBeInstanceOf(Error);
-    expect(err.adapterName).toBe("StubVoiceAdapter");
-    expect(err.capability).toBe("dtmf");
-    expect(err.message).toContain("StubVoiceAdapter");
-    expect(err.message).toContain("dtmf");
-    expect(err.message).toContain("docs/voice/capability-matrix.md");
-  });
+        Then("it works identically to built-in adapters", async () => {
+          const received = await adapter.receiveAudio(1);
+          expect(adapter.connectCount).toBe(1);
+          expect(adapter.disconnectCount).toBe(1);
+          expect(adapter.sent).toHaveLength(1);
+          expect(received).toBeInstanceOf(AudioChunk);
+        });
+      },
+    );
 
-  it("the base interrupt() throws UnsupportedCapabilityError on adapters without override", () => {
-    class NoInterruptAdapter extends VoiceAgentAdapter {
-      readonly capabilities = new AdapterCapabilities();
-      async call(): Promise<string> {
-        return "stub";
-      }
-      async connect(): Promise<void> {}
-      async disconnect(): Promise<void> {}
-      async sendAudio(_chunk: AudioChunk): Promise<void> {}
-      async receiveAudio(_timeout: number): Promise<AudioChunk> {
-        return silentChunk(0);
-      }
-    }
+    // -----------------------------------------------------------------------
+    // Scenario: Every adapter publishes a capabilities attribute (lines 751-756)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "Every adapter publishes a capabilities attribute",
+      ({ Given, Then, And }) => {
+        let adapter: StubVoiceAdapter;
 
-    const adapter = new NoInterruptAdapter();
-    expect(() => adapter.interrupt()).toThrow(UnsupportedCapabilityError);
-  });
-});
+        Given("any concrete VoiceAgentAdapter subclass", () => {
+          adapter = new StubVoiceAdapter();
+        });
 
-describe("specs/voice-agents.feature lines 763-771 — Capability matrix is rendered into adapter docs", () => {
-  const doc = readFileSync(MATRIX_DOC_PATH, "utf8");
+        Then("adapter.capabilities is an AdapterCapabilities instance", () => {
+          expect(adapter.capabilities).toBeInstanceOf(AdapterCapabilities);
+        });
 
-  it("renders a table that lists every shipped + planned adapter", () => {
-    // Same adapter set as the Python source-of-truth at
-    // docs/voice/capability-matrix.md — PR1 placeholder, real flags land
-    // alongside each adapter PR (#372 PR2+).
-    const adapters = [
-      "PipecatAgentAdapter",
-      "TwilioAgentAdapter",
-      "OpenAIRealtimeAgentAdapter",
-      "ElevenLabsAgentAdapter",
-      "GeminiLiveAgentAdapter",
-      "LiveKitAgentAdapter",
-      "VapiAgentAdapter",
-      "WebRTCAgentAdapter",
-      "WebSocketAgentAdapter",
-    ];
-    for (const adapter of adapters) {
-      expect(doc).toContain(adapter);
-    }
-  });
+        And(
+          "it declares: streaming_transcripts, native_vad, dtmf, input_formats, output_formats",
+          () => {
+            const caps = adapter.capabilities;
+            expect(typeof caps.streamingTranscripts).toBe("boolean");
+            expect(typeof caps.nativeVad).toBe("boolean");
+            expect(typeof caps.dtmf).toBe("boolean");
+            expect(Array.isArray(caps.inputFormats)).toBe(true);
+            expect(Array.isArray(caps.outputFormats)).toBe(true);
 
-  it("table header lists streaming_transcripts, native_vad, dtmf, and input/output formats", () => {
-    // The AC enumerates the columns the doc must surface — the column
-    // headers are in human prose in the table header row.
-    expect(doc.toLowerCase()).toContain("streaming transcripts");
-    expect(doc.toLowerCase()).toContain("native vad");
-    expect(doc.toLowerCase()).toContain("dtmf");
-    expect(doc.toLowerCase()).toContain("wire formats");
-  });
-});
+            // An adapter author who forgets to declare anything must NOT silently
+            // claim every capability — default is "supports nothing".
+            const empty = new AdapterCapabilities();
+            expect(empty.streamingTranscripts).toBe(false);
+            expect(empty.nativeVad).toBe(false);
+            expect(empty.dtmf).toBe(false);
+            expect(empty.interruption).toBe(false);
+            expect(empty.inputFormats).toEqual([]);
+            expect(empty.outputFormats).toEqual([]);
+          },
+        );
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // Scenario: dtmf() raises UnsupportedCapabilityError (lines 757-762)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "dtmf() raises UnsupportedCapabilityError on non-telephony adapters",
+      ({ Given, When, Then }) => {
+        Given("an adapter with capabilities.dtmf == False", () => {
+          // The StubVoiceAdapter has dtmf: false; UnsupportedCapabilityError
+          // is exercised directly below without an adapter instance.
+        });
+
+        When('scenario.dtmf("1") runs', () => {
+          // Step represents the trigger; assertions are in Then.
+        });
+
+        Then(
+          'UnsupportedCapabilityError is raised naming the adapter and the "dtmf" capability',
+          () => {
+            // Direct error construction — names the adapter and capability.
+            const err = new UnsupportedCapabilityError("StubVoiceAdapter", "dtmf");
+            expect(err).toBeInstanceOf(Error);
+            expect(err.adapterName).toBe("StubVoiceAdapter");
+            expect(err.capability).toBe("dtmf");
+            expect(err.message).toContain("StubVoiceAdapter");
+            expect(err.message).toContain("dtmf");
+            expect(err.message).toContain("docs/voice/capability-matrix.md");
+
+            // The base interrupt() throws UnsupportedCapabilityError on adapters
+            // without an override — tests the raise-only contract from the spec.
+            class NoInterruptAdapter extends VoiceAgentAdapter {
+              readonly capabilities = new AdapterCapabilities();
+              async call(): Promise<string> {
+                return "stub";
+              }
+              async connect(): Promise<void> {}
+              async disconnect(): Promise<void> {}
+              async sendAudio(_chunk: AudioChunk): Promise<void> {}
+              async receiveAudio(_timeout: number): Promise<AudioChunk> {
+                return silentChunk(0);
+              }
+            }
+
+            const noInterrupt = new NoInterruptAdapter();
+            expect(() => noInterrupt.interrupt()).toThrow(UnsupportedCapabilityError);
+          },
+        );
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // Scenario: Capability matrix is rendered into adapter docs (lines 763-771)
+    // -----------------------------------------------------------------------
+    Scenario(
+      "Capability matrix is rendered into adapter docs",
+      ({ Given, Then, And }) => {
+        let doc: string;
+
+        Given("the voice-agents documentation", () => {
+          doc = readFileSync(MATRIX_DOC_PATH, "utf8");
+        });
+
+        Then("a capability matrix table lists every built-in adapter", () => {
+          const adapters = [
+            "PipecatAgentAdapter",
+            "TwilioAgentAdapter",
+            "OpenAIRealtimeAgentAdapter",
+            "ElevenLabsAgentAdapter",
+            "GeminiLiveAgentAdapter",
+            "LiveKitAgentAdapter",
+            "VapiAgentAdapter",
+            "WebRTCAgentAdapter",
+            "WebSocketAgentAdapter",
+          ];
+          for (const adapter of adapters) {
+            expect(doc).toContain(adapter);
+          }
+        });
+
+        And(
+          "each row shows streaming_transcripts, native_vad, dtmf, input/output formats",
+          () => {
+            expect(doc.toLowerCase()).toContain("streaming transcripts");
+            expect(doc.toLowerCase()).toContain("native vad");
+            expect(doc.toLowerCase()).toContain("dtmf");
+            expect(doc.toLowerCase()).toContain("wire formats");
+          },
+        );
+      },
+    );
+  },
+  { includeTags: ["pr1-binding"] },
+);

--- a/javascript/src/voice/__tests__/voice-contract-surface.test.ts
+++ b/javascript/src/voice/__tests__/voice-contract-surface.test.ts
@@ -1,9 +1,9 @@
 /**
  * Voice contract surface tests — PR1 of issue #372.
  *
- * Binds the five scenarios from `specs/voice-agents.feature` that the PR1
- * scope is responsible for; concrete adapters and runtime behavior land in
- * PR2+ and bring their own tests.
+ * Binds the five scenarios from `specs/voice-agents.feature` tagged
+ * `@ts-bound`; concrete adapters and runtime behavior land in subsequent
+ * PRs and bring their own tests.
  *
  * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
  * the suite if any bound scenario is missing a step binding.
@@ -284,5 +284,5 @@ describeFeature(
       },
     );
   },
-  { includeTags: ["pr1-binding"] },
+  { includeTags: ["ts-bound"] },
 );

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -142,7 +142,7 @@ Feature: Voice agent testing in Scenario SDK
     Then connect() was awaited exactly once before the first script step
     And disconnect() was awaited exactly once regardless of pass/fail/exception
 
-  @unit
+  @unit @pr1-binding
   Scenario: AudioChunk internal format is PCM16 at 24kHz mono
     # Locked decision: AudioChunk normalization
     Given any adapter receives or sends audio
@@ -694,7 +694,7 @@ Feature: Voice agent testing in Scenario SDK
     Then no TTS, STT, ffmpeg, or transport code is invoked
     And behavior is identical to pre-voice SDK
 
-  @unit
+  @unit @pr1-binding
   Scenario: VoiceAgentAdapter base class is public for custom implementations
     # Source §7.3 L1186, §5.7 L830-854
     Given a user subclass of VoiceAgentAdapter implementing connect/send_audio/recv_audio/disconnect
@@ -747,19 +747,19 @@ Feature: Voice agent testing in Scenario SDK
   # Adapter Capability Matrix — new requirement
   # ======================================================================
 
-  @unit
+  @unit @pr1-binding
   Scenario: Every adapter publishes a capabilities attribute
     Given any concrete VoiceAgentAdapter subclass
     Then adapter.capabilities is an AdapterCapabilities instance
     And it declares: streaming_transcripts, native_vad, dtmf, input_formats, output_formats
 
-  @unit
+  @unit @pr1-binding
   Scenario: dtmf() raises UnsupportedCapabilityError on non-telephony adapters
     Given an adapter with capabilities.dtmf == False
     When scenario.dtmf("1") runs
     Then UnsupportedCapabilityError is raised naming the adapter and the "dtmf" capability
 
-  @unit
+  @unit @pr1-binding
   Scenario: Capability matrix is rendered into adapter docs
     Given the voice-agents documentation
     Then a capability matrix table lists every built-in adapter

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -142,7 +142,7 @@ Feature: Voice agent testing in Scenario SDK
     Then connect() was awaited exactly once before the first script step
     And disconnect() was awaited exactly once regardless of pass/fail/exception
 
-  @unit @pr1-binding
+  @unit @ts-bound
   Scenario: AudioChunk internal format is PCM16 at 24kHz mono
     # Locked decision: AudioChunk normalization
     Given any adapter receives or sends audio
@@ -694,7 +694,7 @@ Feature: Voice agent testing in Scenario SDK
     Then no TTS, STT, ffmpeg, or transport code is invoked
     And behavior is identical to pre-voice SDK
 
-  @unit @pr1-binding
+  @unit @ts-bound
   Scenario: VoiceAgentAdapter base class is public for custom implementations
     # Source §7.3 L1186, §5.7 L830-854
     Given a user subclass of VoiceAgentAdapter implementing connect/send_audio/recv_audio/disconnect
@@ -747,19 +747,19 @@ Feature: Voice agent testing in Scenario SDK
   # Adapter Capability Matrix — new requirement
   # ======================================================================
 
-  @unit @pr1-binding
+  @unit @ts-bound
   Scenario: Every adapter publishes a capabilities attribute
     Given any concrete VoiceAgentAdapter subclass
     Then adapter.capabilities is an AdapterCapabilities instance
     And it declares: streaming_transcripts, native_vad, dtmf, input_formats, output_formats
 
-  @unit @pr1-binding
+  @unit @ts-bound
   Scenario: dtmf() raises UnsupportedCapabilityError on non-telephony adapters
     Given an adapter with capabilities.dtmf == False
     When scenario.dtmf("1") runs
     Then UnsupportedCapabilityError is raised naming the adapter and the "dtmf" capability
 
-  @unit @pr1-binding
+  @unit @ts-bound
   Scenario: Capability matrix is rendered into adapter docs
     Given the voice-agents documentation
     Then a capability matrix table lists every built-in adapter


### PR DESCRIPTION
## Summary

Retrofits the merged PR #511 tests so the 5 scenarios they claim to test are actually loaded from \`specs/voice-agents.feature\` and executed by the test runner, rather than only paraphrased in \`describe()\` names.

Closes part of #516 (the spec-binding half). The process-gate half of #516 is being addressed separately by adding the \`ai-reviewed\` label to the repo (already created).

## What changed

- \`javascript/package.json\`: adds \`@amiceli/vitest-cucumber@^6.5.0\` as a dev dep. Peer-dep matches pinned \`vitest ^4.0.14\`.
- \`javascript/src/voice/__tests__/voice-contract-surface.test.ts\`: rewritten to use \`loadFeature\` + scenario-level bindings against \`specs/voice-agents.feature\`. The 5 scenarios are bound by their \`Scenario:\` titles (matching the line ranges PR #511 originally claimed).
- \`specs/voice-agents.feature\`: adds \`@pr1-binding\` tag to the 5 bound scenarios so \`describeFeature\` with \`{ includeTags: ['pr1-binding'] }\` can select only those 5 without requiring the other 100 scenarios to be bound.

## Why vitest-cucumber

- Peer-dep matches pinned vitest exactly (no version negotiation).
- 1-line install, no vitest.config.ts changes.
- Fails the suite if any bound scenario lacks a step binding — the signal the current paraphrase pattern is missing.
- Solo-maintainer is the main long-term risk (bus factor). Public API surface is small; \`quickpickle\` is a viable fork-out if needed.

## Test plan

- [x] \`pnpm test src/voice/__tests__/voice-contract-surface.test.ts\` — all 16 tests (5 scenarios × steps) pass.
- [ ] CI green (javascript-complete).
- [ ] Manual scan of the diff vs the old paraphrase to confirm every assertion has a Then-step equivalent.

## Caveats / followups (not in this PR)

- PRs #513 (draft) and #515 (draft) need in-place rewrites onto their own branches to adopt the same runner — that's PR-B and PR-C of the hybrid plan in #516.
- The \`ai-reviewed\` label exists now on \`langwatch/scenario\`; it's a marker that \`/review\` ran, no CI gate enforces it.

Refs #516, #372.