### PR TITLE
fix(voice): tolerate empty-content user/system turns in snapshot emitter (#600)

### DIFF
--- a/python/scenario/_events/utils.py
+++ b/python/scenario/_events/utils.py
@@ -67,8 +67,6 @@ def convert_messages_to_api_client_messages(
             trace_props["trace_id"] = trace_id
 
         if role == "user":
-            if not content:
-                raise ValueError(f"User message at index {i} missing required content")
             message_ = UserMessage(
                 id=message_id,
                 role="user",
@@ -105,10 +103,6 @@ def convert_messages_to_api_client_messages(
             message_.additional_properties = trace_props
             converted_messages.append(message_)
         elif role == "system":
-            if not content:
-                raise ValueError(
-                    f"System message at index {i} missing required content"
-                )
             message_ = SystemMessage(
                 id=message_id, role="system", content=_serialize_content(content)
             )

--- a/python/scenario/_events/utils.py
+++ b/python/scenario/_events/utils.py
@@ -48,7 +48,9 @@ def convert_messages_to_api_client_messages(
         List of API client Message objects
 
     Raises:
-        ValueError: If message role is not supported or message format is invalid
+        ValueError: If the message role is not one of ``user``, ``assistant``,
+            ``system``, or ``tool``.  ``tool`` messages missing ``tool_call_id``
+            or ``content`` are warned and skipped rather than raised.
     """
 
     converted_messages: list[MessageType] = []

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1630,14 +1630,24 @@ class ScenarioExecutor:
         This event captures the current state of the conversation during
         scenario execution. It's published whenever messages are added to
         the conversation, allowing real-time tracking of scenario progress.
-        """
-        common_fields = self._create_common_event_fields(scenario_run_id)
 
-        event = ScenarioMessageSnapshotEvent(
-            **common_fields,
-            messages=convert_messages_to_api_client_messages(self._state.messages),
-        )
-        self._emit_event(event)
+        Failures are logged as warnings rather than propagated so that a
+        serialization edge-case in the telemetry path cannot abort an
+        otherwise-healthy scenario run.
+        """
+        try:
+            common_fields = self._create_common_event_fields(scenario_run_id)
+
+            event = ScenarioMessageSnapshotEvent(
+                **common_fields,
+                messages=convert_messages_to_api_client_messages(self._state.messages),
+            )
+            self._emit_event(event)
+        except Exception:
+            logger.warning(
+                "Failed to emit message snapshot event; snapshot skipped",
+                exc_info=True,
+            )
 
     def _emit_run_finished_event(
         self,

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1628,12 +1628,19 @@ class ScenarioExecutor:
         Emit a message snapshot event.
 
         This event captures the current state of the conversation during
-        scenario execution. It's published whenever messages are added to
-        the conversation, allowing real-time tracking of scenario progress.
+        scenario execution. It's published after every script step, allowing
+        real-time tracking of scenario progress.
 
-        Failures are logged as warnings rather than propagated so that a
-        serialization edge-case in the telemetry path cannot abort an
-        otherwise-healthy scenario run.
+        Any failure while building or emitting the snapshot is logged as a
+        warning and swallowed so that a telemetry error can never abort an
+        otherwise-healthy scenario run.  This guard is intentionally broad:
+        the snapshot fires on arbitrary in-flight conversation content (e.g.
+        empty-content voice turns) where serialization or transport errors are
+        plausible and must be non-fatal.
+
+        Note: _emit_run_started_event and _emit_run_finished_event are NOT
+        guarded because they carry structured, schema-controlled data produced
+        by the executor itself — not raw, user-supplied message content.
         """
         try:
             common_fields = self._create_common_event_fields(scenario_run_id)

--- a/python/tests/test_convert_messages_serialization.py
+++ b/python/tests/test_convert_messages_serialization.py
@@ -132,3 +132,94 @@ def test_assistant_string_content_with_quotes_passes_through():
         _messages({"role": "assistant", "content": 'he said "hi" and left'})
     )
     assert result[0].content == 'he said "hi" and left'
+
+
+# ---------------------------------------------------------------------------
+# AC2 regression tests — empty/falsy user + system content must not raise
+# Ref: specs/empty-content-turn-snapshot.feature  AC2
+# ---------------------------------------------------------------------------
+
+
+def test_empty_user_content_empty_string_does_not_raise():
+    """AC2 — specs/empty-content-turn-snapshot.feature: converter must not raise for user message with content ''."""
+    result = convert_messages_to_api_client_messages(
+        _messages({"role": "user", "content": ""})
+    )
+    assert len(result) == 1
+    assert result[0].content == ""
+
+
+def test_empty_user_content_none_does_not_raise():
+    """AC2 — specs/empty-content-turn-snapshot.feature: converter must not raise for user message with content None."""
+    result = convert_messages_to_api_client_messages(
+        _messages({"role": "user", "content": None})
+    )
+    assert len(result) == 1
+    assert result[0].content == ""
+
+
+def test_empty_user_content_empty_list_does_not_raise():
+    """AC2 — specs/empty-content-turn-snapshot.feature: converter must not raise for user message with content []; coerces via json.dumps to '[]'."""
+    result = convert_messages_to_api_client_messages(
+        _messages({"role": "user", "content": []})
+    )
+    assert len(result) == 1
+    assert result[0].content == "[]"
+
+
+def test_empty_system_content_empty_string_does_not_raise():
+    """AC2 — specs/empty-content-turn-snapshot.feature: converter must not raise for system message with content ''."""
+    result = convert_messages_to_api_client_messages(
+        _messages({"role": "system", "content": ""})
+    )
+    assert len(result) == 1
+    assert result[0].content == ""
+
+
+def test_empty_system_content_none_does_not_raise():
+    """AC2 — specs/empty-content-turn-snapshot.feature: converter must not raise for system message with content None."""
+    result = convert_messages_to_api_client_messages(
+        _messages({"role": "system", "content": None})
+    )
+    assert len(result) == 1
+    assert result[0].content == ""
+
+
+def test_empty_system_content_empty_list_does_not_raise():
+    """AC2 — specs/empty-content-turn-snapshot.feature: converter must not raise for system message with content []; coerces via json.dumps to '[]'."""
+    result = convert_messages_to_api_client_messages(
+        _messages({"role": "system", "content": []})
+    )
+    assert len(result) == 1
+    assert result[0].content == "[]"
+
+
+def test_empty_content_all_roles_coerce_without_raising():
+    """AC2 — specs/empty-content-turn-snapshot.feature: assistant+user+system all with content='' must all coerce to '' without raising."""
+    result = convert_messages_to_api_client_messages(
+        _messages(
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": ""},
+            {"role": "system", "content": ""},
+        )
+    )
+    assert len(result) == 3
+    for msg in result:
+        assert msg.content == ""
+
+
+def test_non_empty_content_serializes_unchanged():
+    """AC2 (no-regression guard) — specs/empty-content-turn-snapshot.feature: non-empty user/system/assistant/tool content must not be dropped or mangled."""
+    result = convert_messages_to_api_client_messages(
+        _messages(
+            {"role": "user", "content": "hello"},
+            {"role": "system", "content": "be helpful"},
+            {"role": "assistant", "content": "of course"},
+            {"role": "tool", "content": "result data", "tool_call_id": "call_abc"},
+        )
+    )
+    assert len(result) == 4
+    assert result[0].content == "hello"
+    assert result[1].content == "be helpful"
+    assert result[2].content == "of course"
+    assert result[3].content == "result data"

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -1,5 +1,7 @@
+import logging
 import pytest
 from typing import List, Tuple, Dict, Any
+from unittest.mock import patch
 
 from scenario import JudgeAgent, UserSimulatorAgent
 from scenario._generated.langwatch_api_client.lang_watch_api_client.types import Unset
@@ -346,3 +348,120 @@ async def test_name_and_description_take_precedence_over_metadata() -> None:
     metadata_dict = start_event.metadata.to_dict()
     assert metadata_dict["name"] == "real name"
     assert metadata_dict["description"] == "real description"
+
+
+# ---------------------------------------------------------------------------
+# AC1 / AC4b / AC3 / AC5 — executor-level regression tests
+# Ref: specs/empty-content-turn-snapshot.feature
+# ---------------------------------------------------------------------------
+
+
+def _make_empty_turn_executor() -> ScenarioExecutor:
+    """Return an executor whose script injects an empty-content user turn then
+    immediately succeeds.  The snapshot emitter fires after the inject step —
+    that is the crash site under the buggy code."""
+    import scenario as sc
+    from typing import cast as _cast
+    from scenario.scenario_state import ScenarioState
+
+    mock_reporter = MockEventReporter()
+    event_bus = ScenarioEventBus(event_reporter=mock_reporter)
+
+    def _inject_empty_user_turn(state: ScenarioState) -> None:
+        # Directly append a falsy-content user message — simulates what the
+        # voice pipeline does when STT returns "" for silence.
+        state.messages.append(
+            _cast(
+                "scenario.types.ChatCompletionMessageParamWithTrace",
+                {"role": "user", "content": ""},
+            )
+        )
+
+    return ScenarioExecutor(
+        name="voice empty turn scenario",
+        description="STT returns empty string for silence",
+        agents=[
+            MockAgent(),
+            MockUserSimulatorAgent(model="none"),
+            MockJudgeAgent(model="none", criteria=["test"]),
+        ],
+        event_bus=event_bus,
+        script=[
+            _inject_empty_user_turn,  # injects "" user turn; snapshot fires after
+            sc.succeed("voice run completed"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_completes_with_empty_user_turn() -> None:
+    """AC1/AC4b — specs/empty-content-turn-snapshot.feature: run() must return a ScenarioResult, not raise ValueError, when state contains an empty-content user turn."""
+    executor = _make_empty_turn_executor()
+    result = await executor.run()
+    assert isinstance(result, ScenarioResult)
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_snapshot_emitter_failure_degrades_to_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """AC3 — specs/empty-content-turn-snapshot.feature: a failure inside the snapshot emitter must degrade to a logged warning, not abort run()."""
+    import scenario as sc
+
+    mock_reporter = MockEventReporter()
+    event_bus = ScenarioEventBus(event_reporter=mock_reporter)
+
+    executor = ScenarioExecutor(
+        name="snapshot failure scenario",
+        description="force snapshot to raise",
+        agents=[
+            MockAgent(),
+            MockUserSimulatorAgent(model="none"),
+            MockJudgeAgent(model="none", criteria=["test"]),
+        ],
+        event_bus=event_bus,
+        script=[
+            lambda state: None,  # harmless step; snapshot fires after — we monkeypatch it to raise
+            sc.succeed("run should survive snapshot error"),
+        ],
+    )
+
+    with patch(
+        "scenario.scenario_executor.convert_messages_to_api_client_messages",
+        side_effect=ValueError("forced serialization failure"),
+    ):
+        with caplog.at_level(logging.WARNING, logger="scenario"):
+            result = await executor.run()
+
+    assert isinstance(result, ScenarioResult), "run() must return a result even when snapshot emitter raises"
+    assert any(
+        "forced serialization failure" in record.message or "forced serialization failure" in str(record.exc_info)
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ), "A WARNING must be logged when the snapshot emitter fails"
+
+
+@pytest.mark.asyncio
+async def test_empty_user_turn_state_unchanged_after_snapshot() -> None:
+    """AC5 — specs/empty-content-turn-snapshot.feature: _state.messages must still contain the empty-content user turn unchanged after snapshot emission (fix is telemetry-only)."""
+    executor = _make_empty_turn_executor()
+
+    # We need to inspect _state AFTER the snapshot fires but BEFORE the run
+    # returns.  Use the event subscription: on the first snapshot event, record
+    # the executor state.  The snapshot fires synchronously inside run(), so
+    # by the time run() returns the state has already been observed.
+    captured_messages_at_snapshot: List[Any] = []
+
+    def _on_event(event: ScenarioEvent) -> None:
+        if isinstance(event, ScenarioMessageSnapshotEvent) and not captured_messages_at_snapshot:
+            # Snapshot has just been emitted — record a copy of messages now
+            captured_messages_at_snapshot.extend(list(executor._state.messages))
+
+    executor.events.subscribe(_on_event)
+
+    await executor.run()
+
+    # The empty-content user turn must still be present in _state
+    assert any(
+        msg.get("role") == "user" and msg.get("content") == ""
+        for msg in captured_messages_at_snapshot
+    ), "_state.messages must contain the empty-content user turn unchanged after snapshot emission"

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -8,7 +8,7 @@ from scenario import JudgeAgent, UserSimulatorAgent
 from scenario._generated.langwatch_api_client.lang_watch_api_client.types import Unset
 from scenario.agent_adapter import AgentAdapter
 from scenario.scenario_state import ScenarioState
-from scenario.types import AgentInput, ScenarioResult
+from scenario.types import AgentInput, ChatCompletionMessageParamWithTrace, ScenarioResult
 from scenario.scenario_executor import ScenarioExecutor
 from scenario._events import (
     ScenarioEvent,
@@ -370,7 +370,7 @@ def _make_empty_turn_executor() -> ScenarioExecutor:
         # voice pipeline does when STT returns "" for silence.
         state.messages.append(
             _cast(
-                "scenario.types.ChatCompletionMessageParamWithTrace",
+                "ChatCompletionMessageParamWithTrace",
                 {"role": "user", "content": ""},
             )
         )

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -3,8 +3,7 @@ import pytest
 from typing import Any, cast as _cast, List, Tuple, Dict
 from unittest.mock import patch
 
-import scenario as sc
-from scenario import JudgeAgent, UserSimulatorAgent
+from scenario import JudgeAgent, UserSimulatorAgent, succeed
 from scenario._generated.langwatch_api_client.lang_watch_api_client.types import Unset
 from scenario.agent_adapter import AgentAdapter
 from scenario.scenario_state import ScenarioState
@@ -386,7 +385,7 @@ def _make_empty_turn_executor() -> ScenarioExecutor:
         event_bus=event_bus,
         script=[
             _inject_empty_user_turn,  # injects "" user turn; snapshot fires after
-            sc.succeed("voice run completed"),
+            succeed("voice run completed"),
         ],
     )
 
@@ -426,7 +425,7 @@ async def test_snapshot_emitter_failure_degrades_to_warning(caplog: pytest.LogCa
         event_bus=event_bus,
         script=[
             lambda state: None,  # harmless step; snapshot fires after — we monkeypatch it to raise
-            sc.succeed("run should survive snapshot error"),
+            succeed("run should survive snapshot error"),
         ],
     )
 
@@ -466,7 +465,7 @@ async def test_empty_user_turn_state_unchanged_after_snapshot() -> None:
     await executor.run()
 
     # The empty-content user turn must still be present in _state.
-    # _make_empty_turn_executor injects exactly 1 message before sc.succeed() fires.
+    # _make_empty_turn_executor injects exactly 1 message before succeed() fires.
     assert len(captured_messages_at_snapshot) == 1, (
         "_state.messages must have exactly 1 message after the inject step "
         "(nothing dropped or added by the snapshot path)"

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -369,7 +369,7 @@ def _make_empty_turn_executor() -> ScenarioExecutor:
         # voice pipeline does when STT returns "" for silence.
         state.messages.append(
             _cast(
-                "ChatCompletionMessageParamWithTrace",
+                ChatCompletionMessageParamWithTrace,
                 {"role": "user", "content": ""},
             )
         )

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -1,11 +1,13 @@
 import logging
 import pytest
-from typing import List, Tuple, Dict, Any
+from typing import Any, cast as _cast, List, Tuple, Dict
 from unittest.mock import patch
 
+import scenario as sc
 from scenario import JudgeAgent, UserSimulatorAgent
 from scenario._generated.langwatch_api_client.lang_watch_api_client.types import Unset
 from scenario.agent_adapter import AgentAdapter
+from scenario.scenario_state import ScenarioState
 from scenario.types import AgentInput, ScenarioResult
 from scenario.scenario_executor import ScenarioExecutor
 from scenario._events import (
@@ -360,10 +362,6 @@ def _make_empty_turn_executor() -> ScenarioExecutor:
     """Return an executor whose script injects an empty-content user turn then
     immediately succeeds.  The snapshot emitter fires after the inject step —
     that is the crash site under the buggy code."""
-    import scenario as sc
-    from typing import cast as _cast
-    from scenario.scenario_state import ScenarioState
-
     mock_reporter = MockEventReporter()
     event_bus = ScenarioEventBus(event_reporter=mock_reporter)
 
@@ -395,18 +393,25 @@ def _make_empty_turn_executor() -> ScenarioExecutor:
 
 @pytest.mark.asyncio
 async def test_run_completes_with_empty_user_turn() -> None:
-    """AC1/AC4b — specs/empty-content-turn-snapshot.feature: run() must return a ScenarioResult, not raise ValueError, when state contains an empty-content user turn."""
+    """AC1/AC4b — specs/empty-content-turn-snapshot.feature: run() must return a ScenarioResult, not raise ValueError, when state contains an empty-content user turn.
+
+    The snapshot assertion pins AC4b: if the converter raise were reintroduced the
+    emitter would swallow it, emit no snapshot, and this assertion would fail.
+    """
     executor = _make_empty_turn_executor()
+    events: List[ScenarioEvent] = []
+    executor.events.subscribe(events.append)
     result = await executor.run()
     assert isinstance(result, ScenarioResult)
     assert result.success is True
+    assert any(
+        isinstance(e, ScenarioMessageSnapshotEvent) for e in events
+    ), "ScenarioMessageSnapshotEvent must be emitted — silent swallow means the fix is broken"
 
 
 @pytest.mark.asyncio
 async def test_snapshot_emitter_failure_degrades_to_warning(caplog: pytest.LogCaptureFixture) -> None:
     """AC3 — specs/empty-content-turn-snapshot.feature: a failure inside the snapshot emitter must degrade to a logged warning, not abort run()."""
-    import scenario as sc
-
     mock_reporter = MockEventReporter()
     event_bus = ScenarioEventBus(event_reporter=mock_reporter)
 
@@ -460,7 +465,12 @@ async def test_empty_user_turn_state_unchanged_after_snapshot() -> None:
 
     await executor.run()
 
-    # The empty-content user turn must still be present in _state
+    # The empty-content user turn must still be present in _state.
+    # _make_empty_turn_executor injects exactly 1 message before sc.succeed() fires.
+    assert len(captured_messages_at_snapshot) == 1, (
+        "_state.messages must have exactly 1 message after the inject step "
+        "(nothing dropped or added by the snapshot path)"
+    )
     assert any(
         msg.get("role") == "user" and msg.get("content") == ""
         for msg in captured_messages_at_snapshot

--- a/specs/empty-content-turn-snapshot.feature
+++ b/specs/empty-content-turn-snapshot.feature
@@ -1,0 +1,108 @@
+Feature: Voice scenario survives empty-content user turns in the snapshot emitter
+  As a developer running voice scenarios
+  I want scenario.run() to complete when the STT/voice pipeline yields an
+  empty-content user turn (silence, a dropped segment, or a barge-in)
+  So that an otherwise-healthy run is not aborted by the telemetry path that
+  serializes the conversation snapshot after every script step
+
+  Background:
+    Given a scenario whose conversation state may contain an empty-content user turn
+
+  # AC1 — the run-level contract: no crash, ScenarioResult returned.
+  @e2e
+  Scenario: A scenario run completes when an empty-content user turn is present
+    Given a voice scenario whose STT yields one empty-content user turn during the run
+    When scenario.run() executes to completion
+    Then it returns a ScenarioResult
+    And no "missing required content" ValueError escapes scenario.run()
+
+  # AC2 — converter no longer raises on falsy user content; coerces like assistant.
+  @unit
+  Scenario Outline: Converter tolerates empty user content instead of raising
+    Given a user message whose content is <content>
+    When convert_messages_to_api_client_messages serializes the conversation
+    Then it does not raise
+    And the emitted snapshot contains a user message with empty-string content
+
+    Examples:
+      | content      |
+      | empty string |
+      | None         |
+      | empty list   |
+
+  # AC2 — same tolerance must extend to the system role (identical latent crash).
+  @unit
+  Scenario Outline: Converter tolerates empty system content instead of raising
+    Given a system message whose content is <content>
+    When convert_messages_to_api_client_messages serializes the conversation
+    Then it does not raise
+    And the emitted snapshot contains a system message with empty-string content
+
+    Examples:
+      | content      |
+      | empty string |
+      | None         |
+      | empty list   |
+
+  # AC2 — coercion is consistent with the role that already worked.
+  @unit
+  Scenario: Empty user and system content is handled the same way as empty assistant content
+    Given an assistant, a user, and a system message that all have empty content
+    When convert_messages_to_api_client_messages serializes the conversation
+    Then all three roles are coerced to empty-string content without raising
+    And the resulting ScenarioMessageSnapshotEvent is a valid event
+
+  # AC2 — non-empty content must keep flowing through unchanged (no regression).
+  @unit
+  Scenario: Converter preserves non-empty content for every role
+    Given user, system, assistant, and tool messages that all have non-empty content
+    When convert_messages_to_api_client_messages serializes the conversation
+    Then each message's content is serialized unchanged
+    And no message is dropped from the snapshot
+
+  # AC3 — the emitter is the safety net: a serialization failure must not abort the run.
+  @integration
+  Scenario: A failure inside the snapshot emitter degrades to a logged warning
+    Given the per-step snapshot emitter raises during conversation serialization
+    When scenario.run() reaches the snapshot emission step
+    Then the failure is logged as a warning with a traceback
+    And the error does not propagate out of scenario.run()
+    And the run continues to its verdict
+
+  # AC4(b) — executor-level regression: empty user turn appended, run still completes.
+  @integration
+  Scenario: An empty-content user turn appended to state does not abort the run
+    Given a scenario whose state has an empty-content user turn appended before a script step
+    When scenario.run() executes that step and emits the message snapshot
+    Then the snapshot is emitted without raising
+    And scenario.run() completes and returns a ScenarioResult
+
+  # AC5 — the fix is telemetry-only; real conversation state is untouched.
+  @integration
+  Scenario: The fix does not mutate the real conversation state
+    Given a conversation state containing an empty-content user turn
+    When the per-step snapshot is emitted for that state
+    Then the snapshot serialization is the only thing that consumes the empty turn
+    And _state.messages still contains the empty-content user turn unchanged
+    And the agent-visible conversation flow is unchanged
+
+# --- AC Coverage Map ---
+# AC1: "no crash on empty user turn — scenario.run() returns a ScenarioResult instead of raising ValueError"
+#   → @e2e Scenario: A scenario run completes when an empty-content user turn is present
+#   → @integration Scenario: An empty-content user turn appended to state does not abort the run (executor-level)
+#
+# AC2: "converter tolerates empty user + system content, coerced like assistant; snapshot stays valid"
+#   → @unit Scenario Outline: Converter tolerates empty user content instead of raising ("" / None / [])
+#   → @unit Scenario Outline: Converter tolerates empty system content instead of raising ("" / None / [])
+#   → @unit Scenario: Empty user and system content is handled the same way as empty assistant content
+#   → @unit Scenario: Converter preserves non-empty content for every role (no-regression guard)
+#
+# AC3: "snapshot emission can't abort a healthy run — degrades to a logged warning with traceback"
+#   → @integration Scenario: A failure inside the snapshot emitter degrades to a logged warning
+#
+# AC4: "regression coverage — (a) converter accepts ""/None/[] for user+system; (b) executor run with empty user turn completes"
+#   → (a) @unit Converter tolerates empty user/system content (the two Scenario Outlines above)
+#   → (b) @integration Scenario: An empty-content user turn appended to state does not abort the run
+#
+# AC5: "real conversation state untouched — fix is telemetry/serialization only"
+#   → @integration Scenario: The fix does not mutate the real conversation state


### PR DESCRIPTION
## What & why

A voice `scenario.run()` aborted with `ValueError: User message at index N missing required content` whenever the STT/voice pipeline yielded an empty-content `user` turn (silence, a dropped segment, or a barge-in). The crash came from the SDK serializing **its own** valid-but-empty state on the telemetry path — not from caller input. Fixes #600.

## Root cause

1. `convert_messages_to_api_client_messages` (`python/scenario/_events/utils.py`) hard-raised on falsy content for the `user` and `system` roles, while `assistant` coerces (via `_serialize_content`) and `tool` warns+skips — an inconsistency.
2. The per-step snapshot emitter `_emit_message_snapshot_event` (`python/scenario/scenario_executor.py`) ran that converter over the whole conversation with no guard, and its call site sits **outside** the script loop's `except AssertionError`, so the `ValueError` propagated out of `scenario.run()` and aborted an otherwise-healthy run.

Full investigation (traced voice origin, strategy table, JudgeAgent + TS-parity assessment) is on the issue: #600.

## Changes

- **Converter** (`_events/utils.py`): remove the raise-on-empty guards for `user` and `system`; coerce via `_serialize_content` like `assistant` already does (`""`/`None` → `""`, `[]` → `"[]"`). Removes the role asymmetry at the root.
- **Emitter** (`scenario_executor.py`): wrap `_emit_message_snapshot_event` so any serialization error degrades to `logger.warning(..., exc_info=True)` instead of propagating — telemetry must never abort a run. Matches the codebase's existing swallow-and-log pattern (voice-adapter disconnect, rollback trace-update).

## Testing

Regression-test-fails-first, then fix (see commit history):

- `test(voice)` commit — 10 failing tests: converter empty `user`/`system` × (`""`, `None`, `[]`); role-consistency; executor run-completes-with-empty-turn; emitter-degrades-to-warning; state-untouched — plus 1 non-empty no-regression guard.
- `fix(voice)` commit — the two-layer fix; all green.

Local results:
- `28 passed` in the two modified test files (`test_convert_messages_serialization.py`, `test_scenario_executor_events.py`).
- `29 passed` across adjacent offline suites (executor, event reporter, event bus, agent-input serialization, role/scope attributes).
- No existing test depended on the removed `ValueError`.

## Acceptance criteria (#600)

- **AC1** run completes on an empty user turn — ✅ `test_run_completes_with_empty_user_turn`
- **AC2** converter tolerates empty `user`+`system`, coerced like `assistant` — ✅ converter unit tests
- **AC3** snapshot emission cannot abort a healthy run (degrades to a logged warning) — ✅ `test_snapshot_emitter_failure_degrades_to_warning`
- **AC4** regression coverage (red-before / green-after) — ✅ the above
- **AC5** real conversation state untouched (telemetry-only) — ✅ `test_empty_user_turn_state_unchanged_after_snapshot`

## Out of scope (separate issues recommended)

- **JudgeAgent `result.messages` contamination** — a different code path (occurs with no judge → no crash); documented on #600.
- **TypeScript SDK partial parity** — `null`/`undefined` user content hits a misleading `default`-branch throw in `convert-core-messages-to-agui-messages.ts`; empty-string is safe. Documented on #600.

Closes #600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)