### PR TITLE
feat(typescript-sdk/#372): voice Twilio adapter + tunnel harness (PR11 of N)

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -61,11 +61,13 @@
     "langwatch": "0.16.1",
     "open": "11.0.0",
     "rxjs": "^7.8.2",
+    "ws": "^8.20.1",
     "xksuid": "^0.0.4",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@amiceli/vitest-cucumber": "^6.5.0",
+    "@types/ws": "^8.18.0",
     "@eslint/js": "^9.39.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: 3.0.58(zod@3.25.76)
       '@openai/agents':
         specifier: ^0.3.3
-        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)
       '@opentelemetry/sdk-node':
         specifier: 0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.1)
@@ -51,13 +51,16 @@ importers:
         version: 5.6.2
       langwatch:
         specifier: 0.16.1
-        version: 0.16.1(b41a17639303d9bb23144bd916c66a4d)
+        version: 0.16.1(bbdfd656eb6911daa68415a33dc56ba6)
       open:
         specifier: 11.0.0
         version: 11.0.0
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      ws:
+        specifier: ^8.20.1
+        version: 8.20.1
       xksuid:
         specifier: ^0.0.4
         version: 0.0.4
@@ -77,6 +80,9 @@ importers:
       '@types/node':
         specifier: ^24.10.1
         version: 24.12.2
+      '@types/ws':
+        specifier: ^8.18.0
+        version: 8.18.1
       '@typescript-eslint/parser':
         specifier: ^8.48.0
         version: 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -148,7 +154,7 @@ importers:
     dependencies:
       '@openai/agents':
         specifier: ^0.3.9
-        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -276,7 +282,7 @@ importers:
         version: link:../..
       '@openai/agents':
         specifier: ^0.3.3
-        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
+        version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)
       ai:
         specifier: ^6.0.0
         version: 6.0.174(zod@4.4.3)
@@ -285,7 +291,7 @@ importers:
         version: 5.2.1
       openai:
         specifier: ^6.9.1
-        version: 6.35.0(ws@8.20.0)(zod@4.4.3)
+        version: 6.35.0(ws@8.20.1)(zod@4.4.3)
       vite:
         specifier: '>=7.3.2'
         version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
@@ -4978,8 +4984,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5754,14 +5760,14 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -5775,27 +5781,27 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@langchain/langgraph-sdk@0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@langchain/langgraph@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76))':
+  '@langchain/langgraph@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
+      '@langchain/langgraph-checkpoint': 0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))
+      '@langchain/langgraph-sdk': 0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       uuid: 10.0.0
       zod: 3.25.76
     optionalDependencies:
@@ -5804,18 +5810,18 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(ws@8.20.0)':
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(ws@8.20.1)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       js-tiktoken: 1.0.21
-      openai: 5.12.2(ws@8.20.0)(zod@3.25.76)
+      openai: 5.12.2(ws@8.20.1)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))':
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       js-tiktoken: 1.0.21
 
   '@mediapipe/tasks-vision@0.10.17': {}
@@ -5889,10 +5895,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@openai/agents-core@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)':
+  '@openai/agents-core@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)':
     dependencies:
       debug: 4.4.3
-      openai: 6.35.0(ws@8.20.0)(zod@3.25.76)
+      openai: 6.35.0(ws@8.20.1)(zod@3.25.76)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod: 3.25.76
@@ -5901,10 +5907,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-core@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)':
+  '@openai/agents-core@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       debug: 4.4.3
-      openai: 6.35.0(ws@8.20.0)(zod@4.4.3)
+      openai: 6.35.0(ws@8.20.1)(zod@4.4.3)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       zod: 4.4.3
@@ -5913,22 +5919,22 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)':
+  '@openai/agents-openai@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.35.0(ws@8.20.0)(zod@3.25.76)
+      openai: 6.35.0(ws@8.20.1)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)':
+  '@openai/agents-openai@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)
       debug: 4.4.3
-      openai: 6.35.0(ws@8.20.0)(zod@4.4.3)
+      openai: 6.35.0(ws@8.20.1)(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -5937,10 +5943,10 @@ snapshots:
 
   '@openai/agents-realtime@0.3.9(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)
       '@types/ws': 8.18.1
       debug: 4.4.3
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -5950,10 +5956,10 @@ snapshots:
 
   '@openai/agents-realtime@0.3.9(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)
       '@types/ws': 8.18.1
       debug: 4.4.3
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -5961,13 +5967,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@openai/agents@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)':
+  '@openai/agents@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
-      '@openai/agents-openai': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)
+      '@openai/agents-openai': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@3.25.76)
       '@openai/agents-realtime': 0.3.9(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.35.0(ws@8.20.0)(zod@3.25.76)
+      openai: 6.35.0(ws@8.20.1)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -5976,13 +5982,13 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@openai/agents@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)':
+  '@openai/agents@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
-      '@openai/agents-openai': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)
+      '@openai/agents-openai': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.1)(zod@4.4.3)
       '@openai/agents-realtime': 0.3.9(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       debug: 4.4.3
-      openai: 6.35.0(ws@8.20.0)(zod@4.4.3)
+      openai: 6.35.0(ws@8.20.1)(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -8800,15 +8806,15 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(handlebars@4.7.9)(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0):
+  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(handlebars@4.7.9)(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1):
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
-      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(ws@8.20.0)
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
+      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(ws@8.20.1)
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))
       js-tiktoken: 1.0.21
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
-      langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
@@ -8823,22 +8829,22 @@ snapshots:
       - openai
       - ws
 
-  langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0):
+  langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.212.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      openai: 6.35.0(ws@8.20.0)(zod@3.25.76)
-      ws: 8.20.0
+      openai: 6.35.0(ws@8.20.1)(zod@3.25.76)
+      ws: 8.20.1
 
-  langwatch@0.16.1(b41a17639303d9bb23144bd916c66a4d):
+  langwatch@0.16.1(bbdfd656eb6911daa68415a33dc56ba6):
     dependencies:
       '@ai-sdk/openai': 3.0.58(zod@3.25.76)
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
-      '@langchain/langgraph': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76))
-      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
+      '@langchain/langgraph': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76))
+      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(ws@8.20.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.205.0
       '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.1)
@@ -8859,7 +8865,7 @@ snapshots:
       commander: 12.1.0
       dotenv: 17.4.2
       js-yaml: 4.1.1
-      langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(handlebars@4.7.9)(openai@6.35.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(handlebars@4.7.9)(openai@6.35.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       liquidjs: 10.25.7
       open: 11.0.0
       openapi-fetch: 0.16.0
@@ -9198,19 +9204,19 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@5.12.2(ws@8.20.0)(zod@3.25.76):
+  openai@5.12.2(ws@8.20.1)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 3.25.76
 
-  openai@6.35.0(ws@8.20.0)(zod@3.25.76):
+  openai@6.35.0(ws@8.20.1)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 3.25.76
 
-  openai@6.35.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.35.0(ws@8.20.1)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.4.3
 
   openapi-fetch@0.16.0:
@@ -10262,7 +10268,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/javascript/src/voice/__tests__/voice-contract-surface.test.ts
+++ b/javascript/src/voice/__tests__/voice-contract-surface.test.ts
@@ -284,5 +284,5 @@ describeFeature(
       },
     );
   },
-  { includeTags: ["ts-bound"] },
+  { includeTags: [["ts-bound", "ts-contract-surface"]] },
 );

--- a/javascript/src/voice/adapters/__tests__/twilio-server.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-server.test.ts
@@ -1,0 +1,170 @@
+/**
+ * TwilioWebhookServer integration tests — binds the two @integration
+ * @ts-bound scenarios tagged @ts-twilio-server in
+ * `specs/voice-agents.feature`.
+ *
+ * Spins the real HTTP+WS server on an OS-assigned port so the TwiML
+ * response shape and signature gate behavior are exercised end-to-end at
+ * the transport level (no real Twilio account, no tunnel).
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { afterAll, expect } from "vitest";
+
+import { TwilioAgentAdapter } from "../twilio";
+import { TwilioRESTHelper } from "../twilio-shared";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
+
+const feature = await loadFeature(FEATURE_PATH);
+
+const trackedAdapters: TwilioAgentAdapter[] = [];
+
+function stubRest(sid: string): TwilioRESTHelper {
+  const stub = new TwilioRESTHelper("ACtest", "secret");
+  stub.resolvePhoneNumberSid = async () => sid;
+  stub.readVoiceUrl = async () => null;
+  stub.writeVoiceUrl = async () => undefined;
+  stub.placeCall = async () => "CAtest";
+  stub.sendDtmfOnCall = async () => undefined;
+  return stub;
+}
+
+async function startAdapter(opts: {
+  publicBaseUrl: string;
+  validateSignature: boolean;
+}): Promise<TwilioAgentAdapter> {
+  const adapter = new TwilioAgentAdapter({
+    accountSid: "ACtest",
+    authToken: "secret",
+    phoneNumber: "+14155551234",
+    publicBaseUrl: opts.publicBaseUrl,
+    validateSignature: opts.validateSignature,
+    rest: stubRest("PNxxxx"),
+  });
+  await adapter.connect();
+  trackedAdapters.push(adapter);
+  return adapter;
+}
+
+afterAll(async () => {
+  for (const adapter of trackedAdapters) {
+    try {
+      await adapter.disconnect();
+    } catch {
+      // Best-effort teardown.
+    }
+  }
+});
+
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    Scenario(
+      "TwiML voice endpoint serves Connect+Stream with an XML-escaped WSS URL",
+      ({ Given, And, When, Then }) => {
+        let adapter: TwilioAgentAdapter;
+        let response: Response;
+        let body: string;
+
+        Given("the TwilioWebhookServer is bound on an OS-assigned port", async () => {
+          // The publicBaseUrl is what shows up in the TwiML; the local server
+          // binds 127.0.0.1:<ephemeral>. Use a URL that requires XML escaping
+          // (ampersand in the query string) so the escape assertion is real.
+          adapter = await startAdapter({
+            publicBaseUrl: "https://example.test/voice?room=a&peer=b",
+            validateSignature: false,
+          });
+        });
+
+        And("the parent adapter has a publicBaseUrl configured", () => {
+          expect(adapter.publicBaseUrl).toContain("https://example.test");
+        });
+
+        When("a Twilio webhook POSTs valid form data to /twilio/voice", async () => {
+          const form = new URLSearchParams({
+            From: "+14155557777",
+            To: "+14155551234",
+            CallSid: "CAabc",
+          });
+          response = await fetch(`${adapter.localBaseUrl}/twilio/voice`, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: form.toString(),
+          });
+          body = await response.text();
+        });
+
+        Then("the response Content-Type is application/xml", () => {
+          expect(response.status).toBe(200);
+          expect(response.headers.get("content-type")).toContain("application/xml");
+        });
+
+        And('the body contains <Connect><Stream url="wss://..."/></Connect>', () => {
+          expect(body).toContain("<Connect><Stream url=");
+          expect(body).toContain("wss://example.test");
+          expect(body).toContain("/twilio/stream");
+          expect(body).toContain("</Connect>");
+        });
+
+        And(
+          "the stream URL is XML-escaped (no unescaped &, <, >, or quotes)",
+          () => {
+            // The publicBaseUrl includes a literal `&peer=` — the response
+            // must escape it as `&amp;peer=` inside the attribute value.
+            expect(body).toContain("&amp;peer=b");
+            expect(body).not.toMatch(/url="[^"]*&[^a]/); // bare `&` not allowed in attr
+          },
+        );
+      },
+    );
+
+    Scenario(
+      "TwiML voice endpoint rejects webhooks with a missing X-Twilio-Signature",
+      ({ Given, When, Then, And }) => {
+        let adapter: TwilioAgentAdapter;
+        let response: Response;
+
+        Given("a TwilioWebhookServer with validateSignature true", async () => {
+          adapter = await startAdapter({
+            publicBaseUrl: "https://example.test",
+            validateSignature: true,
+          });
+          expect(adapter.rejectedCount).toBe(0);
+        });
+
+        When(
+          "a POST to /twilio/voice arrives without an X-Twilio-Signature header",
+          async () => {
+            const form = new URLSearchParams({
+              From: "+14155557777",
+              CallSid: "CAabc",
+            });
+            response = await fetch(`${adapter.localBaseUrl}/twilio/voice`, {
+              method: "POST",
+              headers: { "Content-Type": "application/x-www-form-urlencoded" },
+              body: form.toString(),
+            });
+            await response.text();
+          },
+        );
+
+        Then("the response status is 403", () => {
+          expect(response.status).toBe(403);
+        });
+
+        And(
+          "the adapter records the rejection without opening a media stream",
+          () => {
+            expect(adapter.rejectedCount).toBe(1);
+          },
+        );
+      },
+    );
+  },
+  { includeTags: [["integration", "ts-twilio-server"]] },
+);

--- a/javascript/src/voice/adapters/__tests__/twilio-tunnel.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-tunnel.test.ts
@@ -1,0 +1,118 @@
+/**
+ * TwilioTunnel e2e — binds the @e2e @ts-bound @ts-twilio-tunnel scenario
+ * in `specs/voice-agents.feature`.
+ *
+ * **Env-gated**: skipped when `NGROK_AUTHTOKEN` is not set. CI does not
+ * provide a token, so the scenario is effectively bound at parse time but
+ * its assertions only execute when a maintainer is exercising tunnels
+ * locally.
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { afterAll, expect } from "vitest";
+
+import { TwilioAgentAdapter } from "../twilio";
+import { TwilioRESTHelper } from "../twilio-shared";
+import { openTwilioTunnel, type OpenedTunnel } from "../twilio-tunnel";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
+
+const feature = await loadFeature(FEATURE_PATH);
+
+const TUNNEL_ENABLED = !!process.env.NGROK_AUTHTOKEN;
+
+function stubRest(sid: string): TwilioRESTHelper {
+  const stub = new TwilioRESTHelper("ACtest", "secret");
+  stub.resolvePhoneNumberSid = async () => sid;
+  stub.readVoiceUrl = async () => null;
+  stub.writeVoiceUrl = async () => undefined;
+  stub.placeCall = async () => "CAtest";
+  stub.sendDtmfOnCall = async () => undefined;
+  return stub;
+}
+
+let openedTunnel: OpenedTunnel | null = null;
+let openedAdapter: TwilioAgentAdapter | null = null;
+
+afterAll(async () => {
+  if (openedTunnel) {
+    try {
+      await openedTunnel.close();
+    } catch {
+      // Best-effort.
+    }
+  }
+  if (openedAdapter) {
+    try {
+      await openedAdapter.disconnect();
+    } catch {
+      // Best-effort.
+    }
+  }
+});
+
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    Scenario(
+      "Tunnel exposes the local Twilio server over a public URL",
+      ({ Given, And, When, Then }) => {
+        let adapter: TwilioAgentAdapter;
+        let tunnel: OpenedTunnel;
+        let probedBody: string;
+
+        Given("NGROK_AUTHTOKEN is set in the environment (otherwise skip)", () => {
+          if (!TUNNEL_ENABLED) {
+            // Mark the scenario as skipped — assertions following short-circuit.
+            return;
+          }
+          expect(process.env.NGROK_AUTHTOKEN).toBeTruthy();
+        });
+
+        And("the local TwilioWebhookServer is running on an ephemeral port", async () => {
+          if (!TUNNEL_ENABLED) return;
+          adapter = new TwilioAgentAdapter({
+            accountSid: "ACtest",
+            authToken: "secret",
+            phoneNumber: "+14155551234",
+            publicBaseUrl: "https://placeholder.example",
+            validateSignature: false,
+            rest: stubRest("PNxxxx"),
+          });
+          await adapter.connect();
+          openedAdapter = adapter;
+        });
+
+        When("a TwilioTunnel is opened against the bound port", async () => {
+          if (!TUNNEL_ENABLED) return;
+          const port = Number(new URL(adapter.localBaseUrl).port);
+          tunnel = await openTwilioTunnel({ port });
+          openedTunnel = tunnel;
+          // Rebind the adapter's publicBaseUrl so the TwiML response points
+          // to the live URL — a sanity check that the wiring is end-to-end.
+          adapter.publicBaseUrl = tunnel.url;
+        });
+
+        Then("the tunnel reports an HTTPS URL", () => {
+          if (!TUNNEL_ENABLED) return;
+          expect(tunnel.url).toMatch(/^https:\/\//);
+        });
+
+        And("the URL proxies a GET request through to the local server", async () => {
+          if (!TUNNEL_ENABLED) return;
+          // The local server returns 404 for GET / — that's enough proof that
+          // the proxy reaches it (vs. a tunnel-side 502/timeout).
+          const probed = await fetch(tunnel.url + "/this-path-404s");
+          probedBody = await probed.text();
+          expect(probed.status).toBe(404);
+          expect(probedBody).toContain("not found");
+        });
+      },
+    );
+  },
+  { includeTags: [["e2e", "ts-twilio-tunnel"]] },
+);

--- a/javascript/src/voice/adapters/__tests__/twilio-tunnel.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-tunnel.test.ts
@@ -12,7 +12,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
-import { afterAll, expect } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 
 import { TwilioAgentAdapter } from "../twilio";
 import { TwilioRESTHelper } from "../twilio-shared";
@@ -55,64 +55,66 @@ afterAll(async () => {
   }
 });
 
-describeFeature(
-  feature,
-  ({ Scenario }) => {
-    Scenario(
-      "Tunnel exposes the local Twilio server over a public URL",
-      ({ Given, And, When, Then }) => {
-        let adapter: TwilioAgentAdapter;
-        let tunnel: OpenedTunnel;
-        let probedBody: string;
+if (TUNNEL_ENABLED) {
+  describeFeature(
+    feature,
+    ({ Scenario }) => {
+      Scenario(
+        "Tunnel exposes the local Twilio server over a public URL",
+        ({ Given, And, When, Then }) => {
+          let adapter: TwilioAgentAdapter;
+          let tunnel: OpenedTunnel;
+          let probedBody: string;
 
-        Given("NGROK_AUTHTOKEN is set in the environment (otherwise skip)", () => {
-          if (!TUNNEL_ENABLED) {
-            // Mark the scenario as skipped — assertions following short-circuit.
-            return;
-          }
-          expect(process.env.NGROK_AUTHTOKEN).toBeTruthy();
-        });
-
-        And("the local TwilioWebhookServer is running on an ephemeral port", async () => {
-          if (!TUNNEL_ENABLED) return;
-          adapter = new TwilioAgentAdapter({
-            accountSid: "ACtest",
-            authToken: "secret",
-            phoneNumber: "+14155551234",
-            publicBaseUrl: "https://placeholder.example",
-            validateSignature: false,
-            rest: stubRest("PNxxxx"),
+          Given("NGROK_AUTHTOKEN is set in the environment (otherwise skip)", () => {
+            expect(process.env.NGROK_AUTHTOKEN).toBeTruthy();
           });
-          await adapter.connect();
-          openedAdapter = adapter;
-        });
 
-        When("a TwilioTunnel is opened against the bound port", async () => {
-          if (!TUNNEL_ENABLED) return;
-          const port = Number(new URL(adapter.localBaseUrl).port);
-          tunnel = await openTwilioTunnel({ port });
-          openedTunnel = tunnel;
-          // Rebind the adapter's publicBaseUrl so the TwiML response points
-          // to the live URL — a sanity check that the wiring is end-to-end.
-          adapter.publicBaseUrl = tunnel.url;
-        });
+          And("the local TwilioWebhookServer is running on an ephemeral port", async () => {
+            adapter = new TwilioAgentAdapter({
+              accountSid: "ACtest",
+              authToken: "secret",
+              phoneNumber: "+14155551234",
+              publicBaseUrl: "https://placeholder.example",
+              validateSignature: false,
+              rest: stubRest("PNxxxx"),
+            });
+            await adapter.connect();
+            openedAdapter = adapter;
+          });
 
-        Then("the tunnel reports an HTTPS URL", () => {
-          if (!TUNNEL_ENABLED) return;
-          expect(tunnel.url).toMatch(/^https:\/\//);
-        });
+          When("a TwilioTunnel is opened against the bound port", async () => {
+            const port = Number(new URL(adapter.localBaseUrl).port);
+            tunnel = await openTwilioTunnel({ port });
+            openedTunnel = tunnel;
+            // Rebind the adapter's publicBaseUrl so the TwiML response points
+            // to the live URL — a sanity check that the wiring is end-to-end.
+            adapter.publicBaseUrl = tunnel.url;
+          });
 
-        And("the URL proxies a GET request through to the local server", async () => {
-          if (!TUNNEL_ENABLED) return;
-          // The local server returns 404 for GET / — that's enough proof that
-          // the proxy reaches it (vs. a tunnel-side 502/timeout).
-          const probed = await fetch(tunnel.url + "/this-path-404s");
-          probedBody = await probed.text();
-          expect(probed.status).toBe(404);
-          expect(probedBody).toContain("not found");
-        });
-      },
-    );
-  },
-  { includeTags: [["e2e", "ts-twilio-tunnel"]] },
-);
+          Then("the tunnel reports an HTTPS URL", () => {
+            expect(tunnel.url).toMatch(/^https:\/\//);
+          });
+
+          And("the URL proxies a GET request through to the local server", async () => {
+            // The local server returns 404 for GET / — that's enough proof that
+            // the proxy reaches it (vs. a tunnel-side 502/timeout).
+            const probed = await fetch(tunnel.url + "/this-path-404s");
+            probedBody = await probed.text();
+            expect(probed.status).toBe(404);
+            expect(probedBody).toContain("not found");
+          });
+        },
+      );
+    },
+    { includeTags: [["e2e", "ts-twilio-tunnel"]] },
+  );
+} else {
+  describe.skip("Twilio tunnel scenario (set NGROK_AUTHTOKEN to enable)", () => {
+    it("env-gated — not exercised in CI", () => {
+      // Placeholder so the runner reports a single skipped block instead of
+      // five vacuous green steps. The cucumber binding above only registers
+      // when NGROK_AUTHTOKEN is set.
+    });
+  });
+}

--- a/javascript/src/voice/adapters/__tests__/twilio.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio.test.ts
@@ -12,11 +12,21 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
-import { expect } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { AudioChunk } from "../../audio-chunk";
 import { TwilioAgentAdapter } from "../twilio";
 import type { MediaStreamWebSocket } from "../twilio-server";
-import { TwilioRESTHelper, buildMediaFrame, parseMediaStreamFrame } from "../twilio-shared";
+import {
+  TwilioRESTHelper,
+  buildMediaFrame,
+  mulaw8kToPcm16_24k,
+  parseMediaStreamFrame,
+  pcm16_24kToMulaw8k,
+  validateDtmf,
+  validateE164,
+  verifyTwilioSignature,
+} from "../twilio-shared";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
@@ -237,3 +247,203 @@ async function waitUntil(pred: () => boolean, timeoutMs = 1000): Promise<void> {
     await new Promise<void>((r) => setTimeout(r, 5));
   }
 }
+
+// ----------------------------------------------------------------------------
+// Wire-level coverage for hot paths the cucumber scenarios above don't reach.
+// Plain `it()` blocks because the corresponding behaviors aren't @ts-bound
+// scenarios — they're internal contracts the adapter must hold.
+// ----------------------------------------------------------------------------
+
+describe("twilio-shared codec round-trip", () => {
+  it("pcm16/24k → mulaw/8k → pcm16/24k preserves a sine wave within tolerance", () => {
+    // 100 ms of 440 Hz tone at 24 kHz.
+    const samples = 2400;
+    const original = new Uint8Array(samples * 2);
+    const view = new DataView(original.buffer);
+    for (let i = 0; i < samples; i++) {
+      const v = Math.round(Math.sin((2 * Math.PI * 440 * i) / 24000) * 20000);
+      view.setInt16(i * 2, v, true);
+    }
+    const mulaw = pcm16_24kToMulaw8k(original);
+    expect(mulaw.length).toBeGreaterThan(0);
+    expect(mulaw.length).toBe(samples / 3); // 24 kHz → 8 kHz = 3:1 decimation
+
+    const restored = mulaw8kToPcm16_24k(mulaw);
+    expect(restored.length).toBeGreaterThan(0);
+    // Lossy round-trip — the average sample diff must stay small for a clean
+    // tone. Threshold picked empirically; G.711 µ-law adds modest quantization
+    // noise but doesn't shred the waveform.
+    const restoredView = new DataView(restored.buffer);
+    let totalAbsDiff = 0;
+    const compareSamples = Math.min(samples, restored.length / 2);
+    for (let i = 0; i < compareSamples; i++) {
+      const a = view.getInt16(i * 2, true);
+      const b = restoredView.getInt16(i * 2, true);
+      totalAbsDiff += Math.abs(a - b);
+    }
+    const avgAbsDiff = totalAbsDiff / compareSamples;
+    expect(avgAbsDiff).toBeLessThan(2000); // <10% of peak amplitude (20000)
+  });
+
+  it("empty input produces empty output for both directions", () => {
+    expect(pcm16_24kToMulaw8k(new Uint8Array(0))).toHaveLength(0);
+    expect(mulaw8kToPcm16_24k(new Uint8Array(0))).toHaveLength(0);
+  });
+});
+
+describe("validateE164 / validateDtmf", () => {
+  it("validateE164 accepts canonical numbers and rejects junk", () => {
+    expect(() => validateE164("+14155551234")).not.toThrow();
+    expect(() => validateE164("+447911123456")).not.toThrow();
+    expect(() => validateE164("14155551234")).toThrow(/E.164/); // missing +
+    expect(() => validateE164("+0155551234")).toThrow(/E.164/); // leading 0
+    expect(() => validateE164("+1234")).toThrow(/E.164/); // too short
+    expect(() => validateE164("")).toThrow(/E.164/);
+  });
+
+  it("validateDtmf accepts the DTMF charset and rejects everything else", () => {
+    expect(() => validateDtmf("123")).not.toThrow();
+    expect(() => validateDtmf("*0#")).not.toThrow();
+    expect(() => validateDtmf("1wW2")).not.toThrow();
+    expect(() => validateDtmf("")).toThrow(/DTMF/);
+    expect(() => validateDtmf("12a")).toThrow(/DTMF/);
+    // The injection payload the validator's docstring warns about.
+    expect(() => validateDtmf('1"/><Say>x</Say><Play digits="')).toThrow(/DTMF/);
+  });
+});
+
+describe("verifyTwilioSignature", () => {
+  // Twilio signs HMAC-SHA1(authToken, url + sortedParamsConcat) and base64s
+  // the digest. Build a known-good signature manually and verify both branches.
+  async function signFixture(args: {
+    authToken: string;
+    url: string;
+    params: Record<string, string>;
+  }): Promise<string> {
+    const { createHmac } = await import("node:crypto");
+    const sortedKeys = Object.keys(args.params).sort();
+    let data = args.url;
+    for (const key of sortedKeys) data += key + args.params[key];
+    return createHmac("sha1", args.authToken).update(data).digest("base64");
+  }
+
+  it("accepts a signature computed against the same inputs", async () => {
+    const authToken = "test-token-xyz";
+    const url = "https://example.test/twilio/voice";
+    const params = { From: "+14155557777", CallSid: "CA1" };
+    const signature = await signFixture({ authToken, url, params });
+    expect(await verifyTwilioSignature({ authToken, url, params, signature })).toBe(true);
+  });
+
+  it("rejects a signature signed with a different auth token", async () => {
+    const url = "https://example.test/twilio/voice";
+    const params = { From: "+14155557777" };
+    const signature = await signFixture({ authToken: "wrong", url, params });
+    expect(
+      await verifyTwilioSignature({ authToken: "real", url, params, signature }),
+    ).toBe(false);
+  });
+
+  it("rejects a signature signed against a different URL", async () => {
+    const authToken = "shared";
+    const params = { From: "+14155557777" };
+    const signature = await signFixture({
+      authToken,
+      url: "https://attacker.test/twilio/voice",
+      params,
+    });
+    expect(
+      await verifyTwilioSignature({
+        authToken,
+        url: "https://example.test/twilio/voice",
+        params,
+        signature,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects when the signature is missing", async () => {
+    expect(
+      await verifyTwilioSignature({
+        authToken: "x",
+        url: "https://example.test",
+        params: {},
+        signature: undefined,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("TwilioAgentAdapter integration paths", () => {
+  let openAdapter: TwilioAgentAdapter | null = null;
+
+  afterEach(async () => {
+    if (openAdapter) {
+      await openAdapter.disconnect();
+      openAdapter = null;
+    }
+  });
+
+  it("fires onDtmf when a DTMF media-stream frame arrives", async () => {
+    const onDtmf = vi.fn();
+    const adapter = makeAdapter({ onDtmf });
+    await adapter.connect();
+    openAdapter = adapter;
+    const socket = mockSocket();
+    const loop = adapter._driveMediaStream(socket);
+    socket.emit(
+      JSON.stringify({ event: "start", start: { streamSid: "MZdtmf", callSid: "CAdtmf" } }),
+    );
+    socket.emit(JSON.stringify({ event: "dtmf", streamSid: "MZdtmf", dtmf: { digit: "5" } }));
+    await waitUntil(() => onDtmf.mock.calls.length > 0);
+    expect(onDtmf).toHaveBeenCalledWith("5");
+    socket.closeNow();
+    await loop;
+  });
+
+  it("rejects POSTs from callers not in allowedCallers and records the rejection", async () => {
+    const adapter = new TwilioAgentAdapter({
+      accountSid: "ACtest",
+      authToken: "secret",
+      phoneNumber: "+14155551234",
+      publicBaseUrl: "https://example.test",
+      validateSignature: false,
+      allowedCallers: ["+14155557777"],
+      rest: stubRest("PNallow"),
+    });
+    await adapter.connect();
+    openAdapter = adapter;
+    expect(adapter.rejectedCount).toBe(0);
+
+    const form = new URLSearchParams({ From: "+14155550000", CallSid: "CAblocked" });
+    const response = await fetch(`${adapter.localBaseUrl}/twilio/voice`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString(),
+    });
+    const body = await response.text();
+    expect(response.status).toBe(200);
+    expect(body).toContain("<Reject/>");
+    expect(adapter.rejectedCount).toBe(1);
+  });
+
+  it("flushes buffered µ-law on a stop frame and exits the loop", async () => {
+    const adapter = makeAdapter();
+    await adapter.connect();
+    openAdapter = adapter;
+    const socket = mockSocket();
+    const loop = adapter._driveMediaStream(socket);
+    socket.emit(
+      JSON.stringify({ event: "start", start: { streamSid: "MZstop", callSid: "CAstop" } }),
+    );
+    // 50 ms of µ-law payload (50 * 8 = 400 bytes) — below the 100 ms flush
+    // threshold, so the loop holds it in the buffer until the stop frame.
+    const payload = new Uint8Array(400).fill(0xff);
+    socket.emit(buildMediaFrame("MZstop", payload));
+    socket.emit(JSON.stringify({ event: "stop", streamSid: "MZstop" }));
+    await loop; // loop exits when it sees `stop`
+    const chunk = await adapter.receiveAudio(0.5);
+    expect(chunk).toBeInstanceOf(AudioChunk);
+    expect(chunk.data.length).toBeGreaterThan(0);
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/twilio.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio.test.ts
@@ -1,0 +1,239 @@
+/**
+ * TwilioAgentAdapter protocol unit tests — binds the three @integration
+ * @ts-bound scenarios tagged @ts-twilio-proto in `specs/voice-agents.feature`.
+ *
+ * Uses an in-process mock WebSocket so the assertions hit only the adapter's
+ * frame parser, capability declaration, and interrupt path — no real HTTP/WS
+ * server, no real Twilio.
+ */
+
+import { Buffer } from "node:buffer";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+
+import { TwilioAgentAdapter } from "../twilio";
+import type { MediaStreamWebSocket } from "../twilio-server";
+import { TwilioRESTHelper, buildMediaFrame, parseMediaStreamFrame } from "../twilio-shared";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
+
+const feature = await loadFeature(FEATURE_PATH);
+
+/** Build an adapter wired to a stubbed REST helper so connect() can run. */
+function makeAdapter(opts?: {
+  publicBaseUrl?: string;
+  validateSignature?: boolean;
+  onDtmf?: (digit: string) => void;
+}): TwilioAgentAdapter {
+  const rest = stubRest("PN1234567890abcdef");
+  return new TwilioAgentAdapter({
+    accountSid: "ACtest",
+    authToken: "secret",
+    phoneNumber: "+14155551234",
+    publicBaseUrl: opts?.publicBaseUrl ?? "https://example.test",
+    validateSignature: opts?.validateSignature ?? false,
+    onDtmf: opts?.onDtmf,
+    rest,
+  });
+}
+
+/** Stub of TwilioRESTHelper — every method is a no-op or returns the SID. */
+function stubRest(sid: string): TwilioRESTHelper {
+  const stub = new TwilioRESTHelper("ACtest", "secret");
+  // Replace network methods with deterministic stubs.
+  stub.resolvePhoneNumberSid = async () => sid;
+  stub.readVoiceUrl = async () => null;
+  stub.writeVoiceUrl = async () => undefined;
+  stub.placeCall = async () => "CAtest";
+  stub.sendDtmfOnCall = async () => undefined;
+  return stub;
+}
+
+/** Lightweight mock WS that captures send() output and feeds receiveText(). */
+function mockSocket(): MediaStreamWebSocket & { sent: string[]; emit(text: string): void; closeNow(): void } {
+  const sent: string[] = [];
+  const incoming: string[] = [];
+  let closed = false;
+  let resolver: ((text: string | null) => void) | null = null;
+
+  return {
+    sent,
+    send(data) {
+      sent.push(typeof data === "string" ? data : Buffer.from(data).toString("utf-8"));
+    },
+    receiveText() {
+      const head = incoming.shift();
+      if (head !== undefined) return Promise.resolve(head);
+      if (closed) return Promise.resolve(null);
+      return new Promise<string | null>((resolve) => {
+        resolver = resolve;
+      });
+    },
+    close() {
+      this.closeNow();
+    },
+    emit(text) {
+      if (resolver) {
+        const r = resolver;
+        resolver = null;
+        r(text);
+        return;
+      }
+      incoming.push(text);
+    },
+    closeNow() {
+      closed = true;
+      if (resolver) {
+        const r = resolver;
+        resolver = null;
+        r(null);
+      }
+    },
+  };
+}
+
+describeFeature(
+  feature,
+  ({ Scenario }) => {
+    Scenario(
+      "TwilioAgentAdapter publishes mulaw/8000 capabilities and clear-buffer interruption",
+      ({ Given, Then, And }) => {
+        let adapter: TwilioAgentAdapter;
+
+        Given(
+          "a TwilioAgentAdapter constructed with valid credentials and an E.164 phone_number",
+          () => {
+            adapter = makeAdapter();
+          },
+        );
+
+        Then(
+          'capabilities.inputFormats and outputFormats both equal ["mulaw/8000"]',
+          () => {
+            expect(adapter.capabilities.inputFormats).toEqual(["mulaw/8000"]);
+            expect(adapter.capabilities.outputFormats).toEqual(["mulaw/8000"]);
+          },
+        );
+
+        And("capabilities.interruption is true (Twilio clear-buffer event)", () => {
+          expect(adapter.capabilities.interruption).toBe(true);
+        });
+
+        And("capabilities.dtmf is true", () => {
+          expect(adapter.capabilities.dtmf).toBe(true);
+        });
+      },
+    );
+
+    Scenario(
+      "Twilio Media Streams JSON protocol parses start, media, and stop events",
+      ({ Given, When, Then, And }) => {
+        const startFrame = JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZxxx", callSid: "CAxxx" },
+        });
+        const mulawPayload = new Uint8Array([0xff, 0x7f, 0x00, 0x80]);
+        const mediaFrame = buildMediaFrame("MZxxx", mulawPayload);
+        const stopFrame = JSON.stringify({ event: "stop", streamSid: "MZxxx" });
+
+        let parsedStart: ReturnType<typeof parseMediaStreamFrame>;
+        let parsedMedia: ReturnType<typeof parseMediaStreamFrame>;
+        let parsedStop: ReturnType<typeof parseMediaStreamFrame>;
+
+        Given(
+          'a stream of Twilio Media Streams JSON frames containing "start", "media", and "stop"',
+          () => {
+            expect(startFrame).toContain('"start"');
+            expect(mediaFrame).toContain('"media"');
+            expect(stopFrame).toContain('"stop"');
+          },
+        );
+
+        When("parseMediaStreamFrame is invoked on each frame", () => {
+          parsedStart = parseMediaStreamFrame(startFrame);
+          parsedMedia = parseMediaStreamFrame(mediaFrame);
+          parsedStop = parseMediaStreamFrame(stopFrame);
+        });
+
+        Then("the start frame yields streamSid and callSid", () => {
+          expect(parsedStart).not.toBeNull();
+          expect(parsedStart!.event).toBe("start");
+          expect(parsedStart!.streamSid).toBe("MZxxx");
+          expect(parsedStart!.callSid).toBe("CAxxx");
+        });
+
+        And("the media frame yields decoded mulaw payload bytes", () => {
+          expect(parsedMedia).not.toBeNull();
+          expect(parsedMedia!.event).toBe("media");
+          expect(parsedMedia!.payloadMulaw).toBeInstanceOf(Uint8Array);
+          expect(Array.from(parsedMedia!.payloadMulaw!)).toEqual(Array.from(mulawPayload));
+        });
+
+        And("the stop frame yields an event with no payload", () => {
+          expect(parsedStop).not.toBeNull();
+          expect(parsedStop!.event).toBe("stop");
+          expect(parsedStop!.payloadMulaw).toBeUndefined();
+        });
+      },
+    );
+
+    Scenario(
+      "Twilio interrupt() sends a clear-buffer frame on the live stream",
+      ({ Given, When, Then }) => {
+        let adapter: TwilioAgentAdapter;
+        let socket: ReturnType<typeof mockSocket>;
+        let loop: Promise<void>;
+
+        Given(
+          "a TwilioAgentAdapter with a live media stream and a known streamSid",
+          async () => {
+            adapter = makeAdapter();
+            await adapter.connect();
+            socket = mockSocket();
+            loop = adapter._driveMediaStream(socket);
+            socket.emit(
+              JSON.stringify({
+                event: "start",
+                start: { streamSid: "MZinterrupt", callSid: "CAinterrupt" },
+              }),
+            );
+            // Let the loop process the start frame.
+            await waitUntil(() => socket.sent.length === 0 && adapter.localBaseUrl !== "");
+          },
+        );
+
+        When("interrupt() is awaited", async () => {
+          await adapter.interrupt();
+        });
+
+        Then(
+          'a JSON frame with event "clear" and the streamSid is written to the WebSocket',
+          async () => {
+            expect(socket.sent.length).toBeGreaterThanOrEqual(1);
+            const frame = JSON.parse(socket.sent.at(-1)!);
+            expect(frame.event).toBe("clear");
+            expect(frame.streamSid).toBe("MZinterrupt");
+            socket.closeNow();
+            await loop;
+            await adapter.disconnect();
+          },
+        );
+      },
+    );
+  },
+  { includeTags: [["integration", "ts-twilio-proto"]] },
+);
+
+async function waitUntil(pred: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitUntil: timed out");
+    }
+    await new Promise<void>((r) => setTimeout(r, 5));
+  }
+}

--- a/javascript/src/voice/adapters/twilio-logger.ts
+++ b/javascript/src/voice/adapters/twilio-logger.ts
@@ -1,0 +1,42 @@
+/**
+ * Minimal logger for the Twilio adapter. Mirrors the Python parity's
+ * `logger = logging.getLogger("scenario.voice.twilio")` so production-ops
+ * signals (rejected webhooks, invalid signatures, DTMF receipt, disconnect)
+ * surface at runtime instead of being silently dropped.
+ *
+ * Stays inside the adapter module on purpose — a real shared-logger module
+ * lands in its own PR (see PR #539 "New Issue" follow-up). For now, a thin
+ * console wrapper with a stable `[twilio]` prefix is enough to match the
+ * Python log-site coverage and is easy to swap out later.
+ */
+
+export type LogLevel = "debug" | "info" | "warn";
+
+export interface VoiceLogger {
+  debug(message: string, fields?: Record<string, unknown>): void;
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+}
+
+function format(message: string, fields?: Record<string, unknown>): string {
+  if (!fields) return `[twilio] ${message}`;
+  const pairs = Object.entries(fields)
+    .map(([k, v]) => `${k}=${typeof v === "string" ? JSON.stringify(v) : String(v)}`)
+    .join(" ");
+  return `[twilio] ${message} ${pairs}`;
+}
+
+export const twilioLogger: VoiceLogger = {
+  debug(message, fields) {
+    // eslint-disable-next-line no-console
+    console.debug(format(message, fields));
+  },
+  info(message, fields) {
+    // eslint-disable-next-line no-console
+    console.info(format(message, fields));
+  },
+  warn(message, fields) {
+    // eslint-disable-next-line no-console
+    console.warn(format(message, fields));
+  },
+};

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -1,0 +1,351 @@
+/**
+ * TwilioWebhookServer — local HTTP + WS server that impersonates Twilio's
+ * webhook + Media Streams endpoints. TypeScript port of
+ * `python/scenario/voice/adapters/_twilio_server.py`.
+ *
+ * Two routes:
+ * - `POST /twilio/voice` returns `<Connect><Stream>` TwiML pointing at our
+ *   own WS URL. Validates `X-Twilio-Signature` when the parent adapter has
+ *   `validateSignature=true`.
+ * - `WS /twilio/stream` is the Media Streams socket — receives start/media/
+ *   stop/dtmf/mark frames, decodes µ-law into PCM16 chunks, hands them to
+ *   the adapter.
+ *
+ * The server uses node's built-in `http` for the request listener and the
+ * `ws` npm package for the WebSocket upgrade. Both default to binding on an
+ * OS-assigned port so tests don't race over hard-coded ports.
+ */
+
+import { Buffer } from "node:buffer";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+
+import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
+
+import { AudioChunk } from "../audio-chunk";
+
+import type { TwilioAgentAdapter } from "./twilio";
+import {
+  escapeXmlAttr,
+  mulaw8kToPcm16_24k,
+  parseMediaStreamFrame,
+  redactE164,
+  verifyTwilioSignature,
+} from "./twilio-shared";
+
+/**
+ * Minimal WS interface used by the media-stream loop. The full `ws.WebSocket`
+ * class implements this, and tests can mock with a 30-line stub.
+ */
+export interface MediaStreamWebSocket {
+  send(data: string | Uint8Array): void;
+  /** Iterate received text frames. Resolves to `null` when the socket closes. */
+  receiveText(): Promise<string | null>;
+  close(): void;
+}
+
+const BATCH_MS = 100;
+const TWILIO_FRAME_MS = 20;
+
+export class TwilioWebhookServer {
+  private readonly _adapter: TwilioAgentAdapter;
+  private _http: Server | null = null;
+  private _wss: WebSocketServer | null = null;
+  private _socketTracker = new Set<Socket>();
+  private _boundPort: number | null = null;
+
+  constructor(adapter: TwilioAgentAdapter) {
+    this._adapter = adapter;
+  }
+
+  /** OS-bound address `http://127.0.0.1:<port>` after `start()` has resolved. */
+  get baseUrl(): string {
+    if (this._boundPort == null) {
+      throw new Error("TwilioWebhookServer: server is not running.");
+    }
+    return `http://127.0.0.1:${this._boundPort}`;
+  }
+
+  get boundPort(): number {
+    if (this._boundPort == null) {
+      throw new Error("TwilioWebhookServer: server is not running.");
+    }
+    return this._boundPort;
+  }
+
+  async start(): Promise<void> {
+    if (this._http) return;
+    const http = createServer((req, res) => this._handleRequest(req, res));
+    const wss = new WebSocketServer({ noServer: true });
+
+    http.on("upgrade", (req, socket, head) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== "/twilio/stream") {
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+      });
+    });
+
+    wss.on("connection", (ws) => {
+      void this._handleStreamSocket(ws);
+    });
+
+    // Track raw sockets so stop() can force-close keep-alive connections
+    // (otherwise `server.close()` blocks until each socket idles out).
+    http.on("connection", (sock) => {
+      this._socketTracker.add(sock);
+      sock.once("close", () => this._socketTracker.delete(sock));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error): void => reject(err);
+      http.once("error", onError);
+      http.listen(this._adapter.httpPort, "127.0.0.1", () => {
+        http.off("error", onError);
+        const address = http.address() as AddressInfo;
+        this._boundPort = address.port;
+        resolve();
+      });
+    });
+
+    this._http = http;
+    this._wss = wss;
+  }
+
+  async stop(): Promise<void> {
+    if (!this._http) return;
+    const http = this._http;
+    const wss = this._wss;
+    this._http = null;
+    this._wss = null;
+    this._boundPort = null;
+
+    // Close active WebSockets so the WSS shutdown completes.
+    if (wss) {
+      for (const client of wss.clients) {
+        try {
+          client.close();
+        } catch {
+          // Ignored.
+        }
+      }
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+    }
+    // Force-close keep-alive sockets so `server.close()` doesn't hang.
+    for (const sock of this._socketTracker) sock.destroy();
+    this._socketTracker.clear();
+    await new Promise<void>((resolve, reject) => {
+      http.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  // --- routing ---------------------------------------------------------------
+
+  private async _handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+    if (req.method === "POST" && url.pathname === "/twilio/voice") {
+      await this._handleVoiceWebhook(req, res, url);
+      return;
+    }
+    res.statusCode = 404;
+    res.end("not found");
+  }
+
+  private async _handleVoiceWebhook(
+    req: IncomingMessage,
+    res: ServerResponse,
+    url: URL,
+  ): Promise<void> {
+    const adapter = this._adapter;
+    const body = await readBody(req);
+    const params = parseFormUrlEncoded(body);
+
+    if (adapter.validateSignature) {
+      const fullUrl = `${adapter.publicBaseUrl?.replace(/\/$/, "") ?? this.baseUrl}${url.pathname}`;
+      const valid = await verifyTwilioSignature({
+        authToken: adapter.authToken,
+        url: fullUrl,
+        params,
+        signature: req.headers["x-twilio-signature"] as string | undefined,
+      });
+      if (!valid) {
+        adapter._onWebhookRejected();
+        res.statusCode = 403;
+        res.end("forbidden");
+        return;
+      }
+    }
+
+    const fromNumber = params.From ?? "";
+    if (adapter.allowedCallers && !adapter.allowedCallers.has(fromNumber)) {
+      adapter._onWebhookRejected();
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/xml");
+      // Redacted log line — caller sees a Reject response.
+      void redactE164(fromNumber);
+      res.end("<Response><Reject/></Response>");
+      return;
+    }
+
+    if (!adapter.publicBaseUrl) {
+      res.statusCode = 500;
+      res.end("publicBaseUrl is not set on the adapter");
+      return;
+    }
+    const wsUrl =
+      adapter.publicBaseUrl
+        .replace(/^https:/, "wss:")
+        .replace(/^http:/, "ws:")
+        .replace(/\/$/, "") + "/twilio/stream";
+    const twiml =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<Response><Connect><Stream url="${escapeXmlAttr(wsUrl)}"/></Connect></Response>`;
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/xml");
+    res.end(twiml);
+  }
+
+  private async _handleStreamSocket(ws: WsWebSocket): Promise<void> {
+    const adapted = adaptWsSocket(ws);
+    try {
+      await this.mediaStreamLoop(adapted);
+    } finally {
+      this._adapter._setStreamWs(null);
+      this._adapter._setStreamSid(undefined);
+    }
+  }
+
+  /**
+   * Per-call Media Streams loop: parse frames, enqueue audio, fire DTMF.
+   *
+   * Exposed (via `TwilioAgentAdapter._driveMediaStream`) so unit tests can
+   * drive the loop with a mock socket and no real HTTP/WS upgrade.
+   */
+  async mediaStreamLoop(ws: MediaStreamWebSocket): Promise<void> {
+    const adapter = this._adapter;
+    adapter._setStreamWs(ws);
+
+    const buffered: number[] = [];
+    const flushThresholdBytes = (BATCH_MS / TWILIO_FRAME_MS) * 160; // 100ms = 800 bytes µ-law
+
+    const flush = (): void => {
+      if (buffered.length === 0) return;
+      const mulaw = new Uint8Array(buffered);
+      buffered.length = 0;
+      const pcm = mulaw8kToPcm16_24k(mulaw);
+      adapter._enqueueInbound(new AudioChunk({ data: pcm }));
+    };
+
+    while (true) {
+      const text = await ws.receiveText();
+      if (text == null) return; // socket closed
+      const frame = parseMediaStreamFrame(text);
+      if (!frame) continue;
+
+      if (frame.event === "start") {
+        if (frame.streamSid) adapter._setStreamSid(frame.streamSid);
+        if (frame.callSid) adapter._setCallSid(frame.callSid);
+        adapter._signalStreamConnected();
+      } else if (frame.event === "media" && frame.payloadMulaw) {
+        for (const byte of frame.payloadMulaw) buffered.push(byte);
+        if (buffered.length >= flushThresholdBytes) flush();
+      } else if (frame.event === "dtmf" && frame.dtmfDigit) {
+        if (adapter.onDtmf) {
+          try {
+            adapter.onDtmf(frame.dtmfDigit);
+          } catch {
+            // Callback errors are swallowed — adapter contract says they don't
+            // tear down the stream.
+          }
+        }
+      } else if (frame.event === "stop") {
+        flush();
+        return;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------- helpers
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+function parseFormUrlEncoded(body: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (!body) return params;
+  for (const pair of body.split("&")) {
+    if (!pair) continue;
+    const [rawKey, rawValue = ""] = pair.split("=");
+    const key = decodeURIComponent(rawKey!.replace(/\+/g, " "));
+    const value = decodeURIComponent(rawValue.replace(/\+/g, " "));
+    params[key] = value;
+  }
+  return params;
+}
+
+/**
+ * Wrap a real `ws.WebSocket` so it presents the abstract `MediaStreamWebSocket`
+ * interface — same shape the adapter test mocks satisfy.
+ */
+function adaptWsSocket(ws: WsWebSocket): MediaStreamWebSocket {
+  type Pending = {
+    resolve: (text: string | null) => void;
+    reject: (err: Error) => void;
+  };
+  const queue: string[] = [];
+  const waiters: Pending[] = [];
+  let closed = false;
+
+  ws.on("message", (data, isBinary) => {
+    if (isBinary) return; // Twilio Media Streams is JSON over text frames only.
+    const text = typeof data === "string" ? data : (data as Buffer).toString("utf-8");
+    const waiter = waiters.shift();
+    if (waiter) waiter.resolve(text);
+    else queue.push(text);
+  });
+  const handleEnd = (): void => {
+    if (closed) return;
+    closed = true;
+    while (waiters.length > 0) waiters.shift()!.resolve(null);
+  };
+  ws.on("close", handleEnd);
+  ws.on("error", handleEnd);
+
+  return {
+    send(data) {
+      try {
+        ws.send(data);
+      } catch {
+        // Socket closed mid-send — receivers will see null on next take.
+      }
+    },
+    receiveText() {
+      const head = queue.shift();
+      if (head !== undefined) return Promise.resolve(head);
+      if (closed) return Promise.resolve(null);
+      return new Promise<string | null>((resolve, reject) => {
+        waiters.push({ resolve, reject });
+      });
+    },
+    close() {
+      try {
+        ws.close();
+      } catch {
+        // Already closed.
+      }
+    },
+  };
+}

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -25,6 +25,7 @@ import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
 import { AudioChunk } from "../audio-chunk";
 
 import type { TwilioAgentAdapter } from "./twilio";
+import { twilioLogger } from "./twilio-logger";
 import {
   escapeXmlAttr,
   mulaw8kToPcm16_24k,
@@ -32,6 +33,14 @@ import {
   redactE164,
   verifyTwilioSignature,
 } from "./twilio-shared";
+
+/**
+ * Maximum request body the webhook reader will accept. Twilio's voice
+ * webhook bodies are ~1 KB form-encoded; this is generous head-room.
+ * Rejecting larger bodies guards against OOM from an attacker who probes
+ * the publicly-tunneled endpoint with a multi-GB POST.
+ */
+const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
 
 /**
  * Minimal WS interface used by the media-stream loop. The full `ws.WebSocket`
@@ -163,7 +172,17 @@ export class TwilioWebhookServer {
     url: URL,
   ): Promise<void> {
     const adapter = this._adapter;
-    const body = await readBody(req);
+    let body: string;
+    try {
+      body = await readBody(req, MAX_BODY_BYTES);
+    } catch (err) {
+      twilioLogger.warn("webhook body rejected", {
+        reason: err instanceof Error ? err.message : "unknown",
+      });
+      res.statusCode = 413;
+      res.end("payload too large");
+      return;
+    }
     const params = parseFormUrlEncoded(body);
 
     if (adapter.validateSignature) {
@@ -176,6 +195,9 @@ export class TwilioWebhookServer {
       });
       if (!valid) {
         adapter._onWebhookRejected();
+        twilioLogger.warn("rejecting voice webhook — missing or invalid X-Twilio-Signature", {
+          from: redactE164(params.From),
+        });
         res.statusCode = 403;
         res.end("forbidden");
         return;
@@ -185,10 +207,11 @@ export class TwilioWebhookServer {
     const fromNumber = params.From ?? "";
     if (adapter.allowedCallers && !adapter.allowedCallers.has(fromNumber)) {
       adapter._onWebhookRejected();
+      twilioLogger.info("rejecting call from disallowed caller", {
+        from: redactE164(fromNumber),
+      });
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/xml");
-      // Redacted log line — caller sees a Reject response.
-      void redactE164(fromNumber);
       res.end("<Response><Reject/></Response>");
       return;
     }
@@ -256,12 +279,16 @@ export class TwilioWebhookServer {
         for (const byte of frame.payloadMulaw) buffered.push(byte);
         if (buffered.length >= flushThresholdBytes) flush();
       } else if (frame.event === "dtmf" && frame.dtmfDigit) {
+        twilioLogger.debug("received DTMF", { digit: frame.dtmfDigit });
         if (adapter.onDtmf) {
           try {
             adapter.onDtmf(frame.dtmfDigit);
-          } catch {
+          } catch (err) {
             // Callback errors are swallowed — adapter contract says they don't
-            // tear down the stream.
+            // tear down the stream — but they ARE worth logging.
+            twilioLogger.warn("onDtmf callback raised; continuing", {
+              error: err instanceof Error ? err.message : String(err),
+            });
           }
         }
       } else if (frame.event === "stop") {
@@ -274,10 +301,19 @@ export class TwilioWebhookServer {
 
 // ---------------------------------------------------------------- helpers
 
-async function readBody(req: IncomingMessage): Promise<string> {
+async function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let received = 0;
+    req.on("data", (chunk: Buffer) => {
+      received += chunk.length;
+      if (received > maxBytes) {
+        req.destroy();
+        reject(new Error(`request body exceeded ${maxBytes} bytes`));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
     req.on("error", reject);
   });

--- a/javascript/src/voice/adapters/twilio-shared.ts
+++ b/javascript/src/voice/adapters/twilio-shared.ts
@@ -17,11 +17,10 @@
 
 import { Buffer } from "node:buffer";
 
-import { PCM16_SAMPLE_RATE } from "../audio-chunk";
+import { PCM16_SAMPLE_RATE, PCM16_SAMPLE_WIDTH_BYTES } from "../audio-chunk";
 
 // Twilio Media Streams always uses µ-law 8 kHz mono.
 export const TWILIO_SAMPLE_RATE = 8000;
-export const PCM16_SAMPLE_WIDTH = 2;
 // 20 ms frames at 8 kHz µ-law → 160 bytes per frame.
 export const TWILIO_FRAME_MS = 20;
 export const TWILIO_FRAME_BYTES =
@@ -100,22 +99,22 @@ function resamplePcm16(
   toRate: number,
 ): Uint8Array {
   if (pcm.length === 0 || fromRate === toRate) return pcm;
-  const inputSamples = pcm.length / PCM16_SAMPLE_WIDTH;
+  const inputSamples = pcm.length / PCM16_SAMPLE_WIDTH_BYTES;
   const outputSamples = Math.floor((inputSamples * toRate) / fromRate);
   if (outputSamples <= 0) return new Uint8Array(0);
   const inView = new DataView(pcm.buffer, pcm.byteOffset, pcm.byteLength);
-  const out = new Uint8Array(outputSamples * PCM16_SAMPLE_WIDTH);
+  const out = new Uint8Array(outputSamples * PCM16_SAMPLE_WIDTH_BYTES);
   const outView = new DataView(out.buffer);
   const ratio = (inputSamples - 1) / Math.max(outputSamples - 1, 1);
   for (let i = 0; i < outputSamples; i++) {
     const pos = i * ratio;
     const idx = Math.floor(pos);
     const frac = pos - idx;
-    const s0 = inView.getInt16(idx * PCM16_SAMPLE_WIDTH, true);
+    const s0 = inView.getInt16(idx * PCM16_SAMPLE_WIDTH_BYTES, true);
     const next = Math.min(idx + 1, inputSamples - 1);
-    const s1 = inView.getInt16(next * PCM16_SAMPLE_WIDTH, true);
+    const s1 = inView.getInt16(next * PCM16_SAMPLE_WIDTH_BYTES, true);
     const interp = Math.round(s0 + (s1 - s0) * frac);
-    outView.setInt16(i * PCM16_SAMPLE_WIDTH, interp, true);
+    outView.setInt16(i * PCM16_SAMPLE_WIDTH_BYTES, interp, true);
   }
   return out;
 }
@@ -123,10 +122,10 @@ function resamplePcm16(
 /** Decode µ-law 8 kHz mono → PCM16 24 kHz mono. */
 export function mulaw8kToPcm16_24k(mulawBytes: Uint8Array): Uint8Array {
   if (mulawBytes.length === 0) return new Uint8Array(0);
-  const pcm8k = new Uint8Array(mulawBytes.length * PCM16_SAMPLE_WIDTH);
+  const pcm8k = new Uint8Array(mulawBytes.length * PCM16_SAMPLE_WIDTH_BYTES);
   const view = new DataView(pcm8k.buffer);
   for (let i = 0; i < mulawBytes.length; i++) {
-    view.setInt16(i * PCM16_SAMPLE_WIDTH, mulawByteToPcmSample(mulawBytes[i]!), true);
+    view.setInt16(i * PCM16_SAMPLE_WIDTH_BYTES, mulawByteToPcmSample(mulawBytes[i]!), true);
   }
   return resamplePcm16(pcm8k, TWILIO_SAMPLE_RATE, PCM16_SAMPLE_RATE);
 }
@@ -135,11 +134,11 @@ export function mulaw8kToPcm16_24k(mulawBytes: Uint8Array): Uint8Array {
 export function pcm16_24kToMulaw8k(pcm16Bytes: Uint8Array): Uint8Array {
   if (pcm16Bytes.length === 0) return new Uint8Array(0);
   const pcm8k = resamplePcm16(pcm16Bytes, PCM16_SAMPLE_RATE, TWILIO_SAMPLE_RATE);
-  const sampleCount = pcm8k.length / PCM16_SAMPLE_WIDTH;
+  const sampleCount = pcm8k.length / PCM16_SAMPLE_WIDTH_BYTES;
   const view = new DataView(pcm8k.buffer, pcm8k.byteOffset, pcm8k.byteLength);
   const out = new Uint8Array(sampleCount);
   for (let i = 0; i < sampleCount; i++) {
-    out[i] = pcmSampleToMulaw(view.getInt16(i * PCM16_SAMPLE_WIDTH, true));
+    out[i] = pcmSampleToMulaw(view.getInt16(i * PCM16_SAMPLE_WIDTH_BYTES, true));
   }
   return out;
 }
@@ -425,15 +424,13 @@ export async function verifyTwilioSignature(args: {
     const sortedKeys = Object.keys(args.params).sort();
     let data = args.url;
     for (const key of sortedKeys) data += key + args.params[key];
-    const { createHmac } = await import("node:crypto");
-    const expected = createHmac("sha1", args.authToken).update(data).digest("base64");
-    // Length-independent compare to avoid leaking timing on hash mismatch.
-    if (expected.length !== args.signature.length) return false;
-    let diff = 0;
-    for (let i = 0; i < expected.length; i++) {
-      diff |= expected.charCodeAt(i) ^ args.signature.charCodeAt(i);
-    }
-    return diff === 0;
+    const { createHmac, timingSafeEqual } = await import("node:crypto");
+    const expected = createHmac("sha1", args.authToken).update(data).digest();
+    const received = Buffer.from(args.signature, "base64");
+    // `timingSafeEqual` requires equal-length inputs. Mismatched lengths are
+    // by definition unequal — return false without measuring further.
+    if (expected.length !== received.length) return false;
+    return timingSafeEqual(expected, received);
   } catch {
     return false;
   }

--- a/javascript/src/voice/adapters/twilio-shared.ts
+++ b/javascript/src/voice/adapters/twilio-shared.ts
@@ -1,0 +1,440 @@
+/**
+ * Shared primitives for the Twilio adapter: µ-law/PCM16 codec, Media Streams
+ * JSON wire-format helpers, E.164 / DTMF validation, and a small REST client.
+ *
+ * TS port of `python/scenario/voice/adapters/_twilio_shared.py`. The Python
+ * version leans on stdlib `audioop` for µ-law conversion and 8 kHz ↔ 24 kHz
+ * resampling; we re-implement those inline because Node has no audioop
+ * equivalent. The algorithms are the same — see comments by each function.
+ *
+ * Not exported from `voice/index.ts`. Internal to the adapter module.
+ *
+ * NOTE: this file conceptually belongs to PR10 (Pipecat g711). PR10 has not
+ * landed at the time this PR was opened, so PR11 ships the shared module to
+ * unblock itself. When PR10 lands, the two files can be reconciled — they
+ * share the same name and same surface area by design.
+ */
+
+import { Buffer } from "node:buffer";
+
+import { PCM16_SAMPLE_RATE } from "../audio-chunk";
+
+// Twilio Media Streams always uses µ-law 8 kHz mono.
+export const TWILIO_SAMPLE_RATE = 8000;
+export const PCM16_SAMPLE_WIDTH = 2;
+// 20 ms frames at 8 kHz µ-law → 160 bytes per frame.
+export const TWILIO_FRAME_MS = 20;
+export const TWILIO_FRAME_BYTES =
+  (TWILIO_SAMPLE_RATE * TWILIO_FRAME_MS) / 1000;
+
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+// DTMF tones: digits 0–9, star, pound, wait-1sec (w, W). No other chars.
+// Guards against TwiML XML injection in sendDtmfOnCall.
+const DTMF_RE = /^[0-9*#wW]+$/;
+
+export function validateE164(phoneNumber: string): void {
+  if (!E164_RE.test(phoneNumber)) {
+    throw new Error(
+      `phone_number ${JSON.stringify(phoneNumber)} is not in E.164 format ` +
+        `(expected e.g. '+14155551234', pattern: leading '+' then 7–15 digits).`,
+    );
+  }
+}
+
+export function validateDtmf(tones: string): void {
+  if (!tones || !DTMF_RE.test(tones)) {
+    throw new Error(
+      `DTMF tones ${JSON.stringify(tones)} must match [0-9*#wW]+ — ` +
+        `this string is embedded in TwiML, non-DTMF chars are rejected ` +
+        `to prevent XML injection.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------- codec
+
+const BIAS = 0x84;
+const CLIP = 32635;
+
+/**
+ * Encode a single PCM16 sample (little-endian, signed) to a µ-law byte.
+ * Reference algorithm: ITU-T G.711 µ-law. Identical math to Python's
+ * `audioop.lin2ulaw` for one sample.
+ */
+function pcmSampleToMulaw(sample: number): number {
+  let sign = 0;
+  if (sample < 0) {
+    sample = -sample;
+    sign = 0x80;
+  }
+  if (sample > CLIP) sample = CLIP;
+  sample += BIAS;
+  let exponent = 7;
+  for (let mask = 0x4000; (sample & mask) === 0 && exponent > 0; mask >>= 1) {
+    exponent -= 1;
+  }
+  const mantissa = (sample >> (exponent + 3)) & 0x0f;
+  const ulaw = ~(sign | (exponent << 4) | mantissa) & 0xff;
+  return ulaw;
+}
+
+/** Decode a single µ-law byte → PCM16 signed sample. */
+function mulawByteToPcmSample(ulaw: number): number {
+  ulaw = ~ulaw & 0xff;
+  const sign = ulaw & 0x80;
+  const exponent = (ulaw >> 4) & 0x07;
+  const mantissa = ulaw & 0x0f;
+  let sample = ((mantissa << 3) + BIAS) << exponent;
+  sample -= BIAS;
+  return sign !== 0 ? -sample : sample;
+}
+
+/**
+ * Linear resample of mono PCM16. Used to bridge 8 kHz (Twilio) and 24 kHz
+ * (our canonical internal rate). Simple linear interpolation; good enough for
+ * speech and matches what `audioop.ratecv` produces in spirit.
+ */
+function resamplePcm16(
+  pcm: Uint8Array,
+  fromRate: number,
+  toRate: number,
+): Uint8Array {
+  if (pcm.length === 0 || fromRate === toRate) return pcm;
+  const inputSamples = pcm.length / PCM16_SAMPLE_WIDTH;
+  const outputSamples = Math.floor((inputSamples * toRate) / fromRate);
+  if (outputSamples <= 0) return new Uint8Array(0);
+  const inView = new DataView(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+  const out = new Uint8Array(outputSamples * PCM16_SAMPLE_WIDTH);
+  const outView = new DataView(out.buffer);
+  const ratio = (inputSamples - 1) / Math.max(outputSamples - 1, 1);
+  for (let i = 0; i < outputSamples; i++) {
+    const pos = i * ratio;
+    const idx = Math.floor(pos);
+    const frac = pos - idx;
+    const s0 = inView.getInt16(idx * PCM16_SAMPLE_WIDTH, true);
+    const next = Math.min(idx + 1, inputSamples - 1);
+    const s1 = inView.getInt16(next * PCM16_SAMPLE_WIDTH, true);
+    const interp = Math.round(s0 + (s1 - s0) * frac);
+    outView.setInt16(i * PCM16_SAMPLE_WIDTH, interp, true);
+  }
+  return out;
+}
+
+/** Decode µ-law 8 kHz mono → PCM16 24 kHz mono. */
+export function mulaw8kToPcm16_24k(mulawBytes: Uint8Array): Uint8Array {
+  if (mulawBytes.length === 0) return new Uint8Array(0);
+  const pcm8k = new Uint8Array(mulawBytes.length * PCM16_SAMPLE_WIDTH);
+  const view = new DataView(pcm8k.buffer);
+  for (let i = 0; i < mulawBytes.length; i++) {
+    view.setInt16(i * PCM16_SAMPLE_WIDTH, mulawByteToPcmSample(mulawBytes[i]!), true);
+  }
+  return resamplePcm16(pcm8k, TWILIO_SAMPLE_RATE, PCM16_SAMPLE_RATE);
+}
+
+/** Encode PCM16 24 kHz mono → µ-law 8 kHz mono. */
+export function pcm16_24kToMulaw8k(pcm16Bytes: Uint8Array): Uint8Array {
+  if (pcm16Bytes.length === 0) return new Uint8Array(0);
+  const pcm8k = resamplePcm16(pcm16Bytes, PCM16_SAMPLE_RATE, TWILIO_SAMPLE_RATE);
+  const sampleCount = pcm8k.length / PCM16_SAMPLE_WIDTH;
+  const view = new DataView(pcm8k.buffer, pcm8k.byteOffset, pcm8k.byteLength);
+  const out = new Uint8Array(sampleCount);
+  for (let i = 0; i < sampleCount; i++) {
+    out[i] = pcmSampleToMulaw(view.getInt16(i * PCM16_SAMPLE_WIDTH, true));
+  }
+  return out;
+}
+
+/** Split a µ-law buffer into 20 ms (160-byte) frames for Media Streams. */
+export function* iterMulawFrames(mulawBytes: Uint8Array): Generator<Uint8Array> {
+  for (let i = 0; i < mulawBytes.length; i += TWILIO_FRAME_BYTES) {
+    yield mulawBytes.subarray(i, Math.min(i + TWILIO_FRAME_BYTES, mulawBytes.length));
+  }
+}
+
+// ---------------------------------------------------------------- frame protocol
+
+export type MediaStreamEventName =
+  | "connected"
+  | "start"
+  | "media"
+  | "stop"
+  | "dtmf"
+  | "mark";
+
+export interface MediaStreamEvent {
+  event: MediaStreamEventName;
+  streamSid?: string;
+  callSid?: string;
+  /** Decoded µ-law payload (present for `media` frames). */
+  payloadMulaw?: Uint8Array;
+  /** DTMF digit (present for `dtmf` frames). */
+  dtmfDigit?: string;
+  /** Mark name (present for `mark` frames). */
+  markName?: string;
+}
+
+const KNOWN_EVENTS = new Set<MediaStreamEventName>([
+  "connected",
+  "start",
+  "media",
+  "stop",
+  "dtmf",
+  "mark",
+]);
+
+/**
+ * Parse a JSON frame received from Twilio Media Streams.
+ *
+ * Returns `null` for unknown event types, malformed JSON, or events with
+ * missing required fields. Callers should treat `null` as "ignore this frame".
+ */
+export function parseMediaStreamFrame(text: string): MediaStreamEvent | null {
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const event = data.event;
+  if (typeof event !== "string") return null;
+  if (!KNOWN_EVENTS.has(event as MediaStreamEventName)) return null;
+
+  const start = (data.start ?? {}) as Record<string, unknown>;
+  const streamSid =
+    (typeof data.streamSid === "string" && data.streamSid) ||
+    (typeof start.streamSid === "string" && start.streamSid) ||
+    undefined;
+  const callSid = typeof start.callSid === "string" ? start.callSid : undefined;
+
+  if (event === "media") {
+    const media = (data.media ?? {}) as Record<string, unknown>;
+    const b64 = media.payload;
+    if (typeof b64 !== "string") return null;
+    let payload: Buffer;
+    try {
+      payload = Buffer.from(b64, "base64");
+    } catch {
+      return null;
+    }
+    return {
+      event: "media",
+      streamSid,
+      callSid,
+      payloadMulaw: new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength),
+    };
+  }
+
+  if (event === "dtmf") {
+    const dtmf = (data.dtmf ?? {}) as Record<string, unknown>;
+    const digit = dtmf.digit;
+    if (typeof digit !== "string") return null;
+    return { event: "dtmf", streamSid, dtmfDigit: digit };
+  }
+
+  if (event === "mark") {
+    const mark = (data.mark ?? {}) as Record<string, unknown>;
+    const name = typeof mark.name === "string" ? mark.name : undefined;
+    return { event: "mark", streamSid, markName: name };
+  }
+
+  // connected, start, stop — no payload-specific fields.
+  return { event: event as MediaStreamEventName, streamSid, callSid };
+}
+
+/** Build an outbound `media` JSON frame for Twilio Media Streams. */
+export function buildMediaFrame(streamSid: string, mulawPayload: Uint8Array): string {
+  return JSON.stringify({
+    event: "media",
+    streamSid,
+    media: { payload: Buffer.from(mulawPayload).toString("base64") },
+  });
+}
+
+/**
+ * Build an outbound `clear` frame — tells Twilio to drop buffered audio.
+ *
+ * Used for interruption handling: if the agent was speaking and the user
+ * interrupts, we send `clear` so in-flight TTS isn't played.
+ */
+export function buildClearFrame(streamSid: string): string {
+  return JSON.stringify({ event: "clear", streamSid });
+}
+
+/** Build an outbound `mark` frame — a named marker in the audio stream. */
+export function buildMarkFrame(streamSid: string, name: string): string {
+  return JSON.stringify({ event: "mark", streamSid, mark: { name } });
+}
+
+// ---------------------------------------------------------------- REST helpers
+
+/**
+ * Minimal Twilio REST client: just the operations the adapter needs. Uses
+ * `fetch` directly so we don't take on the `twilio` npm SDK as a dependency.
+ *
+ * Errors from the REST API are surfaced as plain `Error` with the HTTP status
+ * and response body included; callers wrap the message rather than introspect.
+ */
+export class TwilioRESTHelper {
+  readonly accountSid: string;
+  readonly authToken: string;
+  readonly fetchImpl: typeof fetch;
+
+  constructor(accountSid: string, authToken: string, fetchImpl: typeof fetch = fetch) {
+    this.accountSid = accountSid;
+    this.authToken = authToken;
+    this.fetchImpl = fetchImpl;
+  }
+
+  private get _authHeader(): string {
+    const token = Buffer.from(`${this.accountSid}:${this.authToken}`).toString("base64");
+    return `Basic ${token}`;
+  }
+
+  private get _baseUrl(): string {
+    return `https://api.twilio.com/2010-04-01/Accounts/${this.accountSid}`;
+  }
+
+  private async _request(
+    method: "GET" | "POST",
+    path: string,
+    body?: URLSearchParams,
+  ): Promise<unknown> {
+    const headers: Record<string, string> = {
+      Authorization: this._authHeader,
+      Accept: "application/json",
+    };
+    if (body) headers["Content-Type"] = "application/x-www-form-urlencoded";
+    const response = await this.fetchImpl(`${this._baseUrl}${path}`, {
+      method,
+      headers,
+      body: body ? body.toString() : undefined,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`Twilio REST ${method} ${path} failed: ${response.status} ${text}`);
+    }
+    return text ? (JSON.parse(text) as unknown) : {};
+  }
+
+  /** Look up the `PN…` SID for a Twilio-owned phone number. */
+  async resolvePhoneNumberSid(phoneNumber: string): Promise<string> {
+    const params = new URLSearchParams({ PhoneNumber: phoneNumber, PageSize: "1" });
+    const data = (await this._request("GET", `/IncomingPhoneNumbers.json?${params}`)) as {
+      incoming_phone_numbers?: Array<{ sid?: string }>;
+    };
+    const sid = data.incoming_phone_numbers?.[0]?.sid;
+    if (!sid) {
+      throw new Error(
+        `No incoming phone number found on this Twilio account matching ` +
+          `${JSON.stringify(phoneNumber)}. Check that the number is purchased and in E.164.`,
+      );
+    }
+    return sid;
+  }
+
+  /** Fetch the current `voice_url` configured on the number. */
+  async readVoiceUrl(phoneNumberSid: string): Promise<string | null> {
+    const data = (await this._request(
+      "GET",
+      `/IncomingPhoneNumbers/${phoneNumberSid}.json`,
+    )) as { voice_url?: string };
+    return data.voice_url || null;
+  }
+
+  async writeVoiceUrl(phoneNumberSid: string, voiceUrl: string): Promise<void> {
+    const body = new URLSearchParams({ VoiceUrl: voiceUrl });
+    await this._request("POST", `/IncomingPhoneNumbers/${phoneNumberSid}.json`, body);
+  }
+
+  /**
+   * Originate an outbound call. Returns the call SID.
+   *
+   * `twiml` is inline TwiML run when the call connects. We do not accept a
+   * `twimlUrl` — the historical Python version dropped that too (SSRF-via-
+   * Twilio risk if a caller ever passed an attacker-controlled URL).
+   */
+  async placeCall(args: { to: string; from: string; twiml: string }): Promise<string> {
+    const body = new URLSearchParams({
+      To: args.to,
+      From: args.from,
+      Twiml: args.twiml,
+    });
+    const data = (await this._request("POST", `/Calls.json`, body)) as { sid?: string };
+    if (!data.sid) {
+      throw new Error("Twilio REST Calls.create returned no sid");
+    }
+    return data.sid;
+  }
+
+  /** Send DTMF on an in-progress call via TwiML update with `<Play digits>`. */
+  async sendDtmfOnCall(callSid: string, tones: string): Promise<void> {
+    validateDtmf(tones);
+    const twiml = `<Response><Play digits="${tones}"/></Response>`;
+    const body = new URLSearchParams({ Twiml: twiml });
+    await this._request("POST", `/Calls/${callSid}.json`, body);
+  }
+}
+
+// ---------------------------------------------------------------- utilities
+
+/**
+ * Redact an E.164 phone number for logs: `+14155551234` → `***1234`.
+ *
+ * Last-4 digits only; inputs with fewer than 4 digits collapse to `***`.
+ * Avoids leaking full PSTN numbers into CI logs (GitHub retains workflow
+ * artifacts for 14 days).
+ */
+export function redactE164(number: string | undefined | null): string {
+  if (!number) return "***";
+  const digits = number.replace(/\D/g, "");
+  if (digits.length >= 4) return `***${digits.slice(-4)}`;
+  return "***";
+}
+
+/**
+ * Escape a string for safe interpolation into XML attribute values / element
+ * text. Used by the TwiML response builder so the stream URL never breaks
+ * out of the `url="..."` attribute.
+ */
+export function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Verify an `X-Twilio-Signature` header. Twilio signs the request as
+ * HMAC-SHA1(authToken, url + sortedParamsConcat) and sends the base64-
+ * encoded result. We reconstruct the same input and compare.
+ *
+ * Returns false on any error (missing header, missing crypto, bad shape)
+ * — fail closed.
+ */
+export async function verifyTwilioSignature(args: {
+  authToken: string;
+  url: string;
+  params: Record<string, string>;
+  signature: string | null | undefined;
+}): Promise<boolean> {
+  if (!args.signature) return false;
+  try {
+    const sortedKeys = Object.keys(args.params).sort();
+    let data = args.url;
+    for (const key of sortedKeys) data += key + args.params[key];
+    const { createHmac } = await import("node:crypto");
+    const expected = createHmac("sha1", args.authToken).update(data).digest("base64");
+    // Length-independent compare to avoid leaking timing on hash mismatch.
+    if (expected.length !== args.signature.length) return false;
+    let diff = 0;
+    for (let i = 0; i < expected.length; i++) {
+      diff |= expected.charCodeAt(i) ^ args.signature.charCodeAt(i);
+    }
+    return diff === 0;
+  } catch {
+    return false;
+  }
+}

--- a/javascript/src/voice/adapters/twilio-tunnel.ts
+++ b/javascript/src/voice/adapters/twilio-tunnel.ts
@@ -1,0 +1,133 @@
+/**
+ * TwilioTunnel — wraps a local server with a publicly-reachable tunnel so
+ * Twilio's webhooks can reach a dev machine.
+ *
+ * Two providers, picked at runtime:
+ * - `@ngrok/ngrok` (preferred when `NGROK_AUTHTOKEN` is set) — stable URLs,
+ *   per-account quota, native binary ~20 MB.
+ * - `localtunnel` (fallback) — no auth required, less reliable, public
+ *   subdomain.
+ *
+ * Both packages are **optional peer dependencies**. The tunnel is only used
+ * by the env-gated e2e test; runtime callers who don't need a tunnel never
+ * pull these into the bundle. We dynamic-import inside `open()` so the
+ * module is importable on machines that don't have them installed.
+ */
+
+export type TunnelProvider = "ngrok" | "localtunnel";
+
+export interface OpenedTunnel {
+  /** Public HTTPS URL that proxies to the local port. */
+  url: string;
+  provider: TunnelProvider;
+  close(): Promise<void>;
+}
+
+export interface OpenTunnelOptions {
+  /** Local port to expose. */
+  port: number;
+  /**
+   * Force a specific provider. Defaults to `ngrok` when `NGROK_AUTHTOKEN` is
+   * set, otherwise `localtunnel`.
+   */
+  provider?: TunnelProvider;
+  /** ngrok authtoken; defaults to `process.env.NGROK_AUTHTOKEN`. */
+  authToken?: string;
+  /** Region passed through to ngrok (e.g. "us", "eu"). */
+  region?: string;
+}
+
+/**
+ * Open a tunnel. Throws with a helpful message if neither package is
+ * installed and the caller hasn't supplied an external URL elsewhere.
+ */
+export async function openTwilioTunnel(opts: OpenTunnelOptions): Promise<OpenedTunnel> {
+  const authToken = opts.authToken ?? process.env.NGROK_AUTHTOKEN ?? "";
+  const provider: TunnelProvider =
+    opts.provider ?? (authToken ? "ngrok" : "localtunnel");
+
+  if (provider === "ngrok") {
+    return openNgrokTunnel(opts.port, authToken, opts.region);
+  }
+  return openLocaltunnelTunnel(opts.port);
+}
+
+interface NgrokListener {
+  url(): string | null | undefined;
+  close(): Promise<void>;
+}
+interface NgrokModule {
+  forward(opts: { addr: number; authtoken?: string; region?: string }): Promise<NgrokListener>;
+}
+interface LocaltunnelTunnel {
+  url: string;
+  close(): void;
+}
+interface LocaltunnelModule {
+  default(opts: { port: number }): Promise<LocaltunnelTunnel>;
+}
+
+async function openNgrokTunnel(
+  port: number,
+  authToken: string,
+  region?: string,
+): Promise<OpenedTunnel> {
+  const ngrok = await loadOptional<NgrokModule>("@ngrok/ngrok");
+  if (!ngrok) {
+    throw new Error(
+      "TwilioTunnel: @ngrok/ngrok is not installed. Install with " +
+        "`pnpm add @ngrok/ngrok` or unset NGROK_AUTHTOKEN to fall back to localtunnel.",
+    );
+  }
+  const listener = await ngrok.forward({
+    addr: port,
+    authtoken: authToken || undefined,
+    region,
+  });
+  const url = listener.url();
+  if (!url) {
+    throw new Error("TwilioTunnel: ngrok forward returned no URL.");
+  }
+  return {
+    url,
+    provider: "ngrok",
+    async close() {
+      await listener.close();
+    },
+  };
+}
+
+async function openLocaltunnelTunnel(port: number): Promise<OpenedTunnel> {
+  const lt = await loadOptional<LocaltunnelModule>("localtunnel");
+  if (!lt) {
+    throw new Error(
+      "TwilioTunnel: localtunnel is not installed. Install with " +
+        "`pnpm add localtunnel` or supply NGROK_AUTHTOKEN to use ngrok instead.",
+    );
+  }
+  const tunnel = await lt.default({ port });
+  return {
+    url: tunnel.url,
+    provider: "localtunnel",
+    async close() {
+      tunnel.close();
+    },
+  };
+}
+
+/**
+ * Try to dynamic-import a module name. Returns the module on success, `null`
+ * on resolution failure. Lets callers degrade gracefully when an optional
+ * peer dep isn't installed.
+ */
+async function loadOptional<T>(name: string): Promise<T | null> {
+  try {
+    // Indirect to avoid bundler resolution at build time.
+    const dynImport = (0, eval)("(name) => import(name)") as (
+      n: string,
+    ) => Promise<T>;
+    return await dynImport(name);
+  } catch {
+    return null;
+  }
+}

--- a/javascript/src/voice/adapters/twilio-tunnel.ts
+++ b/javascript/src/voice/adapters/twilio-tunnel.ts
@@ -117,17 +117,16 @@ async function openLocaltunnelTunnel(port: number): Promise<OpenedTunnel> {
 
 /**
  * Try to dynamic-import a module name. Returns the module on success, `null`
- * on resolution failure. Lets callers degrade gracefully when an optional
- * peer dep isn't installed.
+ * on resolution failure (the optional peer dep isn't installed). Bundlers
+ * see this as a runtime dynamic import; consumers that don't take the tunnel
+ * path never pull the dep.
  */
 async function loadOptional<T>(name: string): Promise<T | null> {
   try {
-    // Indirect to avoid bundler resolution at build time.
-    const dynImport = (0, eval)("(name) => import(name)") as (
-      n: string,
-    ) => Promise<T>;
-    return await dynImport(name);
-  } catch {
-    return null;
+    return (await import(/* @vite-ignore */ name)) as T;
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") return null;
+    throw err;
   }
 }

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -23,7 +23,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { AgentRole } from "../../domain/agents";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
-import { AdapterCapabilities, UnsupportedCapabilityError } from "../capabilities";
+import { AdapterCapabilities } from "../capabilities";
 
 import { TwilioWebhookServer, type MediaStreamWebSocket } from "./twilio-server";
 import {
@@ -459,5 +459,3 @@ class InboundQueue {
   }
 }
 
-// Suppress an unused-symbol lint without affecting runtime.
-export type { UnsupportedCapabilityError };

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -1,0 +1,463 @@
+/**
+ * TwilioAgentAdapter — bidirectional real-phone transport via Twilio Media
+ * Streams. TypeScript port of `python/scenario/voice/adapters/twilio.py`.
+ *
+ * One adapter class serves both directions a Twilio number can participate in:
+ *
+ * - **Inbound** — `waitForCall()` sets the number's voice webhook to our
+ *   local server, blocks until a caller dials in, and opens a Media Streams
+ *   WebSocket for the call.
+ * - **Outbound** — `placeCall({ to })` originates a call via Twilio REST,
+ *   then accepts the Media Streams WebSocket Twilio opens back to us.
+ *
+ * `connect()` is direction-agnostic: resolve the number SID, start the HTTP +
+ * WS server, expose it via a public URL (caller-supplied or via a tunnel).
+ * After `connect()`, call either `placeCall()` or `waitForCall()`.
+ *
+ * Wire protocol: Twilio Media Streams JSON over WebSocket. Frame parsing +
+ * codec live in `./twilio-shared.ts`.
+ */
+
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { AgentRole } from "../../domain/agents";
+import { VoiceAgentAdapter } from "../adapter";
+import { AudioChunk } from "../audio-chunk";
+import { AdapterCapabilities, UnsupportedCapabilityError } from "../capabilities";
+
+import { TwilioWebhookServer, type MediaStreamWebSocket } from "./twilio-server";
+import {
+  TWILIO_FRAME_MS,
+  TwilioRESTHelper,
+  buildClearFrame,
+  buildMediaFrame,
+  iterMulawFrames,
+  pcm16_24kToMulaw8k,
+  validateE164,
+} from "./twilio-shared";
+
+export type TwilioAdapterMode = "idle" | "answer" | "call";
+
+const PLACE_CALL_A_LEG_SAY_TEXT =
+  "Thank you for calling. " +
+  "I will hold the line while you complete your scenario.";
+
+export interface TwilioAgentAdapterOptions {
+  accountSid: string;
+  authToken: string;
+  /** Twilio-owned phone number in E.164 format (e.g. "+14155551234"). */
+  phoneNumber: string;
+  /** HTTPS URL routing to this machine. Required at `connect()` time. */
+  publicBaseUrl?: string;
+  /** Allowed-callers filter for inbound calls. Unset = any caller accepted. */
+  allowedCallers?: readonly string[];
+  /** Callback invoked when the remote side sends DTMF mid-call. */
+  onDtmf?: (digit: string) => void;
+  /** HTTP server port. 0 = OS-assigned (recommended for tests). */
+  httpPort?: number;
+  /** Role under test — `AGENT` (default) or `USER`. */
+  role?: AgentRole;
+  /**
+   * Reject inbound webhooks without a valid `X-Twilio-Signature`. Tests pass
+   * `false` to bypass; production callers must leave on.
+   */
+  validateSignature?: boolean;
+  /**
+   * Optional `fetch` override for the REST client. Tests pass an in-memory
+   * mock so unit tests can verify REST traffic without real Twilio.
+   */
+  fetchImpl?: typeof fetch;
+  /**
+   * Optional REST helper override. When provided, replaces the default
+   * `TwilioRESTHelper` constructed from `accountSid`/`authToken`. Lets tests
+   * inject a fully-stubbed REST surface.
+   */
+  rest?: TwilioRESTHelper;
+}
+
+export class TwilioAgentAdapter extends VoiceAgentAdapter {
+  readonly capabilities: AdapterCapabilities = new AdapterCapabilities({
+    streamingTranscripts: false,
+    nativeVad: false,
+    dtmf: true,
+    // Twilio Media Streams `clear` event drops all buffered outbound audio.
+    // Used by `interrupt()` below.
+    interruption: true,
+    inputFormats: ["mulaw/8000"],
+    outputFormats: ["mulaw/8000"],
+  });
+
+  readonly accountSid: string;
+  readonly authToken: string;
+  readonly phoneNumber: string;
+  publicBaseUrl?: string;
+  readonly allowedCallers?: ReadonlySet<string>;
+  readonly onDtmf?: (digit: string) => void;
+  readonly httpPort: number;
+  readonly validateSignature: boolean;
+  readonly fetchImpl: typeof fetch;
+
+  override role: AgentRole;
+
+  private _rest: TwilioRESTHelper | null;
+  private _phoneNumberSid?: string;
+  private _priorVoiceUrl?: string;
+  private _calleePhoneNumberSid?: string;
+  private _priorCalleeVoiceUrl?: string;
+  private _mode: TwilioAdapterMode = "idle";
+  private _webhookServer: TwilioWebhookServer | null = null;
+  private _streamSid?: string;
+  private _callSid?: string;
+  private _streamWs: MediaStreamWebSocket | null = null;
+  private _streamConnected = makeDeferred<void>();
+  private _inboundQueue: InboundQueue = new InboundQueue();
+  private _connected = false;
+
+  constructor(options: TwilioAgentAdapterOptions) {
+    super();
+    validateE164(options.phoneNumber);
+    this.accountSid = options.accountSid;
+    this.authToken = options.authToken;
+    this.phoneNumber = options.phoneNumber;
+    this.publicBaseUrl = options.publicBaseUrl;
+    this.allowedCallers = options.allowedCallers
+      ? new Set(options.allowedCallers)
+      : undefined;
+    this.onDtmf = options.onDtmf;
+    this.httpPort = options.httpPort ?? 0;
+    this.role = options.role ?? AgentRole.AGENT;
+    this.validateSignature = options.validateSignature ?? true;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this._rest = options.rest ?? null;
+  }
+
+  override async call(): Promise<string> {
+    throw new Error(
+      "TwilioAgentAdapter.call is intentionally unimplemented at this layer — " +
+        "the adapter is driven by the voice executor in PR3+. Direct `call()` " +
+        "is not part of the public API.",
+    );
+  }
+
+  // ------------------------------------------------------------------ lifecycle
+
+  async connect(): Promise<void> {
+    if (this._connected) return; // idempotent
+    if (!this.publicBaseUrl) {
+      throw new Error(
+        "TwilioAgentAdapter: publicBaseUrl is required. Wrap the adapter in a " +
+          "TwilioTunnel or supply a stable public HTTPS URL routing to this machine.",
+      );
+    }
+
+    if (!this._rest) {
+      this._rest = new TwilioRESTHelper(this.accountSid, this.authToken, this.fetchImpl);
+    }
+    this._phoneNumberSid = await this._rest.resolvePhoneNumberSid(this.phoneNumber);
+    this._mode = "idle";
+    this._streamConnected = makeDeferred<void>();
+    this._inboundQueue.reset();
+
+    this._webhookServer = new TwilioWebhookServer(this);
+    await this._webhookServer.start();
+    this._connected = true;
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this._connected) return;
+
+    // Restore prior voice_url (answer mode only).
+    if (this._mode === "answer" && this._phoneNumberSid && this._rest) {
+      try {
+        await this._rest.writeVoiceUrl(this._phoneNumberSid, this._priorVoiceUrl ?? "");
+      } catch {
+        // Best-effort.
+      }
+    }
+    if (this._mode === "call" && this._calleePhoneNumberSid && this._rest) {
+      try {
+        await this._rest.writeVoiceUrl(
+          this._calleePhoneNumberSid,
+          this._priorCalleeVoiceUrl ?? "",
+        );
+      } catch {
+        // Best-effort.
+      }
+    }
+
+    if (this._webhookServer) {
+      await this._webhookServer.stop();
+    }
+    this._connected = false;
+    this._webhookServer = null;
+    this._rest = null;
+    this._phoneNumberSid = undefined;
+    this._priorVoiceUrl = undefined;
+    this._calleePhoneNumberSid = undefined;
+    this._priorCalleeVoiceUrl = undefined;
+    this._mode = "idle";
+    this._streamSid = undefined;
+    this._callSid = undefined;
+    this._streamWs = null;
+    this._streamConnected = makeDeferred<void>();
+    this._inboundQueue.reset();
+  }
+
+  // ------------------------------------------------------------------ direction
+
+  async placeCall(args: {
+    to: string;
+    timeoutMs?: number;
+    attachStreamToSelf?: boolean;
+  }): Promise<void> {
+    this._assertConnected();
+    this._enterMode("call");
+    validateE164(args.to);
+
+    const attachStreamToSelf = args.attachStreamToSelf ?? true;
+    const timeoutMs = args.timeoutMs ?? 120_000;
+
+    if (attachStreamToSelf) {
+      this._calleePhoneNumberSid = await this._rest!.resolvePhoneNumberSid(args.to);
+      this._priorCalleeVoiceUrl =
+        (await this._rest!.readVoiceUrl(this._calleePhoneNumberSid)) ?? undefined;
+      const webhookUrl = `${this.publicBaseUrl!.replace(/\/$/, "")}/twilio/voice`;
+      await this._rest!.writeVoiceUrl(this._calleePhoneNumberSid, webhookUrl);
+    }
+
+    const inlineALegTwiml =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<Response>` +
+      `<Say voice="Polly.Joanna">${PLACE_CALL_A_LEG_SAY_TEXT}</Say>` +
+      `<Pause length="120"/>` +
+      `</Response>`;
+    this._callSid = await this._rest!.placeCall({
+      to: args.to,
+      from: this.phoneNumber,
+      twiml: inlineALegTwiml,
+    });
+
+    if (attachStreamToSelf) {
+      await this._streamConnected.promiseWithTimeout(timeoutMs);
+    }
+  }
+
+  async waitForCall(timeoutMs = 120_000): Promise<void> {
+    this._assertConnected();
+    this._enterMode("answer");
+
+    this._priorVoiceUrl =
+      (await this._rest!.readVoiceUrl(this._phoneNumberSid!)) ?? undefined;
+    const webhookUrl = `${this.publicBaseUrl!.replace(/\/$/, "")}/twilio/voice`;
+    await this._rest!.writeVoiceUrl(this._phoneNumberSid!, webhookUrl);
+    await this._streamConnected.promiseWithTimeout(timeoutMs);
+  }
+
+  private _enterMode(mode: TwilioAdapterMode): void {
+    if (this._mode === mode) return; // idempotent retry
+    if (this._mode !== "idle") {
+      throw new Error(
+        `TwilioAgentAdapter: already in '${this._mode}' mode; cannot switch to ` +
+          `'${mode}'. Disconnect and reconnect to reuse this adapter in the ` +
+          `other direction.`,
+      );
+    }
+    this._mode = mode;
+  }
+
+  // ------------------------------------------------------------------ I/O
+
+  override async sendAudio(chunk: AudioChunk): Promise<void> {
+    this._assertStreamLive();
+    const mulaw = pcm16_24kToMulaw8k(chunk.data);
+    const frameSecs = TWILIO_FRAME_MS / 1000;
+    for (const frame of iterMulawFrames(mulaw)) {
+      if (frame.length === 0) continue;
+      this._streamWs!.send(buildMediaFrame(this._streamSid!, frame));
+      // Pace at real-time. Without pacing, the whole utterance arrives in
+      // milliseconds, which trips bots' VAD into a clipped-utterance reading.
+      await sleep(frameSecs * 1000);
+    }
+  }
+
+  override async receiveAudio(timeout: number): Promise<AudioChunk> {
+    this._assertStreamLive();
+    return this._inboundQueue.take(timeout * 1000);
+  }
+
+  async sendDtmf(tones: string): Promise<void> {
+    if (!this._rest || !this._callSid) {
+      throw new Error(
+        "TwilioAgentAdapter: no active call; sendDtmf requires an in-progress call.",
+      );
+    }
+    await this._rest.sendDtmfOnCall(this._callSid, tones);
+  }
+
+  override async interrupt(): Promise<void> {
+    this._assertStreamLive();
+    this._streamWs!.send(buildClearFrame(this._streamSid!));
+  }
+
+  // ------------------------------------------------------------------ server callbacks
+
+  /**
+   * Test seam: the running webhook server's bound HTTP base URL (e.g.
+   * `http://127.0.0.1:54321`). Useful for tests that don't want a tunnel.
+   * Throws if the adapter isn't connected.
+   */
+  get localBaseUrl(): string {
+    if (!this._webhookServer) {
+      throw new Error("TwilioAgentAdapter: not connected; localBaseUrl unavailable.");
+    }
+    return this._webhookServer.baseUrl;
+  }
+
+  /**
+   * Test seam: directly drive a media-stream loop over a provided socket.
+   * Production code reaches the loop via the `/twilio/stream` route.
+   */
+  async _driveMediaStream(ws: MediaStreamWebSocket): Promise<void> {
+    if (!this._webhookServer) {
+      throw new Error("TwilioAgentAdapter: not connected; cannot drive stream.");
+    }
+    await this._webhookServer.mediaStreamLoop(ws);
+  }
+
+  /**
+   * Called by the server when an inbound webhook is rejected (caller filter
+   * or bad signature). Exposed for tests; production callers see the HTTP
+   * response and never look at this counter.
+   */
+  rejectedCount = 0;
+
+  // --- internal accessors used by the server ---------------------------------
+
+  /** @internal */ _setStreamWs(ws: MediaStreamWebSocket | null): void {
+    this._streamWs = ws;
+  }
+  /** @internal */ _setStreamSid(sid: string | undefined): void {
+    this._streamSid = sid;
+  }
+  /** @internal */ _setCallSid(sid: string | undefined): void {
+    if (!this._callSid) this._callSid = sid;
+  }
+  /** @internal */ _signalStreamConnected(): void {
+    this._streamConnected.resolve();
+  }
+  /** @internal */ _enqueueInbound(chunk: AudioChunk): void {
+    this._inboundQueue.put(chunk);
+  }
+  /** @internal */ _onWebhookRejected(): void {
+    this.rejectedCount += 1;
+  }
+  /** @internal */ get _modeForServer(): TwilioAdapterMode {
+    return this._mode;
+  }
+
+  // ------------------------------------------------------------------ assertions
+
+  private _assertConnected(): void {
+    if (!this._connected) {
+      throw new Error("TwilioAgentAdapter: not connected; call connect() first.");
+    }
+  }
+
+  private _assertStreamLive(): void {
+    this._assertConnected();
+    if (!this._streamWs || !this._streamSid) {
+      throw new Error(
+        "TwilioAgentAdapter: no live media stream. Call placeCall() or " +
+          "waitForCall() first.",
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------- helpers
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+  promiseWithTimeout(timeoutMs: number): Promise<T>;
+}
+
+function makeDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    promise,
+    resolve,
+    reject,
+    async promiseWithTimeout(timeoutMs: number): Promise<T> {
+      let timer: NodeJS.Timeout | undefined;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise<T>((_, rej) => {
+            timer = setTimeout(
+              () => rej(new Error(`TwilioAgentAdapter: timed out after ${timeoutMs}ms`)),
+              timeoutMs,
+            );
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    },
+  };
+}
+
+/**
+ * Single-producer/single-consumer queue with timeout-aware take. Audio
+ * chunks pile up if `receiveAudio` is not actively draining; `take()` is the
+ * only consumer the executor uses.
+ */
+class InboundQueue {
+  private _items: AudioChunk[] = [];
+  private _waiters: Array<{
+    resolve: (chunk: AudioChunk) => void;
+    reject: (err: Error) => void;
+    timer: NodeJS.Timeout;
+  }> = [];
+
+  reset(): void {
+    this._items = [];
+    for (const waiter of this._waiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error("TwilioAgentAdapter: stream reset before audio arrived."));
+    }
+    this._waiters = [];
+  }
+
+  put(chunk: AudioChunk): void {
+    const waiter = this._waiters.shift();
+    if (waiter) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(chunk);
+      return;
+    }
+    this._items.push(chunk);
+  }
+
+  take(timeoutMs: number): Promise<AudioChunk> {
+    const head = this._items.shift();
+    if (head) return Promise.resolve(head);
+    return new Promise<AudioChunk>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = this._waiters.findIndex((w) => w.timer === timer);
+        if (idx >= 0) this._waiters.splice(idx, 1);
+        reject(new Error(`TwilioAgentAdapter: no audio received within ${timeoutMs}ms`));
+      }, timeoutMs);
+      this._waiters.push({ resolve, reject, timer });
+    });
+  }
+}
+
+// Suppress an unused-symbol lint without affecting runtime.
+export type { UnsupportedCapabilityError };

--- a/javascript/src/voice/index.ts
+++ b/javascript/src/voice/index.ts
@@ -23,6 +23,19 @@ export {
 
 export { VoiceAgentAdapter } from "./adapter";
 
+export {
+  TwilioAgentAdapter,
+  type TwilioAdapterMode,
+  type TwilioAgentAdapterOptions,
+} from "./adapters/twilio";
+
+export {
+  openTwilioTunnel,
+  type OpenedTunnel,
+  type OpenTunnelOptions,
+  type TunnelProvider,
+} from "./adapters/twilio-tunnel";
+
 export type {
   AudioSegment,
   LatencyMetrics,

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "ESNext",
+    "target": "ES2022",
     "lib": ["ES2023"],
     "moduleResolution": "bundler",
     "declaration": true,

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -46,6 +46,57 @@ Feature: Voice agent testing in Scenario SDK
     When the scenario starts
     Then an outbound Twilio call is created and a Media Streams WebSocket is established
 
+  @integration @ts-bound @ts-twilio-proto
+  Scenario: TwilioAgentAdapter publishes mulaw/8000 capabilities and clear-buffer interruption
+    # PR11 — capability declaration for the Twilio Media Streams transport
+    Given a TwilioAgentAdapter constructed with valid credentials and an E.164 phone_number
+    Then capabilities.inputFormats and outputFormats both equal ["mulaw/8000"]
+    And capabilities.interruption is true (Twilio clear-buffer event)
+    And capabilities.dtmf is true
+
+  @integration @ts-bound @ts-twilio-proto
+  Scenario: Twilio Media Streams JSON protocol parses start, media, and stop events
+    # PR11 — wire-protocol parser bound at unit/integration level
+    Given a stream of Twilio Media Streams JSON frames containing "start", "media", and "stop"
+    When parseMediaStreamFrame is invoked on each frame
+    Then the start frame yields streamSid and callSid
+    And the media frame yields decoded mulaw payload bytes
+    And the stop frame yields an event with no payload
+
+  @integration @ts-bound @ts-twilio-proto
+  Scenario: Twilio interrupt() sends a clear-buffer frame on the live stream
+    # PR11 — interrupt path: capabilities.interruption true → send Twilio "clear" event
+    Given a TwilioAgentAdapter with a live media stream and a known streamSid
+    When interrupt() is awaited
+    Then a JSON frame with event "clear" and the streamSid is written to the WebSocket
+
+  @integration @ts-bound @ts-twilio-server
+  Scenario: TwiML voice endpoint serves Connect+Stream with an XML-escaped WSS URL
+    # PR11 — TwiML response shape, served by the local webhook server
+    Given the TwilioWebhookServer is bound on an OS-assigned port
+    And the parent adapter has a publicBaseUrl configured
+    When a Twilio webhook POSTs valid form data to /twilio/voice
+    Then the response Content-Type is application/xml
+    And the body contains <Connect><Stream url="wss://..."/></Connect>
+    And the stream URL is XML-escaped (no unescaped &, <, >, or quotes)
+
+  @integration @ts-bound @ts-twilio-server
+  Scenario: TwiML voice endpoint rejects webhooks with a missing X-Twilio-Signature
+    # PR11 — signature gate fails closed for forged or unsigned webhooks
+    Given a TwilioWebhookServer with validateSignature true
+    When a POST to /twilio/voice arrives without an X-Twilio-Signature header
+    Then the response status is 403
+    And the adapter records the rejection without opening a media stream
+
+  @e2e @ts-bound @ts-twilio-tunnel
+  Scenario: Tunnel exposes the local Twilio server over a public URL
+    # PR11 — env-gated e2e: opens an ngrok or localtunnel tunnel and confirms it routes back
+    Given NGROK_AUTHTOKEN is set in the environment (otherwise skip)
+    And the local TwilioWebhookServer is running on an ephemeral port
+    When a TwilioTunnel is opened against the bound port
+    Then the tunnel reports an HTTPS URL
+    And the URL proxies a GET request through to the local server
+
   @unit
   Scenario: ElevenLabsAgentAdapter connects to conversational AI endpoint
     # Source §4.1, L171-174 and §5.4, L760-776
@@ -142,7 +193,7 @@ Feature: Voice agent testing in Scenario SDK
     Then connect() was awaited exactly once before the first script step
     And disconnect() was awaited exactly once regardless of pass/fail/exception
 
-  @unit @ts-bound
+  @unit @ts-bound @ts-contract-surface
   Scenario: AudioChunk internal format is PCM16 at 24kHz mono
     # Locked decision: AudioChunk normalization
     Given any adapter receives or sends audio
@@ -694,7 +745,7 @@ Feature: Voice agent testing in Scenario SDK
     Then no TTS, STT, ffmpeg, or transport code is invoked
     And behavior is identical to pre-voice SDK
 
-  @unit @ts-bound
+  @unit @ts-bound @ts-contract-surface
   Scenario: VoiceAgentAdapter base class is public for custom implementations
     # Source §7.3 L1186, §5.7 L830-854
     Given a user subclass of VoiceAgentAdapter implementing connect/send_audio/recv_audio/disconnect
@@ -747,19 +798,19 @@ Feature: Voice agent testing in Scenario SDK
   # Adapter Capability Matrix — new requirement
   # ======================================================================
 
-  @unit @ts-bound
+  @unit @ts-bound @ts-contract-surface
   Scenario: Every adapter publishes a capabilities attribute
     Given any concrete VoiceAgentAdapter subclass
     Then adapter.capabilities is an AdapterCapabilities instance
     And it declares: streaming_transcripts, native_vad, dtmf, input_formats, output_formats
 
-  @unit @ts-bound
+  @unit @ts-bound @ts-contract-surface
   Scenario: dtmf() raises UnsupportedCapabilityError on non-telephony adapters
     Given an adapter with capabilities.dtmf == False
     When scenario.dtmf("1") runs
     Then UnsupportedCapabilityError is raised naming the adapter and the "dtmf" capability
 
-  @unit @ts-bound
+  @unit @ts-bound @ts-contract-surface
   Scenario: Capability matrix is rendered into adapter docs
     Given the voice-agents documentation
     Then a capability matrix table lists every built-in adapter


### PR DESCRIPTION
## Summary

- Ports `python/scenario/voice/adapters/{twilio,_twilio_server,_twilio_shared}.py` to TypeScript: `TwilioAgentAdapter`, local HTTP+WS webhook server, and a tunnel wrapper (`@ngrok/ngrok` preferred, `localtunnel` fallback).
- Adds **6 new scenarios** to `specs/voice-agents.feature` and binds them via `@amiceli/vitest-cucumber` (3 protocol, 2 server, 1 env-gated tunnel).
- Boy-scout fixes: `tsconfig.json` `target: "ES2022"` (was broken on main since #517), narrowed `voice-contract-surface.test.ts` filter to a specific tag so future `@ts-bound` scenarios don't trigger `ScenarioNotCalledError` there.

## Files added

| File | Purpose |
| --- | --- |
| `javascript/src/voice/adapters/twilio-shared.ts` | µ-law/PCM16 codec, frame parser/builders, REST helper, signature verifier |
| `javascript/src/voice/adapters/twilio.ts` | `TwilioAgentAdapter` (`VoiceAgentAdapter` subclass) |
| `javascript/src/voice/adapters/twilio-server.ts` | Local HTTP+WS impersonating Twilio's media-stream endpoint |
| `javascript/src/voice/adapters/twilio-tunnel.ts` | `openTwilioTunnel(...)` (ngrok / localtunnel) |
| `javascript/src/voice/adapters/__tests__/twilio.test.ts` | `@integration @ts-bound @ts-twilio-proto` scenarios |
| `javascript/src/voice/adapters/__tests__/twilio-server.test.ts` | `@integration @ts-bound @ts-twilio-server` scenarios |
| `javascript/src/voice/adapters/__tests__/twilio-tunnel.test.ts` | `@e2e @ts-bound @ts-twilio-tunnel` (env-gated) |

## Capability declaration

```ts
new AdapterCapabilities({
  streamingTranscripts: false,
  nativeVad: false,
  dtmf: true,
  interruption: true,            // Twilio "clear" event
  inputFormats:  ["mulaw/8000"], // Twilio Media Streams is 8 kHz µ-law only
  outputFormats: ["mulaw/8000"],
});
```

## PR10 dependency

PR10 (Pipecat g711) **had not been pushed** at branch-creation time, so this PR owns `twilio-shared.ts`. When PR10 lands, the two implementations reconcile — same module name, same exported surface area.

## Bundle delta

`ws@^8.20.1` is added as a **runtime dependency** for both the WebSocket client and server. Approximate size: <1 MB.

`@ngrok/ngrok` is an **optional peer dependency** — _not_ added to `package.json` because it ships ~20 MB of native binaries. The tunnel module dynamic-imports it inside `openTwilioTunnel()`, so consumers who never call that path never pull it. `localtunnel` is the same — dynamic-imported, no static dependency.

## /browser-qa note

Twilio adapter requires a real Twilio account + phone number + tunnel to exercise end-to-end against prod. If env vars `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`, and `NGROK_AUTHTOKEN` are all set, run smoke test via `node scripts/qa-twilio.ts` which places an outbound call to a test number. CI does not set these; QA owner should run locally. **/browser-qa-against-prod inapplicable** to this adapter (no browser surface — it's a phone-call adapter).

## Test plan

- [x] `pnpm -C javascript build` — green (esm + cjs + dts)
- [x] `pnpm -C javascript typecheck` — green (was broken on main pre-PR; boy-scout fix landed)
- [x] `pnpm -C javascript test` — 24 files, 403 tests, all green
- [x] All 27 Twilio test steps pass (3 protocol scenarios + 2 server scenarios + 1 tunnel scenario)
- [ ] /prove-it + marker at HEAD
- [ ] /review + marker at HEAD
- [ ] `ai-reviewed` label applied
- [ ] `gh pr ready`

## Hazards addressed

- **TwiML XML escaping** — `escapeXmlAttr()` covers `& < > " '` so the stream URL never breaks out of the attribute value. Tested with a publicBaseUrl containing `?room=a&peer=b`.
- **Port conflicts** — server defaults to `httpPort: 0` (OS-assigned). Tests read back the bound port via `adapter.localBaseUrl`.
- **WS lifecycle** — both graceful close (stop frame → flush + return) and abrupt termination (socket close → `receiveText()` returns null) are handled.
- **Signature gate fails closed** — missing header, bad signature, or any exception → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)