### PR TITLE
fix(docs): include hidden files in Pages artifact so .vocs/ is served

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -100,9 +100,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "./docs/docs/dist"
+          include-hidden-files: true
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Why

The docs search and icons were 404ing on the deployed site (#632). The real root cause is `actions/upload-pages-artifact@v4.0.0`: its tar step runs `--exclude=".[^/]*"`, which strips every dot-prefixed path from the artifact before upload. So `.vocs/` (vocs's search index + icons) never reached the deployed site — everything under `.vocs/` returned 404. The GitHub Actions Pages pipeline does **not** run Jekyll, so the `.nojekyll` marker merged in #633 was placed at the wrong layer and had no effect (it was also stripped by the same tar exclude). This PR corrects both issues.

## What changed

- Bumped `actions/upload-pages-artifact` from v4.0.0 (`7b1f4a7`) to v5.0.0 (`fc324d3`) — v5.0.0 is the first version that exposes the `include-hidden-files` input.
- Set `include-hidden-files: true` on the upload step so `.vocs/` (and any other dot-prefixed paths) ships in the Pages artifact.
- Deleted `docs/docs/public/.nojekyll` — it was the wrong-layer fix from #633; with the Actions pipeline not running Jekyll, and the v5 `include-hidden-files` change being what actually fixes the 404s, this file is dead.

## Test plan

- YAML parses: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/deploy-docs.yml')); print('YAML_OK')"` → `YAML_OK` ✓
- The artifact-tar behavior and hidden-file inclusion can only be verified post-deploy (it's a CI-config change with no playable pre-merge artifact).

## How I can prove I was successful

No playable artifact pre-merge — this is a CI-config change. After merge and the Publish Docs workflow completes, verify on the live site:

```bash
JS=$(curl -s https://scenario-docs.langwatch.ai/ | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | head -1)
IDX=$(curl -s "https://scenario-docs.langwatch.ai${JS}" | grep -oE 'search-index-[0-9a-f]+\.json' | head -1)
curl -sI "https://scenario-docs.langwatch.ai/.vocs/${IDX}"          # expect 200 application/json (was 404 text/html)
curl -sI "https://scenario-docs.langwatch.ai/.vocs/icons/link.svg"  # expect 200 image/svg+xml
```

Then open https://langwatch.ai/scenario, type "judge" in the search box, and confirm results appear.

Refs #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)