### PR TITLE
feat(#318): add context param to JudgmentRequest for extra judge evaluation input

### DIFF
--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -808,9 +808,8 @@ describe("JudgeAgent", () => {
       await agent.call(inputWithContext);
 
       expect(capturedParams).toBeDefined();
-      const userMessage = capturedParams!.messages.find(
-        (m) => m.role === "user"
-      );
+      const messages = capturedParams!.messages ?? [];
+      const userMessage = messages.find((m) => m.role === "user");
       if (!userMessage) throw new Error("Expected a user message in LLM call");
       const userContent =
         typeof userMessage.content === "string"
@@ -844,9 +843,8 @@ describe("JudgeAgent", () => {
       await agent.call(createBaseInput());
 
       expect(capturedParams).toBeDefined();
-      const userMessage = capturedParams!.messages.find(
-        (m) => m.role === "user"
-      );
+      const messages = capturedParams!.messages ?? [];
+      const userMessage = messages.find((m) => m.role === "user");
       if (!userMessage) throw new Error("Expected a user message in LLM call");
       const userContent =
         typeof userMessage.content === "string"

--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -776,4 +776,83 @@ describe("JudgeAgent", () => {
       expect(result!.unmetCriteria).toContain("Agent works correctly");
     });
   });
+
+  describe("additional context via judgmentRequest.context", () => {
+    it("includes <additional_context> in the user message when context is provided", async () => {
+      const collector = createMockSpanCollector([]);
+
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent installed the dependency"],
+        spanCollector: collector,
+      };
+
+      const agent = judgeAgent(config);
+
+      let capturedParams: InvokeLLMParams | undefined;
+      agent.invokeLLM = async (params) => {
+        capturedParams = params;
+        return mockLLMResult("finish_test", {
+          criteria: { agent_installed_the_dependency: "true" },
+          reasoning: "npm install exited 0",
+          verdict: "success",
+        });
+      };
+
+      const inputWithContext = createBaseInput({
+        judgmentRequest: {
+          context:
+            "The agent ran `npm install -g git-orchard` which exited 0. The binary is now at /usr/local/bin/orchard.",
+        },
+      });
+
+      await agent.call(inputWithContext);
+
+      expect(capturedParams).toBeDefined();
+      const userMessage = capturedParams!.messages.find(
+        (m) => m.role === "user"
+      );
+      expect(userMessage).toBeDefined();
+      const userContent =
+        typeof userMessage!.content === "string"
+          ? userMessage!.content
+          : JSON.stringify(userMessage!.content);
+      expect(userContent).toContain("<additional_context>");
+      expect(userContent).toContain("npm install -g git-orchard");
+      expect(userContent).toContain("</additional_context>");
+    });
+
+    it("omits <additional_context> when no context is provided", async () => {
+      const collector = createMockSpanCollector([]);
+
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent responded"],
+        spanCollector: collector,
+      };
+
+      const agent = judgeAgent(config);
+
+      let capturedParams: InvokeLLMParams | undefined;
+      agent.invokeLLM = async (params) => {
+        capturedParams = params;
+        return mockLLMResult("finish_test", {
+          criteria: { agent_responded: "true" },
+          reasoning: "ok",
+          verdict: "success",
+        });
+      };
+
+      await agent.call(createBaseInput());
+
+      expect(capturedParams).toBeDefined();
+      const userMessage = capturedParams!.messages.find(
+        (m) => m.role === "user"
+      );
+      expect(userMessage).toBeDefined();
+      const userContent =
+        typeof userMessage!.content === "string"
+          ? userMessage!.content
+          : JSON.stringify(userMessage!.content);
+      expect(userContent).not.toContain("<additional_context>");
+    });
+  });
 });

--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -811,11 +811,11 @@ describe("JudgeAgent", () => {
       const userMessage = capturedParams!.messages.find(
         (m) => m.role === "user"
       );
-      expect(userMessage).toBeDefined();
+      if (!userMessage) throw new Error("Expected a user message in LLM call");
       const userContent =
-        typeof userMessage!.content === "string"
-          ? userMessage!.content
-          : JSON.stringify(userMessage!.content);
+        typeof userMessage.content === "string"
+          ? userMessage.content
+          : JSON.stringify(userMessage.content);
       expect(userContent).toContain("<additional_context>");
       expect(userContent).toContain("npm install -g git-orchard");
       expect(userContent).toContain("</additional_context>");
@@ -847,11 +847,11 @@ describe("JudgeAgent", () => {
       const userMessage = capturedParams!.messages.find(
         (m) => m.role === "user"
       );
-      expect(userMessage).toBeDefined();
+      if (!userMessage) throw new Error("Expected a user message in LLM call");
       const userContent =
-        typeof userMessage!.content === "string"
-          ? userMessage!.content
-          : JSON.stringify(userMessage!.content);
+        typeof userMessage.content === "string"
+          ? userMessage.content
+          : JSON.stringify(userMessage.content);
       expect(userContent).not.toContain("<additional_context>");
     });
   });

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -326,13 +326,18 @@ class JudgeAgent extends JudgeAgentAdapter {
 
     const transcript = JudgeUtils.buildTranscriptFromMessages(input.messages);
 
+    const extraContext = input.judgmentRequest?.context;
+    const additionalContextSection = extraContext
+      ? `\n    <additional_context>\n    ${extraContext}\n    </additional_context>`
+      : "";
+
     const contentForJudge = `
     <transcript>
     ${transcript}
     </transcript>
     <opentelemetry_traces>
     ${digest}
-    </opentelemetry_traces>
+    </opentelemetry_traces>${additionalContextSection}
     `;
 
     const cfg = this.cfg;

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -27,6 +27,14 @@ export interface JudgmentRequest {
    * Optional criteria to evaluate, overriding the judge agent's configured criteria.
    */
   criteria?: string[];
+  /**
+   * Optional additional context for the judge, such as filesystem state,
+   * command outputs, or structured observations collected during custom
+   * assertion steps. Included in the evaluation prompt under
+   * `<additional_context>`. Useful when conversation messages contain raw
+   * tool-call JSON that is difficult for the judge to interpret directly.
+   */
+  context?: string;
 }
 
 /**

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -868,13 +868,19 @@ export class ScenarioExecution implements ScenarioExecutionLike {
    *
    * // Evaluate inline criteria as a checkpoint
    * const result = await execution.judge({ criteria: ["Agent responded helpfully"] });
+   *
+   * // Provide additional context for tool-call-heavy conversations
+   * const result = await execution.judge({
+   *   criteria: ["Agent installed the dependency"],
+   *   context: "The agent ran `npm install -g git-orchard` which exited 0.",
+   * });
    * ```
    */
-  async judge(options?: { criteria?: string[] }): Promise<ScenarioResult | null> {
+  async judge(options?: { criteria?: string[]; context?: string }): Promise<ScenarioResult | null> {
     return await this.scriptCallAgent(
       AgentRole.JUDGE,
       undefined,
-      { criteria: options?.criteria }
+      { criteria: options?.criteria, context: options?.context }
     );
   }
 

--- a/javascript/src/script/index.ts
+++ b/javascript/src/script/index.ts
@@ -49,10 +49,13 @@ export const agent = (content?: string | ModelMessage): ScriptStep => {
  * When no criteria are provided, the judge uses its own configured criteria
  * and returns a final verdict (success or failure), ending the scenario.
  *
- * @param options Optional options object with inline criteria to evaluate.
+ * @param options Optional options object with inline criteria and/or context to evaluate.
+ *   - `criteria`: Criteria to evaluate (overrides judge's configured criteria).
+ *   - `context`: Additional context for the judge, e.g. filesystem state or command output.
+ *     Included in the judge's prompt under `<additional_context>`.
  * @returns A ScriptStep function that can be used in scenario scripts.
  */
-export const judge = (options?: { criteria: string[] }): ScriptStep => {
+export const judge = (options?: { criteria?: string[]; context?: string }): ScriptStep => {
   return async (_state, executor) => {
     await executor.judge(options);
   };

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2023"],
     "moduleResolution": "bundler",

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -465,13 +465,24 @@ class JudgeAgent(AgentAdapter):
 
         logger.debug(f"OpenTelemetry traces built: {digest[:200]}...")
 
+        extra_context = (
+            input.judgment_request.context
+            if input.judgment_request and input.judgment_request.context
+            else None
+        )
+        extra_context_section = (
+            f"\n<additional_context>\n{extra_context}\n</additional_context>"
+            if extra_context
+            else ""
+        )
+
         content_for_judge = f"""
 <transcript>
 {transcript}
 </transcript>
 <opentelemetry_traces>
 {digest}
-</opentelemetry_traces>
+</opentelemetry_traces>{extra_context_section}
 """
 
         criteria_str = "\n".join(

--- a/python/scenario/types.py
+++ b/python/scenario/types.py
@@ -103,9 +103,15 @@ class JudgmentRequest(BaseModel):
     Attributes:
         criteria: Optional list of criteria to evaluate. When provided, overrides
                  the judge agent's configured criteria for this evaluation.
+        context: Optional additional context for the judge, such as filesystem
+                 state, command outputs, or structured observations from custom
+                 assertion steps. Included in the judge's evaluation prompt under
+                 <additional_context>. Useful when the conversation messages
+                 contain raw tool-call JSON that is hard for the judge to parse.
     """
 
     criteria: Optional[List[str]] = None
+    context: Optional[str] = None
 
 
 class AgentInput(BaseModel):

--- a/python/tests/test_judge_agent.py
+++ b/python/tests/test_judge_agent.py
@@ -232,3 +232,110 @@ async def test_judge_is_last_message_on_final_turn(
     finally:
         context_scenario.reset(token)
         ScenarioConfig.default_config = None
+
+
+@pytest.mark.asyncio
+async def test_judge_includes_additional_context_in_prompt():
+    """JudgmentRequest.context is injected into the judge's user message under <additional_context>.
+
+    Test for #318: allows callers to pass structured observations (e.g. command
+    output, filesystem state) to the judge without polluting the message history.
+    """
+    ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
+    judge = JudgeAgent(criteria=["Agent installed the dependency"])
+
+    mock_scenario_state = MagicMock()
+    mock_scenario_state.description = "Install scenario"
+    mock_scenario_state.current_turn = 1
+    mock_scenario_state.config.max_turns = 10
+
+    ctx_text = "The agent ran `npm install -g git-orchard` which exited 0. The binary is now at /usr/local/bin/orchard."
+
+    agent_input = AgentInput(
+        thread_id="test",
+        messages=[{"role": "user", "content": "Install git-orchard"}],
+        new_messages=[],
+        judgment_request=JudgmentRequest(
+            context=ctx_text,
+        ),
+        scenario_state=mock_scenario_state,
+    )
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.tool_calls = [MagicMock()]
+    mock_response.choices[0].message.tool_calls[0].function.name = "finish_test"
+    mock_response.choices[0].message.tool_calls[
+        0
+    ].function.arguments = '{"verdict": "success", "reasoning": "installed", "criteria": {"agent_installed_the_dependency": "true"}}'
+
+    mock_executor = MagicMock()
+    mock_executor.config = MagicMock()
+    mock_executor.config.cache_key = None
+    token = context_scenario.set(mock_executor)
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ) as mock_completion:
+            await judge.call(agent_input)
+
+            assert mock_completion.called
+            call_kwargs = mock_completion.call_args.kwargs
+            messages = call_kwargs["messages"]
+
+            # The context must appear in the user message (index 1) under <additional_context>.
+            user_msg = next(m for m in messages if m["role"] == "user")
+            assert "<additional_context>" in user_msg["content"]
+            assert ctx_text in user_msg["content"]
+            assert "</additional_context>" in user_msg["content"]
+    finally:
+        context_scenario.reset(token)
+        ScenarioConfig.default_config = None
+
+
+@pytest.mark.asyncio
+async def test_judge_omits_additional_context_when_none():
+    """No <additional_context> block when JudgmentRequest.context is absent."""
+    ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
+    judge = JudgeAgent(criteria=["Agent responded"])
+
+    mock_scenario_state = MagicMock()
+    mock_scenario_state.description = "Basic scenario"
+    mock_scenario_state.current_turn = 1
+    mock_scenario_state.config.max_turns = 10
+
+    agent_input = AgentInput(
+        thread_id="test",
+        messages=[{"role": "user", "content": "Hello"}],
+        new_messages=[],
+        judgment_request=JudgmentRequest(),  # no context
+        scenario_state=mock_scenario_state,
+    )
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.tool_calls = [MagicMock()]
+    mock_response.choices[0].message.tool_calls[0].function.name = "finish_test"
+    mock_response.choices[0].message.tool_calls[
+        0
+    ].function.arguments = '{"verdict": "success", "reasoning": "ok", "criteria": {"agent_responded": "true"}}'
+
+    mock_executor = MagicMock()
+    mock_executor.config = MagicMock()
+    mock_executor.config.cache_key = None
+    token = context_scenario.set(mock_executor)
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ) as mock_completion:
+            await judge.call(agent_input)
+
+            call_kwargs = mock_completion.call_args.kwargs
+            messages = call_kwargs["messages"]
+            user_msg = next(m for m in messages if m["role"] == "user")
+            assert "<additional_context>" not in user_msg["content"]
+    finally:
+        context_scenario.reset(token)
+        ScenarioConfig.default_config = None


### PR DESCRIPTION
## Problem

When testing agents that run bash commands, install software, or write files, the conversation messages contain raw tool-call JSON that is difficult for the judge to parse reliably. The only workaround was to mutate `state.messages` with synthetic messages — which pollutes the conversation history. Closes #318.

## Solution

Add an optional `context` parameter to `JudgmentRequest` (and `scenario.judge()`) that is appended to the judge's evaluation prompt under `<additional_context>`:

```typescript
// TypeScript
await execution.judge({
  criteria: ["Agent installed the dependency"],
  context: "The agent ran `npm install -g git-orchard` which exited 0. Binary at /usr/local/bin/orchard.",
});
```

```python
# Python
scenario.judge(
    judgment_request=JudgmentRequest(
        criteria=["Agent installed the dependency"],
        context="The agent ran `npm install -g git-orchard` which exited 0.",
    )
)
```

## Changes

**TypeScript:**
- `JudgmentRequest.context?: string` added to `domain/agents/index.ts`
- `JudgeAgent` injects context as `<additional_context>...</additional_context>` block in `contentForJudge`
- `execution.judge({ criteria, context })` and `script.judge({ criteria, context })` signatures updated
- 2 unit tests added: context present → appears in prompt; context absent → block omitted

**Python:**
- `JudgmentRequest.context: Optional[str] = None` added to `types.py`
- `JudgeAgent` injects context into `content_for_judge` when present
- 2 unit tests added: same as TS

## Test Plan
- [x] Python tests: `pytest tests/test_judge_agent.py` — 9 passed
- [x] CI TypeScript tests will validate the TS side

🤖 Generated with [Claude Code](https://claude.com/claude-code)