### PR TITLE
fix(#501): set PYTHONUNBUFFERED=1 on pipecat bot subprocess to prevent log loss on crash

### DIFF
--- a/python/examples/voice/_bot_lifecycle.py
+++ b/python/examples/voice/_bot_lifecycle.py
@@ -72,6 +72,11 @@ async def ensure_pipecat_bot(
     # Capture VAD + STT decisions so a failed demo run is debuggable from
     # /tmp/voice-pipecat-bot.log.
     env.setdefault("BOT_LOG_LEVEL", "DEBUG")
+    # Force unbuffered stdout/stderr so the log file reflects what happened up
+    # to the moment of a crash or timeout. Without this, Python's default
+    # block-buffering (8 KB) means the log is near-empty when the bot is
+    # killed — exact failure mode from #501.
+    env["PYTHONUNBUFFERED"] = "1"
 
     # Tee bot logs to /tmp/voice-pipecat-bot.log so failed runs are debuggable.
     # Truncate on each spawn — if you need history, grab the file before the


### PR DESCRIPTION
## Summary

- Pipecat bot subprocess inherits Python's default block-buffering (8 KB) when stdout/stderr is redirected to a file
- When the bot is killed or the scenario times out, the unflushed buffer is lost → `/tmp/voice-pipecat-bot.log` near-empty
- Fix: set `PYTHONUNBUFFERED=1` in the subprocess env so output is flushed immediately

**Before:** Log file empty after timeout — no diagnostic signal
**After:** Log file contains everything the bot printed up to the moment of failure

## Test plan

- [x] Code inspection: `PYTHONUNBUFFERED=1` is now in the subprocess env
- [ ] Manual verification: run a Pipecat scenario that times out, check `/tmp/voice-pipecat-bot.log` has content

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)