### PR TITLE
fix(voice/#602): migrate OpenAIRealtimeAgentAdapter to GA Realtime wire protocol

### DIFF
--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -284,9 +284,10 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             etype = event.get("type", "")
 
             if etype in ("response.output_audio.delta", "response.audio.delta"):
-                # Base64-encoded PCM16 audio fragment from the model.
-                # GA name: response.output_audio.delta
-                # Legacy beta name: response.audio.delta (accepted defensively)
+                # Accept both the GA event name and its retired beta alias —
+                # live gpt-realtime* models have been observed still emitting
+                # the beta names. These legacy arms should be removed once the
+                # GA names are confirmed stable at a live endpoint (issue #602).
                 self._warn_if_legacy(etype, "response.output_audio.delta")
                 b64 = event.get("delta", "")
                 pcm = base64.b64decode(b64)
@@ -300,7 +301,6 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 "response.audio_transcript.delta",
             ):
                 # Accumulate streaming agent transcript.
-                # GA name: response.output_audio_transcript.delta
                 self._warn_if_legacy(etype, "response.output_audio_transcript.delta")
                 self._agent_transcript_buf += event.get("delta", "")
 
@@ -309,7 +309,6 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 "response.audio_transcript.done",
             ):
                 # Finalise; the `transcript` field may have the full text.
-                # GA name: response.output_audio_transcript.done
                 self._warn_if_legacy(etype, "response.output_audio_transcript.done")
                 transcript = event.get("transcript", "")
                 if transcript:

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -5,14 +5,19 @@ Source §5.6 + §7.2 L1164-1171. Unlike the other adapters which wrap a user's
 running agent, this one IS the agent under test (or, when
 ``role=AgentRole.USER``, the voice-enabled user simulator).
 
-Wire protocol:
+Wire protocol (GA, post-2026-05-12):
 - Endpoint: ``wss://api.openai.com/v1/realtime?model=<model>``
-- Headers: ``Authorization: Bearer <api_key>``, ``OpenAI-Beta: realtime=v1``
-- On connect: emit ``session.update`` to configure audio formats, voice,
-  instructions, and tools.
+- Headers: ``Authorization: Bearer <api_key>`` only (no ``OpenAI-Beta`` header).
+- On connect: emit ``session.update`` to configure session type, audio formats,
+  voice, instructions, and tools. ``session.type="realtime"``; audio config
+  nested under ``session.audio.{input,output}`` with object format descriptors
+  (e.g. ``{"type": "audio/pcm", "rate": 24000}``).
 - Send audio: ``input_audio_buffer.append`` with base64-encoded PCM16.
-- Receive audio: loop over server events until ``response.audio.delta``;
-  return decoded PCM16. Transcript events update instance attributes.
+- Receive audio: loop over server events until ``response.output_audio.delta``
+  (GA name); legacy ``response.audio.delta`` accepted defensively with a
+  one-time warning. Return decoded PCM16.
+- Transcript events: ``response.output_audio_transcript.delta`` /
+  ``response.output_audio_transcript.done`` update instance attributes.
 - Send text (role=USER): ``conversation.item.create`` (input_text) then
   ``response.create``.
 """
@@ -51,7 +56,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         - ``last_user_transcript`` — set from
           ``conversation.item.input_audio_transcription.completed``
         - ``last_agent_transcript`` — accumulated from
-          ``response.audio_transcript.delta`` / reset on done
+          ``response.output_audio_transcript.delta`` / reset on done
 
     Example::
 
@@ -107,6 +112,10 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         # means recv_audio should commit + request a response before awaiting.
         self._pending_audio_bytes: int = 0
 
+        # Tracks which legacy (pre-GA) event names have already triggered a
+        # one-time warning, so the log isn't spammed on every audio frame.
+        self._legacy_events_warned: set[str] = set()
+
     @property
     def url(self) -> str:
         return REALTIME_URL_TEMPLATE.format(model=self.model)
@@ -120,6 +129,22 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             f"api_key='***')"
         )
 
+    def _warn_if_legacy(self, received: str, ga_name: str) -> None:
+        """Emit a one-time WARNING when a pre-GA (beta) event name is seen.
+
+        Only fires once per distinct legacy name per adapter instance, so a
+        multi-chunk audio response doesn't flood the log. The GA-named event
+        itself never triggers a warning.
+        """
+        if received != ga_name and received not in self._legacy_events_warned:
+            self._legacy_events_warned.add(received)
+            logger.warning(
+                "OpenAIRealtimeAgentAdapter: received legacy event %r; "
+                "GA uses %r — accepting defensively",
+                received,
+                ga_name,
+            )
+
     # ------------------------------------------------------------------ lifecycle
 
     async def connect(self) -> None:
@@ -130,20 +155,27 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             self.url,
             additional_headers={
                 "Authorization": f"Bearer {self._api_key}",
-                "OpenAI-Beta": "realtime=v1",
             },
         )
         logger.debug("OpenAIRealtimeAgentAdapter: connected to %s", self.url)
 
         # Configure session: audio formats, voice, instructions, tools.
-        # Disable server-side VAD so we control turn boundaries explicitly via
-        # input_audio_buffer.commit + response.create after each send_audio.
+        # Disable server-side VAD (session.audio.input.turn_detection=None) so
+        # we control turn boundaries explicitly via input_audio_buffer.commit +
+        # response.create after each send_audio.
         session_config: dict[str, Any] = {
-            "input_audio_format": "pcm16",
-            "output_audio_format": "pcm16",
-            "voice": self.voice,
-            "input_audio_transcription": {"model": OPENAI_STT_MODEL},
-            "turn_detection": None,
+            "type": "realtime",
+            "audio": {
+                "input": {
+                    "format": {"type": "audio/pcm", "rate": 24000},
+                    "turn_detection": None,
+                    "transcription": {"model": OPENAI_STT_MODEL},
+                },
+                "output": {
+                    "format": {"type": "audio/pcm", "rate": 24000},
+                    "voice": self.voice,
+                },
+            },
         }
         if self.instructions:
             session_config["instructions"] = self.instructions
@@ -211,11 +243,13 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         awaiting the reply. Subsequent recv calls without new send calls
         just await the next audio delta (for multi-chunk responses).
 
-        Loops over incoming events until a ``response.audio.delta`` event
-        arrives, then returns decoded PCM16. Transcript events update the
-        instance's ``last_user_transcript`` / ``last_agent_transcript``
-        attributes. An ``error`` event raises a ``RuntimeError``. All other
-        housekeeping events are ignored and the loop continues.
+        Loops over incoming events until a ``response.output_audio.delta``
+        event arrives (GA name), then returns decoded PCM16. The legacy
+        ``response.audio.delta`` name is accepted defensively with a one-time
+        warning. Transcript events update the instance's
+        ``last_user_transcript`` / ``last_agent_transcript`` attributes.
+        An ``error`` event raises a ``RuntimeError``. All other housekeeping
+        events are ignored and the loop continues.
 
         Raises:
             asyncio.TimeoutError: if no audio arrives within ``timeout``.
@@ -249,8 +283,11 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
 
             etype = event.get("type", "")
 
-            if etype == "response.audio.delta":
+            if etype in ("response.output_audio.delta", "response.audio.delta"):
                 # Base64-encoded PCM16 audio fragment from the model.
+                # GA name: response.output_audio.delta
+                # Legacy beta name: response.audio.delta (accepted defensively)
+                self._warn_if_legacy(etype, "response.output_audio.delta")
                 b64 = event.get("delta", "")
                 pcm = base64.b64decode(b64)
                 # Enforce PCM16 invariant: even byte count.
@@ -258,12 +295,22 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                     pcm = pcm[:-1]
                 return AudioChunk(data=pcm)
 
-            elif etype == "response.audio_transcript.delta":
+            elif etype in (
+                "response.output_audio_transcript.delta",
+                "response.audio_transcript.delta",
+            ):
                 # Accumulate streaming agent transcript.
+                # GA name: response.output_audio_transcript.delta
+                self._warn_if_legacy(etype, "response.output_audio_transcript.delta")
                 self._agent_transcript_buf += event.get("delta", "")
 
-            elif etype == "response.audio_transcript.done":
+            elif etype in (
+                "response.output_audio_transcript.done",
+                "response.audio_transcript.done",
+            ):
                 # Finalise; the `transcript` field may have the full text.
+                # GA name: response.output_audio_transcript.done
+                self._warn_if_legacy(etype, "response.output_audio_transcript.done")
                 transcript = event.get("transcript", "")
                 if transcript:
                     self.last_agent_transcript = transcript

--- a/python/tests/voice/test_adapters.py
+++ b/python/tests/voice/test_adapters.py
@@ -493,7 +493,7 @@ async def test_openai_realtime_adapter_connects_and_sends_pcm16():
     events = [
         json.dumps({"type": "session.created", "session": {}}),
         json.dumps({"type": "session.updated", "session": {}}),
-        json.dumps({"type": "response.audio.delta", "delta": b64_audio}),
+        json.dumps({"type": "response.output_audio.delta", "delta": b64_audio}),
     ]
     call_index = 0
 
@@ -517,12 +517,15 @@ async def test_openai_realtime_adapter_connects_and_sends_pcm16():
         assert "model=gpt-realtime-mini" in connect_url
         assert "api.openai.com" in connect_url
 
-        # Verify session.update was emitted (first send call).
+        # Verify session.update was emitted (first send call) with GA shape.
         first_send_raw = mock_ws.send.call_args_list[0][0][0]
         first_sent = json.loads(first_send_raw)
         assert first_sent["type"] == "session.update"
-        assert first_sent["session"]["input_audio_format"] == "pcm16"
-        assert first_sent["session"]["output_audio_format"] == "pcm16"
+        session = first_sent["session"]
+        assert session["type"] == "realtime"
+        assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+        assert session["audio"]["output"]["format"] == {"type": "audio/pcm", "rate": 24000}
+        assert session["audio"]["output"]["voice"] == "alloy"
 
         # send_audio must emit input_audio_buffer.append with base64 PCM16.
         chunk = AudioChunk(data=b"\x10\x20" * 100)
@@ -677,14 +680,14 @@ async def test_openai_realtime_adapter_tracks_transcripts():
     b64_audio = base64.b64encode(pcm_payload).decode()
 
     events = [
-        json.dumps({"type": "response.audio_transcript.delta", "delta": "Hello "}),
-        json.dumps({"type": "response.audio_transcript.delta", "delta": "world"}),
-        json.dumps({"type": "response.audio_transcript.done", "transcript": "Hello world"}),
+        json.dumps({"type": "response.output_audio_transcript.delta", "delta": "Hello "}),
+        json.dumps({"type": "response.output_audio_transcript.delta", "delta": "world"}),
+        json.dumps({"type": "response.output_audio_transcript.done", "transcript": "Hello world"}),
         json.dumps({
             "type": "conversation.item.input_audio_transcription.completed",
             "transcript": "user said hello",
         }),
-        json.dumps({"type": "response.audio.delta", "delta": b64_audio}),
+        json.dumps({"type": "response.output_audio.delta", "delta": b64_audio}),
     ]
     call_index = 0
 
@@ -742,6 +745,57 @@ def test_openai_realtime_adapter_repr_redacts_api_key():
     r = repr(adapter)
     assert "super_secret_key_xyz" not in r
     assert "***" in r
+
+
+@pytest.mark.asyncio
+async def test_openai_realtime_adapter_accepts_legacy_audio_delta_defensively(caplog):
+    """AC3 defensive scenario: legacy response.audio.delta still delivers audio.
+
+    A live gpt-realtime* server may emit the pre-GA beta event name even after
+    the GA migration. The adapter must not drop the frame — it returns the
+    AudioChunk normally and emits a one-time WARNING so the divergence is
+    observable in logs without spamming on every frame.
+    """
+    import logging
+
+    adapter = OpenAIRealtimeAgentAdapter(api_key="sk-test")
+
+    pcm_payload = b"\x00\x01" * 8  # 16 bytes of dummy PCM16
+    b64_audio = base64.b64encode(pcm_payload).decode()
+
+    # Feed the legacy (pre-GA) event name.
+    events = [
+        json.dumps({"type": "response.audio.delta", "delta": b64_audio}),
+    ]
+    call_index = 0
+
+    mock_ws = AsyncMock()
+
+    async def fake_recv():
+        nonlocal call_index
+        msg = events[call_index]
+        call_index += 1
+        return msg
+
+    mock_ws.recv = fake_recv
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+
+        with caplog.at_level(logging.WARNING, logger="scenario.voice.openai_realtime"):
+            result = await adapter.recv_audio(timeout=5.0)
+
+    # Must still return the decoded PCM16 bytes.
+    assert isinstance(result, AudioChunk)
+    assert result.data == pcm_payload
+
+    # A one-time WARNING must have been emitted naming the legacy event.
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("response.audio.delta" in m for m in warning_msgs), (
+        "Expected a WARNING mentioning the legacy event name 'response.audio.delta'"
+    )
 
 
 # ---------------------------------------------------------------- GeminiLive transport

--- a/python/tests/voice/test_adapters.py
+++ b/python/tests/voice/test_adapters.py
@@ -542,6 +542,99 @@ async def test_openai_realtime_adapter_connects_and_sends_pcm16():
 
 
 @pytest.mark.asyncio
+async def test_openai_realtime_adapter_uses_ga_wire_protocol_not_beta():
+    """GA wire protocol regression guard — issue #602.
+
+    The adapter previously spoke the retired OpenAI beta Realtime protocol
+    (OpenAI-Beta header + flat session fields + response.audio.delta event).
+    This test asserts the three GA layers together so CI catches any regression:
+      (a) no OpenAI-Beta header in the WebSocket handshake (AC1),
+      (b) GA-shaped session.update payload with nested audio objects (AC2),
+      (c) recv_audio returns PCM16 from the GA response.output_audio.delta event (AC3).
+    """
+    adapter = OpenAIRealtimeAgentAdapter(
+        model="gpt-realtime-mini",
+        voice="alloy",
+        api_key="sk-test",
+    )
+
+    pcm_payload = b"\x00\x01" * 8  # 16 bytes of dummy PCM16
+    b64_audio = base64.b64encode(pcm_payload).decode()
+
+    events = [
+        json.dumps({"type": "session.created", "session": {}}),
+        json.dumps({"type": "session.updated", "session": {}}),
+        json.dumps({"type": "response.output_audio.delta", "delta": b64_audio}),
+    ]
+    call_index = 0
+
+    mock_ws = AsyncMock()
+
+    async def fake_recv():
+        nonlocal call_index
+        msg = events[call_index]
+        call_index += 1
+        return msg
+
+    mock_ws.recv = fake_recv
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)) as mock_connect:
+        await adapter.connect()
+
+        # --- AC1: no beta header; auth header present ---
+        headers = mock_connect.call_args.kwargs.get(
+            "additional_headers", mock_connect.call_args[1].get("additional_headers", {})
+        )
+        assert "Authorization" in headers, "Authorization header must be present"
+        assert "OpenAI-Beta" not in headers, (
+            "OpenAI-Beta header must be absent in GA protocol"
+        )
+
+        # --- AC2: GA session.update shape ---
+        first_send_raw = mock_ws.send.call_args_list[0][0][0]
+        payload = json.loads(first_send_raw)
+        assert payload["type"] == "session.update"
+        session = payload["session"]
+
+        # GA requires session.type == "realtime"
+        assert session["type"] == "realtime", (
+            "session.type must be 'realtime' in GA protocol"
+        )
+
+        # Audio formats must be nested objects, not flat strings
+        assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}, (
+            "session.audio.input.format must be GA object shape"
+        )
+        assert session["audio"]["output"]["format"] == {"type": "audio/pcm", "rate": 24000}, (
+            "session.audio.output.format must be GA object shape"
+        )
+
+        # Voice and transcription/turn_detection must be under audio subtree
+        assert session["audio"]["output"]["voice"] == "alloy"
+        assert session["audio"]["input"]["turn_detection"] is None
+        assert session["audio"]["input"]["transcription"]["model"] == "gpt-4o-transcribe"
+
+        # Beta flat fields must NOT be present
+        assert "input_audio_format" not in session, (
+            "flat input_audio_format must be absent in GA protocol"
+        )
+        assert "output_audio_format" not in session, (
+            "flat output_audio_format must be absent in GA protocol"
+        )
+
+        # --- AC3: recv_audio handles GA event name response.output_audio.delta ---
+        result = await adapter.recv_audio(timeout=5.0)
+        assert isinstance(result, AudioChunk)
+        assert result.data == pcm_payload, (
+            "recv_audio must decode PCM16 from response.output_audio.delta"
+        )
+
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_openai_realtime_adapter_send_text_routes_user_role():
     """role=USER: send_text emits conversation.item.create + response.create."""
     adapter = OpenAIRealtimeAgentAdapter(

--- a/python/tests/voice/test_adapters.py
+++ b/python/tests/voice/test_adapters.py
@@ -8,6 +8,7 @@ at @integration scope (requires real platform creds).
 
 import base64
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -480,7 +481,18 @@ def test_branded_elevenlabs_voice_agent_is_voice_adapter():
 
 @pytest.mark.asyncio
 async def test_openai_realtime_adapter_connects_and_sends_pcm16():
-    """Verify URL construction, session.update on connect, audio send/recv round-trip."""
+    """Send/commit/response round-trip: send_audio → recv_audio commits the buffer and
+    requests a response before returning the decoded AudioChunk.
+
+    Asserts:
+    - send_audio emits input_audio_buffer.append with base64 PCM16.
+    - recv_audio (when _pending_audio_bytes > 0) sends input_audio_buffer.commit
+      followed by response.create BEFORE awaiting the audio delta.
+    - recv_audio returns the decoded AudioChunk from response.output_audio.delta.
+
+    Session-shape and header assertions are owned solely by
+    test_openai_realtime_adapter_uses_ga_wire_protocol_not_beta.
+    """
     adapter = OpenAIRealtimeAgentAdapter(
         model="gpt-realtime-mini",
         voice="alloy",
@@ -509,35 +521,37 @@ async def test_openai_realtime_adapter_connects_and_sends_pcm16():
     mock_ws.send = AsyncMock()
     mock_ws.close = AsyncMock()
 
-    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)) as mock_connect:
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
 
-        # Verify the URL contains the model.
-        connect_url = mock_connect.call_args[0][0]
-        assert "model=gpt-realtime-mini" in connect_url
-        assert "api.openai.com" in connect_url
-
-        # Verify session.update was emitted (first send call) with GA shape.
-        first_send_raw = mock_ws.send.call_args_list[0][0][0]
-        first_sent = json.loads(first_send_raw)
+        # Minimal check: connect emits session.update as the first send.
+        first_sent = json.loads(mock_ws.send.call_args_list[0][0][0])
         assert first_sent["type"] == "session.update"
-        session = first_sent["session"]
-        assert session["type"] == "realtime"
-        assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
-        assert session["audio"]["output"]["format"] == {"type": "audio/pcm", "rate": 24000}
-        assert session["audio"]["output"]["voice"] == "alloy"
 
         # send_audio must emit input_audio_buffer.append with base64 PCM16.
         chunk = AudioChunk(data=b"\x10\x20" * 100)
         await adapter.send_audio(chunk)
-        send_calls = mock_ws.send.call_args_list
-        audio_send = json.loads(send_calls[1][0][0])
+        audio_send = json.loads(mock_ws.send.call_args_list[1][0][0])
         assert audio_send["type"] == "input_audio_buffer.append"
-        decoded = base64.b64decode(audio_send["audio"])
-        assert decoded == chunk.data
+        assert base64.b64decode(audio_send["audio"]) == chunk.data
 
-        # recv_audio must skip housekeeping events and return the audio delta.
+        # recv_audio must commit the buffer and request a response BEFORE
+        # returning audio — assert commit then response.create ordering.
         result = await adapter.recv_audio(timeout=5.0)
+
+        send_types = [
+            json.loads(c[0][0])["type"] for c in mock_ws.send.call_args_list
+        ]
+        commit_idx = send_types.index("input_audio_buffer.commit")
+        create_idx = send_types.index("response.create")
+        assert commit_idx < create_idx, (
+            "input_audio_buffer.commit must precede response.create"
+        )
+        # Both must appear before the audio delta is returned.
+        assert "input_audio_buffer.commit" in send_types
+        assert "response.create" in send_types
+
+        # recv_audio must return the decoded PCM16 AudioChunk.
         assert isinstance(result, AudioChunk)
         assert result.data == pcm_payload
 
@@ -587,9 +601,7 @@ async def test_openai_realtime_adapter_uses_ga_wire_protocol_not_beta():
         await adapter.connect()
 
         # --- AC1: no beta header; auth header present ---
-        headers = mock_connect.call_args.kwargs.get(
-            "additional_headers", mock_connect.call_args[1].get("additional_headers", {})
-        )
+        headers = mock_connect.call_args.kwargs["additional_headers"]
         assert "Authorization" in headers, "Authorization header must be present"
         assert "OpenAI-Beta" not in headers, (
             "OpenAI-Beta header must be absent in GA protocol"
@@ -782,16 +794,18 @@ async def test_openai_realtime_adapter_accepts_legacy_audio_delta_defensively(ca
     the GA migration. The adapter must not drop the frame — it returns the
     AudioChunk normally and emits a one-time WARNING so the divergence is
     observable in logs without spamming on every frame.
-    """
-    import logging
 
+    Feeds the legacy event TWICE to prove the "one-time" dedup: exactly one
+    warning must be emitted across both calls (validates _legacy_events_warned).
+    """
     adapter = OpenAIRealtimeAgentAdapter(api_key="sk-test")
 
     pcm_payload = b"\x00\x01" * 8  # 16 bytes of dummy PCM16
     b64_audio = base64.b64encode(pcm_payload).decode()
 
-    # Feed the legacy (pre-GA) event name.
+    # Feed the legacy (pre-GA) event name twice.
     events = [
+        json.dumps({"type": "response.audio.delta", "delta": b64_audio}),
         json.dumps({"type": "response.audio.delta", "delta": b64_audio}),
     ]
     call_index = 0
@@ -812,16 +826,23 @@ async def test_openai_realtime_adapter_accepts_legacy_audio_delta_defensively(ca
         await adapter.connect()
 
         with caplog.at_level(logging.WARNING, logger="scenario.voice.openai_realtime"):
-            result = await adapter.recv_audio(timeout=5.0)
+            result1 = await adapter.recv_audio(timeout=5.0)
+            result2 = await adapter.recv_audio(timeout=5.0)
 
-    # Must still return the decoded PCM16 bytes.
-    assert isinstance(result, AudioChunk)
-    assert result.data == pcm_payload
+    # Both recv calls must return the decoded PCM16 bytes.
+    assert isinstance(result1, AudioChunk)
+    assert result1.data == pcm_payload
+    assert isinstance(result2, AudioChunk)
+    assert result2.data == pcm_payload
 
-    # A one-time WARNING must have been emitted naming the legacy event.
-    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("response.audio.delta" in m for m in warning_msgs), (
-        "Expected a WARNING mentioning the legacy event name 'response.audio.delta'"
+    # Exactly ONE warning mentioning the legacy event must have been emitted
+    # across both calls — _legacy_events_warned dedup prevents log spam.
+    warning_msgs = [
+        r.getMessage() for r in caplog.records
+        if r.levelno == logging.WARNING and "response.audio.delta" in r.getMessage()
+    ]
+    assert len(warning_msgs) == 1, (
+        f"Expected exactly 1 WARNING for 'response.audio.delta', got {len(warning_msgs)}"
     )
 
 

--- a/python/tests/voice/test_adapters.py
+++ b/python/tests/voice/test_adapters.py
@@ -748,6 +748,33 @@ def test_openai_realtime_adapter_repr_redacts_api_key():
 
 
 @pytest.mark.asyncio
+async def test_openai_realtime_adapter_interrupt_sends_response_cancel():
+    """AC5 / issue #602: interrupt() sends exactly one ``response.cancel`` message.
+
+    The GA Realtime API exposes ``response.cancel`` as the first-class interrupt
+    signal — the model stops generating immediately. This test guards that
+    ``interrupt()`` emits that exact payload and nothing else, so any accidental
+    regression (e.g. wrong event name, extra sends) is caught in CI.
+    """
+    adapter = OpenAIRealtimeAgentAdapter(api_key="sk-test")
+
+    mock_ws = AsyncMock()
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        # Reset send calls so only interrupt()'s output is under scrutiny.
+        mock_ws.send.reset_mock()
+
+        await adapter.interrupt()
+
+    assert mock_ws.send.call_count == 1
+    payload = json.loads(mock_ws.send.call_args_list[0][0][0])
+    assert payload == {"type": "response.cancel"}
+
+
+@pytest.mark.asyncio
 async def test_openai_realtime_adapter_accepts_legacy_audio_delta_defensively(caplog):
     """AC3 defensive scenario: legacy response.audio.delta still delivers audio.
 

--- a/python/tests/voice/test_adapters.py
+++ b/python/tests/voice/test_adapters.py
@@ -684,8 +684,14 @@ async def test_openai_realtime_adapter_send_text_routes_user_role():
 
 
 @pytest.mark.asyncio
-async def test_openai_realtime_adapter_tracks_transcripts():
-    """Transcript delta events update last_agent_transcript / last_user_transcript."""
+async def test_openai_realtime_adapter_tracks_agent_transcript():
+    """AC4 (agent side) — response.output_audio_transcript.delta/.done update last_agent_transcript.
+
+    Feeds two delta events ("Hello " then "world") followed by a .done event whose
+    ``transcript`` field is the canonical assembled string, then a
+    ``response.output_audio.delta`` so recv_audio returns.  Asserts that
+    ``adapter.last_agent_transcript`` equals the .done transcript value.
+    """
     adapter = OpenAIRealtimeAgentAdapter(api_key="sk-test")
 
     pcm_payload = b"\x00\x00" * 8
@@ -695,6 +701,43 @@ async def test_openai_realtime_adapter_tracks_transcripts():
         json.dumps({"type": "response.output_audio_transcript.delta", "delta": "Hello "}),
         json.dumps({"type": "response.output_audio_transcript.delta", "delta": "world"}),
         json.dumps({"type": "response.output_audio_transcript.done", "transcript": "Hello world"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": b64_audio}),
+    ]
+    call_index = 0
+
+    mock_ws = AsyncMock()
+
+    async def fake_recv():
+        nonlocal call_index
+        msg = events[call_index]
+        call_index += 1
+        return msg
+
+    mock_ws.recv = fake_recv
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        await adapter.recv_audio(timeout=5.0)
+
+    assert adapter.last_agent_transcript == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_openai_realtime_adapter_tracks_user_transcript():
+    """AC4 (user side) — conversation.item.input_audio_transcription.completed updates last_user_transcript.
+
+    Feeds the user-transcription completed event (event name unchanged in GA),
+    then a ``response.output_audio.delta`` so recv_audio returns.  Asserts that
+    ``adapter.last_user_transcript`` holds the transcript text.
+    """
+    adapter = OpenAIRealtimeAgentAdapter(api_key="sk-test")
+
+    pcm_payload = b"\x00\x00" * 8
+    b64_audio = base64.b64encode(pcm_payload).decode()
+
+    events = [
         json.dumps({
             "type": "conversation.item.input_audio_transcription.completed",
             "transcript": "user said hello",
@@ -719,8 +762,99 @@ async def test_openai_realtime_adapter_tracks_transcripts():
         await adapter.connect()
         await adapter.recv_audio(timeout=5.0)
 
-    assert adapter.last_agent_transcript == "Hello world"
     assert adapter.last_user_transcript == "user said hello"
+
+
+def test_openai_realtime_adapter_docstring_documents_ga():
+    """AC7 / issue #602 — module docstring reflects GA wire protocol, not the retired beta one.
+
+    Inspects the adapter MODULE docstring directly to guard against doc-drift.
+    The docstring legitimately says "no OpenAI-Beta header" (describing removal)
+    and "legacy response.audio.delta accepted defensively", so we do NOT assert
+    bare-string absence of those substrings.  Instead we assert:
+      - The retired beta header VALUE ("realtime=v1") is absent.
+      - The GA primary event name ("response.output_audio.delta") is documented.
+      - The auth-only header pattern ("Authorization: Bearer") is documented.
+      - The string "GA" is present (explicitly marks the protocol generation).
+    """
+    import scenario.voice.adapters.openai_realtime as _mod
+
+    doc = _mod.__doc__
+    assert doc is not None, "Module docstring must be present"
+
+    # Retired beta header value must be gone from the docstring.
+    assert "realtime=v1" not in doc, (
+        "Module docstring must not document the retired beta header value 'realtime=v1'"
+    )
+
+    # GA primary audio-delta event name must be documented.
+    assert "response.output_audio.delta" in doc, (
+        "Module docstring must document the GA event name 'response.output_audio.delta'"
+    )
+
+    # Auth-only header pattern must be documented.
+    assert "Authorization: Bearer" in doc, (
+        "Module docstring must document the auth-only header 'Authorization: Bearer'"
+    )
+
+    # The protocol generation must be explicitly stated.
+    assert "GA" in doc, (
+        "Module docstring must explicitly reference GA (General Availability) protocol"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_realtime_adapter_session_update_keeps_tools_instructions_top_level():
+    """AC2 / issue #602 — tools and instructions are top-level under session, not under audio.
+
+    Constructs the adapter with both ``instructions`` and a tool, connects with a
+    mocked WebSocket, and inspects the session.update payload.  Asserts:
+      - ``session["instructions"]`` is the supplied string (top-level).
+      - ``session["tools"]`` is the supplied list (top-level).
+      - ``session["audio"]`` does not contain "instructions" or "tools".
+      - ``session`` does not contain "tool_choice" (the adapter does not set it).
+    """
+    tool = {"type": "function", "name": "f", "description": "d", "parameters": {"type": "object", "properties": {}}}
+    adapter = OpenAIRealtimeAgentAdapter(
+        instructions="be brief",
+        tools=[tool],
+        api_key="sk-test",
+    )
+
+    mock_ws = AsyncMock()
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+
+    first_send_raw = mock_ws.send.call_args_list[0][0][0]
+    payload = json.loads(first_send_raw)
+    assert payload["type"] == "session.update"
+    session = payload["session"]
+
+    # instructions and tools must be top-level under session.
+    assert session["instructions"] == "be brief", (
+        "instructions must be top-level under session"
+    )
+    assert session["tools"] == [tool], (
+        "tools must be top-level under session"
+    )
+
+    # Neither must appear nested under audio.
+    assert "instructions" not in session["audio"], (
+        "instructions must not be nested under session.audio"
+    )
+    assert "tools" not in session["audio"], (
+        "tools must not be nested under session.audio"
+    )
+
+    # The adapter does not set tool_choice.
+    assert "tool_choice" not in session, (
+        "adapter must not set tool_choice (not part of the GA session.update shape)"
+    )
+
+    await adapter.disconnect()
 
 
 @pytest.mark.asyncio

--- a/python/tests/voice/test_openai_realtime_agent_e2e.py
+++ b/python/tests/voice/test_openai_realtime_agent_e2e.py
@@ -1,11 +1,9 @@
 """
-E2E wrapper for Demo — OpenAI Realtime as the agent under test.
+E2E check — OpenAI Realtime adapter (AGENT role) against the GA Realtime API.
 
-AC: model plays the agent role and result.success is True.
-
-Note: transport is Phase-2 stub; skipped via capability probe on the adapter's
-send_audio path (connect/disconnect are wired, but audio I/O raises
-PendingTransportError until the real Realtime WebSocket transport ships).
+Integration / nightly, key-gated (``requires_llm``).  Runs the
+``openai_realtime_agent`` demo script end-to-end against the real OpenAI
+Realtime WebSocket API and asserts ``result.success`` is True.
 """
 
 from __future__ import annotations
@@ -19,29 +17,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice
 
 
 @pytest.mark.asyncio
-async def test_demo_openai_realtime_agent_e2e_success(requires_llm, requires_transport_ready):
+async def test_demo_openai_realtime_agent_e2e_success(requires_llm):
     """OpenAI Realtime adapter (AGENT role) runs; result.success is True."""
-    from scenario.voice import OpenAIRealtimeAgentAdapter
-    from scenario.voice.audio_chunk import AudioChunk
-    from scenario.voice.adapters._stub import PendingTransportError
-
-    # Probe the audio I/O path — connect/disconnect succeed on the stub, but
-    # send_audio raises PendingTransportError until the real transport ships.
-    adapter = OpenAIRealtimeAgentAdapter()
-    await adapter.connect()
-    try:
-        await adapter.send_audio(AudioChunk(data=b"\x00\x00"))
-    except PendingTransportError as exc:
-        await adapter.disconnect()
-        pytest.skip(f"transport not yet shipped: {exc}")
-    except Exception:
-        # Probe-only path: send_audio failed for some reason other than
-        # PendingTransportError (network, auth, etc). We swallow it here
-        # because the real test body below runs against the actual demo
-        # script; that will surface a richer error than the probe could.
-        pass
-    await adapter.disconnect()
-
     from openai_realtime_agent import main  # type: ignore[import]
 
     result = await main()

--- a/python/tests/voice/test_openai_realtime_user_e2e.py
+++ b/python/tests/voice/test_openai_realtime_user_e2e.py
@@ -1,12 +1,11 @@
 """
-E2E wrapper for Demo — OpenAI Realtime as the user simulator.
+E2E check — OpenAI Realtime adapter (USER role) against the GA Realtime API.
 
-AC: scripted user("text") lines are delivered with natural prosody;
-text TTS is bypassed for the user simulator; result.success is True.
-
-Note: transport is Phase-2 stub; skipped via capability probe on the adapter's
-send_audio path (connect/disconnect are wired, but audio I/O raises
-PendingTransportError until the real Realtime WebSocket transport ships).
+Integration / nightly, key-gated (``requires_llm``).  Runs the
+``openai_realtime_user`` demo script end-to-end against the real OpenAI
+Realtime WebSocket API and asserts ``result.success`` is True.  Verifies that
+scripted ``user("text")`` lines are delivered via the text-input channel
+(bypassing TTS) and that the full scenario completes successfully.
 """
 
 from __future__ import annotations
@@ -20,29 +19,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice
 
 
 @pytest.mark.asyncio
-async def test_demo_openai_realtime_user_e2e_success(requires_llm, requires_transport_ready):
+async def test_demo_openai_realtime_user_e2e_success(requires_llm):
     """OpenAI Realtime adapter (USER role) drives simulator; result.success is True."""
-    from scenario.voice import OpenAIRealtimeAgentAdapter
-    from scenario.voice.audio_chunk import AudioChunk
-    from scenario.voice.adapters._stub import PendingTransportError
-
-    # Probe the audio I/O path — connect/disconnect succeed on the stub, but
-    # send_audio raises PendingTransportError until the real transport ships.
-    adapter = OpenAIRealtimeAgentAdapter()
-    await adapter.connect()
-    try:
-        await adapter.send_audio(AudioChunk(data=b"\x00\x00"))
-    except PendingTransportError as exc:
-        await adapter.disconnect()
-        pytest.skip(f"transport not yet shipped: {exc}")
-    except Exception:
-        # Probe-only path: send_audio failed for some reason other than
-        # PendingTransportError (network, auth, etc). We swallow it here
-        # because the real test body below runs against the actual demo
-        # script; that will surface a richer error than the probe could.
-        pass
-    await adapter.disconnect()
-
     from openai_realtime_user import main  # type: ignore[import]
 
     result = await main()

--- a/specs/openai-realtime-ga-migration.feature
+++ b/specs/openai-realtime-ga-migration.feature
@@ -1,0 +1,192 @@
+Feature: OpenAIRealtimeAgentAdapter speaks the GA Realtime wire protocol
+  As a developer testing a voice agent against the OpenAI Realtime API
+  I want the adapter to use the GA wire protocol instead of the retired beta one
+  So that scenario.run() establishes a live session and exchanges turns
+  instead of being server-closed with 4000 / beta_api_shape_disabled
+
+  # Issue #602 — the adapter hardcoded the retired `OpenAI-Beta: realtime=v1`
+  # header and spoke the beta session/event schema end-to-end. OpenAI removed
+  # the beta Realtime interface globally on 2026-05-12 (GA), so every run was
+  # rejected. The beta coupling is three layers deep (handshake header →
+  # session.update payload → receive-loop event names) plus the module
+  # docstring; they must move together (no working intermediate state).
+  #
+  # Scope guards (NOT changed, per Investigation §3):
+  #   - Model constants already GA (gpt-realtime-mini / gpt-4o-transcribe).
+  #   - Client→server events unchanged: input_audio_buffer.append/.commit,
+  #     conversation.item.create (input_text/input_audio), response.create,
+  #     response.cancel.
+  #   - User-input transcription event name unchanged in GA
+  #     (conversation.item.input_audio_transcription.completed).
+  #   - TypeScript adapter unaffected (SDK owns the wire shape).
+  # Out of scope: ephemeral client-secret minting; @openai/agents SDK changes;
+  # Realtime/transcription model-name changes.
+
+  Background:
+    Given an OpenAIRealtimeAgentAdapter constructed with model "gpt-realtime-mini" and voice "alloy"
+
+  # ======================================================================
+  # AC1 — GA handshake, no beta header
+  # ======================================================================
+
+  @unit
+  Scenario: connect() opens the WebSocket with auth only and no OpenAI-Beta header
+    # Layer (a): the retired `OpenAI-Beta: realtime=v1` header must be gone.
+    Given the adapter has a resolved API key
+    When connect() opens the Realtime WebSocket
+    Then the handshake sends an "Authorization: Bearer <key>" header
+    And the handshake sends no "OpenAI-Beta" header
+    And the connect URL is "wss://api.openai.com/v1/realtime?model=gpt-realtime-mini"
+
+  @e2e
+  Scenario: A scenario run against the live GA endpoint is no longer rejected at the handshake
+    # End-state proof — requires a live OPENAI_API_KEY; cannot be reproduced offline.
+    Given a valid OPENAI_API_KEY and the adapter as the agent under test (role=AGENT)
+    When a scripted scenario runs via scenario.run()
+    Then the server does not close the socket with code 4000 / "beta_api_shape_disabled"
+    And the session reaches "session.created" / "session.updated"
+    And result.success is True
+
+  # ======================================================================
+  # AC2 — GA session.update shape
+  # ======================================================================
+
+  @unit
+  Scenario: connect() emits a GA-shaped session.update payload
+    # Layer (b): audio nested under session.audio.{input,output}; formats as
+    # objects; session.type required; voice/transcription/turn_detection relocated.
+    When connect() sends the initial session.update
+    Then session.type is "realtime"
+    And session.audio.input.format is the object {"type": "audio/pcm", "rate": 24000}
+    And session.audio.output.format is the object {"type": "audio/pcm", "rate": 24000}
+    And session.audio.output.voice is "alloy"
+    And session.audio.input.transcription.model is "gpt-4o-transcribe"
+    And session.audio.input.turn_detection is null
+    And no flat "input_audio_format" or "output_audio_format" string field is present
+    And tools and tool_choice remain top-level under session, not under audio
+
+  @integration
+  Scenario: The GA endpoint accepts the session.update with no session.audio error
+    # The beta bare-string format produced "Invalid type for
+    # 'session.audio.input.format': expected an object, but got a string".
+    Given a live GA Realtime session
+    When the adapter sends its GA-shaped session.update
+    Then no "invalid_request_error" referencing "session.audio.*" is returned
+
+  # ======================================================================
+  # AC3 — Audio receive under GA event names
+  # ======================================================================
+
+  @unit
+  Scenario: recv_audio returns decoded PCM16 from the GA audio-delta event
+    # Layer (c): the GA response-output stream name carries the `output_` infix.
+    Given the server emits a "response.output_audio.delta" event with base64 PCM16
+    When recv_audio is awaited
+    Then it returns an AudioChunk whose data is the decoded PCM16 bytes
+
+  @integration
+  Scenario: recv_audio defensively accepts the legacy audio-delta name and logs once
+    # Live gpt-realtime* may still emit the legacy beta name despite the docs.
+    Given the server emits the legacy "response.audio.delta" event with base64 PCM16
+    When recv_audio is awaited
+    Then it returns an AudioChunk whose data is the decoded PCM16 bytes
+    And a one-time log records that the legacy audio-delta name fired
+
+  # ======================================================================
+  # AC4 — Transcript observability preserved
+  # ======================================================================
+
+  @unit
+  Scenario: last_agent_transcript is populated from GA assistant-transcript events
+    # role=AGENT turn — GA names carry the `output_` infix.
+    Given the server emits "response.output_audio_transcript.delta" events then "response.output_audio_transcript.done"
+    When recv_audio processes the events
+    Then last_agent_transcript holds the assembled assistant transcript
+
+  @unit
+  Scenario: last_user_transcript is populated from the user transcription event
+    # role=USER turn — this event name is unchanged in GA.
+    Given the server emits "conversation.item.input_audio_transcription.completed" with a transcript
+    When recv_audio processes the event
+    Then last_user_transcript holds the user transcript text
+
+  # ======================================================================
+  # AC5 — Send + interrupt paths intact (client→server events unchanged in GA)
+  # ======================================================================
+
+  @unit
+  Scenario: Audio send commits the buffer and requests a response under GA
+    Given send_audio has appended PCM16 to the input buffer
+    When recv_audio runs with pending audio
+    Then "input_audio_buffer.append" was sent for the chunk
+    And "input_audio_buffer.commit" then "response.create" are sent before awaiting the reply
+
+  @unit
+  Scenario: Text send routes a user item then requests a response (role=USER)
+    Given the adapter is constructed with role=AgentRole.USER
+    When send_text("hello") is called
+    Then "conversation.item.create" is sent with a user message containing an "input_text" part "hello"
+    And "response.create" is sent immediately after
+
+  @unit
+  Scenario: interrupt() cancels the in-flight response under GA
+    Given a connected GA session
+    When interrupt() is called
+    Then "response.cancel" is sent on the socket
+
+  # ======================================================================
+  # AC6 — Tests assert the GA contract, not the beta one
+  # ======================================================================
+
+  @unit
+  Scenario: The adapter unit test asserts the GA session.update shape
+    Given python/tests/voice/test_adapters.py
+    Then it asserts session.type "realtime" and session.audio.{input,output}.format object shapes
+    And it no longer asserts flat "input_audio_format" == "pcm16" or "output_audio_format" == "pcm16"
+
+  @unit
+  Scenario: The adapter unit test feeds GA-named server events
+    Given python/tests/voice/test_adapters.py mock event streams
+    Then the audio-delta fixtures use "response.output_audio.delta"
+    And the assistant-transcript fixtures use "response.output_audio_transcript.delta" / ".done"
+
+  @integration
+  Scenario: A CI-runnable test fails if the adapter regresses to the beta wire shape
+    # The missing guard that let the regression ship — assertable with no live key.
+    Given no live OPENAI_API_KEY is available
+    When the adapter is regressed to emit a beta-shaped session.update or the beta header
+    Then a CI-runnable test fails
+
+  # ======================================================================
+  # AC7 — Docstring reflects GA
+  # ======================================================================
+
+  @unit
+  Scenario: The adapter module docstring documents the GA protocol
+    Given the module docstring of python/scenario/voice/adapters/openai_realtime.py
+    Then it does not document "OpenAI-Beta: realtime=v1" or "response.audio.delta"
+    And it documents the GA endpoint, the auth-only header, and the GA event names
+
+  # --- AC Coverage Map ---
+  # AC1 "GA handshake, no beta header" →
+  #   Scenario: connect() opens the WebSocket with auth only and no OpenAI-Beta header (@unit)
+  #   Scenario: A scenario run against the live GA endpoint is no longer rejected at the handshake (@e2e)
+  # AC2 "GA session.update shape" →
+  #   Scenario: connect() emits a GA-shaped session.update payload (@unit)
+  #   Scenario: The GA endpoint accepts the session.update with no session.audio error (@integration)
+  # AC3 "Audio receive under GA event names" →
+  #   Scenario: recv_audio returns decoded PCM16 from the GA audio-delta event (@unit)
+  #   Scenario: recv_audio defensively accepts the legacy audio-delta name and logs once (@integration)
+  # AC4 "Transcript observability preserved" →
+  #   Scenario: last_agent_transcript is populated from GA assistant-transcript events (@unit)
+  #   Scenario: last_user_transcript is populated from the user transcription event (@unit)
+  # AC5 "Send + interrupt paths intact" →
+  #   Scenario: Audio send commits the buffer and requests a response under GA (@unit)
+  #   Scenario: Text send routes a user item then requests a response (role=USER) (@unit)
+  #   Scenario: interrupt() cancels the in-flight response under GA (@unit)
+  # AC6 "Tests assert the GA contract, not the beta one" →
+  #   Scenario: The adapter unit test asserts the GA session.update shape (@unit)
+  #   Scenario: The adapter unit test feeds GA-named server events (@unit)
+  #   Scenario: A CI-runnable test fails if the adapter regresses to the beta wire shape (@integration)
+  # AC7 "Docstring reflects GA" →
+  #   Scenario: The adapter module docstring documents the GA protocol (@unit)

--- a/specs/openai-realtime-ga-migration.feature
+++ b/specs/openai-realtime-ga-migration.feature
@@ -63,7 +63,7 @@ Feature: OpenAIRealtimeAgentAdapter speaks the GA Realtime wire protocol
     And session.audio.input.transcription.model is "gpt-4o-transcribe"
     And session.audio.input.turn_detection is null
     And no flat "input_audio_format" or "output_audio_format" string field is present
-    And tools and tool_choice remain top-level under session, not under audio
+    And tools and instructions remain top-level under session, not under audio
 
   @integration
   Scenario: The GA endpoint accepts the session.update with no session.audio error
@@ -84,7 +84,7 @@ Feature: OpenAIRealtimeAgentAdapter speaks the GA Realtime wire protocol
     When recv_audio is awaited
     Then it returns an AudioChunk whose data is the decoded PCM16 bytes
 
-  @integration
+  @unit
   Scenario: recv_audio defensively accepts the legacy audio-delta name and logs once
     # Live gpt-realtime* may still emit the legacy beta name despite the docs.
     Given the server emits the legacy "response.audio.delta" event with base64 PCM16
@@ -150,7 +150,7 @@ Feature: OpenAIRealtimeAgentAdapter speaks the GA Realtime wire protocol
     Then the audio-delta fixtures use "response.output_audio.delta"
     And the assistant-transcript fixtures use "response.output_audio_transcript.delta" / ".done"
 
-  @integration
+  @unit
   Scenario: A CI-runnable test fails if the adapter regresses to the beta wire shape
     # The missing guard that let the regression ship — assertable with no live key.
     Given no live OPENAI_API_KEY is available
@@ -176,7 +176,7 @@ Feature: OpenAIRealtimeAgentAdapter speaks the GA Realtime wire protocol
   #   Scenario: The GA endpoint accepts the session.update with no session.audio error (@integration)
   # AC3 "Audio receive under GA event names" →
   #   Scenario: recv_audio returns decoded PCM16 from the GA audio-delta event (@unit)
-  #   Scenario: recv_audio defensively accepts the legacy audio-delta name and logs once (@integration)
+  #   Scenario: recv_audio defensively accepts the legacy audio-delta name and logs once (@unit)
   # AC4 "Transcript observability preserved" →
   #   Scenario: last_agent_transcript is populated from GA assistant-transcript events (@unit)
   #   Scenario: last_user_transcript is populated from the user transcription event (@unit)
@@ -187,6 +187,6 @@ Feature: OpenAIRealtimeAgentAdapter speaks the GA Realtime wire protocol
   # AC6 "Tests assert the GA contract, not the beta one" →
   #   Scenario: The adapter unit test asserts the GA session.update shape (@unit)
   #   Scenario: The adapter unit test feeds GA-named server events (@unit)
-  #   Scenario: A CI-runnable test fails if the adapter regresses to the beta wire shape (@integration)
+  #   Scenario: A CI-runnable test fails if the adapter regresses to the beta wire shape (@unit)
   # AC7 "Docstring reflects GA" →
   #   Scenario: The adapter module docstring documents the GA protocol (@unit)


### PR DESCRIPTION
## What & why

`scenario.OpenAIRealtimeAgentAdapter` (Python) spoke OpenAI's **retired beta** Realtime wire protocol, so every realtime run was server-closed at the handshake with `4000` / `beta_api_shape_disabled`. OpenAI removed the beta interface globally at GA (2026-05-12). This migrates the adapter to the **GA** wire protocol.

Fixes #602.

## The fix — three coupled layers (Python-only)

The beta coupling was three layers deep; they move together (there is no working intermediate state — a header-only fix just surfaces the next-layer rejection):

1. **Handshake** — drop the `OpenAI-Beta: realtime=v1` header (auth-only `Authorization: Bearer`).
2. **`session.update`** — GA shape: `session.type="realtime"`; audio nested under `session.audio.{input,output}`; formats as objects (`{"type":"audio/pcm","rate":24000}`); `voice` / `transcription` / `turn_detection` relocated under `session.audio`.
3. **`recv_audio`** — branch on the GA `response.output_audio.*` event names, **defensively** accepting the legacy `response.audio.*` names with a one-time warning (live `gpt-realtime*` models have been reported still emitting the beta names despite the GA docs).

Module + class docstrings updated to GA.

**Out of scope** (confirmed in the issue's Investigation): ephemeral client-secret minting; the TypeScript adapter; Realtime/transcription model renames.

## Tests

- **New regression guard** `test_openai_realtime_adapter_uses_ga_wire_protocol_not_beta` — verified **RED** against the beta code and **GREEN** post-fix; runs in CI with **no live key**. Closes the coverage gap that let the regression ship (the previous unit test asserted the beta shape and stayed green while prod was 100% broken).
- Defensive-legacy test (decodes the legacy name + asserts the one-time warning fires exactly once across repeats).
- `interrupt()` → `response.cancel`; send → `input_audio_buffer.commit` → `response.create` round-trip; GA transcript observability (`last_agent_transcript` / `last_user_transcript`).
- **Removed stale stub-era drift** from the realtime e2e tests (`*_e2e.py` carried a dead `PendingTransportError` probe + a "transport not yet shipped" docstring — misleading on the very adapter this PR fixes; they're now honest live, key-gated GA-handshake checks, still `integration`-marked → deselected in PR CI, run nightly).
- `specs/openai-realtime-ga-migration.feature` — 15 scenarios mapping all 7 ACs, now **bound 1:1 to tests**: split the AC4 transcript test into agent-side + user-side; added the previously-unbound AC7 docstring-drift guard and a tools/instructions top-level placement test; corrected two `@integration`→`@unit` tags (their tests are mocked, no-key) and a `tool_choice` over-spec. Every `@unit` scenario has a test; `@e2e`/`@integration` are live-gated.
- `python/tests/voice/test_adapters.py`: **60 passed** (17 realtime); `pyright`: **0 errors**.

## Review

Multi-agent `/review` (principles, hygiene, test, security): **zero must-fix**, security clean. Should-fix items addressed in this PR (test dedup, AC5 commit-sub-path coverage, hygiene conventions); minor nice-to-haves deferred with rationale.

## Scope verified (post-review diligence)

- **TS adapter is genuinely unaffected** — `@openai/agents` moved its Realtime transport to the GA interface at **0.1.0 (2025-08-28)**; the repo pins `^0.3.3` (and demo `^0.3.9`), both well past the cutover, and its event handler already uses the GA `response.output_audio.*` names. No TS-side beta-header fix needed.
- **Model names are valid GA** — `gpt-realtime-mini` and `gpt-4o-transcribe` are both current OpenAI models, so the live handshake won't fail on model-not-found.

## ✅ Caveat cleared — live GA handshake verified (2026-06-04)

The original `4000` / `beta_api_shape_disabled` close **is gone**. A live, key-gated `@e2e` GA realtime run was executed against the real OpenAI Realtime API (model `gpt-realtime-mini`) and reproduced **4×**, each time negotiating cleanly and closing normally — never `4000`. Wire-level evidence (`websockets` DEBUG):

```
> GET /v1/realtime?model=gpt-realtime-mini HTTP/1.1
> Authorization: Bearer sk-proj-…        # auth-only — no OpenAI-Beta header
< HTTP/1.1 101 Switching Protocols
= connection is OPEN                       # handshake ACCEPTED (beta era: server-closed here)
> TEXT {"type":"session.update", …}       # GA session shape
< TEXT {"type":"session.created", …}
< TEXT {"type":"session.updated", …}       # GA session.update accepted, no error event
… input_audio_buffer.append → .commit → response.create …
< TEXT {"type":"response.output_audio.delta", …}   # GA event name (legacy-compat arm never fired)
> CLOSE 1000 (OK)  /  < CLOSE 1000 (OK)    # normal client-initiated close — NOT 4000
result.success = True
```

No `4000`, no `beta_api_shape_disabled`, no `"type":"error"` frame anywhere in the captured stream. `test_demo_openai_realtime_agent_e2e_success` → **PASSED**.

**Lower-confidence GA details (Investigation §6) — now confirmed live:**
- `session.audio.output.format` carrying `rate` (`{"type":"audio/pcm","rate":24000}`) is **accepted** — server returned `session.updated` with no error.
- No `output_modalities` issue surfaced; the current session shape negotiated successfully.

**Scope note:** only the AGENT (direct-to-model) role opens a live socket and was verified live. The USER-role e2e (`test_openai_realtime_user_e2e`) `sys.exit(0)`s at a **pre-existing phase-2 skip-guard** (introduced in #355, predates this PR) before any socket opens — it shows as `FAILED` in the raw run but is unrelated to this handshake and to the GA migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

