### PR TITLE
fix(executor): include exception type when .args is empty

### DIFF
--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -896,7 +896,8 @@ class ScenarioExecutor:
                 return messages
         except Exception as e:
             agent_name = agent.__class__.__name__
-            raise RuntimeError(f"[{agent_name}] {e}") from e
+            msg = str(e) if str(e) else f"<{e.__class__.__name__}: no message>"
+            raise RuntimeError(f"[{agent_name}] {msg}") from e
 
     def _scenario_name(self):
         if self.config.verbose == 2:


### PR DESCRIPTION
When an adapter raises an exception with no message (e.g. asyncio.TimeoutError, bare Exception()), the re-raised RuntimeError rendered as `[AdapterName] ` with empty body.

This PR adds a fallback: if `str(e)` is empty, use `<e.__class__.__name__: no message>` so operators can tell what failed without inspecting `__cause__`.

Fixes #500

## Changes
- `python/scenario/scenario_executor.py`: line 898-899

## Before
```
RuntimeError: [PipecatAgentAdapter]
```

## After
```
RuntimeError: [PipecatAgentAdapter] <TimeoutError: no message>
```

## Test
- [ ] Need guidance on where to add regression test