### PR TITLE
feat(sdk): add langwatch config to ScenarioConfig for race-condition-free multi-tenant runs

### DIFF
--- a/javascript/src/domain/scenarios/index.ts
+++ b/javascript/src/domain/scenarios/index.ts
@@ -9,6 +9,17 @@ export const DEFAULT_MAX_TURNS = 10;
 export const DEFAULT_VERBOSE = false;
 
 /**
+ * Configuration for LangWatch event reporting.
+ * All fields are optional — any omitted fields fall back to environment variables.
+ */
+export interface LangwatchConfig {
+  /** The endpoint URL to send events to. Falls back to LANGWATCH_ENDPOINT env var. */
+  endpoint?: string;
+  /** The API key for authentication. Falls back to LANGWATCH_API_KEY env var. */
+  apiKey?: string;
+}
+
+/**
  * Configuration for a scenario.
  */
 export interface ScenarioConfig {
@@ -100,6 +111,27 @@ export interface ScenarioConfig {
    * always read off `cfg.voice`. See `voice/config.ts#resolveVoiceConfig`.
    */
   voice?: VoiceConfig;
+
+  /**
+   * LangWatch reporting configuration.
+   * Takes precedence over LANGWATCH_API_KEY and LANGWATCH_ENDPOINT environment variables.
+   *
+   * Use this when running multiple scenarios concurrently for different projects
+   * to avoid race conditions from mutating process.env.
+   *
+   * @example
+   * ```typescript
+   * await run({
+   *   name: 'My scenario',
+   *   langwatch: {
+   *     apiKey: project.apiKey,
+   *     endpoint: 'https://app.langwatch.ai',
+   *   },
+   *   agents: [...],
+   * });
+   * ```
+   */
+  langwatch?: LangwatchConfig;
 }
 
 /**

--- a/javascript/src/domain/scenarios/index.ts
+++ b/javascript/src/domain/scenarios/index.ts
@@ -17,6 +17,8 @@ export interface LangwatchConfig {
   endpoint?: string;
   /** The API key for authentication. Falls back to LANGWATCH_API_KEY env var. */
   apiKey?: string;
+  /** The project ID to send events to. Required when using organization-level or bearer API keys. */
+  projectId?: string;
 }
 
 /**

--- a/javascript/src/events/event-bus.ts
+++ b/javascript/src/events/event-bus.ts
@@ -25,7 +25,7 @@ export class EventBus {
   private logger = new Logger("scenario.events.EventBus");
   private static globalListeners: Array<(bus: EventBus) => void> = [];
 
-  constructor(config: { endpoint: string; apiKey: string | undefined }) {
+  constructor(config: { endpoint: string; apiKey: string | undefined; projectId?: string }) {
     this.eventReporter = new EventReporter(config);
     this.eventAlertMessageLogger = new EventAlertMessageLogger();
     EventBus.registry.add(this);

--- a/javascript/src/events/event-reporter.ts
+++ b/javascript/src/events/event-reporter.ts
@@ -10,13 +10,15 @@ import { Logger } from "../utils/logger";
  */
 export class EventReporter {
   private readonly apiKey: string;
+  private readonly projectId: string | undefined;
   private readonly eventsEndpoint: URL;
   private readonly eventAlertMessageLogger: EventAlertMessageLogger;
   private readonly logger = new Logger("scenario.events.EventReporter");
   private readonly isEnabled: boolean;
 
-  constructor(config: { endpoint: string; apiKey: string | undefined }) {
+  constructor(config: { endpoint: string; apiKey: string | undefined; projectId?: string }) {
     this.apiKey = config.apiKey ?? "";
+    this.projectId = config.projectId;
     this.eventsEndpoint = new URL("/api/scenario-events", config.endpoint);
     this.eventAlertMessageLogger = new EventAlertMessageLogger();
     this.eventAlertMessageLogger.handleGreeting();
@@ -39,13 +41,17 @@ export class EventReporter {
     const processedEvent = this.processEventForApi(event);
 
     try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "X-Auth-Token": this.apiKey,
+      };
+      if (this.projectId) {
+        headers["X-Project-Id"] = this.projectId;
+      }
       const response = await fetch(this.eventsEndpoint.href, {
         method: "POST",
         body: JSON.stringify(processedEvent),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": this.apiKey,
-        },
+        headers,
       });
 
       this.logger.debug(

--- a/javascript/src/runner/__tests__/run.test.ts
+++ b/javascript/src/runner/__tests__/run.test.ts
@@ -231,6 +231,50 @@ describe("run", () => {
         apiKey: "custom-api-key",
       });
     });
+
+    it("uses cfg.langwatch when provided in ScenarioConfig (no options)", async () => {
+      const { EventBus } = await import("../../events/event-bus");
+
+      const cfg: ScenarioConfig = {
+        ...createScenarioConfig(),
+        langwatch: {
+          endpoint: "https://cfg.endpoint.com",
+          apiKey: "cfg-api-key",
+        },
+      };
+
+      await run(cfg);
+
+      expect(EventBus).toHaveBeenCalledWith({
+        endpoint: "https://cfg.endpoint.com",
+        apiKey: "cfg-api-key",
+      });
+    });
+
+    it("options.langwatch takes priority over cfg.langwatch", async () => {
+      const { EventBus } = await import("../../events/event-bus");
+
+      const cfg: ScenarioConfig = {
+        ...createScenarioConfig(),
+        langwatch: {
+          endpoint: "https://cfg.endpoint.com",
+          apiKey: "cfg-api-key",
+        },
+      };
+      const options: RunOptions = {
+        langwatch: {
+          endpoint: "https://options.endpoint.com",
+          apiKey: "options-api-key",
+        },
+      };
+
+      await run(cfg, options);
+
+      expect(EventBus).toHaveBeenCalledWith({
+        endpoint: "https://options.endpoint.com",
+        apiKey: "options-api-key",
+      });
+    });
   });
 
   describe("tracing initialization", () => {

--- a/javascript/src/runner/__tests__/run.test.ts
+++ b/javascript/src/runner/__tests__/run.test.ts
@@ -229,6 +229,7 @@ describe("run", () => {
       expect(EventBus).toHaveBeenCalledWith({
         endpoint: "https://custom.endpoint.com",
         apiKey: "custom-api-key",
+        projectId: undefined,
       });
     });
 
@@ -248,6 +249,7 @@ describe("run", () => {
       expect(EventBus).toHaveBeenCalledWith({
         endpoint: "https://cfg.endpoint.com",
         apiKey: "cfg-api-key",
+        projectId: undefined,
       });
     });
 
@@ -273,6 +275,56 @@ describe("run", () => {
       expect(EventBus).toHaveBeenCalledWith({
         endpoint: "https://options.endpoint.com",
         apiKey: "options-api-key",
+        projectId: undefined,
+      });
+    });
+
+    it("passes projectId from cfg.langwatch to EventBus", async () => {
+      const { EventBus } = await import("../../events/event-bus");
+
+      const cfg: ScenarioConfig = {
+        ...createScenarioConfig(),
+        langwatch: {
+          endpoint: "https://cfg.endpoint.com",
+          apiKey: "cfg-api-key",
+          projectId: "cfg-project-id",
+        },
+      };
+
+      await run(cfg);
+
+      expect(EventBus).toHaveBeenCalledWith({
+        endpoint: "https://cfg.endpoint.com",
+        apiKey: "cfg-api-key",
+        projectId: "cfg-project-id",
+      });
+    });
+
+    it("options.langwatch.projectId takes priority over cfg.langwatch.projectId", async () => {
+      const { EventBus } = await import("../../events/event-bus");
+
+      const cfg: ScenarioConfig = {
+        ...createScenarioConfig(),
+        langwatch: {
+          endpoint: "https://cfg.endpoint.com",
+          apiKey: "cfg-api-key",
+          projectId: "cfg-project-id",
+        },
+      };
+      const options: RunOptions = {
+        langwatch: {
+          endpoint: "https://options.endpoint.com",
+          apiKey: "options-api-key",
+          projectId: "options-project-id",
+        },
+      };
+
+      await run(cfg, options);
+
+      expect(EventBus).toHaveBeenCalledWith({
+        endpoint: "https://options.endpoint.com",
+        apiKey: "options-api-key",
+        projectId: "options-project-id",
       });
     });
   });
@@ -313,9 +365,9 @@ describe("run", () => {
   describe("concurrency safety", () => {
     it("creates separate EventBus instances for concurrent runs", async () => {
       const { EventBus } = await import("../../events/event-bus");
-      const eventBusConfigs: Array<{ endpoint: string; apiKey: string | undefined }> = [];
+      const eventBusConfigs: Array<{ endpoint: string; apiKey: string | undefined; projectId?: string }> = [];
 
-      vi.mocked(EventBus).mockImplementation(function (this: unknown, config: { endpoint: string; apiKey: string | undefined }) {
+      vi.mocked(EventBus).mockImplementation(function (this: unknown, config: { endpoint: string; apiKey: string | undefined; projectId?: string }) {
         eventBusConfigs.push(config);
         return {
           config,
@@ -353,7 +405,7 @@ describe("run", () => {
       const { EventBus } = await import("../../events/event-bus");
       const eventsByApiKey = new Map<string, ScenarioEvent[]>();
 
-      vi.mocked(EventBus).mockImplementation(function (this: unknown, config: { endpoint: string; apiKey: string | undefined }) {
+      vi.mocked(EventBus).mockImplementation(function (this: unknown, config: { endpoint: string; apiKey: string | undefined; projectId?: string }) {
         const events: ScenarioEvent[] = [];
         eventsByApiKey.set(config.apiKey ?? "", events);
 

--- a/javascript/src/runner/run.ts
+++ b/javascript/src/runner/run.ts
@@ -155,6 +155,7 @@ export async function run(cfg: ScenarioConfig, options?: RunOptions): Promise<Sc
     eventBus = new EventBus({
       endpoint: options?.langwatch?.endpoint ?? cfg.langwatch?.endpoint ?? envConfig.LANGWATCH_ENDPOINT,
       apiKey: options?.langwatch?.apiKey ?? cfg.langwatch?.apiKey ?? envConfig.LANGWATCH_API_KEY,
+      projectId: options?.langwatch?.projectId ?? cfg.langwatch?.projectId,
     });
     eventBus.listen();
 

--- a/javascript/src/runner/run.ts
+++ b/javascript/src/runner/run.ts
@@ -13,6 +13,7 @@ import { getEnv } from "../config";
 import {
   allAgentRoles,
   AgentRole,
+  LangwatchConfig,
   ScenarioConfig,
   ScenarioResult,
 } from "../domain";
@@ -24,17 +25,6 @@ import { generateThreadId, getBatchRunId } from "../utils/ids";
 import { judgeSpanCollector } from "../agents/judge/judge-span-collector";
 import { ensureTracingInitialized } from "../tracing/setup";
 import { getProjectConfig } from "../config/get-project-config";
-/**
- * Configuration for LangWatch event reporting.
- * All fields are optional — any omitted fields fall back to environment variables.
- */
-export interface LangwatchConfig {
-  /** The endpoint URL to send events to. Falls back to LANGWATCH_ENDPOINT env var. */
-  endpoint?: string;
-  /** The API key for authentication. Falls back to LANGWATCH_API_KEY env var. */
-  apiKey?: string;
-}
-
 /**
  * Options for running a scenario.
  */
@@ -161,10 +151,10 @@ export async function run(cfg: ScenarioConfig, options?: RunOptions): Promise<Sc
     ensureTracingInitialized(projectConfig?.observability);
 
     const envConfig = getEnv();
-    // Use programmatic config if provided, otherwise fall back to env vars
+    // Priority: options.langwatch > cfg.langwatch > env vars
     eventBus = new EventBus({
-      endpoint: options?.langwatch?.endpoint ?? envConfig.LANGWATCH_ENDPOINT,
-      apiKey: options?.langwatch?.apiKey ?? envConfig.LANGWATCH_API_KEY,
+      endpoint: options?.langwatch?.endpoint ?? cfg.langwatch?.endpoint ?? envConfig.LANGWATCH_ENDPOINT,
+      apiKey: options?.langwatch?.apiKey ?? cfg.langwatch?.apiKey ?? envConfig.LANGWATCH_API_KEY,
     });
     eventBus.listen();
 


### PR DESCRIPTION
## Why

Running scenarios concurrently for multiple LangWatch projects forces callers to mutate `process.env` before each `run()`, creating race conditions. This PR adds a `langwatch` field to `ScenarioConfig` (and `RunOptions`) that takes precedence over env vars, eliminating the mutex pattern. It also adds `projectId` so callers using organization-level or bearer API keys can explicitly route events to the right project.

Closes #203

## What changed

- **`LangwatchConfig` added to `ScenarioConfig` and `RunOptions`** — priority chain is `options.langwatch > cfg.langwatch > LANGWATCH_* env vars`; no env mutation needed for concurrent multi-tenant runs.
- **`projectId` field added to `LangwatchConfig`** — forwarded as `X-Project-Id` header to `/api/scenario-events`, enabling the server-side auth middleware's bearer+X-Project-Id auth path for org-level keys.
- **`LangwatchConfig` type moved to the domain layer** — avoids circular import; `runner/run.ts` now imports it from `../domain`.

## How it works

```
ScenarioConfig.langwatch      RunOptions.langwatch
     {endpoint, apiKey, projectId}
              ↓ merge (options wins)
           EventBus(config)
              ↓
        EventReporter
          X-Auth-Token: apiKey
          X-Project-Id: projectId   ← new
          POST /api/scenario-events
```

The server-side auth middleware already supports `X-Project-Id` alongside `X-Auth-Token` for bearer/org-level keys — this PR wires the client side to match.

## Test plan

```bash
cd javascript && pnpm test   # 834 passed, 0 failed
pnpm typecheck               # clean
```

New unit tests (in `run.test.ts`):
- `cfg.langwatch` used when no `options` provided
- `options.langwatch` takes priority over `cfg.langwatch`
- `projectId` passed through from `cfg.langwatch` to `EventBus`
- `options.langwatch.projectId` takes priority over `cfg.langwatch.projectId`

## How I can prove I was successful

No playable artifact — pure SDK change. See Test plan: 834 unit tests green (including 4 new tests covering the priority chain and projectId propagation), typecheck clean.
