### PR TITLE
fix(voice): surface tool-only realtime turns (no audio chunk)

### DIFF
--- a/javascript/src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
@@ -380,7 +380,7 @@ describe("OpenAIRealtimeAgentAdapter — realtime tool-call surfacing (#630)", (
     });
   });
 
-  it("#646 (AC4) — output-item form terminates a tool-only turn", async () => {
+  it("#646 (AC4, variant) — output-item form terminates a tool-only turn", async () => {
     const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
     adapter.responseTimeout = 0.5;
 
@@ -431,6 +431,8 @@ describe("OpenAIRealtimeAgentAdapter — realtime tool-call surfacing (#630)", (
     const messages = await runTurn(adapter, () => {
       pushAudioDelta();
       pushStreamingCall("call_co", "fetch", '{"k":"v"}');
+      // audio delta + tool call + explicit response.done — exercises the coexistence terminal (both messages must survive).
+      push({ type: "response.done" });
     });
 
     expect(messages.length).toBe(2);
@@ -470,19 +472,22 @@ describe("OpenAIRealtimeAgentAdapter — realtime tool-call surfacing (#630)", (
     await adapter.connect();
     await socketReady;
     await waitForType("session.update");
+    let caught: unknown;
     try {
       // Empty turn: no audio, no function call — just response.done. The
       // accumulator stays empty, so the new terminal path does NOT fire and
       // the drain must still hit the receiveAudio timeout (proves the
       // discriminator is the non-empty accumulator, not response.done alone).
-      await expect(
-        feedAndCall(adapter, () => {
-          push({ type: "response.done" });
-        }),
-      ).rejects.toThrow("receiveAudio timed out");
+      await feedAndCall(adapter, () => {
+        push({ type: "response.done" });
+      });
+    } catch (e) {
+      caught = e;
     } finally {
       await adapter.disconnect();
     }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("receiveAudio timed out");
   });
 
   it("#646 (AC10) — malformed args degrade on a tool-only turn", async () => {

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
@@ -316,6 +316,34 @@ describe("OpenAIRealtimeAgentAdapter — realtime tool-call surfacing (#630)", (
     ).toBe(true);
   });
 
+  // --- #646: tool-only (no-audio) turn ---
+  it("#646 (AC2) — tool-only turn (no audio delta) returns the role:'tool' message, does not time out", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5; // fail fast if the no-audio path still hangs
+
+    const messages = await runTurn(adapter, () => {
+      // Tool-only: a function call with NO audio delta, terminated by response.done.
+      pushStreamingCall("call_weather", "get_weather", '{"city":"Paris"}');
+      push({ type: "response.done" });
+    });
+
+    const toolMsg = toolMessageOf(messages);
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg!.role).toBe("tool");
+    const part = toolMsg!.content.find(
+      (p) => p.type === "tool-result" && p.toolName === "get_weather",
+    );
+    expect(part).toBeDefined();
+    expect(part).toMatchObject({
+      type: "tool-result",
+      toolCallId: "call_weather",
+      toolName: "get_weather",
+    });
+
+    // The real consumer recognizes it.
+    expect(stateWith(messages).hasToolCall("get_weather")).toBe(true);
+  });
+
   it("AC4 (variant) — a call delivered ONLY via output_item.done is surfaced", async () => {
     const adapter = buildAdapter({ apiKey: "test-key" });
 

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
@@ -296,13 +296,6 @@ describe("OpenAIRealtimeAgentAdapter — realtime tool-call surfacing (#630)", (
       toolName: "get_weather",
     });
 
-    // PROOF — the actual message that lands in the run's messages.
-     
-    console.log(
-      "[#630 PROOF] tool message added to run:",
-      JSON.stringify(toolMsg, null, 2),
-    );
-
     // The real consumer (ScenarioExecutionState) recognizes it.
     const state = stateWith(messages);
     expect(state.hasToolCall("get_weather")).toBe(true);
@@ -342,6 +335,169 @@ describe("OpenAIRealtimeAgentAdapter — realtime tool-call surfacing (#630)", (
 
     // The real consumer recognizes it.
     expect(stateWith(messages).hasToolCall("get_weather")).toBe(true);
+  });
+
+  // --- #646: tool-only coverage + failure modes ---
+
+  it("#646 (AC3) — tool-only turn is consumable via hasToolCall/lastToolCall", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5;
+
+    const messages = await runTurn(adapter, () => {
+      pushStreamingCall("call_ac3", "get_weather", '{"city":"London"}');
+      push({ type: "response.done" });
+    });
+
+    const state = stateWith(messages);
+    expect(state.hasToolCall("get_weather")).toBe(true);
+    const last = state.lastToolCall("get_weather");
+    expect(
+      last.content.some(
+        (p) => p.type === "tool-result" && p.toolName === "get_weather",
+      ),
+    ).toBe(true);
+  });
+
+  it("#646 (AC4) — streaming-args form terminates a tool-only turn", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5;
+
+    const messages = await runTurn(adapter, () => {
+      pushStreamingCall("call_ac4s", "get_weather", '{"city":"Berlin"}');
+      push({ type: "response.done" });
+    });
+
+    const toolMsg = toolMessageOf(messages);
+    expect(toolMsg).toBeDefined();
+    const part = toolMsg!.content.find(
+      (p) => p.type === "tool-result" && p.toolName === "get_weather",
+    );
+    expect(part).toBeDefined();
+    expect(part).toMatchObject({
+      type: "tool-result",
+      toolCallId: "call_ac4s",
+      toolName: "get_weather",
+    });
+  });
+
+  it("#646 (AC4) — output-item form terminates a tool-only turn", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5;
+
+    const messages = await runTurn(adapter, () => {
+      pushOutputItemCall("call_ac4o", "lookup_order", '{"id":99}');
+      push({ type: "response.done" });
+    });
+
+    const toolMsg = toolMessageOf(messages);
+    expect(toolMsg).toBeDefined();
+    const part = toolMsg!.content.find(
+      (p) => p.type === "tool-result" && p.toolName === "lookup_order",
+    );
+    expect(part).toBeDefined();
+    expect(part).toMatchObject({
+      type: "tool-result",
+      toolCallId: "call_ac4o",
+      toolName: "lookup_order",
+    });
+  });
+
+  it("#646 (AC5) — two calls on a tool-only turn both surface", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5;
+
+    const messages = await runTurn(adapter, () => {
+      pushStreamingCall("call_1", "get_weather", '{"city":"NYC"}');
+      pushOutputItemCall("call_2", "get_time", '{"tz":"UTC"}');
+      push({ type: "response.done" });
+    });
+
+    const toolMsg = toolMessageOf(messages);
+    expect(toolMsg).toBeDefined();
+    const names = toolMsg!.content
+      .filter((p) => p.type === "tool-result")
+      .map((p) => (p as { toolName: string }).toolName)
+      .sort();
+    expect(names).toEqual(["get_time", "get_weather"]);
+
+    const state = stateWith(messages);
+    expect(state.hasToolCall("get_weather")).toBe(true);
+    expect(state.hasToolCall("get_time")).toBe(true);
+  });
+
+  it("#646 (AC7) — audio+tool turn still returns BOTH the audio message AND the tool message", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+
+    const messages = await runTurn(adapter, () => {
+      pushAudioDelta();
+      pushStreamingCall("call_co", "fetch", '{"k":"v"}');
+    });
+
+    expect(messages.length).toBe(2);
+    expect(messages.some((m) => m.role === "assistant")).toBe(true);
+    expect(toolMessageOf(messages)).toBeDefined();
+  });
+
+  it("#646 (AC8) — turn 1 tool-only, turn 2 audio-only — no bleed", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5;
+    await adapter.connect();
+    await socketReady;
+    await waitForType("session.update");
+
+    // Turn 1: no-audio tool-only — must push response.done to terminate drain.
+    const turn1 = await feedAndCall(adapter, () => {
+      pushOutputItemCall("call_t1", "get_weather", "{}");
+      push({ type: "response.done" });
+    });
+    expect(toolMessageOf(turn1)).toBeDefined();
+
+    // Turn 2: audio-only — terminates on tail-silence; must not carry turn-1's tool.
+    adapter.responseTimeout = 2; // restore default for the audio-bearing turn
+    const turn2 = await feedAndCall(adapter, () => {
+      pushAudioDelta();
+    });
+    await adapter.disconnect();
+
+    expect(toolMessageOf(turn2)).toBeUndefined();
+    expect(turn2.length).toBe(1);
+  });
+
+  it("#646 (AC9) — empty turn (no audio, no tool call) still times out", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5;
+
+    await adapter.connect();
+    await socketReady;
+    await waitForType("session.update");
+    try {
+      // Empty turn: no audio, no function call — just response.done. The
+      // accumulator stays empty, so the new terminal path does NOT fire and
+      // the drain must still hit the receiveAudio timeout (proves the
+      // discriminator is the non-empty accumulator, not response.done alone).
+      await expect(
+        feedAndCall(adapter, () => {
+          push({ type: "response.done" });
+        }),
+      ).rejects.toThrow("receiveAudio timed out");
+    } finally {
+      await adapter.disconnect();
+    }
+  });
+
+  it("#646 (AC10) — malformed args degrade on a tool-only turn", async () => {
+    const adapter = buildAdapter({ apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.5;
+
+    const messages = await runTurn(adapter, () => {
+      pushOutputItemCall("call_bad", "noop", "{not json");
+      push({ type: "response.done" });
+    });
+
+    const part = toolMessageOf(messages)!.content.find(
+      (p) => p.type === "tool-result" && p.toolName === "noop",
+    ) as { output: { type: string; value: unknown } };
+    expect(part.output).toEqual({ type: "text", value: "{not json" });
   });
 
   it("AC4 (variant) — a call delivered ONLY via output_item.done is surfaced", async () => {

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -460,6 +460,18 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
             this._finalizeToolCall(fc.call_id, fc.name, fc.arguments);
           }
         }
+      } else if (etype === "response.done" || etype === "response.cancelled") {
+        // Issue #646: a tool-only turn (function call, NO audio delta) would
+        // otherwise loop here forever and hit the receiveAudio timeout — the
+        // accumulated tool call is parsed but never returned. When the response
+        // is done and >=1 tool call has been finalized this turn, return an
+        // empty chunk so the base drain (drainAgentResponse) terminates cleanly
+        // and call() surfaces the role:"tool" message. A genuinely empty turn
+        // (done + EMPTY accumulator) must still fall through to the timeout —
+        // the non-empty accumulator is the discriminator, NOT response.done alone.
+        if (this._completedToolCalls.length > 0) {
+          return new AudioChunk({ data: new Uint8Array(0) });
+        }
       } else if (etype === "error") {
         const errDetail =
           (event as { error?: { message?: string } }).error ?? {};

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -29,7 +29,9 @@ import base64
 import json
 import logging
 import os
-from typing import Any, ClassVar, List, Optional
+from typing import Any, ClassVar, List, Optional, cast
+
+from openai.types.chat import ChatCompletionMessageParam
 
 from ...config.voice_models import OPENAI_REALTIME_MODEL, OPENAI_STT_MODEL
 from ...types import AgentInput, AgentReturnTypes, AgentRole
@@ -604,12 +606,15 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
 
         # One assistant message carrying ALL of this turn's tool calls — the
         # conventional OpenAI shape (one assistant turn, many tool_calls).
-        tool_call_message: dict[str, Any] = {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": list(self._completed_tool_calls),
-        }
-        return [audio_message, tool_call_message]
+        tool_call_message: ChatCompletionMessageParam = cast(
+            ChatCompletionMessageParam,
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": list(self._completed_tool_calls),
+            },
+        )
+        return [cast(ChatCompletionMessageParam, audio_message), tool_call_message]
 
     async def _drain_agent_response(
         self, on_first_chunk=None

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -32,7 +32,7 @@ import os
 from typing import Any, ClassVar, List, Optional
 
 from ...config.voice_models import OPENAI_REALTIME_MODEL, OPENAI_STT_MODEL
-from ...types import AgentRole
+from ...types import AgentInput, AgentReturnTypes, AgentRole
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
 from ..capabilities import AdapterCapabilities
@@ -570,7 +570,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                     "OpenAIRealtimeAgentAdapter: ignoring event type %r", etype
                 )
 
-    async def call(self, input):  # type: ignore[override]
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
         """Surface realtime tool calls alongside the spoken audio turn (#630).
 
         The base ``call()`` returns a single assistant audio message and does

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -497,6 +497,16 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # Response finished or was cancelled — mark it so the next
                 # drain re-entry returns an empty chunk (clean exit).
                 self._response_active = False
+                # Issue #646: a tool-only turn (function call, NO audio delta) would
+                # otherwise loop here to the deadline and raise — the accumulated tool
+                # call is parsed but never returned. When the response is done and at
+                # least one tool call has been finalized this turn, return an empty
+                # chunk so the drain exits cleanly and call() surfaces the tool_calls
+                # message. A genuinely empty turn (done + EMPTY accumulator) must still
+                # fall through to the timeout — the non-empty accumulator is the
+                # discriminator, NOT response.done alone.
+                if self._completed_tool_calls:
+                    return AudioChunk(data=b"")
 
             elif etype == "conversation.item.input_audio_transcription.completed":
                 # User-side transcript from Whisper.

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -505,6 +505,8 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # message. A genuinely empty turn (done + EMPTY accumulator) must still
                 # fall through to the timeout — the non-empty accumulator is the
                 # discriminator, NOT response.done alone.
+                # (Distinct from the drain-re-entry empty-chunk path above at the
+                # _response_ever_active guard, which handles a COMPLETED prior response.)
                 if self._completed_tool_calls:
                     return AudioChunk(data=b"")
 

--- a/python/tests/voice/test_realtime_tool_calls.py
+++ b/python/tests/voice/test_realtime_tool_calls.py
@@ -252,11 +252,6 @@ async def test_ac1_tool_call_surfaced_via_dedicated_branch():
     parsed = json.loads(tc["function"]["arguments"])  # must parse
     assert parsed == {"location": "Paris"}
 
-    # PROVE THE SHAPE — print the actual assistant tool_calls message.
-    msg = _tool_call_messages(returned)[0]
-    print("\n[AC1] assistant tool_calls message:")
-    print(json.dumps(msg, indent=2))
-
 
 @pytest.mark.asyncio
 async def test_ac1_item_only_form_surfaced():
@@ -404,8 +399,6 @@ async def test_ac2_has_tool_call_and_last_tool_call(_configure_scenario):
     calls = _all_tool_calls(list(result.messages))
     assert any(c["function"]["name"] == "get_weather" for c in calls)
 
-    print("\n[AC2] state.last_tool_call('get_weather'):")
-    print(json.dumps(tc, indent=2))
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/voice/test_realtime_tool_calls.py
+++ b/python/tests/voice/test_realtime_tool_calls.py
@@ -25,6 +25,7 @@ connection is needed. Two test surfaces:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 from typing import Any, List, Optional, Sequence
@@ -652,3 +653,242 @@ async def test_ac11_no_tool_result_message_emitted():
         f"adapter emitted a role:'tool' result message (out of scope): "
         f"{tool_role_msgs}"
     )
+
+
+# --- #646: tool-only coverage + failure modes ---
+
+
+@pytest.mark.asyncio
+async def test_issue646_tool_only_consumable_via_scenario_state(_configure_scenario):
+    """
+    AC3: a tool-only (no-audio) turn is consumable end-to-end through a real
+    scenario run — state.has_tool_call / last_tool_call work against integrated
+    adapter output.
+
+    Mirrors test_ac2 exactly but swaps the event list for a pure tool-only
+    sequence (no _audio_delta_events): [response.created] +
+    _function_call_streaming_events(...) + [response.done].
+    """
+    events = (
+        [json.dumps({"type": "response.created"})]
+        + _function_call_streaming_events(
+            "call_w646", "get_weather", '{"city":"London"}'
+        )
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = OpenAIRealtimeAgentAdapter(speaks_first=True)
+    _wire_adapter(adapter, events)
+
+    captured: dict[str, Optional[ScenarioState]] = {"state": None}
+
+    def _capture_state(state: ScenarioState):
+        captured["state"] = state
+
+    result = await scenario.arun(
+        name="ac3-tool-only-scenario",
+        description="Agent calls a tool with no audio",
+        agents=[adapter],
+        script=[
+            scenario.agent(),
+            _capture_state,
+            scenario.succeed("done"),
+        ],
+    )
+
+    state = captured["state"]
+    assert state is not None, "script callable did not capture state"
+
+    # Real consumer API must reflect the tool-only turn.
+    assert state.has_tool_call("get_weather") is True
+    tc = state.last_tool_call("get_weather")
+    assert tc is not None
+    assert json.loads(tc["function"]["arguments"]) == {"city": "London"}
+
+    # Also present in result.messages.
+    calls = _all_tool_calls(list(result.messages))
+    assert any(c["function"]["name"] == "get_weather" for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_issue646_tool_only_streaming_args_form():
+    """
+    AC4 (streaming-args variant): the _function_call_streaming_events form alone
+    (delta × N + .done), with no audio, terminates the turn and surfaces the call.
+    """
+    events = (
+        [json.dumps({"type": "response.created"})]
+        + _function_call_streaming_events(
+            "call_stream", "get_weather", '{"city":"Berlin"}'
+        )
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = _make_adapter(events)
+    adapter.response_timeout = 0.5
+
+    returned = _normalize(await adapter.call(_FakeInput()))  # type: ignore[arg-type]
+
+    calls = _all_tool_calls(returned)
+    assert len(calls) == 1, f"AC4 streaming: expected 1 tool_call, got {calls}"
+    assert calls[0]["function"]["name"] == "get_weather"
+    assert json.loads(calls[0]["function"]["arguments"]) == {"city": "Berlin"}
+
+
+@pytest.mark.asyncio
+async def test_issue646_tool_only_output_item_form():
+    """
+    AC4 (output-item variant): the _function_call_item_events form alone
+    (single response.output_item.done), with no audio, terminates the turn and
+    surfaces the call.
+    """
+    events = (
+        [json.dumps({"type": "response.created"})]
+        + _function_call_item_events(
+            "call_item646", "get_weather", '{"city":"Paris"}'
+        )
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = _make_adapter(events)
+    adapter.response_timeout = 0.5
+
+    returned = _normalize(await adapter.call(_FakeInput()))  # type: ignore[arg-type]
+
+    calls = _all_tool_calls(returned)
+    assert len(calls) == 1, f"AC4 item: expected 1 tool_call, got {calls}"
+    assert calls[0]["function"]["name"] == "get_weather"
+    assert json.loads(calls[0]["function"]["arguments"]) == {"city": "Paris"}
+
+
+@pytest.mark.asyncio
+async def test_issue646_tool_only_two_calls_both_surface():
+    """
+    AC5: two simultaneous calls (one streaming-args, one output-item) on a
+    tool-only turn — both surface in ONE assistant tool_calls message.
+    """
+    events = (
+        [json.dumps({"type": "response.created"})]
+        + _function_call_streaming_events("call_A", "get_weather", '{"city":"NYC"}')
+        + _function_call_item_events("call_B", "get_time", '{"tz":"UTC"}')
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = _make_adapter(events)
+    adapter.response_timeout = 0.5
+
+    returned = _normalize(await adapter.call(_FakeInput()))  # type: ignore[arg-type]
+
+    all_calls = _all_tool_calls(returned)
+    assert len(all_calls) == 2, (
+        f"AC5: expected 2 tool_calls, got {len(all_calls)}: {all_calls}"
+    )
+    names = {c["function"]["name"] for c in all_calls}
+    assert "get_weather" in names
+    assert "get_time" in names
+
+    # Both live in exactly ONE assistant tool_calls message.
+    tc_msgs = _tool_call_messages(returned)
+    assert len(tc_msgs) == 1, (
+        f"AC5: expected 1 tool_calls message, got {len(tc_msgs)}"
+    )
+    assert len(tc_msgs[0]["tool_calls"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_issue646_cross_turn_no_bleed():
+    """
+    AC8: ONE adapter instance, two sequential call() invocations — tool calls
+    from turn 1 do NOT bleed into turn 2.
+
+    Turn 1: tool-only (no audio).
+    Turn 2: audio-only (no tool call) — re-point adapter._ws to a fresh MockWS.
+
+    Asserts:
+    - Turn 1 returns the tool_calls message.
+    - Turn 2 returns a single audio dict with no tool_calls key.
+    - adapter._completed_tool_calls == [] after turn 2 (reset cleared turn 1).
+    """
+    turn1_events = (
+        [json.dumps({"type": "response.created"})]
+        + _function_call_streaming_events(
+            "call_t1", "get_weather", '{"city":"Rome"}'
+        )
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = _make_adapter(turn1_events)
+    adapter.response_timeout = 0.5
+
+    # --- Turn 1 ---
+    returned1 = _normalize(await adapter.call(_FakeInput()))  # type: ignore[arg-type]
+    calls1 = _all_tool_calls(returned1)
+    assert len(calls1) == 1, (
+        f"AC8 turn-1: expected 1 tool_call, got {calls1}"
+    )
+    assert calls1[0]["function"]["name"] == "get_weather"
+
+    # --- Swap WS to an audio-only turn ---
+    adapter._ws = _MockWS(_audio_delta_events())
+
+    # --- Turn 2 ---
+    returned2 = await adapter.call(_FakeInput())  # type: ignore[arg-type]
+
+    # Audio-only turn returns a single dict (base adapter shape).
+    assert isinstance(returned2, dict), (
+        f"AC8 turn-2: expected single dict, got {type(returned2)}"
+    )
+    assert "tool_calls" not in returned2, (
+        "AC8 turn-2: tool_calls bled from turn 1 into turn 2"
+    )
+
+    # Accumulator was cleared by turn 2's reset.
+    assert adapter._completed_tool_calls == [], (
+        "AC8: _completed_tool_calls not cleared after turn 2"
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue646_empty_turn_still_times_out():
+    """
+    AC9: a turn with response.created + response.done but NO function-call events
+    and NO audio must still raise asyncio.TimeoutError.
+
+    This proves the discriminator is the non-empty _completed_tool_calls
+    accumulator, not response.done alone — an empty accumulator cannot terminate
+    the turn early.
+    """
+    events = [
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter = _make_adapter(events)
+    adapter.response_timeout = 0.5
+
+    with pytest.raises(asyncio.TimeoutError):
+        await adapter.call(_FakeInput())  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_issue646_tool_only_malformed_args_degrade():
+    """
+    AC10: malformed (non-JSON) arguments on a tool-only (no-audio) path are
+    surfaced verbatim — the call is NOT dropped, does NOT raise, and
+    arguments == the raw string (per the #635 contract, mirroring test_ac7a).
+    """
+    events = (
+        [json.dumps({"type": "response.created"})]
+        + _function_call_item_events("call_bad", "do_thing", "not json {{{")
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = _make_adapter(events)
+    adapter.response_timeout = 0.5
+
+    # Must NOT raise even on the no-audio path.
+    returned = _normalize(await adapter.call(_FakeInput()))  # type: ignore[arg-type]
+
+    calls = _all_tool_calls(returned)
+    assert len(calls) == 1, (
+        f"AC10: expected 1 tool_call (malformed args surfaced), got {calls}"
+    )
+    tc = calls[0]
+    assert tc["function"]["name"] == "do_thing"
+    # Raw string passed through verbatim — no silent dropping, no re-raise.
+    assert tc["function"]["arguments"] == "not json {{{"
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(tc["function"]["arguments"])

--- a/python/tests/voice/test_realtime_tool_calls.py
+++ b/python/tests/voice/test_realtime_tool_calls.py
@@ -276,6 +276,44 @@ async def test_ac1_item_only_form_surfaced():
     assert json.loads(calls[0]["function"]["arguments"]) == {"q": "langwatch"}
 
 
+# --- #646: tool-only (no-audio) turn ---
+
+
+@pytest.mark.asyncio
+async def test_issue646_tool_only_no_audio_returns_tool_call():
+    """
+    #646 (AC1): a tool-only turn — a function call with NO response.output_audio.delta
+    before response.done — must RETURN the assistant tool_calls message, NOT time out.
+
+    This FAILS on the pre-fix code: call() drains via recv_audio which returns only on
+    an audio delta; with no audio it loops to the response_timeout deadline and raises
+    asyncio.TimeoutError. The function-call events ARE accumulated (parsed) and then lost.
+    """
+    # Tool-only: function-call events with NO _audio_delta_events() prepended.
+    events = (
+        [json.dumps({"type": "response.created"})]
+        + _function_call_streaming_events("call_weather", "get_weather", '{"location":"Paris"}')
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = _make_adapter(events)
+    adapter.response_timeout = 0.5  # fail fast — bound the drain so the test is quick
+
+    returned = _normalize(await adapter.call(_FakeInput()))  # type: ignore[arg-type]
+
+    # The function-call events were consumed by the dedicated branch (accumulator effect).
+    assert adapter._completed_tool_calls, (
+        "tool-call events were dropped — _completed_tool_calls is empty"
+    )
+
+    calls = _all_tool_calls(returned)
+    assert len(calls) == 1, f"expected 1 tool_call on a tool-only turn, got {calls}"
+    tc = calls[0]
+    assert tc["type"] == "function"
+    assert tc["id"] == "call_weather"
+    assert tc["function"]["name"] == "get_weather"
+    assert json.loads(tc["function"]["arguments"]) == {"location": "Paris"}
+
+
 # ---------------------------------------------------------------------------
 # AC2 — assertion API works (full scenario run, live ScenarioState)
 # ---------------------------------------------------------------------------

--- a/specs/realtime-tool-only-turn.feature
+++ b/specs/realtime-tool-only-turn.feature
@@ -1,0 +1,308 @@
+Feature: OpenAI Realtime adapter handles tool-only turns without audio
+  As a developer writing a voice scenario test against a tool-calling realtime agent
+  I want call() to return the accumulated tool call when the model responds with a function
+  call but no spoken audio
+  So that my scenario can assert on tool-call state even when the agent acts silently
+
+  # Issue #646 — call() (both SDKs) was gated on an audio chunk it may never receive.
+  # A tool-only turn (function call, no response.output_audio.delta) caused call() to
+  # hang until the response_timeout deadline and raise, discarding the fully-parsed tool
+  # call. The fix: treat response.done + a non-empty tool-call accumulator as a valid
+  # terminal path, returning the accumulated message without requiring audio.
+  #
+  # Scope guards (NOT changed, per Investigation):
+  #   - Cross-SDK message shape convergence (PY tool_calls array vs JS tool-result parts)
+  #     is out of scope — each SDK keeps its own existing consumer shape (#640).
+  #   - Live-API / real-OpenAI-key E2E smoke is deferred (hermetic mock-WS tests are
+  #     the contract for this issue).
+  #   - Type-annotation cleanup nits tracked separately (#644).
+  #
+  # SDK symmetry: AC1/AC2/AC3/AC4/AC5 name both SDKs explicitly. Where the behaviour
+  # differs by SDK (message shape), paired scenarios or outline examples make both
+  # visible. AC6-AC11 cover consequences + regressions, each with both-SDK evidence.
+
+  Background:
+    Given an OpenAIRealtimeAgentAdapter under test with a mock WebSocket (no live API key)
+    And the adapter's response_timeout is set to a short value so tests complete quickly
+
+  # ======================================================================
+  # AC1 — PY: tool-only turn returns the tool-call assistant message, no timeout
+  # ======================================================================
+
+  @unit
+  Scenario: PY call() returns an assistant tool-call message on a tool-only turn
+    # AC1: streaming-args event form — response.created → function_call_arguments.delta×N
+    # → .done → response.done, no audio delta. call() must return and not raise.
+    Given the mock WebSocket will emit:
+      response.created, response.function_call_arguments.delta (×2), response.function_call_arguments.done, response.done
+      and NO response.output_audio.delta event
+    When PY call() is invoked
+    Then it returns a message with role "assistant"
+    And the message contains a non-empty tool_calls list
+    And each tool_calls entry has id, type "function", and function.name and function.arguments
+    And call() does not raise asyncio.TimeoutError
+
+  @unit
+  Scenario: PY call() accepts the output-item event form for a tool-only turn
+    # AC4 (PY half): response.output_item.done carrying a function_call item as the
+    # sole terminal source — no streaming-delta form needed.
+    Given the mock WebSocket will emit:
+      response.created, response.output_item.done (carrying a function_call item), response.done
+      and NO response.output_audio.delta event
+    When PY call() is invoked
+    Then it returns a message with role "assistant" and a non-empty tool_calls list
+    And call() does not raise asyncio.TimeoutError
+
+  # ======================================================================
+  # AC2 — JS: tool-only turn returns the tool-result message, no timeout
+  # ======================================================================
+
+  @unit
+  Scenario: JS call() returns a tool-result message on a tool-only turn
+    # AC2: streaming-args event form — response.created → function_call_arguments.delta×N
+    # → .done → response.done, no audio delta. JS call() must return and not raise.
+    # NOTE: JS surfaced shape is role:"tool" + tool-result content parts, NOT the PY
+    # tool_calls array — each SDK asserts its own consumer shape (#640 out of scope).
+    Given the mock WebSocket will emit:
+      response.created, response.function_call_arguments.delta (×2), response.function_call_arguments.done, response.done
+      and NO audio delta event
+    When JS call() is invoked
+    Then it returns a message with role "tool"
+    And the message content contains at least one part with type "tool-result"
+    And each tool-result part carries toolCallId, toolName, and output
+    And call() does not throw the receiveAudio timeout error
+
+  @unit
+  Scenario: JS call() accepts the output-item event form for a tool-only turn
+    # AC4 (JS half): output-item event form as the sole terminal source.
+    Given the mock WebSocket will emit:
+      response.created, response.output_item.done (carrying a function_call item), response.done
+      and NO audio delta event
+    When JS call() is invoked
+    Then it returns a message with role "tool" and at least one tool-result part
+    And call() does not throw the receiveAudio timeout error
+
+  # ======================================================================
+  # AC3 — End-to-end consumability through converter into ScenarioState
+  # ======================================================================
+
+  @integration
+  Scenario: PY tool-only message is consumable via state.has_tool_call after conversion
+    # AC3 (PY): the returned message must survive convert_agent_return_types_to_openai_messages
+    # into ScenarioState so the public assertion API works — not merely returned raw.
+    Given call() returns a tool-only assistant message for a function named "get_weather"
+      with arguments '{"location": "Paris"}'
+    When the message is passed through the PY converter into ScenarioState
+    Then state.has_tool_call("get_weather") is True
+    And state.last_tool_call("get_weather")["function"]["arguments"] equals '{"location": "Paris"}'
+
+  @integration
+  Scenario: JS tool-only message is consumable via state.hasToolCall after conversion
+    # AC3 (JS): the returned message must survive convertAgentReturnTypesToMessages
+    # into ScenarioState. JS shape is role:"tool"/tool-result, not tool_calls array.
+    Given JS call() returns a tool-only role:"tool" message for a function named "get_weather"
+      with output containing '{"location": "Paris"}'
+    When the message is passed through the JS converter into ScenarioState
+    Then state.hasToolCall("get_weather") is True
+    And state.lastToolCall("get_weather") returns a message with a matching tool-result part
+
+  # ======================================================================
+  # AC4 — Both event forms accepted (streaming-args AND output-item)
+  # Covered above in AC1/AC2 scenario pairs; this scenario covers parametric proof.
+  # ======================================================================
+
+  @unit
+  Scenario Outline: Both SDKs accept both tool-call event forms on a tool-only turn
+    # AC4: parametrized over SDK × event-form. All four combinations must pass.
+    Given a <sdk> adapter with a mock WebSocket
+    And the mock WebSocket emits a tool-only turn via the <event_form> event form
+      with no audio delta
+    When call() is invoked
+    Then it returns a tool call message in the <sdk> consumer shape
+    And call() does not raise or throw a timeout error
+
+    Examples:
+      | sdk | event_form                    |
+      | PY  | streaming-args (delta×N+done) |
+      | PY  | output-item.done              |
+      | JS  | streaming-args (delta×N+done) |
+      | JS  | output-item.done              |
+
+  # ======================================================================
+  # AC5 — Multiple simultaneous function calls on a tool-only turn
+  # ======================================================================
+
+  @unit
+  Scenario: PY call() surfaces both function calls when a tool-only turn emits two
+    # AC5 (PY): two distinct function calls before response.done — both must appear
+    # in the returned message; neither is dropped.
+    Given the mock WebSocket will emit a tool-only turn with two function calls:
+      "get_weather" with args '{"location": "Paris"}' and "get_time" with args '{"tz": "UTC"}'
+      and NO audio delta
+    When PY call() is invoked
+    Then the returned message has role "assistant"
+    And tool_calls contains exactly 2 entries
+    And one entry has function.name "get_weather"
+    And one entry has function.name "get_time"
+
+  @unit
+  Scenario: JS call() surfaces both function calls when a tool-only turn emits two
+    # AC5 (JS): same multi-call invariant for the JS consumer shape.
+    Given the mock WebSocket will emit a tool-only turn with two function calls:
+      "get_weather" and "get_time" and NO audio delta
+    When JS call() is invoked
+    Then the returned message has role "tool"
+    And the content contains exactly 2 tool-result parts
+    And one part has toolName "get_weather"
+    And one part has toolName "get_time"
+
+  # ======================================================================
+  # AC6 — Regression: tool-free spoken turn still returns a single audio message
+  # ======================================================================
+
+  @integration
+  Scenario: A tool-free spoken turn still returns a single audio message unchanged
+    # AC6: the existing audio-only path must be unperturbed by the new terminal.
+    # PY: a dict (not a list) with role "assistant", no "tool_calls" key.
+    # JS: a single role:"assistant" audio message, no trailing role:"tool" message.
+    Given the mock WebSocket emits a normal spoken turn with audio deltas and NO function call
+    When call() is invoked in both SDKs
+    Then PY returns a single dict with role "assistant" and no "tool_calls" key
+    And JS returns a single role "assistant" audio message with no tool-result content
+    And neither SDK raises an error
+
+  # ======================================================================
+  # AC7 — Regression: audio+tool turn still returns both messages (#635 case)
+  # ======================================================================
+
+  @integration
+  Scenario: An audio-plus-tool turn still surfaces both the audio message and the tool-call message
+    # AC7: the #635 coexistence case — model speaks AND calls a tool in the same turn.
+    # Both messages must be present after the fix.
+    Given the mock WebSocket emits a turn with both audio deltas and a function call
+    When call() is invoked in both SDKs
+    Then PY returns a list with an audio assistant message followed by a tool_calls assistant message
+    And JS returns a list with an audio assistant message followed by a role:"tool" message
+    And neither SDK raises an error
+
+  # ======================================================================
+  # AC8 — Cross-turn no-bleed: turn 1 tool-only, turn 2 audio-only
+  # ======================================================================
+
+  @unit
+  Scenario: Turn-2 audio message carries no tool calls when turn-1 was tool-only
+    # AC8: two sequential call() invocations on the same adapter instance.
+    # Turn 1 is tool-only (no audio); turn 2 is audio-only (no function call).
+    # Turn 2 must return a clean audio message with no bleed-over from turn 1.
+    Given a single adapter instance is used for two sequential turns
+    And turn 1 emits a tool-only event sequence (function call, no audio)
+    And turn 2 emits an audio-only event sequence (audio deltas, no function call)
+    When call() is invoked twice in sequence on the same adapter
+    Then the turn-2 return value has role "assistant" in PY (a dict, not a list)
+    And the turn-2 return value has no "tool_calls" key in PY
+    And the turn-2 return value has no role:"tool" trailing message in JS
+    And the turn-1 tool call does not appear in the turn-2 result
+
+  # ======================================================================
+  # AC9 — Failure mode: genuinely empty turn still raises the timeout error
+  # ======================================================================
+
+  @unit
+  Scenario: A genuinely empty turn raises the timeout error and does not return
+    # AC9: response.created → response.done with NO audio delta AND an empty tool-call
+    # accumulator. The new terminal path keys on done+non-empty-accumulator; an empty
+    # accumulator must still surface the real hang rather than returning silently.
+    Given the mock WebSocket emits response.created then response.done
+      with NO audio delta and NO function call events
+    When PY call() is invoked
+    Then asyncio.TimeoutError is raised
+    And the error message is "OpenAIRealtimeAgentAdapter: recv_audio timed out"
+    And call() does not return a value
+
+  @unit
+  Scenario: A genuinely empty turn raises the timeout error in JS and does not return
+    # AC9 (JS half): same contract for the JS adapter.
+    Given the mock WebSocket emits response.created then response.done
+      with NO audio delta and NO function call events
+    When JS call() is invoked
+    Then it throws an Error
+    And the error message is "OpenAIRealtimeAgentAdapter: receiveAudio timed out"
+    And call() does not return a value
+
+  # ======================================================================
+  # AC10 — Failure mode: malformed arguments degrade gracefully (no-audio path)
+  # ======================================================================
+
+  @unit
+  Scenario: A tool-only turn with malformed function arguments returns without raising
+    # AC10: the no-audio path combined with bad/missing args — mirrors the existing
+    # #635 malformed-args contract (test_ac7a/test_ac7b) but on the no-audio path.
+    # PY: arguments degraded to raw string or "{}". JS: output is parsed JSON or raw string.
+    Given the mock WebSocket emits a tool-only turn where the function_call arguments
+      are malformed or missing
+    When PY call() is invoked
+    Then it returns a message with role "assistant" and a tool_calls entry
+    And the function.arguments field is the raw argument string or "{}" without raising
+
+  @unit
+  Scenario: A tool-only JS turn with malformed function arguments returns without raising
+    # AC10 (JS half): same degraded-args contract on the no-audio JS path.
+    Given the mock WebSocket emits a tool-only turn where the function_call arguments
+      are malformed or missing
+    When JS call() is invoked
+    Then it returns a role:"tool" message with a tool-result part
+    And the output field contains the parsed JSON value or the raw string verbatim without throwing
+
+  # ======================================================================
+  # AC11 — Full keyless suites stay green after the change
+  # ======================================================================
+
+  @unit
+  Scenario: The full PY keyless realtime tool-call suite passes after the fix
+    # AC11 (PY): uv run pytest tests/voice/test_realtime_tool_calls.py must pass.
+    # All pre-existing scenarios (audio+tool coexistence, tool-free turn, etc.) plus
+    # the new no-audio cases must all be green together.
+    Given the PY keyless suite tests/voice/test_realtime_tool_calls.py
+    When the suite is run with no live API key
+    Then all tests pass
+    And the pass count includes both the pre-existing #635 regression tests and the new AC1-AC10 cases
+
+  @unit
+  Scenario: The full JS keyless realtime tool-call suite passes after the fix
+    # AC11 (JS): pnpm vitest run src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
+    # (from javascript/) must pass. All pre-existing and new no-audio cases green together.
+    Given the JS keyless suite javascript/src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
+    When the suite is run with no live API key
+    Then all tests pass
+    And the pass count includes both the pre-existing #635 regression tests and the new AC1-AC10 cases
+
+  # --- AC Coverage Map ---
+  # AC 1: "PY call() returns tool-call assistant message on tool-only turn, no timeout" ->
+  #   Scenario: PY call() returns an assistant tool-call message on a tool-only turn (@unit)
+  # AC 2: "JS call() returns tool-result message on tool-only turn, no timeout" ->
+  #   Scenario: JS call() returns a tool-result message on a tool-only turn (@unit)
+  # AC 3: "Surfaced tool call consumable end-to-end via has_tool_call/hasToolCall" ->
+  #   Scenario: PY tool-only message is consumable via state.has_tool_call after conversion (@integration)
+  #   Scenario: JS tool-only message is consumable via state.hasToolCall after conversion (@integration)
+  # AC 4: "Both streaming-args and output-item event forms accepted as sole terminal source" ->
+  #   Scenario: PY call() accepts the output-item event form for a tool-only turn (@unit)
+  #   Scenario: JS call() accepts the output-item event form for a tool-only turn (@unit)
+  #   Scenario Outline: Both SDKs accept both tool-call event forms on a tool-only turn (@unit)
+  # AC 5: "Two simultaneous function calls both surfaced on a tool-only turn" ->
+  #   Scenario: PY call() surfaces both function calls when a tool-only turn emits two (@unit)
+  #   Scenario: JS call() surfaces both function calls when a tool-only turn emits two (@unit)
+  # AC 6: "Regression — tool-free spoken turn still returns a single audio message" ->
+  #   Scenario: A tool-free spoken turn still returns a single audio message unchanged (@integration)
+  # AC 7: "Regression — audio+tool turn (#635 case) still surfaces both messages" ->
+  #   Scenario: An audio-plus-tool turn still surfaces both the audio message and the tool-call message (@integration)
+  # AC 8: "Cross-turn no-bleed — turn-1 tool state does not appear in turn-2 audio result" ->
+  #   Scenario: Turn-2 audio message carries no tool calls when turn-1 was tool-only (@unit)
+  # AC 9: "Genuinely empty turn still raises the timeout error, not return" ->
+  #   Scenario: A genuinely empty turn raises the timeout error and does not return (@unit)
+  #   Scenario: A genuinely empty turn raises the timeout error in JS and does not return (@unit)
+  # AC 10: "Malformed arguments on no-audio path degrade gracefully without raising" ->
+  #   Scenario: A tool-only turn with malformed function arguments returns without raising (@unit)
+  #   Scenario: A tool-only JS turn with malformed function arguments returns without raising (@unit)
+  # AC 11: "Full keyless suites in both SDKs stay green" ->
+  #   Scenario: The full PY keyless realtime tool-call suite passes after the fix (@unit)
+  #   Scenario: The full JS keyless realtime tool-call suite passes after the fix (@unit)


### PR DESCRIPTION
## Why

Closes #646.

The OpenAI Realtime adapter **times out on a tool-only turn** — a model response that is a function/tool call with no spoken audio. `call()` awaited the first audio chunk before it could return; a tool-only response produces no audio, so the receive loop ran to its deadline and raised a timeout. **The tool call was fully parsed, then thrown away.** This blocked any model turn that emits a function call instead of speech. Surfaced by a reviewer on the merged PR #635 (https://github.com/langwatch/scenario/pull/635#issuecomment-4670728897).

## What changed

- **Added a tool-only terminal path to the receive/drain loop in both SDKs.** When `response.done` arrives with no audio produced but **≥1 tool call finalized this turn**, the drain returns an empty chunk so `call()` reaches its existing tool-call assembly and surfaces the message — instead of looping to the `response_timeout` deadline.
- **The discriminator is the non-empty accumulator, not `response.done` alone** — a genuinely empty/silent turn (done + empty accumulator) must still raise the timeout, so the new path is gated on accumulated calls. This is the load-bearing decision (verified by the empty-turn regression).
- **Each SDK keeps its own consumer shape** — Python emits the assistant `tool_calls` message; JS emits `role:"tool"` / `tool-result` parts. The fix only changes *when the drain terminates*, never the surfaced shape. Cross-SDK shape convergence is a separate concern (#640), deliberately out of scope.
- **Folded two #644 cleanup nits** that live in files this PR already touches (boy-scout): removed a debug `console.log(JSON.stringify(...))` from the JS test, and restored the dropped type annotations on the Python `call()` override.

## How it works

The bug and fix are one branch each, symmetric across SDKs:

| SDK | Drain method | Fix |
|-----|-------------|-----|
| Python | `recv_audio` (`openai_realtime.py`) | the existing `response.done`/`response.cancelled` branch returns `AudioChunk(data=b"")` when `self._completed_tool_calls` is non-empty |
| JS | `receiveAudio` (`openai-realtime.ts`) | a **new** `response.done`/`response.cancelled` branch (there was none) returns `new AudioChunk({data: new Uint8Array(0)})` when `this._completedToolCalls.length > 0` |

The empty chunk lets the base `drainAgentResponse` tail-silence loop terminate cleanly; control returns to `call()`, which finds the accumulator non-empty and returns the tool-call message that was already parsed.

## Test plan

Each SDK got a **fail-first regression test** (committed *before* its fix — see the git history) then the fix; the suites are keyless (mock-WS / in-process WS), no API key needed.

```
# Python — from python/
uv run pytest tests/voice/test_realtime_tool_calls.py
# → 18 passed

# JavaScript — from javascript/
pnpm vitest run src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts
# → 17 passed
```

- Fail-first proof (Python): `test_issue646_tool_only_no_audio_returns_tool_call` raised `TimeoutError: mock WS: no more events` on the pre-fix code; passes after.
- Fail-first proof (JS): `#646 (AC2) — tool-only turn (no audio delta)...` rejected with `receiveAudio timed out` (11.85s) on the pre-fix code; passes after (1.96s).
- Coverage spans AC1–AC11: both event forms (streaming-args + output-item), multi-call, end-to-end consumability through `has_tool_call`/`hasToolCall`, cross-turn no-bleed, **the empty-turn-still-times-out failure mode** (proves the discriminator), malformed-args degradation, and the audio+tool coexistence regression.

## How I can prove I was successful

**No playable artifact — see Test plan.** This is a pure control-flow change in a transport adapter; the demonstration is the regression test that *times out on the parent commit and passes on this branch*. The fail-first commits (`24811aa`, `c289bf4`) are the in-PR evidence that the bug was real and is now fixed: check out the test commit alone and the suite times out; add the fix commit and it goes green.

## Anything surprising?

- **The JS `receiveAudio` had no `response.done` handling at all** — `response.done` fell into the housekeeping fall-through and the loop just continued. The Python side at least had a `response.done` branch (it only set a flag). So the JS fix adds a branch; the Python fix extends one.
- **A `role:"tool"` message carrying arguments is intentional, not a bug** — JS surfaces a tool-call *request* in a tool-*result* shape because that is what its `hasToolCall` consumer matches today. Converging that with Python's `tool_calls` shape is tracked by #640 and is explicitly not in this PR.

## Acceptance Criteria

All 11 ACs verified in-tree this turn — keyless suites, no API key. PY: `uv run pytest tests/voice/test_realtime_tool_calls.py` → **18 passed**. JS: `pnpm vitest run src/voice/adapters/__tests__/openai-realtime-tool-calls.test.ts` → **17 passed**.

| # | Criterion | Evidence (test, green this turn) | Status |
|---|-----------|----------------------------------|--------|
| 1 | PY tool-only turn returns the `tool_calls` assistant message, no timeout | `test_issue646_tool_only_no_audio_returns_tool_call` | ✅ |
| 2 | JS tool-only turn returns `role:"tool"`/`tool-result`, not the PY shape | `#646 (AC2) — tool-only turn (no audio delta)…` | ✅ |
| 3 | Consumable end-to-end via `has_tool_call`/`hasToolCall` | PY `test_issue646_tool_only_consumable_via_scenario_state`; JS `#646 (AC3)` | ✅ |
| 4 | Both event forms (streaming-args + output-item) terminate a tool-only turn | PY `…_streaming_args_form` + `…_output_item_form`; JS `#646 (AC4)` ×2 | ✅ |
| 5 | Two simultaneous calls both surface | PY `…_two_calls_both_surface`; JS `#646 (AC5)` | ✅ |
| 6 | Regression: tool-free spoken turn unchanged | PY `test_ac8_tool_free_turn_has_no_tool_calls_key`; JS `AC8 — audio-only turn…` | ✅ |
| 7 | Regression: audio+tool coexist (both messages) | PY `test_ac9_audio_and_tool_call_coexist`; JS `#646 (AC7)` (new coexistence assertion) | ✅ |
| 8 | Cross-turn no-bleed | PY `test_issue646_cross_turn_no_bleed`; JS `#646 (AC8)` | ✅ |
| 9 | Genuinely empty turn STILL times out (discriminator = non-empty accumulator) | PY `test_issue646_empty_turn_still_times_out`; JS `#646 (AC9)` | ✅ |
| 10 | Malformed args degrade (no raise) on the no-audio path | PY `test_issue646_tool_only_malformed_args_degrade`; JS `#646 (AC10)` | ✅ |
| 11 | Full keyless suites green | PY 18 passed; JS 17 passed (quoted above) | ✅ |

✅ = verified in-tree this turn. CI re-confirmation pending (PR is draft until CI green).
