### PR TITLE
fix(voice/sdk/#451): stop re-stringifying input_audio array in event-reporter

### DIFF
--- a/javascript/src/events/__tests__/event-reporter.test.ts
+++ b/javascript/src/events/__tests__/event-reporter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+
+import { EventReporter } from "../event-reporter";
+import { ScenarioEventType, type ScenarioEvent } from "../schema";
+
+/**
+ * Build a MESSAGE_SNAPSHOT event whose message carries ARRAY content with an
+ * OpenAI Realtime `input_audio` part.
+ *
+ * This is the runtime shape produced by `convertModelMessagesToAguiMessages`
+ * (commit 180bab4): array content with audio translated to `input_audio` so
+ * the langwatch ingest content-extractor can externalise the base64 bytes to
+ * stored-objects. AG-UI's `MessagesSnapshotEventSchema` types message
+ * `content` as `string`, so the array only exists at runtime — we cast at the
+ * boundary exactly like the converter does. The langwatch ingest schema
+ * accepts array content via `chatMessageSchema.content: union(string, array)`.
+ */
+function makeAudioSnapshotEvent(): ScenarioEvent {
+  const arrayContent = [
+    { type: "text", text: "Hello" },
+    {
+      type: "input_audio",
+      input_audio: {
+        data: "BASE64AUDIOBYTES",
+        format: "wav",
+        mimeType: "audio/wav",
+      },
+    },
+  ];
+
+  return {
+    type: ScenarioEventType.MESSAGE_SNAPSHOT,
+    timestamp: 1,
+    batchRunId: "batch-1",
+    scenarioId: "scenario-1",
+    scenarioRunId: "run-1",
+    scenarioSetId: "default",
+    messages: [
+      {
+        id: "msg-1",
+        role: "user",
+        // Runtime carries an array post-180bab4; AG-UI types content as string.
+        content: arrayContent as unknown as string,
+      },
+    ],
+  } as unknown as ScenarioEvent;
+}
+
+/**
+ * `processEventForApi` is private — exercise it through bracket access. This is
+ * the transform applied to every event immediately before the POST body is
+ * built in `postEvent`, so asserting its output asserts the wire shape.
+ */
+function processEventForApi(
+  reporter: EventReporter,
+  event: ScenarioEvent
+): ScenarioEvent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (reporter as any).processEventForApi(event);
+}
+
+describe("EventReporter.processEventForApi", () => {
+  const reporter = new EventReporter({
+    endpoint: "https://example.test",
+    apiKey: "test-key",
+  });
+
+  it("passes ARRAY message content through without JSON.stringify-ing it (input_audio stays an array part)", () => {
+    const event = makeAudioSnapshotEvent();
+
+    const processed = processEventForApi(reporter, event);
+
+    if (processed.type !== ScenarioEventType.MESSAGE_SNAPSHOT) {
+      throw new Error("expected a MESSAGE_SNAPSHOT event");
+    }
+
+    const content = processed.messages[0].content as unknown;
+
+    // Re-stringifying an array re-buries inline audio: the ingest extractor
+    // walks ARRAY content only, so a JSON-string array is skipped and the
+    // base64 persists inline (the 90 MB list-query bug). Content must stay an
+    // array so the extractor can externalise the audio.
+    expect(Array.isArray(content)).toBe(true);
+    expect(typeof content).not.toBe("string");
+    expect(content).toEqual([
+      { type: "text", text: "Hello" },
+      {
+        type: "input_audio",
+        input_audio: {
+          data: "BASE64AUDIOBYTES",
+          format: "wav",
+          mimeType: "audio/wav",
+        },
+      },
+    ]);
+  });
+
+  it("leaves plain string message content untouched", () => {
+    const event = {
+      type: ScenarioEventType.MESSAGE_SNAPSHOT,
+      timestamp: 1,
+      batchRunId: "batch-1",
+      scenarioId: "scenario-1",
+      scenarioRunId: "run-1",
+      scenarioSetId: "default",
+      messages: [{ id: "msg-1", role: "user", content: "just text" }],
+    } as unknown as ScenarioEvent;
+
+    const processed = processEventForApi(reporter, event);
+
+    if (processed.type !== ScenarioEventType.MESSAGE_SNAPSHOT) {
+      throw new Error("expected a MESSAGE_SNAPSHOT event");
+    }
+
+    expect(processed.messages[0].content).toBe("just text");
+  });
+});

--- a/javascript/src/events/event-reporter.ts
+++ b/javascript/src/events/event-reporter.ts
@@ -79,7 +79,26 @@ export class EventReporter {
 
   /**
    * Processes event data to ensure API compatibility.
-   * Converts message content objects to strings when needed.
+   *
+   * Message content normalisation:
+   *   - string  → passed through unchanged.
+   *   - array   → passed through unchanged (NOT JSON.stringify-ed). Array
+   *     content carries OpenAI Realtime `input_audio` parts produced by
+   *     `convertModelMessagesToAguiMessages` (commit 180bab4). The langwatch
+   *     ingest content-extractor walks ARRAY content only and externalises
+   *     inline audio to stored-objects; pre-stringifying re-buries those bytes
+   *     as a plain string the extractor skips, so the base64 persists inline
+   *     (the 90 MB getSuiteRunData / "audio not sending" bug). The ingest
+   *     schema accepts arrays via
+   *     `chatMessageSchema.content: union(string, array(chatRichContent))`, so
+   *     sending an array on the wire is schema-valid.
+   *   - other   → JSON.stringify-ed defensively (kept from PR #42's original
+   *     coercion for AG-UI's string-typed content).
+   *
+   *   AG-UI's `MessagesSnapshotEventSchema` types message `content` as
+   *   `string`, but post-180bab4 it carries arrays at runtime — the same
+   *   mismatch 180bab4 bridges with a cast at the conversion boundary. We cast
+   *   back here.
    */
   private processEventForApi(event: ScenarioEvent): ScenarioEvent {
     if (event.type === ScenarioEventType.MESSAGE_SNAPSHOT) {
@@ -87,13 +106,42 @@ export class EventReporter {
         ...event,
         messages: event.messages.map((message) => ({
           ...message,
-          content:
-            typeof message.content !== "string"
-              ? JSON.stringify(message.content)
-              : message.content,
+          // AG-UI types `content` as `string`; the normalised value may be an
+          // array (runtime audio content) or `undefined` (optional assistant
+          // content). Cast at the boundary like 180bab4's converter — the
+          // ingest schema accepts the union via `chatMessageSchema.content`.
+          content: normalizeMessageContent(message.content) as unknown as string,
         })),
       };
     }
     return event;
   }
+}
+
+/**
+ * Coerce a message's `content` into a wire-safe shape for /api/scenario-events.
+ *
+ * Strings and arrays pass through unchanged (arrays must survive intact so the
+ * ingest extractor can walk them and externalise inline `input_audio` — see
+ * `processEventForApi`). Any other runtime shape is JSON.stringify-ed.
+ *
+ * AG-UI types `content` as `string`; arrays only appear at runtime
+ * (post-180bab4), so the return is cast back to `string` at this boundary. The
+ * runtime payload is valid per the ingest `chatMessageSchema.content` union of
+ * string and array.
+ */
+function normalizeMessageContent(
+  content: string | undefined
+): string | undefined {
+  const runtimeContent = content as unknown;
+
+  if (
+    runtimeContent == null ||
+    typeof runtimeContent === "string" ||
+    Array.isArray(runtimeContent)
+  ) {
+    return runtimeContent as string | undefined;
+  }
+
+  return JSON.stringify(runtimeContent);
 }


### PR DESCRIPTION
## Why

**Closes #451.** The voice "see + listen" bug: an `input_audio` **array** message part was getting **re-stringified** in the JS SDK event reporter before being POSTed to langwatch, re-burying the base64 bytes inline. The langwatch ingest content-extractor walks **ARRAY content only** to externalise inline audio to stored-objects, so `JSON.stringify`-ing the array defeats externalisation and the base64 persists inline — the **~90 MB `getSuiteRunData` blow-up** ("audio not sending").

## What changed

- **`normalizeMessageContent` in `event-reporter.ts`** — **arrays, strings, `null`/`undefined` now pass through UN-stringified**; only **unknown object shapes** are `JSON.stringify`'d. Arrays must survive intact so the ingest extractor can walk them and externalise the inline `input_audio`.
- **Preserves PR #42's AG-UI string-coercion** for the non-array object case — the defensive `JSON.stringify` is kept for runtime shapes that are neither string nor array, so nothing regresses for AG-UI's `string`-typed `content`.
- Cast lives at the conversion boundary exactly like the converter in commit `180bab4` does — AG-UI types `content` as `string`, but post-`180bab4` it carries arrays at runtime; the ingest `chatMessageSchema.content` is a `union(string, array)`, so an array on the wire is schema-valid.

## Test plan

- **`javascript/src/events/__tests__/event-reporter.test.ts`** (new):
  - Asserts a `MESSAGE_SNAPSHOT` whose content is `[{type:"text"}, {type:"input_audio", ...}]` **survives un-stringified** through `processEventForApi` — `Array.isArray(content)` is `true`, `typeof content !== "string"`, and the `input_audio` part is byte-for-byte intact (**B-AC6**).
  - Asserts plain string content is left untouched.
- TS build/type verification runs via the **`javascript-ci`** workflow on this PR. Local toolchain: node/pnpm via nvm.

## How I can prove I was successful

**No playable artifact — pure SDK wire-shape fix** (the event reporter no longer corrupts the POST body shape; there is nothing to render/play). See the **Test plan** above and the **`javascript-ci`** vitest run on this PR for the proof that array `input_audio` content survives un-stringified.

## Anything surprising?

**Supersedes #601.** #601 carries the byte-identical narrow fix, but its head branch `fix/voice-event-reporter-audio-restringify` rides `experiment/ts-root-span-audio`, which **does not exist on origin** (local-only) — so **#601 cannot merge as-is**. This PR is the clean **single-commit extraction off `main`** with the same narrow diff. #601 is left open for the author to close.
