### PR TITLE
fix(#502): raise VoiceAgentAdapter.response_timeout default from 30s to 60s

### DIFF
--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -44,12 +44,23 @@ class VoiceAgentAdapter(AgentAdapter):
         capabilities: Declaration of what the adapter can and cannot do. Each
             concrete subclass must set this as a class attribute.
         response_timeout: Seconds to wait for agent audio after sending user
-            audio. Defaults to 30 seconds.
+            audio. Defaults to 60 seconds.
+
+            60 seconds covers a typical real-world STT → LLM → TTS round-trip
+            including backoff/retry inside each provider, tool calls, and RAG
+            lookups. If you see TimeoutError flakes against a fast LLM-only
+            chain, you can lower this; if your agent does heavy processing
+            (MCP roundtrips, multi-step tool chains), consider raising it.
+
+            Override per-adapter at construction time::
+
+                adapter = MyVoiceAdapter()
+                adapter.response_timeout = 90.0  # slow tool-call chain
     """
 
     role: ClassVar[AgentRole] = AgentRole.AGENT
     capabilities: ClassVar[AdapterCapabilities] = AdapterCapabilities()
-    response_timeout: float = 30.0
+    response_timeout: float = 60.0  # 60s: STT + LLM + TTS budget (see docstring)
     # Tail silence: once the first agent chunk arrives, keep draining recv_audio
     # until no chunk shows up within this many seconds — that's how we detect the
     # agent finished talking. Without this, demos record only the first ~100ms.


### PR DESCRIPTION
## Summary

- Bumps `VoiceAgentAdapter.response_timeout` from `30.0` → `60.0` seconds.
- Adds explanatory docstring describing what the 60s budget covers (STT transcription + LLM inference + TTS generation, including retries and tool calls) and how to override per-adapter.
- `response_max_duration` (hard cap on agent-speech length) stays at 30s — that's a different timeout.

## Problem

30s was measured to be tight for ElevenLabs Conversational AI: observed first-run failures after ~30s of agent silence during WebSocket keep-alive periods (the socket was healthy, the agent was processing). Retry runs succeeded. The fix is conservative: a more generous default that covers real-world worst-case round-trips.

## Acceptance criteria

- [x] `response_timeout` default changed to 60s, `response_max_duration` unchanged.
- [x] Docstring explains the round-trip budget and override pattern.
- [x] No hardcoded `30.0` references in tests (grep confirms none).
- [x] `pyright` clean.

Closes #502. Mitigates (does not eliminate) #493.

## Test plan

- [ ] CI passes
- [ ] `pyright .` — 0 errors (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)