### PR TITLE
fix(ci/#571): soft-pass oversized PR diffs in pr-auto-approve evaluate

### DIFF
--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -260,7 +260,12 @@ jobs:
             ERR_MSG=$(head -c 500 /tmp/pr_diff_err.txt 2>/dev/null || echo "(no stderr captured)")
             echo "gh pr diff failed (likely oversized diff): $ERR_MSG"
             echo "oversized=true" >> "$GITHUB_OUTPUT"
-            echo "oversized_reason=Diff too large to fetch via GitHub API (fetch error: $ERR_MSG)" >> "$GITHUB_OUTPUT"
+            # Use a heredoc so multi-line stderr doesn't corrupt GITHUB_OUTPUT format.
+            {
+              printf 'oversized_reason<<__EOF_OVERSIZE__\n'
+              printf 'Diff too large to fetch via GitHub API (fetch error: %s)\n' "$ERR_MSG"
+              printf '__EOF_OVERSIZE__\n'
+            } >> "$GITHUB_OUTPUT"
           else
             # Fail closed if diff exceeds model window — large PRs could hide risky changes.
             DIFF_LIMIT=100000
@@ -268,7 +273,12 @@ jobs:
             if [ "$DIFF_SIZE" -gt "$DIFF_LIMIT" ]; then
               echo "PR diff is ${DIFF_SIZE} chars (> ${DIFF_LIMIT}); too large for automated evaluation."
               echo "oversized=true" >> "$GITHUB_OUTPUT"
-              echo "oversized_reason=Diff too large for automated evaluation (${DIFF_SIZE} chars exceeds ${DIFF_LIMIT}-char limit)" >> "$GITHUB_OUTPUT"
+              # Use a heredoc so the reason string doesn't corrupt GITHUB_OUTPUT format.
+              {
+                printf 'oversized_reason<<__EOF_OVERSIZE__\n'
+                printf 'Diff too large for automated evaluation (%s chars exceeds %s-char limit)\n' "$DIFF_SIZE" "$DIFF_LIMIT"
+                printf '__EOF_OVERSIZE__\n'
+              } >> "$GITHUB_OUTPUT"
             else
               echo "oversized=false" >> "$GITHUB_OUTPUT"
               cp /tmp/pr_diff.txt /tmp/pr_diff_truncated.txt
@@ -278,12 +288,21 @@ jobs:
       - name: Mark oversized diffs as not-low-risk
         id: oversized
         if: steps.pr-data.outputs.oversized == 'true'
+        # Pass oversized_reason via env: (not ${{ }} direct expansion in run:) — the
+        # documented GitHub Actions pattern for shell-injection hardening even when the
+        # source is trusted (gh CLI stderr). See:
+        # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        env:
+          OVERSIZED_REASON: ${{ steps.pr-data.outputs.oversized_reason }}
         run: |
-          REASON="${{ steps.pr-data.outputs.oversized_reason }}"
           {
             echo "qualifies=false"
             echo "scope=Diff too large for automated evaluation"
-            echo "reasoning=This PR's diff could not be evaluated automatically: ${REASON}. Manual review required."
+            # Use heredoc for reasoning since OVERSIZED_REASON can be multi-line
+            # (gh CLI stderr) and would otherwise corrupt the GITHUB_OUTPUT format.
+            printf 'reasoning<<__EOF_REASON__\n'
+            printf 'This PR'\''s diff could not be evaluated automatically: %s. Manual review required.\n' "$OVERSIZED_REASON"
+            printf '__EOF_REASON__\n'
           } >> "$GITHUB_OUTPUT"
 
       - name: Check for restricted paths

--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -252,27 +252,38 @@ jobs:
           gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json title,body --template '{{.title}}' > /tmp/pr_title.txt
           gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json title,body --template '{{.body}}' > /tmp/pr_body.txt
           gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path' > /tmp/pr_files.txt
-          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > /tmp/pr_diff.txt
 
-          # Fail closed if diff exceeds model window — large PRs could hide risky changes.
-          DIFF_LIMIT=100000
-          DIFF_SIZE=$(wc -c < /tmp/pr_diff.txt)
-          if [ "$DIFF_SIZE" -gt "$DIFF_LIMIT" ]; then
-            echo "PR diff is ${DIFF_SIZE} chars (> ${DIFF_LIMIT}); too large for automated evaluation."
+          # Fetch the diff; tolerate non-zero exit (e.g. HTTP 406 for diffs
+          # exceeding GitHub's ~20k-line API limit) — treat fetch failure as
+          # oversized so the existing oversized path fires correctly.
+          if ! gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > /tmp/pr_diff.txt 2>/tmp/pr_diff_err.txt; then
+            ERR_MSG=$(head -c 500 /tmp/pr_diff_err.txt 2>/dev/null || echo "(no stderr captured)")
+            echo "gh pr diff failed (likely oversized diff): $ERR_MSG"
             echo "oversized=true" >> "$GITHUB_OUTPUT"
+            echo "oversized_reason=Diff too large to fetch via GitHub API (fetch error: $ERR_MSG)" >> "$GITHUB_OUTPUT"
           else
-            echo "oversized=false" >> "$GITHUB_OUTPUT"
-            cp /tmp/pr_diff.txt /tmp/pr_diff_truncated.txt
+            # Fail closed if diff exceeds model window — large PRs could hide risky changes.
+            DIFF_LIMIT=100000
+            DIFF_SIZE=$(wc -c < /tmp/pr_diff.txt)
+            if [ "$DIFF_SIZE" -gt "$DIFF_LIMIT" ]; then
+              echo "PR diff is ${DIFF_SIZE} chars (> ${DIFF_LIMIT}); too large for automated evaluation."
+              echo "oversized=true" >> "$GITHUB_OUTPUT"
+              echo "oversized_reason=Diff too large for automated evaluation (${DIFF_SIZE} chars exceeds ${DIFF_LIMIT}-char limit)" >> "$GITHUB_OUTPUT"
+            else
+              echo "oversized=false" >> "$GITHUB_OUTPUT"
+              cp /tmp/pr_diff.txt /tmp/pr_diff_truncated.txt
+            fi
           fi
 
-      - name: Fail fast for oversized diffs
+      - name: Mark oversized diffs as not-low-risk
         id: oversized
         if: steps.pr-data.outputs.oversized == 'true'
         run: |
+          REASON="${{ steps.pr-data.outputs.oversized_reason }}"
           {
             echo "qualifies=false"
             echo "scope=Diff too large for automated evaluation"
-            echo "reasoning=This PR's diff exceeds the size limit for automated low-risk evaluation. Manual review required."
+            echo "reasoning=This PR's diff could not be evaluated automatically: ${REASON}. Manual review required."
           } >> "$GITHUB_OUTPUT"
 
       - name: Check for restricted paths


### PR DESCRIPTION
## Why

`evaluate` in `pr-auto-approve.yml` hard-failed on PRs with diffs over GitHub's API limit (~20k lines). The `gh pr diff` fetch returned HTTP 406 and the step exited non-zero — the existing 100k-char ceiling that should have handled this never got reached. The check went red on every large PR (e.g. #561).

## What changed

- **Tolerant fetch**: `gh pr diff` failure now sets `oversized=true` + captures stderr to `oversized_reason`. The existing oversized path runs (sets `qualifies=false` with an honest reason) and the workflow exits 0.
- **Honest reasoning**: the auto-posted PR comment now explains *why* the diff couldn't be evaluated (fetch failure vs. char-count exceeded), so the human reviewer doesn't have to dig into the workflow log.
- **Hardened interpolation**: `oversized_reason` is passed via `env:` rather than `${{ }}` direct expansion in `run:` — the documented pattern for shell-injection hardening even when the source is trusted.

Per the policy: oversized = NOT-low-risk. The size signal alone gives the answer; the AI evaluator isn't needed.

## Test plan

- YAML validated locally (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- The failure path will be exercised by the next oversized PR (e.g. PR #561 once it re-syncs against `main` post-merge). Expected outcome: `evaluate` posts the `qualifies=false` comment with the fetch-failure reason in the body, and the check exits 0.

Closes #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
