### PR TITLE
fix(#454): add liveness check + auto-restart to requires_pipecat_bot fixture

### DIFF
--- a/python/tests/voice/conftest.py
+++ b/python/tests/voice/conftest.py
@@ -158,9 +158,36 @@ def requires_llm():
 
 @pytest.fixture
 def requires_pipecat_bot():
-    """Ensure a Pipecat-compatible bot is on :8765, auto-starting if needed."""
-    if not _tcp_port_open("localhost", 8765):
-        _start_pipecat_bot()
+    """Ensure a Pipecat-compatible bot is on :8765, with liveness check + auto-restart.
+
+    If the bot was previously started but has since crashed, we restart it and
+    fail the current test so the operator knows the infrastructure hiccuped —
+    subsequent tests will find a healthy bot and run normally.
+    """
+    import logging
+
+    bot_was_known_running = (
+        _bot_process is not None and _bot_process.poll() is None
+    )
+    port_open = _tcp_port_open("localhost", 8765, timeout=0.5)
+
+    if not port_open:
+        if bot_was_known_running:
+            # Bot died between tests — restart it, then fail this test so the
+            # operator knows it was an infrastructure failure, not a test bug.
+            logging.getLogger("scenario.voice").warning(
+                "Pipecat stub bot (:8765) died between tests; restarting for "
+                "subsequent tests."
+            )
+            _start_pipecat_bot()
+            pytest.fail(
+                "[infrastructure] Pipecat stub bot died mid-suite and was restarted. "
+                "This test is an infrastructure failure, not a bug in the code under test. "
+                "Subsequent tests should run normally with the restarted bot."
+            )
+        else:
+            # Bot was never started — auto-provision it (nominal path).
+            _start_pipecat_bot()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- `requires_pipecat_bot` now runs a 0.5s TCP probe before every Pipecat-dependent test.
- **Bot never started** (nominal path): auto-provisions the bot silently (unchanged behaviour).
- **Bot was running but has since crashed**: restarts it for subsequent tests, then calls `pytest.fail("[infrastructure] …")` on the current test so the operator sees it as an infrastructure failure, not a code bug.
- Subsequent tests after a crash-and-restart find a healthy bot and proceed normally.

## Acceptance criteria (from #454)

- [x] Before each test, probe `:8765` with a 0.5s connect timeout.
- [x] If probe fails and the bot was previously running, log a WARNING and restart.
- [x] Current test fails with `[infrastructure]` marker; subsequent tests run normally.
- [x] First-start path unchanged (no regression).

## Test plan

- [ ] CI passes (fixture is integration-scope; the structural change is validated by test collection)
- [ ] `pytest tests/voice/ --collect-only` succeeds without import errors
- [ ] `pyright .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)