### PR TITLE
fix(#191): rename --debug to --scenario-debug in pytest plugin to prevent file overwrite

### DIFF
--- a/python/scenario/pytest_plugin.py
+++ b/python/scenario/pytest_plugin.py
@@ -247,6 +247,16 @@ original_run = ScenarioExecutor.run
 
 def pytest_addoption(parser):
     parser.addoption("--headless", action="store_true")
+    parser.addoption(
+        "--scenario-debug",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable step-by-step Scenario debug mode. "
+            "Use --scenario-debug instead of --debug to avoid conflicting "
+            "with pytest's built-in --debug flag."
+        ),
+    )
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):
@@ -267,13 +277,17 @@ def pytest_configure(config):
         Users don't need to call it directly.
 
     Debug Mode:
-        When --debug is passed to pytest, enables step-by-step scenario
-        execution with user intervention capabilities.
+        When --scenario-debug is passed to pytest, enables step-by-step
+        scenario execution with user intervention capabilities.
+
+        Note: do NOT use ``--debug`` — that is a built-in pytest flag that
+        writes internal debug info to a file path, which can silently
+        overwrite test files (issue #191).
 
     Example:
         ```bash
         # Enable debug mode for all scenarios
-        pytest tests/ --debug -s
+        pytest tests/ --scenario-debug -s
 
         # Run normally
         pytest tests/
@@ -284,8 +298,8 @@ def pytest_configure(config):
         "markers", "agent_test: mark test as an agent scenario test"
     )
 
-    if config.getoption("--debug"):
-        print(colored("\nScenario debug mode enabled (--debug).", "yellow"))
+    if config.getoption("--scenario-debug"):
+        print(colored("\nScenario debug mode enabled (--scenario-debug).", "yellow"))
         ScenarioConfig.configure(verbose=True, debug=True)
 
     if config.getoption("--headless"):


### PR DESCRIPTION
## Summary

pytest's built-in `--debug <path>` flag writes internal debug info to a file — which silently **overwrites test files** when users run:

```bash
pytest --debug examples/test_weather_agent.py
```

The scenario plugin was reading `--debug` without registering it (borrowing pytest's built-in option), and the truth check was accidentally truthy whenever `--debug <path>` was passed.

- **Register** `--scenario-debug` with `parser.addoption()`
- **Read** `--scenario-debug` instead of `--debug`
- **Update** docstring to warn against `--debug`

## Test plan

- [x] `uv run pytest tests/test_scenario.py` — 17/17 pass
- [x] `--headless` option still works (unaffected)
- [x] `--scenario-debug` registers cleanly; `--debug` no longer hijacked

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)