### PR TITLE
fix(voice/ts): explicit EL ConvAI turn-commit so scripted next-turn receive re-engages

### DIFF
--- a/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
@@ -128,14 +128,15 @@ if (hasHostedKey || hasComposableKey) {
             );
             // #567: the explicit user_message turn-commit re-engages the agent
             // on the scripted 2nd user turn, so the live socket now carries
-            // multiple agent audio turns (greeting + ≥2 responses). Assert the
-            // multi-turn shape — more segments than the old single-exchange
-            // limit could produce — as the load-bearing live proof.
+            // greeting + user1 + agent1 + user2 + agent2 = 5 segments. Assert
+            // the full 5-segment shape — the pre-fix silence path stalls on
+            // user2 and produces at most 4 segments before the timeout, so ≥5
+            // is the falsifying floor that separates fixed from broken.
             expect(
               result!.audio!.segments.length,
-              "expected ≥3 audio segments (greeting + 2 agent responses) — " +
-                "a scripted 2nd-turn re-engagement is the #567 fix",
-            ).toBeGreaterThanOrEqual(3);
+              "expected ≥5 audio segments (greeting + user1 + agent1 + user2 + agent2) — " +
+                "the pre-fix silence path stalls on user2 and cannot produce 5",
+            ).toBeGreaterThanOrEqual(5);
             // The judge verdict is informative; surface success for the reviewer.
             expect(result!.success, `judge verdict: ${result!.reasoning}`).toBe(true);
           });

--- a/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
@@ -84,22 +84,22 @@ if (hasHostedKey || hasComposableKey) {
               // with agent() so the greeting drains before user audio hits the
               // wire (mirrors the Python twin's script).
               //
-              // SINGLE scripted exchange (greeting → user → agent) — NOT extended
-              // to a second scripted user turn. The hosted ConvAI transport is
-              // server-VAD-driven: it segments turns from the *audio stream*, and
-              // a scripted second user turn after the agent has already replied
-              // does not reliably re-engage the server's turn-taking — the next
-              // `agent()` receive then times out (`receiveAudio timed out`,
-              // verified empirically). The MULTI-TURN ElevenLabs proof lives in
-              // the in-process `elevenlabs_branded` demo below, which has full
-              // turn control. This demo proves the live hosted-ConvAI WS path.
+              // MULTI-TURN (≥2 scripted exchanges) over the LIVE hosted ConvAI
+              // socket — un-gated by #567. The adapter now commits each user turn
+              // with an explicit `user_message` event instead of leaning on
+              // mic-style server VAD, so a scripted 2nd user turn after the agent
+              // has already replied reliably re-engages the next agent response
+              // (the old single-exchange limit + `receiveAudio timed out` are
+              // fixed). This is the load-bearing live proof for #567.
               script: [
                 scenario.agent(),
                 scenario.user("Hello, I have a question about my account."),
                 scenario.agent(),
+                scenario.user("Thanks. Can you tell me your support hours?"),
+                scenario.agent(),
                 scenario.judge(),
               ],
-              maxTurns: 6,
+              maxTurns: 8,
             });
             recordingDir = saveDemoRecording(result.audio, "elevenlabs_hosted");
           });
@@ -119,16 +119,24 @@ if (hasHostedKey || hasComposableKey) {
             },
           );
 
-          And("result.success is True after one turn", () => {
+          And("result.success is True after ≥2 exchanges", () => {
             if (!hasHostedKey) return;
             expect(recordingDir, "recording was not written").not.toBeNull();
             console.log(
               `[demo] elevenlabs_hosted → ${recordingDir} ` +
                 `(success=${result!.success}, ${result!.audio!.segments.length} segments)`,
             );
-            // The judge verdict is informative but EL hosted turn-taking is
-            // server-VAD-driven; the load-bearing proof is real audio over the
-            // live socket. Surface success for the reviewer.
+            // #567: the explicit user_message turn-commit re-engages the agent
+            // on the scripted 2nd user turn, so the live socket now carries
+            // multiple agent audio turns (greeting + ≥2 responses). Assert the
+            // multi-turn shape — more segments than the old single-exchange
+            // limit could produce — as the load-bearing live proof.
+            expect(
+              result!.audio!.segments.length,
+              "expected ≥3 audio segments (greeting + 2 agent responses) — " +
+                "a scripted 2nd-turn re-engagement is the #567 fix",
+            ).toBeGreaterThanOrEqual(3);
+            // The judge verdict is informative; surface success for the reviewer.
             expect(result!.success, `judge verdict: ${result!.reasoning}`).toBe(true);
           });
         },

--- a/javascript/src/voice/__tests__/elevenlabs-hosted-shape.guard.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-hosted-shape.guard.test.ts
@@ -1,7 +1,7 @@
-// Ungated CI guard for #638 — keyless, no live keys. Proves the hosted example
-// stays single greeting-led (AC8), the composable example stays multi-turn (AC9),
-// and the adapter timeout error is enriched (AC6). Fails if the bug pattern
-// (2nd user turn on hosted) is reintroduced.
+// Ungated CI guard for #638 / #567 — keyless, no live keys. Proves the hosted
+// example is greeting-led multi-turn (AC8 updated: #567 fixed the adapter so
+// multi-turn is now the expected shape), the composable example stays multi-turn
+// (AC9), and the adapter timeout error is enriched with actionable guidance (AC6).
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -74,13 +74,18 @@ function extractScriptBlock(source: string, scenarioTitle: string): string {
 // ---------------------------------------------------------------------------
 
 describe("elevenlabs-hosted-shape guard (#638)", () => {
-  it("AC8 — hosted example is greeting-led single exchange", () => {
+  it("AC8 — hosted example is greeting-led multi-turn (#567 load-bearing proof)", () => {
+    // Pre-#567: the adapter's server-VAD path timed out on the 2nd scripted user
+    // turn, so the hosted example was capped at 1 user turn. Post-#567: the
+    // adapter commits each user turn with an explicit user_message event, so
+    // multi-turn works reliably. This guard now enforces the opposite invariant:
+    // the hosted example MUST have ≥2 user turns (regression = reverting to 1).
     const source = fs.readFileSync(EXAMPLE_FILE, "utf-8");
     const block = extractScriptBlock(source, "Demo — ElevenLabs hosted Conversational AI");
 
     // Count occurrences of scenario.user( in the hosted script block.
     const userTurns = (block.match(/scenario\.user\(/g) ?? []).length;
-    expect(userTurns).toBe(1);
+    expect(userTurns).toBeGreaterThanOrEqual(2);
 
     // The FIRST scenario. step in the block must be scenario.agent() — greeting-led.
     // Strip leading `[` and whitespace, then match the first method call.
@@ -113,6 +118,8 @@ describe("elevenlabs-hosted-shape guard (#638)", () => {
     // After collapsing the join both appear in sequence.
     expect(collapsed).toContain("Hosted ElevenLabs");
     expect(collapsed).toContain("ConvAI");
-    expect(collapsed).toContain("single exchange");
+    // #567: the error now names the legacy silence-VAD path and recommends
+    // the "text" mode; the old "single exchange" framing is retired.
+    expect(collapsed).toContain("turnCommitMode");
   });
 });

--- a/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Issue #567 — ElevenLabs ConvAI scripted next-turn / post-interrupt receive.
+ *
+ * The hosted ConvAI transport has NO audio end-of-turn client event (verified
+ * against the official EL Python + JS SDKs), so the pre-#567 adapter leaned on
+ * a fixed silence tail to coax server-side VAD. That tail does not reliably
+ * re-engage a response for a scripted turn 2+ (EL ConvAI 2.0 end-of-turn is a
+ * hybrid VAD + deep-learning turn-detector, not a pure silence threshold), so
+ * the 2nd `receiveAudio` timed out.
+ *
+ * The fix sends an explicit `{"type":"user_message","text":<transcript>}`
+ * turn-commit — the only documented client→server event that deterministically
+ * forces an agent response without mic-style VAD. On the text path the raw
+ * audio is NOT also streamed to EL (audio + text in one turn raced the server's
+ * ingestion and was live-flaky); the user audio is still recorded locally by
+ * the voice runtime and EL echoes the text back as a user_transcript.
+ *
+ * These tests drive the adapter through the injectable `webSocketFactory` /
+ * a fake socket and prove:
+ *  1. a scripted 2nd user turn after an agent turn drives a 2nd `receiveAudio`
+ *     resolution (the bug), AND each user turn emits a `user_message` commit;
+ *  2. the post-interrupt shape (agent audio mid-flight → user re-engages) also
+ *     commits + re-engages;
+ *  3. `turnCommitMode:"silence"` preserves the legacy pure-audio path;
+ *  4. `"text"` mode with no transcript falls back to the silence tail.
+ *
+ * Offline — no network, no real EL socket. The LIVE ≥2-exchange proof lives in
+ * `examples/vitest/tests/voice/elevenlabs-hosted.test.ts`.
+ */
+import { Buffer } from "node:buffer";
+
+import { describe, it, expect, beforeEach } from "vitest";
+import type { RawData } from "ws";
+
+import {
+  ElevenLabsAgentAdapter,
+  type WebSocketLike,
+} from "../adapters/elevenlabs";
+import { AudioChunk } from "../audio-chunk";
+
+/**
+ * Minimal in-memory {@link WebSocketLike}. Captures every frame the adapter
+ * sends and lets the test push inbound frames + lifecycle events.
+ */
+class FakeElevenLabsSocket implements WebSocketLike {
+  readonly sent: string[] = [];
+  private listeners: {
+    message: Array<(data: RawData) => void>;
+    error: Array<(err: Error) => void>;
+    close: Array<() => void>;
+    open: Array<() => void>;
+  } = { message: [], error: [], close: [], open: [] };
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.listeners.close.forEach((l) => l());
+  }
+
+  on(event: "message", listener: (data: RawData) => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "close", listener: () => void): this;
+  on(event: "open", listener: () => void): this;
+  on(event: string, listener: (...args: never[]) => void): this {
+    (this.listeners as Record<string, Array<(...a: never[]) => void>>)[event]?.push(
+      listener,
+    );
+    return this;
+  }
+
+  once(event: "open", listener: () => void): this;
+  once(event: "error", listener: (err: Error) => void): this;
+  once(event: string, listener: (...args: never[]) => void): this {
+    return this.on(event as "open", listener as () => void);
+  }
+
+  removeAllListeners(): void {
+    this.listeners = { message: [], error: [], close: [], open: [] };
+  }
+
+  // ----- test drivers -----
+
+  /** Fire the `open` event so the adapter's connect() promise resolves. */
+  fireOpen(): void {
+    this.listeners.open.forEach((l) => l());
+  }
+
+  /** Deliver a raw inbound JSON frame to the adapter's message handler. */
+  deliver(event: Record<string, unknown>): void {
+    const raw = Buffer.from(JSON.stringify(event), "utf-8") as unknown as RawData;
+    this.listeners.message.forEach((l) => l(raw));
+  }
+
+  /** Deliver an `audio` event carrying `byteLen` bytes of PCM16. */
+  deliverAudio(byteLen = 4): void {
+    const pcm = Buffer.alloc(byteLen, 1);
+    this.deliver({
+      type: "audio",
+      audio_event: { audio_base_64: pcm.toString("base64") },
+    });
+  }
+
+  /** Parsed view of every frame the adapter sent. */
+  get sentParsed(): Array<Record<string, unknown>> {
+    return this.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+  }
+
+  /** Frames that are user_message turn-commits. */
+  get userMessages(): Array<{ type: string; text: string }> {
+    return this.sentParsed.filter(
+      (m) => m.type === "user_message",
+    ) as Array<{ type: string; text: string }>;
+  }
+
+  /** Frames that are user_audio_chunk sends (speech or silence). */
+  get audioChunks(): string[] {
+    return this.sentParsed
+      .filter((m) => typeof m.user_audio_chunk === "string")
+      .map((m) => m.user_audio_chunk as string);
+  }
+}
+
+/** Build an adapter wired to a fresh fake socket, already connected. */
+async function connectedAdapter(
+  opts: { turnCommitMode?: "text" | "silence"; silenceTailBytes?: number } = {},
+): Promise<{ adapter: ElevenLabsAgentAdapter; socket: FakeElevenLabsSocket }> {
+  const socket = new FakeElevenLabsSocket();
+  const adapter = new ElevenLabsAgentAdapter({
+    agentId: "agent-test",
+    apiKey: "xi-test",
+    webSocketFactory: () => socket,
+    ...opts,
+  });
+  const connecting = adapter.connect();
+  socket.fireOpen();
+  await connecting;
+  return { adapter, socket };
+}
+
+/** A user audio chunk that carries its transcript (as the voice runtime threads it). */
+function userTurn(text: string): AudioChunk {
+  return new AudioChunk({ data: new Uint8Array(8), transcript: text });
+}
+
+describe("ElevenLabsAgentAdapter turn-commit (#567)", () => {
+  let adapter: ElevenLabsAgentAdapter;
+  let socket: FakeElevenLabsSocket;
+
+  beforeEach(async () => {
+    ({ adapter, socket } = await connectedAdapter());
+  });
+
+  it("a scripted 2nd user turn after an agent turn drives a 2nd receiveAudio resolution", async () => {
+    // ---- Exchange 1: greeting drains (real-voice convention) ----
+    socket.deliverAudio();
+    const greeting = await adapter.receiveAudio(1);
+    expect(greeting.data.length).toBeGreaterThan(0);
+
+    // ---- Exchange 1: user turn 1 → agent responds ----
+    await adapter.sendAudio(userTurn("Hello, I have a question about my account."));
+    // Agent audio for turn 1.
+    socket.deliverAudio();
+    const agent1 = await adapter.receiveAudio(1);
+    expect(agent1.data.length).toBeGreaterThan(0);
+
+    // ---- Exchange 2: the BUG case — scripted 2nd user turn ----
+    await adapter.sendAudio(userTurn("Yes, can you check my balance?"));
+    // With the explicit commit, EL re-engages: deliver the 2nd agent audio.
+    socket.deliverAudio();
+    const agent2 = await adapter.receiveAudio(1);
+    // This resolving (not timing out) is the #567 proof.
+    expect(agent2.data.length).toBeGreaterThan(0);
+
+    // Each user turn emitted an explicit user_message turn-commit (not a
+    // silence tail) — the deterministic re-engagement signal.
+    expect(socket.userMessages).toEqual([
+      { type: "user_message", text: "Hello, I have a question about my account." },
+      { type: "user_message", text: "Yes, can you check my balance?" },
+    ]);
+    // The default "text" path sends ONLY the text commit — NO user_audio_chunk
+    // frames at all (sending audio + text in the same turn raced EL's ingestion
+    // and was live-flaky; the text turn alone re-engages deterministically).
+    expect(socket.audioChunks).toEqual([]);
+  });
+
+  it("post-interrupt: a user turn after partial agent audio re-engages a fresh response", async () => {
+    // Agent starts talking (turn 1 audio queued but the executor barges in).
+    socket.deliverAudio();
+    await adapter.receiveAudio(1);
+
+    // User interrupts/responds with a new scripted turn.
+    await adapter.sendAudio(userTurn("Actually, wait — cancel that."));
+    // EL issues an agent_response_correction (post-barge-in), then fresh audio.
+    socket.deliver({
+      type: "agent_response_correction",
+      agent_response_correction_event: {
+        original_agent_response: "Sure, your balance is…",
+        corrected_agent_response: "Okay, cancelled.",
+      },
+    });
+    socket.deliverAudio();
+    const corrected = await adapter.receiveAudio(1);
+
+    expect(corrected.data.length).toBeGreaterThan(0);
+    expect(adapter.lastAgentTranscript).toBe("Okay, cancelled.");
+    expect(socket.userMessages).toEqual([
+      { type: "user_message", text: "Actually, wait — cancel that." },
+    ]);
+  });
+
+  it('user_message commit echoes through as user_transcript observability', async () => {
+    await adapter.sendAudio(userTurn("What are your hours?"));
+    // EL echoes the committed text back as the user transcript.
+    socket.deliver({
+      type: "user_transcript",
+      user_transcription_event: { user_transcript: "What are your hours?" },
+    });
+    expect(adapter.lastUserTranscript).toBe("What are your hours?");
+  });
+
+  it("the committed user_message is a server-accepted shape (type + text only)", async () => {
+    await adapter.sendAudio(userTurn("ping"));
+    const commit = socket.userMessages[0]!;
+    expect(Object.keys(commit).sort()).toEqual(["text", "type"]);
+    expect(commit.type).toBe("user_message");
+  });
+});
+
+describe("ElevenLabsAgentAdapter silence-tail fallbacks (#567)", () => {
+  it('turnCommitMode:"silence" preserves the legacy pure-audio VAD path (no user_message)', async () => {
+    const { adapter, socket } = await connectedAdapter({ turnCommitMode: "silence" });
+
+    await adapter.sendAudio(userTurn("Hello again."));
+
+    // Legacy path: speech chunk + a zero-byte silence tail, NO user_message.
+    expect(socket.userMessages).toEqual([]);
+    const silenceTail = Buffer.alloc(16000).toString("base64");
+    expect(socket.audioChunks).toContain(silenceTail);
+    expect(socket.audioChunks.length).toBe(2); // speech + silence
+  });
+
+  it('"text" mode with no transcript falls back to the silence tail', async () => {
+    const { adapter, socket } = await connectedAdapter(); // default "text"
+
+    // No transcript on the chunk (e.g. raw audio with no STT text upstream).
+    await adapter.sendAudio(new AudioChunk({ data: new Uint8Array(8) }));
+
+    expect(socket.userMessages).toEqual([]);
+    const silenceTail = Buffer.alloc(16000).toString("base64");
+    expect(socket.audioChunks).toContain(silenceTail);
+  });
+
+  it("silenceTailBytes option resizes the fallback tail", async () => {
+    const { adapter, socket } = await connectedAdapter({
+      turnCommitMode: "silence",
+      silenceTailBytes: 2400,
+    });
+
+    await adapter.sendAudio(userTurn("size me"));
+
+    const expectedTail = Buffer.alloc(2400).toString("base64");
+    expect(socket.audioChunks).toContain(expectedTail);
+    expect(socket.audioChunks).not.toContain(Buffer.alloc(16000).toString("base64"));
+  });
+});

--- a/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
@@ -72,12 +72,10 @@ class FakeElevenLabsSocket implements WebSocketLike {
 
   once(event: "open", listener: () => void): this;
   once(event: "error", listener: (err: Error) => void): this;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   once(event: string, listener: (...args: never[]) => void): this {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const wrapped = (...args: any[]): void => {
+    const wrapped = (...args: unknown[]): void => {
       this.off(event, wrapped as (...a: never[]) => void);
-      (listener as (...a: any[]) => void)(...args);
+      (listener as (...a: unknown[]) => void)(...args);
     };
     return this.on(event as "open", wrapped as () => void);
   }

--- a/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
@@ -72,17 +72,20 @@ class FakeElevenLabsSocket implements WebSocketLike {
 
   once(event: "open", listener: () => void): this;
   once(event: "error", listener: (err: Error) => void): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   once(event: string, listener: (...args: never[]) => void): this {
-    const key = event as keyof (typeof this.listeners);
-    const wrapped = ((...args: unknown[]) => {
-      (this.listeners as Record<string, Array<(...a: unknown[]) => void>>)[key] =
-        (this.listeners as Record<string, Array<(...a: unknown[]) => void>>)[key].filter(
-          (l) => l !== wrapped,
-        );
-      (listener as (...a: unknown[]) => void)(...args);
-    }) as (...a: never[]) => void;
-    (this.listeners as Record<string, Array<(...a: never[]) => void>>)[key]?.push(wrapped);
-    return this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wrapped = (...args: any[]): void => {
+      this.off(event, wrapped as (...a: never[]) => void);
+      (listener as (...a: any[]) => void)(...args);
+    };
+    return this.on(event as "open", wrapped as () => void);
+  }
+
+  private off(event: string, listener: (...args: never[]) => void): void {
+    const arr = (this.listeners as Record<string, Array<(...a: never[]) => void>>)[event];
+    const idx = arr?.indexOf(listener) ?? -1;
+    if (idx >= 0) arr!.splice(idx, 1);
   }
 
   removeAllListeners(): void {
@@ -302,5 +305,33 @@ describe("ElevenLabsAgentAdapter silence-tail fallbacks (#567)", () => {
     // This is exactly the #567 bug. On the "text" path (default), sendAudio
     // sends a user_message which deterministically triggers agent audio — no stall.
     await expect(adapter.receiveAudio(0.01)).rejects.toThrow("receiveAudio timed out");
+  });
+});
+
+describe("ElevenLabsAgentAdapter constructor validation", () => {
+  const base = { agentId: "x", apiKey: "y" };
+
+  it("throws on unknown turnCommitMode", () => {
+    expect(
+      () => new ElevenLabsAgentAdapter({ ...base, turnCommitMode: "vad" as never }),
+    ).toThrow(/Unknown turnCommitMode/);
+  });
+
+  it("throws on zero silenceTailBytes", () => {
+    expect(
+      () => new ElevenLabsAgentAdapter({ ...base, silenceTailBytes: 0 }),
+    ).toThrow(/positive integer/);
+  });
+
+  it("throws on negative silenceTailBytes", () => {
+    expect(
+      () => new ElevenLabsAgentAdapter({ ...base, silenceTailBytes: -1 }),
+    ).toThrow(/positive integer/);
+  });
+
+  it("throws on fractional silenceTailBytes", () => {
+    expect(
+      () => new ElevenLabsAgentAdapter({ ...base, silenceTailBytes: 1.5 }),
+    ).toThrow(/positive integer/);
   });
 });

--- a/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
@@ -73,7 +73,16 @@ class FakeElevenLabsSocket implements WebSocketLike {
   once(event: "open", listener: () => void): this;
   once(event: "error", listener: (err: Error) => void): this;
   once(event: string, listener: (...args: never[]) => void): this {
-    return this.on(event as "open", listener as () => void);
+    const key = event as keyof (typeof this.listeners);
+    const wrapped = ((...args: unknown[]) => {
+      (this.listeners as Record<string, Array<(...a: unknown[]) => void>>)[key] =
+        (this.listeners as Record<string, Array<(...a: unknown[]) => void>>)[key].filter(
+          (l) => l !== wrapped,
+        );
+      (listener as (...a: unknown[]) => void)(...args);
+    }) as (...a: never[]) => void;
+    (this.listeners as Record<string, Array<(...a: never[]) => void>>)[key]?.push(wrapped);
+    return this;
   }
 
   removeAllListeners(): void {

--- a/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts
@@ -264,4 +264,34 @@ describe("ElevenLabsAgentAdapter silence-tail fallbacks (#567)", () => {
     expect(socket.audioChunks).toContain(expectedTail);
     expect(socket.audioChunks).not.toContain(Buffer.alloc(16000).toString("base64"));
   });
+
+  it("silence mode — 2nd user turn emits no user_message; receiveAudio times out if server VAD does not fire (the pre-#567 bug path)", async () => {
+    // This is the NEGATIVE case that proves the fix is necessary: the pre-#567
+    // "silence" path sends only audio + tail and relies on server-side VAD, which
+    // does NOT reliably fire on a scripted non-mic stream (EL ConvAI 2.0 hybrid
+    // VAD + DL turn-detector). Without a user_message commit, if the server's
+    // VAD doesn't fire, no agent audio arrives and receiveAudio times out.
+    const { adapter, socket } = await connectedAdapter({ turnCommitMode: "silence" });
+
+    // Greeting.
+    socket.deliverAudio();
+    await adapter.receiveAudio(1);
+
+    // Turn 1: user sends, we manually deliver agent audio (simulating VAD firing).
+    await adapter.sendAudio(userTurn("Hello."));
+    socket.deliverAudio();
+    await adapter.receiveAudio(1);
+
+    // Turn 2: silence mode — no user_message emitted, server VAD does not fire
+    // (we do NOT call socket.deliverAudio() — simulating the real production stall).
+    await adapter.sendAudio(userTurn("What are my options?"));
+
+    // Confirm: silence path sends NO user_message commit.
+    expect(socket.userMessages).toHaveLength(0);
+
+    // Without a commit, the server never re-engages → receiveAudio times out.
+    // This is exactly the #567 bug. On the "text" path (default), sendAudio
+    // sends a user_message which deterministically triggers agent audio — no stall.
+    await expect(adapter.receiveAudio(0.01)).rejects.toThrow("receiveAudio timed out");
+  });
 });

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -367,11 +367,11 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
         reject(
           new Error(
             "ElevenLabsAgentAdapter: receiveAudio timed out. Hosted ElevenLabs " +
-              "ConvAI is server-VAD-driven and supports only a single exchange " +
-              "(agent() → user() → agent() → judge()); a scripted 2nd user() turn " +
-              "does not re-engage its turn-taking, so the next agent() never " +
-              "receives a response. For multi-turn voice use a composable adapter " +
-              "(ElevenLabsVoiceAgent / pipecatAgent). See " +
+              "ConvAI supports multi-turn via the default text turn-commit mode " +
+              "(turnCommitMode: \"text\"). If you are using turnCommitMode: \"silence\" " +
+              "(legacy server-VAD path), a scripted 2nd user() turn may not re-engage " +
+              "the agent because ConvAI 2.0 hybrid VAD does not reliably fire on a " +
+              "non-mic stream — switch to the default \"text\" mode. See " +
               "https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs",
           ),
         );

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -177,13 +177,16 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     this.apiKey = options.apiKey;
     this.systemPromptOverride = options.systemPromptOverride;
     this.firstMessageOverride = options.firstMessageOverride;
-    this.turnCommitMode = options.turnCommitMode ?? "text";
-    this.silenceTailBytes = options.silenceTailBytes ?? SILENCE_TAIL_BYTES;
-    if (this.turnCommitMode !== "text" && this.turnCommitMode !== "silence") {
+    // Validate raw option before defaulting so JS callers hitting the boundary
+    // get a clear error even when TypeScript types are bypassed.
+    const rawMode = options.turnCommitMode ?? "text";
+    if (rawMode !== "text" && rawMode !== "silence") {
       throw new Error(
-        `Unknown turnCommitMode: "${this.turnCommitMode}". Expected "text" or "silence".`,
+        `Unknown turnCommitMode: "${rawMode}". Expected "text" or "silence".`,
       );
     }
+    this.turnCommitMode = rawMode;
+    this.silenceTailBytes = options.silenceTailBytes ?? SILENCE_TAIL_BYTES;
     if (!Number.isInteger(this.silenceTailBytes) || this.silenceTailBytes <= 0) {
       throw new Error(
         `silenceTailBytes must be a positive integer, got ${this.silenceTailBytes}.`,

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -179,6 +179,16 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     this.firstMessageOverride = options.firstMessageOverride;
     this.turnCommitMode = options.turnCommitMode ?? "text";
     this.silenceTailBytes = options.silenceTailBytes ?? SILENCE_TAIL_BYTES;
+    if (this.turnCommitMode !== "text" && this.turnCommitMode !== "silence") {
+      throw new Error(
+        `Unknown turnCommitMode: "${this.turnCommitMode}". Expected "text" or "silence".`,
+      );
+    }
+    if (!Number.isInteger(this.silenceTailBytes) || this.silenceTailBytes <= 0) {
+      throw new Error(
+        `silenceTailBytes must be a positive integer, got ${this.silenceTailBytes}.`,
+      );
+    }
     this.webSocketFactory =
       options.webSocketFactory ??
       ((url, headers) => new WebSocket(url, { headers }) as unknown as WebSocketLike);

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -51,12 +51,36 @@ export const ELEVENLABS_CONVAI_URL_TEMPLATE =
   "wss://api.elevenlabs.io/v1/convai/conversation?agent_id={agent_id}";
 
 /**
- * Empirical tail: EL ConvAI stops responding to subsequent turns unless the
- * client signals end-of-turn via silence padding. 16000 zero bytes at 24 kHz
- * = ~333 ms silence — reliable middle ground between "no tail" (greeting only)
- * and "double tail" (mid-conversation stalls). See Python adapter docstring.
+ * Default silence-tail length for the legacy {@link TurnCommitMode} `"silence"`
+ * path. 16000 zero bytes at 24 kHz = ~333 ms silence — the empirical middle
+ * ground that historically let the *greeting → first user turn* exchange work
+ * (see Python adapter docstring).
+ *
+ * This tail is NOT reliable for scripted turn 2+ (issue #567): EL ConvAI 2.0's
+ * end-of-turn is a hybrid VAD + deep-learning turn-detector (prosody, rhythm,
+ * micro-pauses), not a pure silence threshold, so a fixed zero-byte blob does
+ * not deterministically trip it on a non-mic stream. The default commit mode is
+ * therefore {@link TurnCommitMode} `"text"`; the silence tail survives as an
+ * opt-in for callers who want the pure server-VAD audio path.
  */
 const SILENCE_TAIL_BYTES = 16000;
+
+/**
+ * How {@link ElevenLabsAgentAdapter.sendAudio} signals end-of-turn to EL ConvAI.
+ *
+ * - `"text"` (default): after streaming the user audio, send an explicit
+ *   `{"type":"user_message","text":<transcript>}` — the only client→server
+ *   event EL's documented protocol exposes that *deterministically* commits a
+ *   turn and forces an agent response, without relying on mic-style server VAD
+ *   (issue #567). Requires a transcript on the outgoing {@link AudioChunk}
+ *   (the voice runtime threads the `scenario.user("…")` script text through as
+ *   the chunk transcript); when absent, falls back to the silence tail.
+ * - `"silence"`: legacy behavior — stream the audio then a fixed
+ *   {@link ElevenLabsAgentAdapterOptions.silenceTailBytes} zero-byte tail and
+ *   hope server VAD fires. Kept for the pure-audio path and parity with the
+ *   pre-#567 transport, but unreliable for scripted turn 2+.
+ */
+export type TurnCommitMode = "text" | "silence";
 
 export interface ElevenLabsAgentAdapterOptions {
   /** ID of the ElevenLabs Conversational AI agent (provisioned in the EL dashboard). */
@@ -71,6 +95,19 @@ export interface ElevenLabsAgentAdapterOptions {
   systemPromptOverride?: string;
   /** Per-session first message override. */
   firstMessageOverride?: string;
+  /**
+   * How `sendAudio` commits a user turn. Defaults to `"text"` (explicit
+   * `user_message` commit) so scripted turn 2+ reliably re-engages an agent
+   * response (issue #567). Set to `"silence"` for the legacy pure-audio
+   * server-VAD path. See {@link TurnCommitMode}.
+   */
+  turnCommitMode?: TurnCommitMode;
+  /**
+   * Zero-byte silence-tail length appended after user audio. Only consulted on
+   * the `"silence"` commit path (and the `"text"` fallback when no transcript
+   * is available). Defaults to {@link SILENCE_TAIL_BYTES} (~333 ms @ 24 kHz).
+   */
+  silenceTailBytes?: number;
   /**
    * WebSocket factory — injected for tests. Defaults to the `ws` package's
    * `WebSocket` constructor. Production callers should leave this unset.
@@ -116,6 +153,8 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
   private readonly apiKey: string;
   private readonly systemPromptOverride?: string;
   private readonly firstMessageOverride?: string;
+  private readonly turnCommitMode: TurnCommitMode;
+  private readonly silenceTailBytes: number;
   private readonly webSocketFactory: (
     url: string,
     headers: Record<string, string>,
@@ -138,6 +177,8 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     this.apiKey = options.apiKey;
     this.systemPromptOverride = options.systemPromptOverride;
     this.firstMessageOverride = options.firstMessageOverride;
+    this.turnCommitMode = options.turnCommitMode ?? "text";
+    this.silenceTailBytes = options.silenceTailBytes ?? SILENCE_TAIL_BYTES;
     this.webSocketFactory =
       options.webSocketFactory ??
       ((url, headers) => new WebSocket(url, { headers }) as unknown as WebSocketLike);
@@ -245,14 +286,52 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
       throw new Error("ElevenLabsAgentAdapter: not connected");
     }
 
-    // 1. Speech.
+    // EL ConvAI exposes NO audio-flush / end-of-turn client event (verified
+    // against the official Python + JS SDKs — the full client→server union is
+    // pong | client_tool_result | conversation_initiation_client_data |
+    // feedback | contextual_update | user_message | user_activity |
+    // multimodal_message, plus the bare user_audio_chunk; none commit audio).
+    // Server-side turn detection (ConvAI 2.0 hybrid VAD + DL turn-detector) does
+    // NOT reliably fire on a scripted, non-mic stream, so the legacy "stream
+    // audio + silence tail" path stalls on turn 2+ (issue #567).
+    const transcript = chunk.transcript?.trim();
+
+    if (this.turnCommitMode === "text" && transcript) {
+      // Deterministic commit: send ONLY the user_message text turn. We do NOT
+      // also stream the raw audio to EL here — sending user_audio_chunk and then
+      // user_message in the same turn races the server's audio ingestion
+      // against the text commit and was empirically flaky (the agent receive
+      // intermittently timed out). The text turn alone forces an agent response
+      // every time. Nothing observable is lost: the voice runtime records the
+      // user audio locally (recorder.recordUser, independent of this send), and
+      // EL echoes the committed text back as a user_transcript event, so
+      // lastUserTranscript still populates.
+      this.sendUserMessage(transcript);
+      return;
+    }
+
+    // Legacy / fallback path: stream the speech then a silence tail and let
+    // server VAD try. Used when turnCommitMode is "silence", or in "text" mode
+    // when the chunk carries no transcript to commit.
     const speechB64 = Buffer.from(chunk.data).toString("base64");
     this.ws.send(JSON.stringify({ user_audio_chunk: speechB64 }));
+    this.sendSilenceTail();
+  }
 
-    // 2. Silence tail — see SILENCE_TAIL_BYTES doc for sizing rationale.
-    const silence = new Uint8Array(SILENCE_TAIL_BYTES);
+  /**
+   * Explicit turn-commit: tells EL the user is done and forces an agent
+   * response without relying on mic-style server VAD (issue #567). Wire shape
+   * matches the official SDK's `user_message` event.
+   */
+  private sendUserMessage(text: string): void {
+    this.ws?.send(JSON.stringify({ type: "user_message", text }));
+  }
+
+  /** Legacy end-of-turn nudge: a fixed zero-byte tail to coax server VAD. */
+  private sendSilenceTail(): void {
+    const silence = new Uint8Array(this.silenceTailBytes);
     const silenceB64 = Buffer.from(silence).toString("base64");
-    this.ws.send(JSON.stringify({ user_audio_chunk: silenceB64 }));
+    this.ws?.send(JSON.stringify({ user_audio_chunk: silenceB64 }));
   }
 
   async receiveAudio(timeout: number): Promise<AudioChunk> {

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -18,7 +18,7 @@ Wire protocol:
     deep-learning turn-detector (prosody, rhythm, micro-pauses), not a pure
     silence threshold — so a fixed zero-byte tail does NOT reliably commit
     a scripted, non-mic turn 2+ (issue #567). See ``send_audio`` and
-    ``TURN_COMMIT_MODES``.
+    ``TurnCommitMode``.
 - Recv events:
   - ``conversation_initiation_metadata`` — checked for audio-format
     mismatch against advertised capability; warning logged on drift
@@ -140,6 +140,14 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         # ``user_message`` commit) so scripted turn 2+ reliably re-engages an
         # agent response (issue #567). ``"silence"`` selects the legacy
         # pure-audio server-VAD path. See ``TurnCommitMode`` / ``send_audio``.
+        if turn_commit_mode not in ("text", "silence"):
+            raise ValueError(
+                f'Unknown turn_commit_mode: {turn_commit_mode!r}. Expected "text" or "silence".'
+            )
+        if not isinstance(silence_tail_bytes, int) or silence_tail_bytes <= 0:
+            raise ValueError(
+                f"silence_tail_bytes must be a positive integer, got {silence_tail_bytes!r}."
+            )
         self._turn_commit_mode: TurnCommitMode = turn_commit_mode
         # Zero-byte silence-tail length, consulted only on the ``"silence"``
         # path (and the ``"text"`` fallback when no transcript is available).

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -129,7 +129,7 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
     ) -> None:
         super().__init__()
         self.agent_id = agent_id
-        self.api_key = api_key
+        self._api_key = api_key
         # Per-session overrides applied via conversation_initiation_client_data
         # at the start of every WS connect. Used by demos that need a
         # different prompt shape (e.g. verbose for interrupt demos) without
@@ -155,7 +155,7 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         return CONVAI_URL_TEMPLATE.format(agent_id=self.agent_id)
 
     def __repr__(self) -> str:  # redact credentials
-        return f"ElevenLabsAgentAdapter(agent_id={self.agent_id!r}, api_key='***')"
+        return f"ElevenLabsAgentAdapter(agent_id={self.agent_id!r}, api_key='***')"  # noqa: S105
 
     # ------------------------------------------------------------------ lifecycle
 
@@ -174,7 +174,7 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
 
         self._ws = await websockets.connect(
             self.url,
-            additional_headers={"xi-api-key": self.api_key},
+            additional_headers={"xi-api-key": self._api_key},
         )
         logger.debug("ElevenLabsAgentAdapter: connected to %s", self.url)
 
@@ -264,9 +264,7 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         b64 = base64.b64encode(chunk.data).decode()
         await self._ws.send(json.dumps({"user_audio_chunk": b64}))
 
-        silence = b"\x00" * self._silence_tail_bytes
-        silence_b64 = base64.b64encode(silence).decode()
-        await self._ws.send(json.dumps({"user_audio_chunk": silence_b64}))
+        await self._send_silence_tail()
 
     async def _send_user_message(self, text: str) -> None:
         """Explicit turn-commit: tell EL the user is done and force an agent
@@ -274,6 +272,12 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         shape matches the official SDK's ``user_message`` event.
         """
         await self._ws.send(json.dumps({"type": "user_message", "text": text}))
+
+    async def _send_silence_tail(self) -> None:
+        """Legacy end-of-turn nudge: a fixed zero-byte tail to coax server VAD."""
+        silence = b"\x00" * self._silence_tail_bytes
+        silence_b64 = base64.b64encode(silence).decode()
+        await self._ws.send(json.dumps({"user_audio_chunk": silence_b64}))
 
     async def recv_audio(self, timeout: float) -> AudioChunk:
         """

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -5,7 +5,20 @@ Source §5.4. Endpoint: wss://api.elevenlabs.io/v1/convai/conversation?agent_id=
 Exchanges PCM16 audio chunks.
 
 Wire protocol:
-- Send: JSON ``{"user_audio_chunk": "<base64 PCM16>"}``
+- Send:
+  - JSON ``{"user_audio_chunk": "<base64 PCM16>"}`` (legacy ``"silence"``
+    turn-commit path, and the ``"text"`` fallback when a chunk carries no
+    transcript)
+  - JSON ``{"type": "user_message", "text": "<transcript>"}`` (default
+    ``"text"`` turn-commit path) — the only documented client→server event
+    that *deterministically* commits a user turn and forces an agent
+    response without relying on mic-style server VAD. EL ConvAI exposes NO
+    audio-flush / end-of-turn client event (verified against the official
+    EL Python + JS SDKs), and ConvAI 2.0's end-of-turn is a hybrid VAD +
+    deep-learning turn-detector (prosody, rhythm, micro-pauses), not a pure
+    silence threshold — so a fixed zero-byte tail does NOT reliably commit
+    a scripted, non-mic turn 2+ (issue #567). See ``send_audio`` and
+    ``TURN_COMMIT_MODES``.
 - Recv events:
   - ``conversation_initiation_metadata`` — checked for audio-format
     mismatch against advertised capability; warning logged on drift
@@ -27,7 +40,7 @@ import asyncio
 import base64
 import json
 import logging
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Literal, Optional
 
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
@@ -37,6 +50,33 @@ from ..capabilities import AdapterCapabilities
 logger = logging.getLogger("scenario.voice.elevenlabs")
 
 CONVAI_URL_TEMPLATE = "wss://api.elevenlabs.io/v1/convai/conversation?agent_id={agent_id}"
+
+#: Default zero-byte silence-tail length for the legacy ``"silence"`` turn-commit
+#: path. 16000 zero bytes at pcm_24000 = ~333 ms of silence — the empirical
+#: middle ground that historically let the *greeting → first user turn* exchange
+#: work (see ``send_audio``).
+#:
+#: This tail is NOT reliable for scripted turn 2+ (issue #567): EL ConvAI 2.0's
+#: end-of-turn is a hybrid VAD + deep-learning turn-detector, not a pure silence
+#: threshold, so a fixed zero-byte blob does not deterministically trip it on a
+#: non-mic stream. The default commit mode is therefore ``"text"``; the silence
+#: tail survives as an opt-in for callers who want the pure server-VAD audio path.
+SILENCE_TAIL_BYTES = 16000
+
+#: How :meth:`ElevenLabsAgentAdapter.send_audio` signals end-of-turn to EL ConvAI.
+#:
+#: - ``"text"`` (default): send an explicit
+#:   ``{"type": "user_message", "text": <transcript>}`` — the only documented
+#:   client→server event that *deterministically* commits a turn and forces an
+#:   agent response without relying on mic-style server VAD (issue #567).
+#:   Requires a transcript on the outgoing :class:`AudioChunk` (the voice
+#:   runtime threads the ``scenario.user("…")`` script text through as the chunk
+#:   transcript via TTS); when absent, falls back to the silence tail.
+#: - ``"silence"``: legacy behaviour — stream the audio then a fixed
+#:   ``silence_tail_bytes`` zero-byte tail and hope server VAD fires. Kept for
+#:   the pure-audio path and parity with the pre-#567 transport, but unreliable
+#:   for scripted turn 2+.
+TurnCommitMode = Literal["text", "silence"]
 
 
 class ElevenLabsAgentAdapter(VoiceAgentAdapter):
@@ -84,6 +124,8 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         *,
         system_prompt_override: Optional[str] = None,
         first_message_override: Optional[str] = None,
+        turn_commit_mode: TurnCommitMode = "text",
+        silence_tail_bytes: int = SILENCE_TAIL_BYTES,
     ) -> None:
         super().__init__()
         self.agent_id = agent_id
@@ -94,6 +136,14 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         # mutating the shared test agent's persistent config.
         self._system_prompt_override = system_prompt_override
         self._first_message_override = first_message_override
+        # How a user turn is committed. Defaults to ``"text"`` (explicit
+        # ``user_message`` commit) so scripted turn 2+ reliably re-engages an
+        # agent response (issue #567). ``"silence"`` selects the legacy
+        # pure-audio server-VAD path. See ``TurnCommitMode`` / ``send_audio``.
+        self._turn_commit_mode: TurnCommitMode = turn_commit_mode
+        # Zero-byte silence-tail length, consulted only on the ``"silence"``
+        # path (and the ``"text"`` fallback when no transcript is available).
+        self._silence_tail_bytes = silence_tail_bytes
         self._ws: Any = None
 
         # Transcript observability — updated on each transcript event.
@@ -162,38 +212,68 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
     # ------------------------------------------------------------------ I/O
 
     async def send_audio(self, chunk: AudioChunk) -> None:
-        """Send a PCM16 audio chunk encoded as base64 in a JSON message.
+        """Commit a user turn to EL ConvAI.
 
-        Empirically, EL ConvAI stops responding to subsequent turns if
-        the client sends only a single chunk and never signals end of
-        turn. The EL docs document no client-driven end-of-turn signal
-        (server-side VAD is supposed to handle it) but in practice the
-        VAD only fires after enough silence has been observed. We
-        append a fixed-size tail of zero-bytes after every chunk to
-        provide that silence signal.
+        EL ConvAI exposes NO audio-flush / end-of-turn client event (verified
+        against the official EL Python + JS SDKs — the full client→server union
+        is pong | client_tool_result | conversation_initiation_client_data |
+        feedback | contextual_update | user_message | user_activity |
+        multimodal_message, plus the bare user_audio_chunk; none commit audio).
+        Server-side turn detection (ConvAI 2.0 hybrid VAD + DL turn-detector)
+        does NOT reliably fire on a scripted, non-mic stream, so the legacy
+        "stream audio + silence tail" path stalls on turn 2+ (issue #567).
 
-        Tail size: 16000 zero bytes — empirically the sweet spot.
-        - Removing the tail entirely: EL stops responding to user
-          turns after the greeting.
-        - Doubling to 24000 bytes (a "true 500ms" at the provisioned
-          pcm_24000 rate): EL stops responding mid-conversation, same
-          stall pattern.
-        - 16000 bytes at pcm_24000 = ~333ms of silence: reliable.
+        Two commit modes (see ``TurnCommitMode``):
 
-        If EL ever exposes an explicit end-of-turn message we should
-        switch to that instead.
+        - ``"text"`` (default): when the chunk carries a transcript, send ONLY
+          a ``{"type": "user_message", "text": <transcript>}`` turn — the only
+          documented client event that deterministically forces an agent
+          response without mic-style VAD. We do NOT also stream the raw audio
+          here: sending ``user_audio_chunk`` and then ``user_message`` in the
+          same turn races the server's audio ingestion against the text commit
+          and was empirically flaky (the agent receive intermittently timed
+          out). The text turn alone re-engages every time. Nothing observable
+          is lost — the voice runtime records the user audio locally
+          (independent of this send), and EL echoes the committed text back as
+          a ``user_transcript`` event, so ``last_user_transcript`` still
+          populates.
+        - Fallback / ``"silence"``: stream the speech then a fixed
+          ``silence_tail_bytes`` zero-byte tail and let server VAD try. Used
+          when ``turn_commit_mode == "silence"``, or in ``"text"`` mode when
+          the chunk carries no transcript to commit.
+
+        Silence-tail size rationale (legacy path): 16000 zero bytes at
+        pcm_24000 = ~333ms — empirically the sweet spot for the greeting →
+        first-turn exchange. Removing it entirely, or doubling to 24000, both
+        reproduced the stall pattern.
         """
         if self._ws is None:
             raise RuntimeError("ElevenLabsAgentAdapter: not connected")
 
-        # 1. Speech.
+        transcript = chunk.transcript.strip() if chunk.transcript else ""
+
+        if self._turn_commit_mode == "text" and transcript:
+            # Deterministic commit: send ONLY the user_message text turn (no
+            # racing user_audio_chunk). See method docstring for the rationale.
+            await self._send_user_message(transcript)
+            return
+
+        # Legacy / fallback path: stream the speech then a silence tail and let
+        # server VAD try. Used when turn_commit_mode is "silence", or in "text"
+        # mode when the chunk carries no transcript to commit.
         b64 = base64.b64encode(chunk.data).decode()
         await self._ws.send(json.dumps({"user_audio_chunk": b64}))
 
-        # 2. Silence tail. See docstring for size rationale.
-        silence = b"\x00" * 16000
+        silence = b"\x00" * self._silence_tail_bytes
         silence_b64 = base64.b64encode(silence).decode()
         await self._ws.send(json.dumps({"user_audio_chunk": silence_b64}))
+
+    async def _send_user_message(self, text: str) -> None:
+        """Explicit turn-commit: tell EL the user is done and force an agent
+        response without relying on mic-style server VAD (issue #567). Wire
+        shape matches the official SDK's ``user_message`` event.
+        """
+        await self._ws.send(json.dumps({"type": "user_message", "text": text}))
 
     async def recv_audio(self, timeout: float) -> AudioChunk:
         """

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -277,3 +277,37 @@ async def test_silence_tail_bytes_resizes_the_fallback_tail():
     expected_tail = base64.b64encode(b"\x00" * 2400).decode()
     assert expected_tail in socket.audio_chunks
     assert base64.b64encode(b"\x00" * 16000).decode() not in socket.audio_chunks
+
+
+@pytest.mark.asyncio
+async def test_silence_mode_second_turn_times_out_without_user_message_commit():
+    """The pre-#567 bug: silence mode emits no user_message commit.
+
+    When server-side VAD does not fire on the scripted non-mic stream (EL
+    ConvAI 2.0 hybrid VAD + DL turn-detector), no agent audio arrives and
+    ``recv_audio`` times out. This is the NEGATIVE counterexample that proves
+    the fix is necessary: the default ``"text"`` path (issue #567 fix) avoids
+    this stall by sending an explicit ``user_message`` commit.
+    """
+    adapter, socket = await _connected_adapter(turn_commit_mode="silence")
+
+    # Greeting.
+    socket.deliver_audio()
+    await adapter.recv_audio(timeout=1.0)
+
+    # Turn 1: user sends, manually deliver agent audio (simulating VAD firing).
+    await adapter.send_audio(_user_turn("Hello."))
+    socket.deliver_audio()
+    await adapter.recv_audio(timeout=1.0)
+
+    # Turn 2: silence mode — no user_message emitted.
+    # We do NOT call socket.deliver_audio() — simulating the production stall
+    # where server VAD doesn't fire on the scripted non-mic stream.
+    await adapter.send_audio(_user_turn("What are my options?"))
+
+    # Confirm: silence path sends NO user_message commit.
+    assert socket.user_messages == []
+
+    # Without a commit, the server never re-engages → recv_audio times out.
+    with pytest.raises(asyncio.TimeoutError):
+        await adapter.recv_audio(timeout=0.01)

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -1,0 +1,279 @@
+"""
+Issue #567 — ElevenLabs ConvAI scripted next-turn / post-interrupt receive.
+
+Python parity with ``javascript/src/voice/__tests__/elevenlabs-turn-commit.test.ts``.
+
+The hosted ConvAI transport has NO audio end-of-turn client event (verified
+against the official EL Python + JS SDKs), so the pre-#567 adapter leaned on a
+fixed silence tail to coax server-side VAD. That tail does not reliably
+re-engage a response for a scripted turn 2+ (EL ConvAI 2.0 end-of-turn is a
+hybrid VAD + deep-learning turn-detector, not a pure silence threshold), so the
+2nd ``recv_audio`` timed out.
+
+The fix sends an explicit ``{"type": "user_message", "text": <transcript>}``
+turn-commit — the only documented client→server event that deterministically
+forces an agent response without mic-style VAD. On the text path the raw audio
+is NOT also streamed to EL (audio + text in one turn raced the server's
+ingestion and was live-flaky); the user audio is still recorded locally by the
+voice runtime and EL echoes the text back as a ``user_transcript`` event.
+
+These tests drive the adapter through an injected fake WebSocket (patching
+``websockets.connect``, the same seam the existing EL transport tests use) and
+prove:
+ 1. a scripted 2nd user turn after an agent turn drives a 2nd ``recv_audio``
+    resolution (the bug), AND each user turn emits a ``user_message`` commit;
+ 2. the post-interrupt shape (agent audio mid-flight → user re-engages) also
+    commits + re-engages, and ``agent_response_correction`` updates the
+    transcript;
+ 3. the committed ``user_message`` is a server-accepted shape (type + text);
+ 4. ``turn_commit_mode="silence"`` preserves the legacy pure-audio path;
+ 5. ``"text"`` mode with no transcript falls back to the silence tail;
+ 6. ``silence_tail_bytes`` resizes the fallback tail.
+
+Offline — no network, no real EL socket. The LIVE >=2-exchange proof lives in
+``examples/voice/elevenlabs_hosted.py`` (wrapped by
+``test_elevenlabs_hosted_e2e.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from typing import Any, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scenario.voice import AudioChunk, ElevenLabsAgentAdapter
+
+
+class FakeElevenLabsSocket:
+    """Minimal in-memory EL ConvAI WebSocket.
+
+    Records every frame the adapter sends and lets the test push inbound
+    frames on demand via :meth:`deliver` / :meth:`deliver_audio`. ``recv``
+    blocks on an :class:`asyncio.Queue` so a test can interleave ``send_audio``
+    and ``recv_audio`` across multiple turns the way the executor does.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._inbound: "asyncio.Queue[str]" = asyncio.Queue()
+        self.closed = False
+
+    # ----- transport surface the adapter uses -----
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def recv(self) -> str:
+        return await self._inbound.get()
+
+    async def close(self) -> None:
+        self.closed = True
+
+    # ----- test drivers -----
+
+    def deliver(self, event: dict[str, Any]) -> None:
+        """Queue a raw inbound JSON frame for the adapter to recv."""
+        self._inbound.put_nowait(json.dumps(event))
+
+    def deliver_audio(self, byte_len: int = 4) -> None:
+        """Queue an ``audio`` event carrying ``byte_len`` bytes of PCM16."""
+        pcm = b"\x01" * byte_len
+        self.deliver(
+            {
+                "type": "audio",
+                "audio_event": {"audio_base_64": base64.b64encode(pcm).decode()},
+            }
+        )
+
+    # ----- parsed views of what the adapter sent -----
+
+    @property
+    def sent_parsed(self) -> list[dict[str, Any]]:
+        return [json.loads(s) for s in self.sent]
+
+    @property
+    def user_messages(self) -> list[dict[str, Any]]:
+        """Frames that are ``user_message`` turn-commits."""
+        return [m for m in self.sent_parsed if m.get("type") == "user_message"]
+
+    @property
+    def audio_chunks(self) -> list[str]:
+        """Base64 payloads of every ``user_audio_chunk`` frame (speech or silence)."""
+        return [
+            m["user_audio_chunk"]
+            for m in self.sent_parsed
+            if isinstance(m.get("user_audio_chunk"), str)
+        ]
+
+
+async def _connected_adapter(
+    *,
+    turn_commit_mode: str = "text",
+    silence_tail_bytes: Optional[int] = None,
+) -> tuple[ElevenLabsAgentAdapter, FakeElevenLabsSocket]:
+    """Build an adapter wired to a fresh fake socket, already connected."""
+    socket = FakeElevenLabsSocket()
+    kwargs: dict[str, Any] = {"turn_commit_mode": turn_commit_mode}
+    if silence_tail_bytes is not None:
+        kwargs["silence_tail_bytes"] = silence_tail_bytes
+    adapter = ElevenLabsAgentAdapter(agent_id="agent-test", api_key="xi-test", **kwargs)
+    with patch("websockets.connect", new=AsyncMock(return_value=socket)):
+        await adapter.connect()
+    return adapter, socket
+
+
+def _user_turn(text: str) -> AudioChunk:
+    """A user audio chunk that carries its transcript (as the voice runtime threads it)."""
+    return AudioChunk(data=b"\x00" * 8, transcript=text)
+
+
+# --------------------------------------------------------------------------- #
+# Text turn-commit (default) — the #567 fix                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_scripted_second_user_turn_drives_second_recv_audio():
+    """The BUG case: a scripted 2nd user turn re-engages a 2nd agent response."""
+    adapter, socket = await _connected_adapter()
+
+    # ---- Exchange 1: greeting drains (real-voice convention) ----
+    socket.deliver_audio()
+    greeting = await adapter.recv_audio(timeout=1.0)
+    assert len(greeting.data) > 0
+
+    # ---- Exchange 1: user turn 1 -> agent responds ----
+    await adapter.send_audio(_user_turn("Hello, I have a question about my account."))
+    socket.deliver_audio()
+    agent1 = await adapter.recv_audio(timeout=1.0)
+    assert len(agent1.data) > 0
+
+    # ---- Exchange 2: the BUG case — scripted 2nd user turn ----
+    await adapter.send_audio(_user_turn("Yes, can you check my balance?"))
+    socket.deliver_audio()
+    # This resolving (not raising TimeoutError) is the #567 proof.
+    agent2 = await adapter.recv_audio(timeout=1.0)
+    assert len(agent2.data) > 0
+
+    # Each user turn emitted an explicit user_message turn-commit (not a
+    # silence tail) — the deterministic re-engagement signal.
+    assert socket.user_messages == [
+        {"type": "user_message", "text": "Hello, I have a question about my account."},
+        {"type": "user_message", "text": "Yes, can you check my balance?"},
+    ]
+    # The default "text" path sends ONLY the text commit — NO user_audio_chunk
+    # frames at all (audio + text in one turn raced EL's ingestion and was
+    # live-flaky; the text turn alone re-engages deterministically).
+    assert socket.audio_chunks == []
+
+
+@pytest.mark.asyncio
+async def test_post_interrupt_user_turn_re_engages_and_correction_updates_transcript():
+    """A user turn after partial agent audio re-engages a fresh (corrected) response."""
+    adapter, socket = await _connected_adapter()
+
+    # Agent starts talking (turn 1 audio); executor barges in.
+    socket.deliver_audio()
+    await adapter.recv_audio(timeout=1.0)
+
+    # User interrupts/responds with a new scripted turn.
+    await adapter.send_audio(_user_turn("Actually, wait — cancel that."))
+    # EL issues an agent_response_correction (post-barge-in), then fresh audio.
+    socket.deliver(
+        {
+            "type": "agent_response_correction",
+            "agent_response_correction_event": {
+                "original_agent_response": "Sure, your balance is…",
+                "corrected_agent_response": "Okay, cancelled.",
+            },
+        }
+    )
+    socket.deliver_audio()
+    corrected = await adapter.recv_audio(timeout=1.0)
+
+    assert len(corrected.data) > 0
+    assert adapter.last_agent_transcript == "Okay, cancelled."
+    assert socket.user_messages == [
+        {"type": "user_message", "text": "Actually, wait — cancel that."}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_user_message_commit_echoes_through_as_user_transcript():
+    """EL echoes the committed text back as user_transcript observability."""
+    adapter, socket = await _connected_adapter()
+
+    await adapter.send_audio(_user_turn("What are your hours?"))
+    socket.deliver(
+        {
+            "type": "user_transcript",
+            "user_transcription_event": {"user_transcript": "What are your hours?"},
+        }
+    )
+    socket.deliver_audio()  # let recv_audio return after consuming the transcript
+    await adapter.recv_audio(timeout=1.0)
+
+    assert adapter.last_user_transcript == "What are your hours?"
+
+
+@pytest.mark.asyncio
+async def test_committed_user_message_is_server_accepted_shape():
+    """The committed user_message carries exactly ``type`` + ``text``."""
+    adapter, socket = await _connected_adapter()
+
+    await adapter.send_audio(_user_turn("ping"))
+
+    commit = socket.user_messages[0]
+    assert sorted(commit.keys()) == ["text", "type"]
+    assert commit["type"] == "user_message"
+    assert commit["text"] == "ping"
+
+
+# --------------------------------------------------------------------------- #
+# Silence-tail fallbacks                                                       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_silence_mode_preserves_legacy_pure_audio_path():
+    """``turn_commit_mode="silence"`` keeps the legacy audio + silence-tail path."""
+    adapter, socket = await _connected_adapter(turn_commit_mode="silence")
+
+    await adapter.send_audio(_user_turn("Hello again."))
+
+    # Legacy path: speech chunk + a zero-byte silence tail, NO user_message.
+    assert socket.user_messages == []
+    silence_tail = base64.b64encode(b"\x00" * 16000).decode()
+    assert silence_tail in socket.audio_chunks
+    assert len(socket.audio_chunks) == 2  # speech + silence
+
+
+@pytest.mark.asyncio
+async def test_text_mode_without_transcript_falls_back_to_silence_tail():
+    """``"text"`` mode with no transcript falls back to the silence tail."""
+    adapter, socket = await _connected_adapter()  # default "text"
+
+    # No transcript on the chunk (e.g. raw audio with no STT text upstream).
+    await adapter.send_audio(AudioChunk(data=b"\x00" * 8))
+
+    assert socket.user_messages == []
+    silence_tail = base64.b64encode(b"\x00" * 16000).decode()
+    assert silence_tail in socket.audio_chunks
+
+
+@pytest.mark.asyncio
+async def test_silence_tail_bytes_resizes_the_fallback_tail():
+    """``silence_tail_bytes`` resizes the legacy fallback tail."""
+    adapter, socket = await _connected_adapter(
+        turn_commit_mode="silence", silence_tail_bytes=2400
+    )
+
+    await adapter.send_audio(_user_turn("size me"))
+
+    expected_tail = base64.b64encode(b"\x00" * 2400).decode()
+    assert expected_tail in socket.audio_chunks
+    assert base64.b64encode(b"\x00" * 16000).decode() not in socket.audio_chunks

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -318,7 +318,7 @@ async def test_silence_mode_second_turn_times_out_without_user_message_commit():
 
 def test_rejects_unknown_turn_commit_mode():
     with pytest.raises(ValueError, match="Unknown turn_commit_mode"):
-        ElevenLabsAgentAdapter(agent_id="x", api_key="y", turn_commit_mode="vad")  # type: ignore[arg-type]
+        ElevenLabsAgentAdapter(agent_id="x", api_key="y", turn_commit_mode="vad")  # type: ignore[arg-type]  # intentionally invalid value to test runtime validation
 
 
 def test_rejects_zero_silence_tail_bytes():

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -311,3 +311,21 @@ async def test_silence_mode_second_turn_times_out_without_user_message_commit():
     # Without a commit, the server never re-engages → recv_audio times out.
     with pytest.raises(asyncio.TimeoutError):
         await adapter.recv_audio(timeout=0.01)
+
+
+# ------------------------------------------------------------------ constructor validation
+
+
+def test_rejects_unknown_turn_commit_mode():
+    with pytest.raises(ValueError, match="Unknown turn_commit_mode"):
+        ElevenLabsAgentAdapter(agent_id="x", api_key="y", turn_commit_mode="vad")  # type: ignore[arg-type]
+
+
+def test_rejects_zero_silence_tail_bytes():
+    with pytest.raises(ValueError, match="positive integer"):
+        ElevenLabsAgentAdapter(agent_id="x", api_key="y", silence_tail_bytes=0)
+
+
+def test_rejects_negative_silence_tail_bytes():
+    with pytest.raises(ValueError, match="positive integer"):
+        ElevenLabsAgentAdapter(agent_id="x", api_key="y", silence_tail_bytes=-1)

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -717,7 +717,7 @@ Feature: Voice agent testing in Scenario SDK
     Given an ElevenLabsAgentAdapter with a live agent_id and ELEVENLABS_API_KEY
     When the demo script runs via scenario.run()
     Then the WS reaches wss://api.elevenlabs.io/v1/convai/conversation
-    And result.success is True after one turn
+    And result.success is True after ≥2 exchanges
 
   @e2e @ts-elevenlabs
   Scenario: Demo — ElevenLabs composable + branded agent


### PR DESCRIPTION
## Why

Addresses the core of #567 (the next-turn / post-interrupt `receiveAudio` timeout). The ElevenLabs hosted ConvAI adapter timed out on `receiveAudio` for scripted next-turn (and post-interrupt) cases: EL ConvAI 2.0's hybrid VAD + DL turn-detector doesn't treat a fixed ~333ms zero-byte silence tail as a deterministic end-of-turn on a scripted (non-mic) stream, so turn 2+ intermittently never re-engaged. This is the blocker that recently made a TS voice-demo attempt abandon hosted EL ConvAI and fall back to OpenAI Realtime — it's fixable, not an EL-side dead end.

> Stacked on #561 (`voice/372-refactor`) — the voice stack isn't on `main` yet, so this targets that branch, not `main`. Merge after / into #561.

## What changed

- **Explicit turn-commit over silence-VAD.** Verified against both official EL SDKs that ConvAI exposes no audio-flush/commit event; `user_message` (`{"type":"user_message","text":<transcript>}`) is the only client→server event that deterministically forces an agent response without mic-VAD (and is the SDK's own wire shape, so it won't 400 the socket).
- **New adapter options** `turnCommitMode: "text" | "silence"` (default `"text"`) + configurable `silenceTailBytes`. Text mode sends only the `user_message` commit (audio is still recorded locally; EL echoes `user_transcript`, so `lastUserTranscript`/observability stay intact). `"silence"` preserves the legacy path; `"text"` with no transcript falls back to silence.
- Untouched: ping/pong, transcript capture, `agent_response_correction`, `drainPendingWaiters`, capabilities, the `wsFactory` test seam.

## Test plan

- **Unit** (`src/voice/__tests__/elevenlabs-turn-commit.test.ts`, injectable fake socket): scripted 2nd user turn drives a 2nd `receiveAudio` resolution; exact `user_message` shape asserted; post-interrupt re-engages; both silence fallbacks. 7 pass; full voice suite 179 pass (21 files); examples typecheck clean.

## How I can prove I was successful

- **Live, real EL socket, ≥2 exchanges, 3 consecutive clean runs (no retries, no timeouts):** `examples/vitest/tests/voice/elevenlabs-hosted.test.ts` extended to greeting→user→agent→user→agent→judge. `success=true, 5 segments`, 3 agent / 2 user turns, 14.24s. The previously-timing-out 2nd turn now answers. (A first revision that streamed audio+text together flaked 2/3 — that drove the text-only commit; recorded here as the honest negative.)

## Anything surprising?

- **Python parity (shipped, commit `a878cc1`):** `python/scenario/voice/adapters/elevenlabs.py` had the identical bug (16000-byte tail, no commit); ported the same `user_message` turn-commit + `turn_commit_mode`/`silence_tail_bytes` options, mirroring the TS change. Live-verified ≥2 exchanges against the real EL socket (agent answered turn 2); unit 7 pass / 74 no-regression. TS + Python ship together in this PR.
- **Remaining #567 scope (NOT in this PR):** un-gating `elevenlabs_interruption` (still `RUN_EL_INTERRUPTION=1`-gated) needs live post-interrupt verification not yet done — tracked as follow-up, which is why this PR *addresses* rather than fully *closes* #567. (`elevenlabs_hosted` IS extended to ≥2 exchanges here.)
- **Not un-gated:** `elevenlabs_interruption` (the issue's secondary ask) — the post-interrupt path is covered by the unit test and the same commit should fix it, but I didn't live-run it. Worth a follow-up.

