### PR TITLE
feat(typescript-sdk/#372): voice Gemini Live adapter (PR9 of N)

### DIFF
--- a/javascript/examples/vitest/package.json
+++ b/javascript/examples/vitest/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@amiceli/vitest-cucumber": "^6.5.0",
     "concurrently": "^9.2.1",
     "dotenv": "^17.2.3",
     "dotenv-cli": "^11.0.0",

--- a/javascript/examples/vitest/tests/voice/gemini-live.test.ts
+++ b/javascript/examples/vitest/tests/voice/gemini-live.test.ts
@@ -1,0 +1,112 @@
+/**
+ * E2E demo — Gemini Live native audio.
+ *
+ * Binds the single `@ts-gemini-live-e2e` scenario from
+ * `specs/voice-agents.feature` to a real `@google/genai` Live session
+ * gated on `GEMINI_API_KEY` (or `GOOGLE_API_KEY`).
+ *
+ * This is an `@e2e` slice: it talks to Google's hosted Live API, so it is
+ * skipped by default. To run it locally, install `@google/genai` in the
+ * examples workspace and set `GEMINI_API_KEY` in `examples/vitest/.env`.
+ *
+ * Skipped automatically when no key is present so CI stays green without
+ * Gemini credentials.
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+
+import {
+  AudioChunk,
+  GEMINI_LIVE_MODEL,
+  GeminiLiveAgentAdapter,
+} from "@langwatch/scenario";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "specs",
+  "voice-agents.feature",
+);
+
+const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY ?? "";
+const hasKey = apiKey.length > 0;
+
+const feature = await loadFeature(FEATURE_PATH);
+
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    Scenario(
+      "Demo — Gemini Live native audio",
+      ({ Given, When, Then }) => {
+        let adapter: GeminiLiveAgentAdapter | null = null;
+        let success = false;
+
+        Given(
+          'a GeminiLiveAgentAdapter with model "gemini-2.5-flash-native-audio" and GEMINI_API_KEY',
+          (ctx: { skip: () => void }) => {
+            if (!hasKey) {
+              ctx.skip();
+              return;
+            }
+            adapter = new GeminiLiveAgentAdapter({
+              model: GEMINI_LIVE_MODEL,
+              systemInstruction:
+                "You are a brief, helpful voice assistant. Answer in one short sentence.",
+            });
+            expect(adapter).toBeInstanceOf(GeminiLiveAgentAdapter);
+          },
+        );
+
+        When("the demo script runs via scenario.run()", async (ctx: { skip: () => void }) => {
+          if (!adapter) {
+            ctx.skip();
+            return;
+          }
+          // Minimal real-transport happy path: open a session, push a
+          // short silent user turn, drain audio until turn_complete. This
+          // proves the wire format + lifecycle without needing the full
+          // scenario.run() pipeline (which lands in PR3/runtime). The
+          // /browser-qa-against-prod hook will exercise the full pipeline
+          // once it ships.
+          await adapter.connect();
+          // 0.5s of silence at canonical 24kHz mono PCM16 = 24000 samples
+          // * 2 bytes = 48000 bytes. Pure silence is enough to satisfy
+          // Gemini's "user turn" framing once activity_end fires.
+          const silence = new Uint8Array(24000 * 2);
+          await adapter.sendAudio(new AudioChunk({ data: silence }));
+
+          // Drain until turn_complete (empty data). Hard-cap iterations
+          // so a wedged stream can't hang the test forever.
+          for (let i = 0; i < 200; i++) {
+            const chunk = await adapter.receiveAudio(10);
+            if (chunk.data.length === 0) break;
+          }
+          success = true;
+        });
+
+        Then(
+          "a live session is established and result.success is True",
+          async (ctx: { skip: () => void }) => {
+            if (!adapter) {
+              ctx.skip();
+              return;
+            }
+            expect(success).toBe(true);
+            await adapter.disconnect();
+          },
+        );
+      },
+    );
+  },
+  { includeTags: ["ts-gemini-live-e2e"] },
+);

--- a/javascript/examples/vitest/tests/voice/gemini-live.test.ts
+++ b/javascript/examples/vitest/tests/voice/gemini-live.test.ts
@@ -17,13 +17,12 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
-import { expect } from "vitest";
-
 import {
   AudioChunk,
   GEMINI_LIVE_MODEL,
   GeminiLiveAgentAdapter,
 } from "@langwatch/scenario";
+import { expect } from "vitest";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FEATURE_PATH = resolve(

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@amiceli/vitest-cucumber": "^6.5.0",
     "@eslint/js": "^9.39.1",
+    "@google/genai": "^2.5.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",
     "@typescript-eslint/parser": "^8.48.0",
@@ -115,7 +116,13 @@
   },
   "peerDependencies": {
     "ai": ">=6.0.0",
-    "vitest": ">=3.2.4"
+    "vitest": ">=3.2.4",
+    "@google/genai": ">=2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@google/genai": {
+      "optional": true
+    }
   },
   "pnpm": {
     "overrides": {

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -67,10 +67,13 @@ importers:
     devDependencies:
       '@amiceli/vitest-cucumber':
         specifier: ^6.5.0
-        version: 6.5.0(vitest@4.1.5)
+        version: 6.5.0(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.0.14)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)))
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.4
+      '@google/genai':
+        specifier: ^2.5.0
+        version: 2.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -296,6 +299,9 @@ importers:
         specifier: ^4.1.13
         version: 4.4.3
     devDependencies:
+      '@amiceli/vitest-cucumber':
+        specifier: ^6.5.0
+        version: 6.5.0(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.0.14)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)))
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -763,6 +769,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@google/genai@2.5.0':
+    resolution: {integrity: sha512-qDi3LLh9I3llJK0f9uV8kZ8EdT9oHPxGJJ9yOJ/i5YXYrVwRCs8jHo9x4e99uOeKYDvD3TZwT70p/H/LS3BixQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.29.0'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -2128,6 +2143,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ai@6.0.174:
     resolution: {integrity: sha512-bTrfLUWHWtkjzWyCY4bmyuk4Qvmj4S4NSNsXyNSVVqkmftQNtxRj7dzUoMeQDBBwlJO6fC7m2Q/lNOPqQQfAGA==}
     engines: {node: '>=18'}
@@ -2270,6 +2289,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -2295,6 +2317,9 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2489,6 +2514,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2604,6 +2633,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2854,6 +2886,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2877,6 +2912,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
@@ -2918,6 +2957,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -2943,6 +2986,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -3007,6 +3058,14 @@ packages:
   glsl-noise@0.0.0:
     resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
 
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3065,6 +3124,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -3464,6 +3527,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3497,6 +3563,12 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3914,9 +3986,18 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -4924,6 +5005,10 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webgl-constants@1.1.1:
     resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
 
@@ -5149,7 +5234,7 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
       zod: 4.4.3
 
-  '@amiceli/vitest-cucumber@6.5.0(vitest@4.1.5)':
+  '@amiceli/vitest-cucumber@6.5.0(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.0.14)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
       callsites: 4.2.0
       minimist: 1.2.8
@@ -5503,6 +5588,19 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@google/genai@2.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.5.6
+      ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@grpc/grpc-js@1.14.3':
     dependencies:
@@ -7100,6 +7198,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ai@6.0.174(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 3.0.109(zod@3.25.76)
@@ -7297,6 +7397,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -7341,6 +7443,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -7498,6 +7602,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -7595,6 +7701,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -7980,6 +8090,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -7996,6 +8108,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fflate@0.6.10: {}
 
@@ -8048,6 +8165,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -8069,6 +8190,22 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -8141,6 +8278,19 @@ snapshots:
 
   glsl-noise@0.0.0: {}
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -8196,6 +8346,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@2.1.0: {}
 
@@ -8770,6 +8927,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -8793,6 +8954,17 @@ snapshots:
   json5@2.2.3: {}
 
   jsonpointer@5.0.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -9116,12 +9288,20 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  node-domexception@1.0.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
 
@@ -10184,6 +10364,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
 
   webgl-constants@1.1.1: {}
 

--- a/javascript/src/voice/adapters/__tests__/gemini-live.test.ts
+++ b/javascript/src/voice/adapters/__tests__/gemini-live.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for GeminiLiveAgentAdapter — PR9 of issue #372.
+ *
+ * Binds the two `@ts-gemini-live` `@unit` scenarios from
+ * `specs/voice-agents.feature`:
+ *
+ *   1. GeminiLiveAgentAdapter connects via native-audio endpoint
+ *   2. GeminiLiveAgentAdapter advertises native-audio capabilities matrix
+ *
+ * The `@google/genai` SDK is mocked at the module level via vitest's
+ * `vi.mock` so this file runs offline without a Gemini API key.
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { vi, expect } from "vitest";
+
+import { AdapterCapabilities } from "../../capabilities";
+import { GeminiLiveAgentAdapter } from "../gemini-live";
+
+// -----------------------------------------------------------------------
+// Mock the SDK so connect() never opens a real WebSocket.
+// -----------------------------------------------------------------------
+
+interface CapturedConnect {
+  model?: string;
+  config?: Record<string, unknown>;
+}
+
+const captured: { last: CapturedConnect | null } = { last: null };
+
+vi.mock("@google/genai", () => {
+  class FakeSession {
+    sendRealtimeInput = vi.fn();
+    close = vi.fn();
+  }
+  return {
+    Modality: { AUDIO: "AUDIO" },
+    GoogleGenAI: class {
+      live = {
+        connect: async (params: {
+          model: string;
+          config: Record<string, unknown>;
+        }) => {
+          captured.last = { model: params.model, config: params.config };
+          return new FakeSession();
+        },
+      };
+      constructor(_init: { apiKey?: string }) {}
+    },
+  };
+});
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "specs",
+  "voice-agents.feature",
+);
+
+const feature = await loadFeature(FEATURE_PATH);
+
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    // -----------------------------------------------------------------------
+    // Scenario 1 — Connect via native-audio endpoint
+    // -----------------------------------------------------------------------
+    Scenario(
+      "GeminiLiveAgentAdapter connects via native-audio endpoint",
+      ({ Given, When, Then }) => {
+        let adapter: GeminiLiveAgentAdapter;
+
+        Given(
+          'a GeminiLiveAgentAdapter with model "gemini-2.5-flash-native-audio", voice "Algieba"',
+          () => {
+            captured.last = null;
+            adapter = new GeminiLiveAgentAdapter({
+              model: "gemini-2.5-flash-native-audio",
+              voice: "Algieba",
+              systemInstruction: "You are a helpful tour guide.",
+              apiKey: "test-key",
+            });
+            expect(adapter.model).toBe("gemini-2.5-flash-native-audio");
+            expect(adapter.voice).toBe("Algieba");
+          },
+        );
+
+        When("the scenario starts", async () => {
+          await adapter.connect();
+        });
+
+        Then(
+          "a Gemini Live session is established with the given system_instruction",
+          async () => {
+            // The mock recorded the connect-params; verify model + system
+            // instruction landed correctly, and that AAD is disabled (the
+            // explicit-turn-boundary contract Gemini Live relies on).
+            expect(captured.last).not.toBeNull();
+            expect(captured.last?.model).toBe("gemini-2.5-flash-native-audio");
+            const cfg = captured.last?.config as Record<string, unknown> | undefined;
+            expect(cfg?.systemInstruction).toBe("You are a helpful tour guide.");
+            expect(cfg?.responseModalities).toEqual(["AUDIO"]);
+            const realtime = cfg?.realtimeInputConfig as
+              | { automaticActivityDetection?: { disabled?: boolean } }
+              | undefined;
+            expect(realtime?.automaticActivityDetection?.disabled).toBe(true);
+            await adapter.disconnect();
+          },
+        );
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // Scenario 2 — Capabilities matrix invariants
+    // -----------------------------------------------------------------------
+    Scenario(
+      "GeminiLiveAgentAdapter advertises native-audio capabilities matrix",
+      ({ Given, Then, And }) => {
+        let adapter: GeminiLiveAgentAdapter;
+
+        Given("a GeminiLiveAgentAdapter", () => {
+          adapter = new GeminiLiveAgentAdapter({ apiKey: "test-key" });
+          expect(adapter.capabilities).toBeInstanceOf(AdapterCapabilities);
+        });
+
+        Then("capabilities.streaming_transcripts is True", () => {
+          expect(adapter.capabilities.streamingTranscripts).toBe(true);
+        });
+
+        And("capabilities.native_vad is True", () => {
+          expect(adapter.capabilities.nativeVad).toBe(true);
+        });
+
+        And("capabilities.interruption is True", () => {
+          expect(adapter.capabilities.interruption).toBe(true);
+        });
+
+        And('capabilities.input_formats include "pcm16/16000"', () => {
+          expect(adapter.capabilities.inputFormats).toContain("pcm16/16000");
+        });
+
+        And('capabilities.output_formats include "pcm16/24000"', () => {
+          expect(adapter.capabilities.outputFormats).toContain("pcm16/24000");
+        });
+      },
+    );
+  },
+  { includeTags: ["ts-gemini-live"] },
+);

--- a/javascript/src/voice/adapters/gemini-live.ts
+++ b/javascript/src/voice/adapters/gemini-live.ts
@@ -1,0 +1,492 @@
+/**
+ * GeminiLiveAgentAdapter — TypeScript port of
+ * `python/scenario/voice/adapters/gemini_live.py`.
+ *
+ * Connects directly to the Gemini Live API via the official `@google/genai`
+ * SDK. STT, LLM, and TTS all run on Google's infrastructure; audio flows
+ * bidirectionally as raw PCM16.
+ *
+ * Sample rates:
+ *   Canonical internal:  PCM16 mono 24000 Hz  (AudioChunk)
+ *   Gemini Live input:   PCM16 mono 16000 Hz  ("audio/pcm;rate=16000")
+ *   Gemini Live output:  PCM16 mono 24000 Hz  (docs say 24kHz output)
+ *
+ * Resampling is linear interpolation in pure JS — no numpy/scipy dependency.
+ *
+ * Session lifecycle (Decision (b), see PR body):
+ *   Unlike Python's `async with client.aio.live.connect(...)` context
+ *   manager, the JS SDK exposes `client.live.connect()` as a plain
+ *   `Promise<Session>` with `session.close()` to terminate. There is no
+ *   need for a background promise pump holding the context open — the
+ *   `Session` object itself owns the underlying WebSocket and stays open
+ *   between `connect()` and `close()`. We therefore map `connect()` /
+ *   `disconnect()` from the {@link VoiceAgentAdapter} base directly onto
+ *   the SDK's open/close primitives, with no extra ceremony.
+ *
+ *   Message dispatch is a separate concern: the JS SDK delivers
+ *   {@link LiveServerMessage} via the `onmessage` callback passed to
+ *   `connect()`, not via an async iterator. We bridge the callback to an
+ *   in-memory queue with a promise-based signal so `receiveAudio(timeout)`
+ *   can `await` for the next message with `Promise.race` against a timer.
+ */
+
+import { Buffer } from "node:buffer";
+
+import { AgentInput } from "../../domain/agents";
+import { AgentReturnTypes } from "../../domain/agents/types/agent-return.types";
+import { VoiceAgentAdapter } from "../adapter";
+import { AudioChunk } from "../audio-chunk";
+import { AdapterCapabilities } from "../capabilities";
+import { GEMINI_LIVE_MODEL } from "../voice-models";
+
+/** Gemini Live ingests PCM16 at 16kHz. */
+const GEMINI_INPUT_RATE = 16000;
+/** Canonical internal rate. Gemini Live's output rate also equals this. */
+const CANONICAL_RATE = 24000;
+
+/**
+ * Resample mono PCM16 little-endian bytes between two sample rates using
+ * linear interpolation. Returns an even-length byte buffer (PCM16 invariant).
+ */
+function resamplePcm16(data: Uint8Array, fromRate: number, toRate: number): Uint8Array {
+  if (fromRate === toRate || data.length === 0) {
+    return data;
+  }
+
+  const sampleCount = Math.floor(data.length / 2);
+  // Read input as little-endian int16.
+  const src = new Int16Array(sampleCount);
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  for (let i = 0; i < sampleCount; i++) {
+    src[i] = view.getInt16(i * 2, true);
+  }
+
+  const nOut = Math.floor((sampleCount * toRate) / fromRate);
+  if (nOut === 0) {
+    return new Uint8Array(0);
+  }
+
+  const dst = new Int16Array(nOut);
+  if (sampleCount === 1) {
+    dst.fill(src[0]);
+  } else {
+    const step = (sampleCount - 1) / (nOut - 1 || 1);
+    for (let i = 0; i < nOut; i++) {
+      const pos = i * step;
+      const idx = Math.floor(pos);
+      const frac = pos - idx;
+      const a = src[idx];
+      const b = src[Math.min(idx + 1, sampleCount - 1)];
+      dst[i] = Math.round(a + (b - a) * frac);
+    }
+  }
+
+  // Encode back to little-endian bytes.
+  let outLen = dst.length * 2;
+  if (outLen % 2 === 1) outLen -= 1;
+  const out = new Uint8Array(outLen);
+  const outView = new DataView(out.buffer);
+  for (let i = 0; i < dst.length; i++) {
+    outView.setInt16(i * 2, dst[i], true);
+  }
+  return out;
+}
+
+/**
+ * Internal message queue entry: each `onmessage` event from the SDK becomes
+ * a `Pending` item; a closure event becomes a sentinel `closed: true`.
+ */
+interface QueueItem {
+  message?: unknown;
+  closed?: boolean;
+  error?: unknown;
+}
+
+/**
+ * Construction options for {@link GeminiLiveAgentAdapter}.
+ */
+export interface GeminiLiveAgentAdapterInit {
+  /** Live model identifier. Defaults to {@link GEMINI_LIVE_MODEL}. */
+  model?: string;
+  /** Prebuilt voice name. Defaults to "Algieba". */
+  voice?: string;
+  /** Optional system instruction sent at session setup. */
+  systemInstruction?: string;
+  /** Explicit API key. Falls back to `GEMINI_API_KEY` / `GOOGLE_API_KEY` env vars. */
+  apiKey?: string;
+}
+
+/**
+ * Gemini Live native-audio adapter.
+ *
+ * Connects directly to the Gemini Live API via the `@google/genai` SDK.
+ * Audio flows bidirectionally as raw PCM16; canonical 24kHz internally,
+ * resampled to/from 16kHz at the wire boundary.
+ *
+ * @remarks
+ * The `@google/genai` package is declared as an **optional peer
+ * dependency** so the SDK ships without a hard Gemini coupling. Users who
+ * import this adapter must install `@google/genai` themselves.
+ */
+export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
+  readonly capabilities = new AdapterCapabilities({
+    streamingTranscripts: true,
+    nativeVad: true,
+    dtmf: false,
+    // With explicit Activity markers and the default
+    // START_OF_ACTIVITY_INTERRUPTS handling, the next activityStart we
+    // send while the model is replying causes Gemini to cut its
+    // in-flight audio. `interrupt()` itself just drains stale chunks out
+    // of the local queue so the recovery agent turn doesn't replay them.
+    interruption: true,
+    inputFormats: ["pcm16/16000"],
+    outputFormats: ["pcm16/24000"],
+  });
+
+  readonly model: string;
+  readonly voice: string;
+  readonly systemInstruction: string;
+
+  private readonly apiKey: string;
+
+  // Session state — populated by `connect()`, cleared by `disconnect()`.
+  private session: unknown = null;
+  private queue: QueueItem[] = [];
+  private resolveNext: ((item: QueueItem) => void) | null = null;
+  private connected = false;
+  /** Tracks whether the current turn iterator has yielded any audio. */
+  private iterHadAudio = false;
+
+  /** Most-recent output transcript received from the server, for observability. */
+  lastAgentTranscript: string | null = null;
+
+  constructor(init: GeminiLiveAgentAdapterInit = {}) {
+    super();
+    this.model = init.model ?? GEMINI_LIVE_MODEL;
+    this.voice = init.voice ?? "Algieba";
+    this.systemInstruction = init.systemInstruction ?? "";
+    this.apiKey =
+      init.apiKey ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY ?? "";
+  }
+
+  /**
+   * Stub `call()` — the runtime PR (#515) overrides this on the base class
+   * with the executor-aware audio-loop implementation. PR9 just satisfies the
+   * abstract surface so the adapter class is constructible standalone.
+   */
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return "";
+  }
+
+  // ----------------------------------------------------------------- lifecycle
+
+  /**
+   * Open a Gemini Live session.
+   *
+   * Lazy-imports `@google/genai` so the SDK only loads when this adapter
+   * is actually used. Registers an `onmessage` callback that pushes
+   * {@link LiveServerMessage} instances onto an internal queue, which
+   * {@link receiveAudio} drains.
+   */
+  async connect(): Promise<void> {
+    if (this.connected) return;
+
+    let genai: typeof import("@google/genai");
+    try {
+      genai = await import("@google/genai");
+    } catch {
+      throw new Error(
+        "GeminiLiveAgentAdapter: '@google/genai' is not installed. " +
+          "Install it as a peer dependency: `pnpm add @google/genai`.",
+      );
+    }
+
+    const { GoogleGenAI, Modality } = genai;
+    const client = new GoogleGenAI({ apiKey: this.apiKey });
+
+    const config: Record<string, unknown> = {
+      responseModalities: [Modality.AUDIO],
+      speechConfig: {
+        voiceConfig: {
+          prebuiltVoiceConfig: { voiceName: this.voice },
+        },
+      },
+      // Disable Automatic Activity Detection — we drive turn boundaries
+      // explicitly via activityStart / activityEnd in sendAudio() so the
+      // model replies the moment we close the turn. Mirrors the Python
+      // adapter's choice; see python/scenario/voice/adapters/gemini_live.py
+      // for the full rationale.
+      realtimeInputConfig: {
+        automaticActivityDetection: { disabled: true },
+      },
+      inputAudioTranscription: {},
+      outputAudioTranscription: {},
+    };
+    if (this.systemInstruction) {
+      config.systemInstruction = this.systemInstruction;
+    }
+
+    this.queue = [];
+    this.resolveNext = null;
+    this.iterHadAudio = false;
+
+    this.session = await client.live.connect({
+      model: this.model,
+      config: config as never,
+      callbacks: {
+        onmessage: (msg) => this.enqueue({ message: msg }),
+        onerror: (e: unknown) =>
+          this.enqueue({ error: e instanceof Error ? e : new Error(String(e)) }),
+        onclose: () => this.enqueue({ closed: true }),
+      },
+    });
+    this.connected = true;
+  }
+
+  /**
+   * Close the Gemini Live session and release the WebSocket.
+   */
+  async disconnect(): Promise<void> {
+    if (!this.connected) return;
+    try {
+      const sess = this.session as { close?: () => void | Promise<void> } | null;
+      if (sess?.close) {
+        await sess.close();
+      }
+    } catch {
+      // Best-effort: closing an already-closed session is fine. Other
+      // errors during teardown are non-actionable — we're discarding the
+      // session anyway.
+    }
+    this.session = null;
+    this.connected = false;
+    this.queue = [];
+    if (this.resolveNext) {
+      this.resolveNext({ closed: true });
+      this.resolveNext = null;
+    }
+  }
+
+  // ----------------------------------------------------------------------- I/O
+
+  /**
+   * Send a canonical 24kHz {@link AudioChunk} to Gemini Live as a complete turn.
+   *
+   * Resamples 24kHz → 16kHz at the wire boundary and wraps the audio in
+   * explicit `activityStart` / `activityEnd` markers. With Automatic Activity
+   * Detection disabled (see {@link connect}), each `sendAudio` call is a
+   * complete user turn from Gemini's perspective: the model replies the moment
+   * we close the turn.
+   */
+  async sendAudio(chunk: AudioChunk): Promise<void> {
+    this.requireConnected();
+    const pcm16k = resamplePcm16(chunk.data, CANONICAL_RATE, GEMINI_INPUT_RATE);
+    if (pcm16k.length === 0) return;
+
+    // New user turn — reset the per-turn transcript so the agent's first
+    // reply text doesn't get permanently prefixed onto every subsequent turn.
+    this.lastAgentTranscript = null;
+    this.iterHadAudio = false;
+
+    const session = this.session as {
+      sendRealtimeInput: (params: Record<string, unknown>) => void;
+    };
+    session.sendRealtimeInput({ activityStart: {} });
+    session.sendRealtimeInput({
+      audio: {
+        data: Buffer.from(pcm16k).toString("base64"),
+        mimeType: `audio/pcm;rate=${GEMINI_INPUT_RATE}`,
+      },
+    });
+    session.sendRealtimeInput({ activityEnd: {} });
+  }
+
+  /**
+   * Receive the next audio fragment from Gemini Live for the current turn.
+   *
+   * The SDK delivers messages via an `onmessage` callback that we've bridged
+   * to an internal queue. This method walks the queue, accumulating
+   * transcript text and audio bytes, and returns:
+   *
+   *   - the next non-empty audio chunk as soon as it arrives, OR
+   *   - an empty {@link AudioChunk} when the turn completes (so the drain
+   *     loop's tail-silence path can exit), OR
+   *   - re-enters the receive loop transparently on the spurious
+   *     "interrupted → turnComplete" pair that the server sometimes emits
+   *     between turns (when activityStart for turn N+1 lands during turn
+   *     N's playback delay — see Python adapter for the full pattern).
+   *
+   * Throws {@link Error} with name `"TimeoutError"` if no chunk arrives
+   * within `timeout` seconds.
+   */
+  async receiveAudio(timeout: number): Promise<AudioChunk> {
+    this.requireConnected();
+    const deadline = Date.now() + timeout * 1000;
+    let pendingTranscript = "";
+    let sawInterrupted = false;
+
+    while (true) {
+      const remainingMs = Math.max(0, deadline - Date.now());
+      const item = await this.dequeue(remainingMs);
+
+      if (item.error) throw item.error;
+      if (item.closed) {
+        // Connection closed mid-turn — surface as empty end-of-turn so
+        // callers see a graceful shutdown rather than a hang.
+        return new AudioChunk({
+          data: new Uint8Array(0),
+          transcript: pendingTranscript || undefined,
+        });
+      }
+
+      const msg = item.message as {
+        serverContent?: {
+          modelTurn?: { parts?: Array<{ inlineData?: { data?: string } }> };
+          turnComplete?: boolean;
+          interrupted?: boolean;
+          outputTranscription?: { text?: string };
+        };
+        goAway?: unknown;
+      };
+
+      if (msg.goAway) {
+        throw new Error(
+          `GeminiLiveAgentAdapter: server sent goAway: ${JSON.stringify(msg.goAway)}`,
+        );
+      }
+
+      const sc = msg.serverContent;
+      if (!sc) continue;
+
+      if (sc.interrupted) sawInterrupted = true;
+
+      if (sc.outputTranscription?.text) {
+        const text = sc.outputTranscription.text;
+        pendingTranscript += text;
+        this.lastAgentTranscript = (this.lastAgentTranscript ?? "") + text;
+      }
+
+      const parts = sc.modelTurn?.parts ?? [];
+      if (parts.length > 0) {
+        const buffers: Buffer[] = [];
+        for (const part of parts) {
+          const b64 = part.inlineData?.data;
+          if (b64) buffers.push(Buffer.from(b64, "base64"));
+        }
+        if (buffers.length > 0) {
+          let audioBytes = Buffer.concat(buffers);
+          if (audioBytes.length % 2 === 1) {
+            audioBytes = audioBytes.subarray(0, audioBytes.length - 1);
+          }
+          if (audioBytes.length > 0) {
+            this.iterHadAudio = true;
+            return new AudioChunk({
+              data: new Uint8Array(
+                audioBytes.buffer,
+                audioBytes.byteOffset,
+                audioBytes.byteLength,
+              ),
+              transcript: pendingTranscript || undefined,
+            });
+          }
+        }
+      }
+
+      if (sc.turnComplete) {
+        // Spurious empty-interrupt turn? When activityStart opens turn
+        // N+1 after turn N's generationComplete, the server emits
+        // "interrupted → turnComplete" with no audio FIRST, then the
+        // real reply in a separate turn. Detect that pattern (saw
+        // interrupted=true, no audio on THIS iterator, no transcript)
+        // and continue the receive loop to read the actual reply.
+        if (sawInterrupted && !this.iterHadAudio && !pendingTranscript) {
+          sawInterrupted = false;
+          continue;
+        }
+        // Real end-of-turn — yield empty AudioChunk.
+        return new AudioChunk({
+          data: new Uint8Array(0),
+          transcript: pendingTranscript || undefined,
+        });
+      }
+    }
+  }
+
+  /**
+   * Drain leftover chunks from the in-flight agent turn so the recovery
+   * agent's `receiveAudio` doesn't pick them up as a fake first reply.
+   *
+   * On Gemini Live, when we send a fresh `activityStart` (the next
+   * `sendAudio`) while the model is mid-reply, the server cuts its
+   * in-flight audio AND emits `turnComplete` for that cancelled turn.
+   * `interrupt()` consumes any pending messages up to that boundary so
+   * the next `receiveAudio` reads the recovery turn cleanly.
+   *
+   * Best-effort: bounded by 2 seconds so a stuck stream doesn't block
+   * the executor's interrupt sequence.
+   */
+  override async interrupt(): Promise<void> {
+    if (!this.connected) return;
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const remainingMs = Math.max(0, deadline - Date.now());
+      let item: QueueItem;
+      try {
+        item = await this.dequeue(remainingMs);
+      } catch {
+        // Bounded drain: if no message arrives within the remaining
+        // budget, give up — the next receiveAudio will pick up cleanly.
+        break;
+      }
+      if (item.closed) break;
+      const sc = (item.message as { serverContent?: { turnComplete?: boolean } })
+        ?.serverContent;
+      if (sc?.turnComplete) break;
+    }
+  }
+
+  // ------------------------------------------------------------- internal
+
+  private requireConnected(): void {
+    if (!this.connected || !this.session) {
+      throw new Error("GeminiLiveAgentAdapter: not connected");
+    }
+  }
+
+  private enqueue(item: QueueItem): void {
+    if (this.resolveNext) {
+      const resolver = this.resolveNext;
+      this.resolveNext = null;
+      resolver(item);
+      return;
+    }
+    this.queue.push(item);
+  }
+
+  /**
+   * Pull the next queued item, waiting up to `timeoutMs` milliseconds.
+   * Throws a TimeoutError-named Error on expiry.
+   */
+  private dequeue(timeoutMs: number): Promise<QueueItem> {
+    const next = this.queue.shift();
+    if (next) return Promise.resolve(next);
+
+    return new Promise<QueueItem>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // Detach the pending resolver if we're the active waiter.
+        if (this.resolveNext === wrapped) this.resolveNext = null;
+        const err = new Error(
+          `GeminiLiveAgentAdapter: no message within ${timeoutMs}ms`,
+        );
+        err.name = "TimeoutError";
+        reject(err);
+      }, timeoutMs);
+
+      const wrapped = (item: QueueItem): void => {
+        clearTimeout(timer);
+        resolve(item);
+      };
+      this.resolveNext = wrapped;
+    });
+  }
+}

--- a/javascript/src/voice/index.ts
+++ b/javascript/src/voice/index.ts
@@ -23,6 +23,11 @@ export {
 
 export { VoiceAgentAdapter } from "./adapter";
 
+export {
+  GeminiLiveAgentAdapter,
+  type GeminiLiveAgentAdapterInit,
+} from "./adapters/gemini-live";
+
 export type {
   AudioSegment,
   LatencyMetrics,

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2023"],
     "moduleResolution": "bundler",

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -112,12 +112,22 @@ Feature: Voice agent testing in Scenario SDK
     Then the realtime model drives the user side of the conversation with natural prosody
     And text TTS is bypassed for the user simulator
 
-  @unit
+  @unit @ts-gemini-live
   Scenario: GeminiLiveAgentAdapter connects via native-audio endpoint
     # Source §4.1, L193-197 and §5.6, L815-826
     Given a GeminiLiveAgentAdapter with model "gemini-2.5-flash-native-audio", voice "Algieba"
     When the scenario starts
     Then a Gemini Live session is established with the given system_instruction
+
+  @unit @ts-gemini-live
+  Scenario: GeminiLiveAgentAdapter advertises native-audio capabilities matrix
+    # Source §5.6, L815-826 — capability matrix invariants
+    Given a GeminiLiveAgentAdapter
+    Then capabilities.streaming_transcripts is True
+    And capabilities.native_vad is True
+    And capabilities.interruption is True
+    And capabilities.input_formats include "pcm16/16000"
+    And capabilities.output_formats include "pcm16/24000"
 
   @unit
   Scenario: WebSocketAgentAdapter uses a user-supplied protocol
@@ -601,7 +611,7 @@ Feature: Voice agent testing in Scenario SDK
     Then the STT, LLM, and TTS seams each fire at least once
     And result.success is True
 
-  @e2e
+  @e2e @ts-gemini-live-e2e
   Scenario: Demo — Gemini Live native audio
     # Covers: GeminiLiveAgentAdapter real transport + simulator + judge
     Given a GeminiLiveAgentAdapter with model "gemini-2.5-flash-native-audio" and GEMINI_API_KEY


### PR DESCRIPTION
## Summary

- Ports `python/scenario/voice/adapters/gemini_live.py` → `javascript/src/voice/adapters/gemini-live.ts` using `@google/genai` v2.x.
- 2 `@unit` scenarios (connect + capabilities matrix) bound via vitest-cucumber + 1 `@e2e` demo scenario (env-gated on `GEMINI_API_KEY` / `GOOGLE_API_KEY`).
- `@google/genai` declared as an **optional peer dependency** — lazy-imported on `connect()` so the SDK ships without a hard Gemini coupling.

## What changed

**New files:**
- `javascript/src/voice/adapters/gemini-live.ts` — `GeminiLiveAgentAdapter`, capabilities matrix, PCM16 24kHz↔16kHz resampler (pure JS, no scipy), callback-to-queue bridge for `receiveAudio()`.
- `javascript/src/voice/adapters/__tests__/gemini-live.test.ts` — 2 cucumber-bound `@unit` scenarios, mocks `@google/genai` at module level so tests run offline.
- `javascript/examples/vitest/tests/voice/gemini-live.test.ts` — 1 cucumber-bound `@e2e` demo scenario, skips when no API key is present.

**Modified files:**
- `javascript/src/voice/index.ts` — exports `GeminiLiveAgentAdapter` and `GeminiLiveAgentAdapterInit`.
- `javascript/package.json` — adds `@google/genai ^2.5.0` as devDep + optional peer dep.
- `javascript/examples/vitest/package.json` — adds `@amiceli/vitest-cucumber` devDep so the e2e suite can `loadFeature`.
- `specs/voice-agents.feature` — splits the existing Gemini Live unit scenario into 2 (connect + capabilities matrix) and tags both `@ts-gemini-live`; tags the e2e demo scenario `@ts-gemini-live-e2e` to keep the two suites' tag filters disjoint.

## Decision pending: Gemini Live session lifecycle

**Choice landed: (b) — reuse `connect()` / `disconnect()` from `VoiceAgentAdapter`, mapping directly onto SDK lifecycle.**

The Python adapter holds the SDK context manager open across the adapter's lifetime via a background task because `google-genai`'s `client.aio.live.connect(...)` is exposed as an `async with` context manager — there is no plain open/close API in Python. JS has no such constraint:

- `@google/genai` v2.5.0 exposes `client.live.connect()` as `Promise<Session>` and `session.close()` as an explicit teardown method (source: `node_modules/@google/genai/dist/genai.d.ts` lines 7240, 10076–10154). The returned `Session` owns the underlying WebSocket and stays open between `connect()` and `close()`, no context manager required.
- The base `VoiceAgentAdapter` (PR1/#511, merged) already defines abstract `connect()` / `disconnect()`, so option (a) — adding `start()` / `stop()` — would diverge the JS lifecycle from every other adapter for no benefit.
- The only thing the JS SDK doesn't give us is an async iterator over server messages — it dispatches via the `callbacks.onmessage(LiveServerMessage)` hook registered at `connect()` time. So we bridge that callback to an internal queue + promise-based signal, and `receiveAudio(timeout)` awaits on `Promise.race(queue.next(), setTimeout)`. That's the only piece of (c)-flavored background work needed; the lifecycle itself is plain (b).

If a future SDK version surfaces an async iterator (`session.receive()`) we can drop the queue and let `receiveAudio` `for await` directly — a strictly mechanical refactor.

**Trade-off acknowledged:** option (c) — a full background promise pump — was rejected because it adds a lifetime to manage (the pump's promise) without buying anything the queue bridge doesn't already provide. The Python equivalent only exists because Python's context-manager-only API forced it.

## Test plan

- [x] `pnpm test src/voice/adapters/__tests__/gemini-live.test.ts` — 9/9 unit assertions pass.
- [x] `pnpm test src/voice/` — 25/25 voice tests pass (9 new + 16 contract surface from PR #517).
- [x] `pnpm -F vitest-examples vitest run tests/voice/gemini-live.test.ts` — 3/3 e2e steps skip cleanly without `GEMINI_API_KEY` set.
- [x] `pnpm lint src/voice/adapters/` — 0 errors in the new adapter and its test (pre-existing errors elsewhere in `src/voice/` are not introduced by this PR).
- [x] `pnpm typecheck` — adapter file typechecks clean. Pre-existing errors remain in `src/agents/judge/*` and `src/voice/__tests__/voice-contract-surface.test.ts` (top-level `await`); both are on `main` and unrelated to PR9.
- [ ] Run e2e against real Gemini Live with `GEMINI_API_KEY` set (requires reviewer with API key or `/browser-qa-against-prod`).

## /browser-qa-against-prod

Env-gated on `GEMINI_API_KEY` or `GOOGLE_API_KEY`. To exercise:

```bash
cd javascript/examples/vitest
GEMINI_API_KEY=… pnpm vitest run tests/voice/gemini-live.test.ts
```

The e2e scenario opens a real Live session, pushes a 0.5s silence-padded user turn, drains audio until `turn_complete`, and asserts the round-trip completed.

## Caveats / followups (not in this PR)

- `call()` is a stub returning `""` — PR3 (#515, voice adapter runtime) ports the executor-aware audio-loop `call()` from `python/scenario/voice/adapter.py` onto the base class. This PR satisfies the abstract surface so the adapter is constructible standalone, then inherits the real `call()` when PR3 lands.
- `@google/generative-ai` (the deprecated Google SDK at v0.24.x) is **not** used. The original task brief named it, but the Python adapter uses `google-genai` (the new SDK) and the JS parity is `@google/genai` v2.x. Documented here so reviewers don't chase the wrong package.
- The `interrupt()` test path is not yet bound to a scenario — once PR3's executor wiring lands and the interruption-recovery scenarios get tagged, those will pick up `interrupt()` naturally.

## Refs

- #372 (slice plan and issue)
- #511 (PR1, types + contract surface, merged)
- #515 (PR3, voice adapter runtime, open — provides the executor-side `call()` that this adapter inherits when wired)
- Python parity: `python/scenario/voice/adapters/gemini_live.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
