### PR TITLE
fix(voice): hosted ElevenLabs single-exchange ceiling — docs + enriched timeout error

### DIFF
--- a/docs/docs/pages/voice/getting-started.mdx
+++ b/docs/docs/pages/voice/getting-started.mdx
@@ -58,6 +58,8 @@ The assistant reads your codebase, detects which voice transport your agent is o
 
 Here's what the generated test looks like for a **Pipecat WS bot**, the most common path — the `url` is the connection point to YOUR running bot:
 
+> **Note:** `proceed()` drives auto-generated turns reliably on composable/pipecat/realtime voice adapters, but **not** on the hosted `elevenLabsAgent` (single-exchange only — see the [multi-turn recipe](/voice/recipes/multi-turn)).
+
 :::code-group
 
 ```python [python]
@@ -114,7 +116,7 @@ async def test_voice_agent_handles_billing_question():
         script=[
             scenario.agent(),
             scenario.user(),
-            scenario.proceed(turns=5),
+            scenario.proceed(turns=5),  # not reliable on hosted elevenLabsAgent — see multi-turn recipe
             scenario.judge(),
         ],
     )
@@ -176,7 +178,7 @@ describe("Voice agent — billing inquiry", () => {
         script: [
           scenario.agent(),
           scenario.user(),
-          scenario.proceed(5),
+          scenario.proceed(5),  // not reliable on hosted elevenLabsAgent — see multi-turn recipe
           scenario.judge(),
         ],
       });

--- a/docs/docs/pages/voice/getting-started.mdx
+++ b/docs/docs/pages/voice/getting-started.mdx
@@ -116,7 +116,7 @@ async def test_voice_agent_handles_billing_question():
         script=[
             scenario.agent(),
             scenario.user(),
-            scenario.proceed(turns=5),  # not reliable on hosted elevenLabsAgent — see multi-turn recipe
+            scenario.proceed(turns=5),
             scenario.judge(),
         ],
     )
@@ -178,7 +178,7 @@ describe("Voice agent — billing inquiry", () => {
         script: [
           scenario.agent(),
           scenario.user(),
-          scenario.proceed(5),  // not reliable on hosted elevenLabsAgent — see multi-turn recipe
+          scenario.proceed(5),
           scenario.judge(),
         ],
       });

--- a/docs/docs/pages/voice/happy-path-elevenlabs.mdx
+++ b/docs/docs/pages/voice/happy-path-elevenlabs.mdx
@@ -74,6 +74,7 @@ async def test_greeting_is_warm():
             ),
         ],
         script=[
+            scenario.agent(),  # greeting drains first (EL sends first_message on connect)
             scenario.user("Hi, I have a question about my account"),
             scenario.agent(),
             scenario.judge(),

--- a/docs/docs/pages/voice/recipes/multi-turn.mdx
+++ b/docs/docs/pages/voice/recipes/multi-turn.mdx
@@ -7,6 +7,12 @@ import { Callout } from "vocs/components";
 
 # Multi-Turn Conversations
 
+<Callout type="warning">
+**Multi-turn is not supported on hosted `elevenLabsAgent` (ElevenLabs Conversational AI).** That transport is server-VAD-driven: it segments turns from a continuous audio stream, so a *scripted* second `user()` turn after the agent has already replied does not re-engage its turn-taking, and the next `agent()` fails with `receiveAudio timed out`. Hosted ElevenLabs supports only a **single greeting-led exchange** (`agent() → user() → agent() → judge()`) — see [happy-path-elevenlabs](/voice/happy-path-elevenlabs) and [troubleshooting](/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs).
+
+**For multi-turn voice, use a composable adapter with full in-process turn control:** `ElevenLabsVoiceAgent` (ElevenLabs STT + LLM + ElevenLabs TTS), `pipecatAgent`, Gemini Live, or OpenAI Realtime. `proceed(n)` is also reliable on these adapters but NOT on hosted `elevenLabsAgent`. The script below is validated on those adapters — the worked example uses `pipecatAgent`.
+</Callout>
+
 This recipe shows how to script a voice scenario with multiple back-and-forth turns, and
 how to configure the `JudgeAgent` to verify the agent maintains conversational continuity
 across turns — not just that individual replies are coherent, but that the second reply

--- a/docs/docs/pages/voice/troubleshooting.mdx
+++ b/docs/docs/pages/voice/troubleshooting.mdx
@@ -186,6 +186,22 @@ never appended to the internal `VoiceRecording` buffer, so `save_segments()`
 
 ---
 
+## `receiveAudio timed out` (hosted ElevenLabs) {#receiveaudio-timed-out-hosted-elevenlabs}
+
+If a hosted `elevenLabsAgent` scenario fails with `ElevenLabsAgentAdapter: receiveAudio timed out`, you almost certainly scripted **more than one `user()` turn**. The hosted ElevenLabs Conversational AI transport is **server-VAD-driven** and supports only a **single greeting-led exchange**: a scripted second `user()` turn does not re-engage the server's turn-taking, so the following `agent()` waits for a response that never arrives and times out.
+
+**Fix:**
+- Use the single greeting-led shape: `agent() → user("...") → agent() → judge()`. **Lead with `agent()`** so the on-connect greeting (`first_message`) drains before your user audio hits the wire.
+- For genuine **multi-turn** voice (more than one user→agent exchange), switch to a composable adapter — `ElevenLabsVoiceAgent`, `pipecatAgent`, Gemini Live, or OpenAI Realtime — which own turn-taking in-process. See the [multi-turn recipe](/voice/recipes/multi-turn).
+
+---
+
+## "Audio duration mismatch" / "non-continuous audio input" warning
+
+This warning is emitted **by the ElevenLabs server, not the Scenario SDK**. It is benign: it reflects that a *scripted* voice turn sends a discrete speech chunk plus a short silence pad rather than the continuous microphone stream ElevenLabs' VAD expects. It does not by itself indicate an SDK bug, and the single greeting-led exchange completes normally despite it. If you also see `receiveAudio timed out`, the cause is the multi-turn limitation above, not this warning.
+
+---
+
 ## Historical fixes
 
 <details>

--- a/docs/docs/pages/voice/troubleshooting.mdx
+++ b/docs/docs/pages/voice/troubleshooting.mdx
@@ -186,7 +186,7 @@ never appended to the internal `VoiceRecording` buffer, so `save_segments()`
 
 ---
 
-## `receiveAudio timed out` (hosted ElevenLabs) {#receiveaudio-timed-out-hosted-elevenlabs}
+## `receiveAudio timed out` (hosted ElevenLabs)
 
 If a hosted `elevenLabsAgent` scenario fails with `ElevenLabsAgentAdapter: receiveAudio timed out`, you almost certainly scripted **more than one `user()` turn**. The hosted ElevenLabs Conversational AI transport is **server-VAD-driven** and supports only a **single greeting-led exchange**: a scripted second `user()` turn does not re-engage the server's turn-taking, so the following `agent()` waits for a response that never arrives and times out.
 

--- a/javascript/.env.example
+++ b/javascript/.env.example
@@ -1,0 +1,23 @@
+# Copy to .env and fill in. .env is gitignored.
+OPENAI_API_KEY=
+LANGWATCH_API_KEY=
+
+# Voice e2e tests (issue #350)
+# Twilio — required for adapter tests
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
+
+# ElevenLabs — required for adapter and STT
+ELEVENLABS_API_KEY=
+ELEVENLABS_AGENT_ID=
+
+# Gemini
+GEMINI_API_KEY=
+
+# Pipecat
+PIPECAT_BOT_URL=
+
+# Logging
+SCENARIO_LOG_LEVEL=
+SCENARIO_LOG_FILE=

--- a/javascript/examples/vitest/tests/voice/repro-638-hosted-multiturn.test.ts
+++ b/javascript/examples/vitest/tests/voice/repro-638-hosted-multiturn.test.ts
@@ -1,0 +1,80 @@
+// Repro for https://github.com/langwatch/scenario/issues/638 — a 2nd scripted user turn on a hosted elevenLabsAgent should time out with `receiveAudio timed out`. Standalone; does not modify the canonical elevenlabs-hosted.test.ts.
+
+import scenario, { type ScenarioResult } from "@langwatch/scenario";
+import { describe, it, expect } from "vitest";
+
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+const hasHostedKey = Boolean(ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY);
+
+describe("repro #638 — hosted elevenLabsAgent 2nd scripted user turn", () => {
+  it(
+    "hosted agent: a 2nd scripted user turn times out (repro #638)",
+    async () => {
+      if (!hasHostedKey) {
+        console.log("SKIP: no hosted creds");
+        return;
+      }
+
+      let caught: unknown = null;
+      let result: ScenarioResult | null = null;
+
+      try {
+        result = await scenario.run({
+          name: "repro_638_hosted_multiturn",
+          description:
+            "Repro for #638: a second scripted user() turn on a hosted " +
+            "elevenLabsAgent. The hosted ConvAI transport is server-VAD-driven; " +
+            "after the agent has already replied, a second scripted user turn " +
+            "does not reliably re-engage the server's turn-taking, causing the " +
+            "next agent() receive to time out with 'receiveAudio timed out'.",
+          agents: [
+            scenario.elevenLabsAgent({
+              agentId: ELEVENLABS_AGENT_ID!,
+              apiKey: ELEVENLABS_API_KEY!,
+            }),
+            scenario.userSimulatorAgent({ voice: "openai/nova" }),
+            scenario.judgeAgent({
+              criteria: [
+                "The conversation completed multiple coherent turns",
+              ],
+            }),
+          ],
+          // KEY difference from the canonical hosted test: a SECOND scripted
+          // user/agent pair. On a hosted ConvAI agent the next agent() after the
+          // 2nd scripted user turn is expected to throw "receiveAudio timed out".
+          script: [
+            scenario.agent(),                                                // greeting drains
+            scenario.user("Hello, I have a question about my account."),
+            scenario.agent(),                                                // 1st reply — works
+            scenario.user("Great — can I also switch to an annual plan?"),   // 2nd scripted user turn
+            scenario.agent(),                                                // EXPECTED: receiveAudio timed out here
+            scenario.judge(),
+          ],
+          maxTurns: 8,
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      // Log whichever happened so the run output is self-explanatory:
+      if (caught) {
+        console.log("[repro#638] THREW:", (caught as Error)?.message ?? caught);
+      } else {
+        console.log(
+          "[repro#638] completed without throw; success=",
+          result?.success,
+          "reasoning=",
+          result?.reasoning,
+        );
+      }
+
+      // We EXPECT the 2nd agent() to time out on hosted ConvAI (the bug). If it does NOT throw,
+      // that is itself a finding (the ceiling may have changed). Record, don't hard-fail.
+      expect(caught !== null || result !== null, "neither threw nor returned").toBe(true);
+    },
+    180_000,
+  );
+});

--- a/javascript/src/agents/__tests__/user-simulator-no-voice-warning.test.ts
+++ b/javascript/src/agents/__tests__/user-simulator-no-voice-warning.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Focused unit test for AC7 of issue #638:
+ * UserSimulatorAgent.voiceifyText with NO voice resolved must
+ * (a) return the text message unchanged and
+ * (b) emit a console.warn containing "no voice resolved".
+ *
+ * Empty-text is a legitimate no-op — no warn expected in that case.
+ * Keyless: no LLM/TTS calls are made.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { userSimulatorAgent } from "../user-simulator-agent";
+
+// Mock getProjectConfig so the module loads without a real filesystem config.
+vi.mock("../../config", () => ({
+  getProjectConfig: vi.fn().mockResolvedValue({
+    defaultModel: { model: "openai/gpt-4.1-mini", temperature: 0 },
+  }),
+}));
+
+describe("UserSimulatorAgent.voiceifyText — no voice resolved (AC7 #638)", () => {
+  it("warns and returns text when no voice resolves", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // No voice in config, no run-level voice → no voice resolves.
+    const sim = userSimulatorAgent({});
+    const msg = await sim.voiceifyText("Hello, I have a question.");
+
+    expect(msg.role).toBe("user");
+    expect(msg.content).toBe("Hello, I have a question.");
+
+    expect(warn).toHaveBeenCalled();
+    const calledWithNoVoice = warn.mock.calls.some((args) =>
+      typeof args[0] === "string" && args[0].includes("no voice resolved"),
+    );
+    expect(calledWithNoVoice).toBe(true);
+
+    warn.mockRestore();
+  });
+
+  it("does NOT warn when text is empty", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const sim = userSimulatorAgent({});
+    const msg = await sim.voiceifyText("");
+
+    expect(msg.role).toBe("user");
+    expect(msg.content).toBe("");
+
+    const warnedNoVoice = warn.mock.calls.some((args) =>
+      typeof args[0] === "string" && args[0].includes("no voice resolved"),
+    );
+    expect(warnedNoVoice).toBe(false);
+
+    warn.mockRestore();
+  });
+});

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -256,7 +256,17 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
   ): Promise<ModelMessage> {
     const voice = this.cfg?.voice ?? runVoiceConfig?.tts?.voice;
     const textMessage: ModelMessage = { role: "user", content: text };
-    if (!voice || !text) return textMessage;
+    if (!voice || !text) {
+      if (!voice && text) {
+        console.warn(
+          "[scenario] UserSimulatorAgent.voiceifyText: no voice resolved — " +
+            "sending a TEXT user turn to the agent under test. A voice agent " +
+            "(e.g. ElevenLabs) will receive text, not audio. Set `voice` on the " +
+            "UserSimulatorAgent (e.g. { voice: 'openai/nova' }) or via run-level voice config.",
+        );
+      }
+      return textMessage;
+    }
     return this.synthesizeToAudioMessage(text, voice);
   }
 
@@ -269,7 +279,17 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
     input: AgentInput,
   ): Promise<ModelMessage> {
     const voice = this.effectiveVoice(input);
-    if (!voice) return textMessage;
+    if (!voice) {
+      const c = typeof textMessage.content === "string" ? textMessage.content : "";
+      if (c) {
+        console.warn(
+          "[scenario] UserSimulatorAgent.voiceify: no voice resolved — sending a " +
+            "TEXT user turn to the agent under test. A voice agent will receive " +
+            "text, not audio. Set `voice` on the UserSimulatorAgent or run config.",
+        );
+      }
+      return textMessage;
+    }
 
     const content =
       typeof textMessage.content === "string" ? textMessage.content : "";

--- a/javascript/src/voice/__tests__/elevenlabs-hosted-shape.guard.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-hosted-shape.guard.test.ts
@@ -1,0 +1,118 @@
+// Ungated CI guard for #638 — keyless, no live keys. Proves the hosted example
+// stays single greeting-led (AC8), the composable example stays multi-turn (AC9),
+// and the adapter timeout error is enriched (AC6). Fails if the bug pattern
+// (2nd user turn on hosted) is reintroduced.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+const EXAMPLE_FILE = path.resolve(
+  __dirname,
+  "../../../examples/vitest/tests/voice/elevenlabs-hosted.test.ts",
+);
+
+const ADAPTER_FILE = path.resolve(__dirname, "../adapters/elevenlabs.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the `script: [ ... ]` block from a named Scenario block.
+ * Finds the scenario by its title string, then locates the first `script: [`
+ * that follows it, and walks forward counting bracket depth until the closing
+ * `]` of the script array.
+ */
+function extractScriptBlock(source: string, scenarioTitle: string): string {
+  const titleIdx = source.indexOf(scenarioTitle);
+  if (titleIdx === -1) {
+    throw new Error(
+      `Guard: could not locate scenario "${scenarioTitle}" in example file — ` +
+        `the guard regex needs updating or the scenario was renamed.`,
+    );
+  }
+
+  const afterTitle = source.slice(titleIdx);
+
+  // Find the first `script: [` after the title.
+  const scriptMatch = afterTitle.match(/script:\s*\[/);
+  if (!scriptMatch || scriptMatch.index === undefined) {
+    throw new Error(
+      `Guard: could not find "script: [" after scenario "${scenarioTitle}" — ` +
+        `the example's script block shape changed.`,
+    );
+  }
+
+  const scriptStart = scriptMatch.index + scriptMatch[0].length - 1; // position of the opening `[`
+  let depth = 0;
+  let end = -1;
+
+  for (let i = scriptStart; i < afterTitle.length; i++) {
+    if (afterTitle[i] === "[") depth++;
+    else if (afterTitle[i] === "]") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+
+  if (end === -1) {
+    throw new Error(
+      `Guard: unbalanced brackets in script block for scenario "${scenarioTitle}".`,
+    );
+  }
+
+  return afterTitle.slice(scriptStart, end + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("elevenlabs-hosted-shape guard (#638)", () => {
+  it("AC8 — hosted example is greeting-led single exchange", () => {
+    const source = fs.readFileSync(EXAMPLE_FILE, "utf-8");
+    const block = extractScriptBlock(source, "Demo — ElevenLabs hosted Conversational AI");
+
+    // Count occurrences of scenario.user( in the hosted script block.
+    const userTurns = (block.match(/scenario\.user\(/g) ?? []).length;
+    expect(userTurns).toBe(1);
+
+    // The FIRST scenario. step in the block must be scenario.agent() — greeting-led.
+    // Strip leading `[` and whitespace, then match the first method call.
+    const firstStepMatch = block.match(/scenario\.(\w+)\(/);
+    expect(firstStepMatch).not.toBeNull();
+    expect(firstStepMatch![1]).toBe("agent");
+  });
+
+  it("AC9 — composable/branded example proves multi-turn", () => {
+    const source = fs.readFileSync(EXAMPLE_FILE, "utf-8");
+    const block = extractScriptBlock(source, "Demo — ElevenLabs composable + branded agent");
+
+    const userTurns = (block.match(/scenario\.user\(/g) ?? []).length;
+    const agentTurns = (block.match(/scenario\.agent\(/g) ?? []).length;
+
+    expect(userTurns).toBeGreaterThanOrEqual(2);
+    expect(agentTurns).toBeGreaterThanOrEqual(2);
+  });
+
+  it("AC6 — adapter timeout error is enriched with context", () => {
+    // Read the source (not the compiled output) and assert all three diagnostic
+    // substrings appear. The message is spread across string literals joined by
+    // `+`; normalize away the concatenation by stripping ` + ` boundaries.
+    const source = fs.readFileSync(ADAPTER_FILE, "utf-8");
+    // Collapse " +\n<whitespace>" joins so we can match across literal boundaries.
+    const collapsed = source.replace(/"\s*\+\s*\n\s*"/g, "");
+
+    expect(collapsed).toContain("receiveAudio timed out");
+    // "Hosted ElevenLabs " lives in one literal, "ConvAI" in the next.
+    // After collapsing the join both appear in sequence.
+    expect(collapsed).toContain("Hosted ElevenLabs");
+    expect(collapsed).toContain("ConvAI");
+    expect(collapsed).toContain("single exchange");
+  });
+});

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -271,7 +271,17 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
       timer = setTimeout(() => {
         const idx = this.waiters.indexOf(waiter);
         if (idx >= 0) this.waiters.splice(idx, 1);
-        reject(new Error("ElevenLabsAgentAdapter: receiveAudio timed out"));
+        reject(
+          new Error(
+            "ElevenLabsAgentAdapter: receiveAudio timed out. Hosted ElevenLabs " +
+              "ConvAI is server-VAD-driven and supports only a single exchange " +
+              "(agent() → user() → agent() → judge()); a scripted 2nd user() turn " +
+              "does not re-engage its turn-taking, so the next agent() never " +
+              "receives a response. For multi-turn voice use a composable adapter " +
+              "(ElevenLabsVoiceAgent / pipecatAgent). See " +
+              "https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs",
+          ),
+        );
       }, timeout * 1000);
       this.waiters.push(waiter);
     });

--- a/python/examples/voice/elevenlabs_hosted.py
+++ b/python/examples/voice/elevenlabs_hosted.py
@@ -59,11 +59,9 @@ async def main() -> scenario.ScenarioResult:
     result = await scenario.run(
         name="demo_elevenlabs_hosted",
         description=(
-            "Two-turn happy path against a live ElevenLabs Conversational AI "
+            "Single greeting-led exchange against a live ElevenLabs Conversational AI "
             "agent. Greeting plays on connect (real-voice convention), user "
-            "asks a question, agent responds, user asks a follow-up that "
-            "references the first turn, agent answers in context; judge "
-            "evaluates naturalness AND continuity."
+            "asks a question, agent responds; judge evaluates naturalness."
         ),
         agents=[
             scenario.ElevenLabsAgentAdapter(
@@ -75,23 +73,23 @@ async def main() -> scenario.ScenarioResult:
                 criteria=[
                     "The agent's initial greeting (sent on connect) is natural and conversational",
                     "The agent and user exchanged real audio turns via the live WebSocket",
-                    "The agent's reply to the follow-up addresses it coherently in context of the first user turn",
-                    "The conversation is a coherent example of the hosted ElevenLabs Conversational AI path",
+                    "The conversation is a coherent single-turn example of the hosted ElevenLabs Conversational AI path",
                 ]
             ),
         ],
         script=[
             # Real voice convention: EL sends first_message on connect.
             # Lead with agent() so the greeting drains before user audio
-            # hits the wire.
+            # hits the wire. Hosted ElevenLabs ConvAI supports a SINGLE
+            # greeting-led exchange only — a 2nd scripted user() turn times
+            # out (receiveAudio timed out). For multi-turn use a composable
+            # adapter (ElevenLabsVoiceAgent / pipecatAgent).
             scenario.agent(),
             scenario.user("Hello, I have a question about my account."),
             scenario.agent(),
-            scenario.user("What information do you need from me to look it up?"),
-            scenario.agent(),
             scenario.judge(),
         ],
-        max_turns=8,
+        max_turns=6,
     )
 
     print(f"success: {result.success}")

--- a/specs/voice-elevenlabs-hosted-e2e.feature
+++ b/specs/voice-elevenlabs-hosted-e2e.feature
@@ -1,0 +1,187 @@
+Feature: Voice E2E against hosted ElevenLabs — single-exchange ceiling, multi-turn routing, and reconciled docs
+  As a developer porting chatbox scenarios to voice against a hosted ElevenLabs ConvAI agent
+  I want the docs to teach the real hosted single-exchange ceiling and route multi-turn to the adapters that support it
+  So that I stop hitting `receiveAudio timed out` on patterns the docs implied were universal
+  And so the SDK fails informatively instead of with a bare timeout
+
+  Background:
+    Given the hosted ElevenLabs ConvAI transport is server-VAD-driven, so its ceiling is ONE greeting-led user↔agent exchange
+    And the adapter send-path is verified correct — user audio reaches ElevenLabs on the 2nd scripted turn (adapter.runtime.ts:261-266), the timeout is the server VAD not re-engaging, not a missing-audio bug
+    And the SILENCE_TAIL_BYTES end-of-turn pad (elevenlabs.ts:241-254) is the maintainers' acknowledged best-effort for hosted turn-taking
+    And multi-turn voice is supported only on the composable ElevenLabsVoiceAgent, pipecatAgent, Gemini Live, and OpenAI Realtime adapters
+
+  # ============================================================
+  # Group: Reporter deliverable
+  # ============================================================
+
+  @e2e
+  Scenario: The resolving comment answers the reporter's three questions, each tied to a docs anchor
+    Given a developer reading the issue's resolving comment
+    When they look for the answers to the three reporter questions
+    Then the comment states the correct hosted script is the greeting-led single exchange `agent()→user→agent→judge`, anchored to happy-path-elevenlabs.mdx (AC4a)
+    And the comment states `proceed()` is NOT reliable on hosted `elevenLabsAgent` and works on composable/pipecat/realtime, anchored to recipes/multi-turn.mdx (AC11)
+    And the comment states 5–45-turn flows are unsupported on hosted ConvAI and route to `ElevenLabsVoiceAgent`/`pipecatAgent`, anchored to recipes/multi-turn.mdx (AC1, AC11)
+    And each of the three answers carries a clickable docs URL, not a bare claim
+
+  # ============================================================
+  # Group: Docs reconciliation — hosted ceiling and multi-turn routing
+  # ============================================================
+
+  @e2e
+  Scenario: A reader of the multi-turn recipe learns the hosted ceiling and is routed to a working adapter
+    Given a developer opening docs/voice/recipes/multi-turn on the published site
+    When they read the page that teaches the `agent→user→agent→…→judge` pattern
+    Then the page states the multi-turn pattern is NOT supported on hosted `elevenLabsAgent`
+    And the page affirmatively routes multi-turn AND `proceed(n)` to the composable `ElevenLabsVoiceAgent`, `pipecatAgent`, Gemini Live, and OpenAI Realtime adapters
+    And the "worked example" link resolves to a multi-turn test using a composable/pipecat adapter, NOT `elevenLabsAgent`
+
+  @integration
+  Scenario: The multi-turn recipe carries the hosted-NOT-supported caveat as a grep-gated invariant
+    Given recipes/multi-turn.mdx after the reconciliation pass
+    When the docs-honesty grep gate runs in CI
+    Then `grep -nF 'not supported on hosted' docs/docs/pages/voice/recipes/multi-turn.mdx` returns a line
+    And `grep -nF 'elevenLabsAgent' docs/docs/pages/voice/recipes/multi-turn.mdx` returns the caveat line
+    And both tokens are ABSENT on the unmodified tree, so the gate goes red until the caveat lands (AC1)
+
+  @integration
+  Scenario: The multi-turn recipe's positive-routing line is grep-gated to a composable adapter
+    Given recipes/multi-turn.mdx after the reconciliation pass
+    When the positive-routing grep gate runs in CI
+    Then `grep -nF 'ElevenLabsVoiceAgent' docs/docs/pages/voice/recipes/multi-turn.mdx` returns the routing line
+    And the worked-example link target resolves to a composable/pipecat multi-turn test, never `elevenLabsAgent` (AC11)
+
+  @integration
+  Scenario: The getting-started page caveats proceed() against hosted ConvAI next to each occurrence
+    Given docs/docs/pages/voice/getting-started.mdx which presents `proceed(n)` at lines 117 and 179
+    When `grep -nA3 'scenario.proceed' docs/docs/pages/voice/getting-started.mdx` runs in CI
+    Then a hosted-ConvAI caveat appears within 3 lines of EACH `proceed(` occurrence
+    And the page no longer presents `proceed(n)` as a universal voice driver (AC2)
+
+  # ============================================================
+  # Group: Docs reconciliation — troubleshooting
+  # ============================================================
+
+  @e2e
+  Scenario: A developer hitting the hosted timeout finds the diagnosis and the greeting-drain fix
+    Given a developer who hit `receiveAudio timed out` on hosted ElevenLabs
+    When they open docs/voice/troubleshooting on the published site
+    Then the page has a `receiveAudio timed out` entry naming the server-VAD single-exchange ceiling
+    And the entry states the "lead with `agent()` to drain the greeting" rule
+    And the entry documents the "Audio duration mismatch / non-continuous audio input" message as a benign server-side ConvAI warning, not an SDK error
+
+  @integration
+  Scenario: The troubleshooting timeout and duration-warning entries are grep-gated
+    Given troubleshooting.mdx after the reconciliation pass
+    When the troubleshooting grep gate runs in CI
+    Then `grep -nF 'receiveAudio timed out' docs/docs/pages/voice/troubleshooting.mdx` returns the entry (AC3)
+    And `grep -niE 'duration mismatch|non-continuous' docs/docs/pages/voice/troubleshooting.mdx` returns the benign-warning entry (AC5)
+    And both strings are ABSENT on the unmodified tree, so the gate goes red until the entries land
+
+  # ============================================================
+  # Group: Docs reconciliation — happy-path doc and example parity
+  # ============================================================
+
+  @e2e
+  Scenario: The happy-path doc teaches the greeting-led single exchange
+    Given a developer opening happy-path-elevenlabs.mdx on the published site
+    When they read the canonical hosted script block (currently user-first at lines 76-79)
+    Then the script leads with `scenario.agent()` to drain the on-connect greeting before the first `scenario.user(`
+    And the taught shape is `agent()→user→agent→judge`, the documented single-exchange ceiling
+
+  @integration
+  Scenario: The happy-path script is grep-gated to greeting-led order
+    Given happy-path-elevenlabs.mdx after the reconciliation pass
+    When `grep -nB1 'scenario.user(' docs/docs/pages/voice/happy-path-elevenlabs.mdx` runs in CI
+    Then `scenario.agent()` immediately precedes the first `scenario.user(` in the script block (AC4a)
+
+  @integration
+  Scenario: The python and TS hosted examples share one greeting-led script with no self-contradicting docstring
+    Given the python and TS hosted ElevenLabs example files
+    When the example-parity grep gate runs in CI
+    Then `grep -rnE 'scenario\.(agent|user|judge)' <python-hosted-example> <ts-hosted-example>` shows the identical ordered step sequence in both
+    And `grep -niE 'single.?turn' <python-hosted-example>` returns no "single-turn" docstring/comment sitting above a 2nd scripted `user()` turn (AC4b)
+
+  # ============================================================
+  # Group: Behavior / failure-mode (SDK boundary condition)
+  # ============================================================
+
+  @integration
+  Scenario: A 2nd scripted user turn on hosted elevenLabsAgent fails informatively, not with a bare timeout
+    Given a hosted `elevenLabsAgent` script with a 2nd scripted `user()` turn after the greeting exchange
+    When the 2nd `agent()` turn hits the server-VAD re-engagement failure
+    Then the emitted error/warning string contains "hosted ConvAI" AND one of "single exchange"/"single-turn ceiling"
+    And the message points to the troubleshooting anchor, not just the bare `receiveAudio timed out`
+    And the test log line quoting the emitted message is the evidence — OR a linked decision record accepts the bare timeout plus the AC3 troubleshooting entry as the contract, citing the troubleshooting URL (AC6)
+
+  @integration
+  Scenario: A voice agent-under-test receiving a text user turn gets a louder warning than silent passthrough
+    Given a no-voice-resolves path where `voiceify` falls through and a voice agent-under-test receives a TEXT user turn
+    When the turn is dispatched to the agent
+    Then the SDK emits a louder warning than silent text passthrough, and a test exercising the no-voice-resolves path quotes it
+    And the OR-branch is visible: if the reporter's posted `scenario.run({...})` config shows `voice:'openai/nova'` resolves with no pre-built ModelMessage user turns, AC7 is struck with that quoted config as the rationale (AC7)
+
+  # ============================================================
+  # Group: Regression + proven-path tests (gated live pass + ungated CI shape)
+  # ============================================================
+
+  @unit
+  Scenario: The hosted single-exchange shape is provable in keyless CI without a paid endpoint
+    Given the env-gated hosted suite skip-passes in keyless CI (describe.skip at line 224, hasHostedKey gate at lines 36-39), so a keyless green is VACUOUS
+    When the ungated shape assertion runs in keyless CI
+    Then `grep -nF 'scenario.agent(),' elevenlabs-hosted.test.ts` confirms the leading `agent()` drain step still precedes `user()` at lines 96-101
+    And the assertion invokes no paid LLM or ElevenLabs endpoint, so keyless-CI green proves the canonical shape is preserved, not skipped (AC8)
+
+  @e2e @ts-elevenlabs
+  Scenario: The hosted single-exchange recipe passes live with keys set
+    Given `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`, and `OPENAI_API_KEY` are all set
+    When the greeting-led `agent()→user→agent→judge` test at elevenlabs-hosted.test.ts:96-101 runs
+    Then the vitest summary line shows the hosted test PASSED, not skipped
+    And the script at lines 96-101 is unchanged after the docs/code work (AC8)
+
+  @unit
+  Scenario: The composable multi-turn shape is provable in keyless CI without live keys
+    Given the composable multi-turn recipe at elevenlabs-hosted.test.ts:184-190 with two `user↔agent` exchanges
+    When the ungated mock-transport / shape assertion runs in keyless CI
+    Then it confirms two scripted `user→agent` exchanges are dispatched without live keys
+    And keyless-CI green therefore means the multi-turn path was registered and exercised, not skipped (AC9)
+
+  @e2e @ts-elevenlabs
+  Scenario: The composable multi-turn recipe passes live with keys set
+    Given `ELEVENLABS_API_KEY` and `OPENAI_API_KEY` are set for the branded composable path
+    When the two-exchange recipe at elevenlabs-hosted.test.ts:184-190 runs
+    Then the vitest summary line shows the branded composable test PASSED, not skipped (AC9)
+
+  # ============================================================
+  # AC Coverage Map
+  # ============================================================
+  # AC1  (hosted ceiling stated in multi-turn.mdx — `not supported on hosted` + `elevenLabsAgent`)
+  #      -> Scenario: A reader of the multi-turn recipe learns the hosted ceiling and is routed to a working adapter
+  #      -> Scenario: The multi-turn recipe carries the hosted-NOT-supported caveat as a grep-gated invariant
+  # AC2  (getting-started.mdx hosted caveat within 3 lines of each proceed()
+  #      -> Scenario: The getting-started page caveats proceed() against hosted ConvAI next to each occurrence
+  # AC3  (troubleshooting.mdx `receiveAudio timed out` entry — server-VAD ceiling + greeting-drain rule)
+  #      -> Scenario: A developer hitting the hosted timeout finds the diagnosis and the greeting-drain fix
+  #      -> Scenario: The troubleshooting timeout and duration-warning entries are grep-gated
+  # AC4a (happy-path-elevenlabs.mdx greeting-led agent()→user→agent→judge, agent() precedes first user())
+  #      -> Scenario: The happy-path doc teaches the greeting-led single exchange
+  #      -> Scenario: The happy-path script is grep-gated to greeting-led order
+  # AC4b (python + TS hosted examples identical greeting-led script; no "single-turn" docstring above a 2nd user())
+  #      -> Scenario: The python and TS hosted examples share one greeting-led script with no self-contradicting docstring
+  # AC5  (troubleshooting.mdx duration-mismatch / non-continuous warning documented as benign server-side)
+  #      -> Scenario: A developer hitting the hosted timeout finds the diagnosis and the greeting-drain fix
+  #      -> Scenario: The troubleshooting timeout and duration-warning entries are grep-gated
+  # AC6  (2nd scripted user turn yields "hosted ConvAI" + single-exchange + anchor, OR linked decision record)
+  #      -> Scenario: A 2nd scripted user turn on hosted elevenLabsAgent fails informatively, not with a bare timeout
+  # AC7  (louder warning on text passthrough to a voice agent-under-test, OR struck on reporter config quote)
+  #      -> Scenario: A voice agent-under-test receiving a text user turn gets a louder warning than silent passthrough
+  # AC8  (greeting-led hosted script at elevenlabs-hosted.test.ts:96-101 unchanged + ungated CI shape assertion)
+  #      -> Scenario: The hosted single-exchange shape is provable in keyless CI without a paid endpoint
+  #      -> Scenario: The hosted single-exchange recipe passes live with keys set
+  # AC9  (composable multi-turn at elevenlabs-hosted.test.ts:184-190 passes live + ungated two-exchange assertion)
+  #      -> Scenario: The composable multi-turn shape is provable in keyless CI without live keys
+  #      -> Scenario: The composable multi-turn recipe passes live with keys set
+  # AC10 (resolving comment answers the 3 reporter questions, each tied to a docs anchor)
+  #      -> Scenario: The resolving comment answers the reporter's three questions, each tied to a docs anchor
+  # AC11 (multi-turn.mdx positive routing to composable/pipecat/gemini/realtime + worked link to a non-hosted test)
+  #      -> Scenario: A reader of the multi-turn recipe learns the hosted ceiling and is routed to a working adapter
+  #      -> Scenario: The multi-turn recipe's positive-routing line is grep-gated to a composable adapter


### PR DESCRIPTION
## Why

Closes #638.

Teams building voice E2E against **hosted ElevenLabs** (`scenario.elevenLabsAgent()`) hit `ElevenLabsAgentAdapter: receiveAudio timed out` on every multi-turn attempt, while the docs taught a generic multi-turn / `proceed()` pattern as if it were universal. Root cause (reproduced live): the hosted ElevenLabs Conversational AI transport is **server-VAD-driven** and supports only a **single greeting-led exchange** — a scripted 2nd `user()` turn doesn't re-engage its turn-taking, so the next `agent()` never gets a response. This is **not an adapter send-path bug** (audio reaches ElevenLabs; their server just won't re-engage); it's a docs-reconciliation gap + a bare, unhelpful error. Multi-turn voice works on composable adapters (`ElevenLabsVoiceAgent`, `pipecatAgent`, Gemini Live, OpenAI Realtime).

## What changed

- **Docs now teach the real hosted ceiling, not a universal multi-turn pattern.** The multi-turn recipe carries a warning that multi-turn is unsupported on hosted `elevenLabsAgent` and routes multi-turn/`proceed()` to the composable adapters (worked example points at the pipecat test); `getting-started` caveats `proceed()`; `happy-path-elevenlabs` switched to the greeting-led single exchange; the Python hosted example dropped its (timing-out) 2nd user turn to match the TS example.
- **The timeout error now explains itself.** Instead of a bare `receiveAudio timed out`, the adapter names the hosted-ConvAI single-exchange ceiling, the composable alternatives, and links the troubleshooting entry — so a user hits an actionable message, not a dead end.
- **Silent text-passthrough now warns.** When a voice user turn falls through to text because no voice resolved, `UserSimulatorAgent` warns (this is the "agent replied 'Sorry, I can't listen to audio'" trap).
- **A keyless CI guard locks the invariant in.** A new ungated test fails if anyone reintroduces the 2nd-user-turn pattern into the hosted example, or strips the enriched error — so the regression can't silently return in keyless CI.

## Test plan

- Ungated (keyless, runs in CI): `cd javascript && npx vitest run src/voice/__tests__/elevenlabs-hosted-shape.guard.test.ts` → 3 pass (hosted stays single greeting-led; composable stays multi-turn; timeout error stays enriched).
- Regression: `npx vitest run src/voice src/agents` → **665 passed, 1 skipped** (the enriched error + voiceify warnings break nothing).
- Gated live repro (needs `ELEVENLABS_API_KEY` + `ELEVENLABS_AGENT_ID` + `OPENAI_API_KEY`): `cd javascript/examples/vitest && pnpm exec vitest run tests/voice/repro-638-hosted-multiturn.test.ts` → reproduces the 2nd-user-turn timeout.
- Behavioral contract: `specs/voice-elevenlabs-hosted-e2e.feature` (16 scenarios).

## How I can prove I was successful

**Reproduced live, and the enriched error confirmed against the real ElevenLabs API.** Running a hosted scenario with a 2nd scripted `user()` turn against a live agent throws (at the 2nd `agent()`, "Script step 5"):

```
[repro#638] THREW: ElevenLabsAgentAdapter: receiveAudio timed out. Hosted ElevenLabs ConvAI is server-VAD-driven and supports only a single exchange (agent() → user() → agent() → judge()); a scripted 2nd user() turn does not re-engage its turn-taking, so the next agent() never receives a response. For multi-turn voice use a composable adapter (ElevenLabsVoiceAgent / pipecatAgent). See https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs
```

In the same live run: the **single greeting-led** hosted exchange and the **composable/branded multi-turn** demo (2 `user↔agent` exchanges, `audio/pcm16` both turns) both passed — confirming the fix path. The keyless guard test (`src/voice/__tests__/elevenlabs-hosted-shape.guard.test.ts`, 3/3) is the CI-runnable proof that the invariant holds without live keys.

## Anything surprising?

- Hosted multi-turn itself is **out of scope** — it'd require a different send model (continuous streaming / explicit end-of-turn signalling), i.e. a separate feature. This PR documents + routes around the ceiling and makes the failure self-explanatory.
- One reporter sub-symptom ("agent replied 'Sorry, I can't listen to audio'") depends on the reporter's exact `voice` wiring; the new passthrough warning surfaces that path, but confirming their specific config is a follow-up.
