### PR TITLE
feat(voice/#597): voice-mode user-simulator prompt — spoken sentences, not telegraphic

### DIFF
--- a/python/scenario/user_simulator_agent.py
+++ b/python/scenario/user_simulator_agent.py
@@ -373,7 +373,24 @@ class UserSimulatorAgent(AgentAdapter):
             {
                 "role": "system",
                 "content": (self.system_prompt + persona_block) if self.system_prompt
-                else f"""
+                else (f"""
+<role>
+You are pretending to be a user, you are testing an AI Agent (shown as the user role) based on a scenario.
+You are SPEAKING on a phone call — your words will be read aloud by text-to-speech — so talk the way a real person speaks aloud: in full, natural spoken sentences with normal capitalization and punctuation, full clauses, not telegraphic search-query fragments.
+</role>
+
+<goal>
+Your goal (assistant) is to interact with the Agent Under Test (user) as if you were a human user to see if it can complete the scenario successfully.
+</goal>
+
+<scenario>
+{scenario.description}
+</scenario>
+
+<rules>
+- DO NOT carry over any requests yourself, YOU ARE NOT the assistant today, you are the user, send the user message and just STOP.
+</rules>
+{persona_block}""" if self.voice else f"""
 <role>
 You are pretending to be a user, you are testing an AI Agent (shown as the user role) based on a scenario.
 Approach this naturally, as a human user would, with very short inputs, few words, all lowercase, imperative, not periods, like when they google or talk to chatgpt.
@@ -390,7 +407,7 @@ Your goal (assistant) is to interact with the Agent Under Test (user) as if you 
 <rules>
 - DO NOT carry over any requests yourself, YOU ARE NOT the assistant today, you are the user, send the user message and just STOP.
 </rules>
-{persona_block}""",
+{persona_block}"""),
             },
             {"role": "assistant", "content": "Hello, how can I help you today?"},
             *_strip_audio_content(input.messages),

--- a/python/tests/voice/test_user_sim_voice_prompt.py
+++ b/python/tests/voice/test_user_sim_voice_prompt.py
@@ -1,0 +1,157 @@
+"""
+System-prompt tests for UserSimulatorAgent VOICE mode (issue #597).
+
+The default user-simulator system prompt is text-chat-style ("very short
+inputs, few words, all lowercase, imperative, not periods, like when they
+google or talk to chatgpt"). That telegraphic style is wrong for TTS voice
+scenarios — spoken users use full clauses, not lowercase-no-punctuation
+search fragments. The fix (a coder will land it) adds a VOICE-mode prompt
+variant selected when ``self.voice`` is set.
+
+These tests assert on the SYSTEM PROMPT actually sent to the model — fully
+deterministic, no live LLM. They use the same seam as
+``tests/test_user_simulator_agent.py``: monkeypatch
+``scenario.user_simulator_agent.litellm.completion`` with a mock, call
+``await sim.call(...)``, then read the captured system prompt at
+``mock_completion.call_args.kwargs["messages"][0]["content"]``.
+
+``reverse_roles`` (applied just before the completion call) leaves the
+system message untouched at index 0, so index 0 is the system prompt.
+
+Voice mode: ``call()`` runs the generated text through ``_voiceify``, which
+performs a live TTS ``synthesize`` call. We patch ``scenario.voice.synthesize``
+(imported lazily inside ``_voiceify``) so no network/TTS happens — the prompt
+is already captured by the time TTS would run.
+
+Baseline expectation against UNMODIFIED code:
+    P-AC1, P-AC2, P-AC4b  -> RED (no voice prompt variant exists yet)
+    P-AC3, P-AC4a         -> GREEN (today's behavior)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from scenario import UserSimulatorAgent
+from scenario.cache import context_scenario
+from scenario.types import AgentInput
+from scenario.voice import AudioChunk
+
+# A valid non-None voice id (same value the existing voice plumbing tests use).
+VOICE_ID = "openai/nova"
+MODEL = "openai/gpt-4.1-mini"
+
+
+def _agent_input() -> AgentInput:
+    """An AgentInput with a stub scenario_state (mirrors the seam test)."""
+    scenario_state = MagicMock()
+    scenario_state.description = "Caller wants to book a table for two tonight"
+    return AgentInput(
+        thread_id="test",
+        messages=[],
+        new_messages=[],
+        scenario_state=scenario_state,
+    )
+
+
+def _mock_completion_response() -> MagicMock:
+    """A litellm.completion return whose content is a real non-empty string,
+    so the voice path exercises _voiceify (which we stub) rather than its
+    early-return-on-empty branch."""
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = "hi, id like to book a table"
+    return response
+
+
+async def _capture_system_prompt(sim: UserSimulatorAgent) -> str:
+    """Drive ``sim.call`` through the mocked seam and return the system prompt
+    (``messages[0]["content"]``) that was sent to ``litellm.completion``.
+
+    ``scenario.voice.synthesize`` is stubbed so voice-mode agents never make a
+    live TTS call; the prompt is captured regardless of voice mode.
+    """
+    # The @scenario_cache decorator reads context_scenario; a cache_key of None
+    # disables caching so the mocked completion always runs.
+    mock_executor = MagicMock()
+    mock_executor.config = MagicMock()
+    mock_executor.config.cache_key = None
+    token = context_scenario.set(mock_executor)
+    try:
+        with patch(
+            "scenario.user_simulator_agent.litellm.completion",
+            return_value=_mock_completion_response(),
+        ) as mock_completion, patch(
+            "scenario.voice.synthesize",
+            new=AsyncMock(return_value=AudioChunk(data=b"", transcript="x")),
+        ):
+            await sim.call(_agent_input())
+
+        assert mock_completion.called, "litellm.completion was never called"
+        return mock_completion.call_args.kwargs["messages"][0]["content"]
+    finally:
+        context_scenario.reset(token)
+
+
+# --------------------------------------------------------------------------- #
+# P-AC1 — voice prompt is spoken-style (RED today)                            #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_voice_prompt_is_spoken_style():
+    sim = UserSimulatorAgent(model=MODEL, voice=VOICE_ID)
+    prompt = await _capture_system_prompt(sim)
+    assert "SPEAKING on a phone" in prompt
+    assert "full clauses" in prompt
+
+
+# --------------------------------------------------------------------------- #
+# P-AC2 — telegraphic text-chat copy is GONE in voice mode (LOAD-BEARING, RED)#
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_voice_prompt_drops_text_chat_copy():
+    sim = UserSimulatorAgent(model=MODEL, voice=VOICE_ID)
+    prompt = await _capture_system_prompt(sim)
+    assert "all lowercase" not in prompt
+    assert "not periods" not in prompt
+    assert "like when they google" not in prompt
+
+
+# --------------------------------------------------------------------------- #
+# P-AC3 — text mode unchanged (regression guard, GREEN today)                 #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_text_prompt_unchanged_when_voice_unset():
+    sim = UserSimulatorAgent(model=MODEL)
+    assert sim.voice is None  # precondition: voice genuinely unset
+    prompt = await _capture_system_prompt(sim)
+    assert "all lowercase, imperative, not periods" in prompt
+
+
+# --------------------------------------------------------------------------- #
+# P-AC4a — voice + custom system_prompt short-circuits (regression, GREEN)    #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_voice_with_custom_system_prompt_short_circuits():
+    sim = UserSimulatorAgent(
+        model=MODEL,
+        voice=VOICE_ID,
+        system_prompt="SENTINEL_CUSTOM_PROMPT_XYZ",
+    )
+    prompt = await _capture_system_prompt(sim)
+    assert "SENTINEL_CUSTOM_PROMPT_XYZ" in prompt
+    assert "SPEAKING on a phone" not in prompt
+
+
+# --------------------------------------------------------------------------- #
+# P-AC4b — voice + persona composes with the voice variant (RED today)        #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_voice_with_persona_composes():
+    sim = UserSimulatorAgent(
+        model=MODEL,
+        voice=VOICE_ID,
+        persona="SENTINEL_PERSONA_XYZ",
+    )
+    prompt = await _capture_system_prompt(sim)
+    assert "SPEAKING on a phone" in prompt
+    assert "SENTINEL_PERSONA_XYZ" in prompt


### PR DESCRIPTION
## Why

Closes #597. The default `UserSimulatorAgent` system prompt is **text-chat-shaped** — it tells the simulated user to talk *"with very short inputs, few words, all lowercase, imperative, not periods, like when they google or talk to chatgpt."* Piped through **TTS** for a voice scenario, that produces telegraphic search-query utterances ("flight status tomorrow") instead of how a person actually speaks aloud ("hey, can you tell me if my flight tomorrow is still on time?"). This makes voice scenarios unrealistic.

## What changed

- **Branch the `<role>` block on `self.voice`** (Python only): when voice is set **and** no custom `system_prompt` is supplied, the simulator is told it is **SPEAKING on a phone call** — *"full, natural spoken sentences with normal capitalization and punctuation, full clauses, not telegraphic search-query fragments."* Text mode keeps the existing google/chatgpt phrasing **verbatim**.
- **Prompt-only fix, not a markdown strip.** An AC review confirmed the failure mode is *telegraphic phrasing*, not markdown leaking into TTS — so the change rewrites the style instructions rather than post-processing the output.
- **`<goal>` / `<scenario>` / `<rules>` / persona block stay shared** across both modes — only the `<role>` style guidance forks, keeping the two prompts in lock-step on everything else.
- The custom-`system_prompt` short-circuit is **untouched**: a user-provided prompt still wins in both modes.

## Test plan

`python/tests/voice/test_user_sim_voice_prompt.py` — 5 tests pinning the split (added in this PR, commit `800b36d`):

| AC | Test | Asserts | Today |
|----|------|---------|-------|
| **P-AC1** | `test_voice_prompt_is_spoken_style` | voice prompt instructs **spoken, full-sentence** style | red → green |
| **P-AC2** | `test_voice_prompt_drops_text_chat_copy` | the telegraphic *"google or talk to chatgpt"* copy is **GONE** in voice mode — the load-bearing red→green flip | red → green |
| **P-AC3** | `test_text_prompt_unchanged_when_voice_unset` | text mode prompt is **byte-for-byte unchanged** (regression guard) | green |
| **P-AC4a** | `test_voice_with_custom_system_prompt_short_circuits` | custom `system_prompt` still short-circuits in **both** modes | green |
| **P-AC4b** | `test_voice_with_persona_composes` | voice + persona **composes** with the voice variant | red → green |

```
$ uv run pytest tests/voice/test_user_sim_voice_prompt.py tests/voice/test_user_sim_voice.py -q
...........                                                              [100%]
11 passed, 2 warnings in 0.05s
```

5 new + 6 existing voice-sim tests = **11 green**. `uv run pyright .` → **0 errors, 0 warnings**.

## How I can prove I was successful

**No playable artifact — this is a pure prompt change; see Test plan.** The demonstration is **P-AC2**: it fails on `origin/main` (the telegraphic text-chat copy is present in the voice prompt) and passes after this change (it's gone) — the red→green flip is the proof the search-query style is no longer emitted in voice mode.

## Anything surprising?

**TypeScript leg is deferred** — TS has no `voice` config seam to branch on yet: `TestingAgentConfig` exposes no `voice` field and `VoiceAgentAdapter.call()` is still abstract (part of #372 PR1). Porting this prompt split to TS is tracked as a follow-up on https://github.com/langwatch/scenario/issues/372. This PR is intentionally **Python-only**.
