### PR TITLE
fix(#500): include exception type name when str(e) is empty in _call_agent re-raise

### DIFF
--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -896,7 +896,10 @@ class ScenarioExecutor:
                 return messages
         except Exception as e:
             agent_name = agent.__class__.__name__
-            raise RuntimeError(f"[{agent_name}] {e}") from e
+            # str(e) is empty for no-args exceptions like asyncio.TimeoutError().
+            # Fall back to the exception type name so the error body is never blank.
+            error_detail = str(e) or type(e).__name__
+            raise RuntimeError(f"[{agent_name}] {error_detail}") from e
 
     def _scenario_name(self):
         if self.config.verbose == 2:

--- a/python/tests/test_arun_exception_chain.py
+++ b/python/tests/test_arun_exception_chain.py
@@ -75,3 +75,42 @@ async def test_user_traceback_survives_arun():
         assert isinstance(e.__cause__, ZeroDivisionError)
     else:  # pragma: no cover
         pytest.fail("arun did not raise, but the adapter did")
+
+
+class _TimeoutAgent(AgentAdapter):
+    """Raises a no-args TimeoutError, reproducing the blank-body bug."""
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        raise TimeoutError()
+
+
+@pytest.mark.asyncio
+async def test_no_args_exception_includes_type_name_in_message():
+    """RuntimeError body must never be blank for no-args exceptions.
+
+    Regression for #500: ``str(TimeoutError())`` returns ``""`` so the old
+    ``f"[{agent_name}] {e}"`` produced ``"[_TimeoutAgent] "`` — unreadable.
+    The fix uses ``type(e).__name__`` as a fallback so the body always names
+    the exception kind.
+    """
+    try:
+        await scenario.arun(
+            name="timeout",
+            description="adapter raises bare TimeoutError()",
+            agents=[_TimeoutAgent(), _User(), _Judge()],
+            script=[
+                scenario.user("hi"),
+                scenario.agent(),
+                scenario.judge(),
+            ],
+        )
+    except RuntimeError as e:
+        msg = str(e)
+        assert msg.strip(), f"RuntimeError body must not be blank; got: {msg!r}"
+        assert "TimeoutError" in msg, (
+            f"expected exception type name in message; got: {msg!r}"
+        )
+        assert e.__cause__ is not None
+        assert isinstance(e.__cause__, TimeoutError)
+    else:  # pragma: no cover
+        pytest.fail("arun did not raise, but the adapter did")


### PR DESCRIPTION
## Summary

- Bare exceptions like `asyncio.TimeoutError()` stringify to `""` so `f"[{agent_name}] {e}"` produced `"[PipecatAgentAdapter] "` — unreadable
- Fix: fall back to `type(e).__name__` when `str(e)` is empty

**Before:** `RuntimeError: [PipecatAgentAdapter] `
**After:** `RuntimeError: [PipecatAgentAdapter] TimeoutError`

## Test plan

- [x] `test_no_args_exception_includes_type_name_in_message` (regression test) — passes
- [x] `test_user_traceback_survives_arun` — still passes (exception chain preserved)

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)