### PR TITLE
chore: add .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Why
+
+<!-- 1-3 sentences. What problem does this solve? Link the issue with `Closes #N`. A reviewer who hasn't seen the issue should understand the motivation after reading this. Don't restate the issue title verbatim. -->
+
+Closes #
+
+## What changed
+
+<!-- 2-4 bullets. Each bullet is a DECISION, not an action. "Chose X over Y because Z" beats "Modified file.py to do X." The commits already say what changed line-by-line — surface the decisions a reviewer would otherwise miss. -->
+
+## How it works
+
+<!-- Default OFF — delete this section unless the mechanism is non-obvious AND not already explained in a commit message. -->
+
+## Test plan
+
+<!-- Bullets or commands, not prose. Name test files, paste commands, show assertions. For bug fixes: name the regression test and confirm it fails without the fix. Per CONTRIBUTING.md, add tests for new functionality and run the full suite. -->
+
+## How I can prove I was successful
+
+<!-- REQUIRED. Artifacts a reviewer can play / open / run to verify the change works end-to-end (this is the demonstration, not the test plan). Pick what fits: UI → screenshots / preview URL; API → curl + response; voice/audio → checked-in .wav blob URL (GitHub embeds a player) + manifest; data/migration → before/after counts; CLI → recorded session. Link in-tree or in-PR artifacts, not external links that rot. Pure infra/library where no artifact makes sense: say "no playable artifact — see Test plan". -->
+
+## Anything surprising?
+
+<!-- Default OFF — delete unless flagging a limitation, follow-up, or edge case a reviewer would otherwise miss. -->
+
+<!--
+Before marking ready (see CONTRIBUTING.md → Pull Request Process):
+- Keep this description up to date with the current head; no PII; reference only linkable, persistent things (issues/PRs, commit SHAs, in-repo paths, public URLs) — not internal AC numbers or working docs a reviewer can't open.
+- Open as draft until CI is green; mark ready only once it passes.
+-->


### PR DESCRIPTION
## Why

The repo has no `.github/PULL_REQUEST_TEMPLATE.md`, so PR descriptions are unstructured and tend to drift — stale claims, references a reviewer can't open (internal AC numbers, working docs), and missing test/proof sections. A template makes the baseline consistent and reviewer-oriented.

_No backing issue — direct repo-hygiene cleanup (the gap was surfaced while drafting the PR-description policy in the codex). Nothing to `Closes`._

## What changed

- **Add `.github/PULL_REQUEST_TEMPLATE.md`** — sections mirror `CONTRIBUTING.md`'s *Pull Request Process* (tests, docs, clear description): Why / What changed / Test plan / **How I can prove I was successful** (required) / optional How-it-works + Anything-surprising.
- **Inline guidance** in HTML comments (stripped on render): keep the description current, PII-free, and self-contained (link only issues/PRs, commit SHAs, in-repo paths, public URLs); open as draft until CI is green.

## Test plan

- N/A — docs-only. Open the "Files changed" tab to confirm the template renders, and note that opening this very PR exercised the template (GitHub pre-fills new PRs from it going forward).

## How I can prove I was successful

- This PR's own description was written from the new template's sections — it *is* the demonstration. After merge, opening any new PR will pre-populate with this structure.

## Anything surprising?

- Chose `.github/PULL_REQUEST_TEMPLATE.md` (single-template form) over a `PULL_REQUEST_TEMPLATE/` directory — the repo only needs one default. Multi-template can be added later if distinct PR types diverge.

