### PR TITLE
chore(#489): drop stale Python 3.8/3.9 classifiers from pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,8 +15,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]


### PR DESCRIPTION
## Summary

- Removes `Programming Language :: Python :: 3.8` and `Programming Language :: Python :: 3.9` from the classifier block in `python/pyproject.toml`.
- `requires-python = ">=3.10"` already declares the minimum; the stale 3.8/3.9 entries caused false-positive PyPI search results.
- No doc files with the stale `68 @unit` counts were found in-repo (they were never committed or were already absent).

## Acceptance criteria (from #489)

- [x] `python/pyproject.toml` classifier block drops "Programming Language :: Python :: 3.8" and "3.9" entries.
- [x] Any in-repo doc referencing "68 @unit" updated — grep found zero hits; no files to change.
- [x] `docs/proposals/issue-350-prove-it-report.md` is absent from the repo (was only on @drewdrewthis's local checkout per the audit report reference); no change needed.

## Test plan

- [ ] CI passes (Python classifiers are metadata; no runtime behaviour changed)
- [ ] `python/pyproject.toml` contains no `3.8` or `3.9` classifier lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)