### PR TITLE
fix(voice/#498): surface attributable first-chunk timeout (phase + timeout + cause)

### DIFF
--- a/python/scenario/voice/__init__.py
+++ b/python/scenario/voice/__init__.py
@@ -9,6 +9,7 @@ Public surface:
     - VoiceAgentAdapter — base class for voice-capable agents
     - AudioChunk — canonical internal audio (PCM16 @ 24kHz mono)
     - AdapterCapabilities / UnsupportedCapabilityError — capability matrix
+    - FirstChunkTimeoutError — attributable first-chunk recv timeout
     - VoiceRecording / VoiceEvent / LatencyMetrics — result-side types
     - AudioSegment — per-speaker slice of the recording
     - synthesize / STTProvider / set_stt_provider / get_stt_provider —
@@ -21,7 +22,7 @@ Public surface:
 
 from __future__ import annotations
 
-from .adapter import VoiceAgentAdapter
+from .adapter import FirstChunkTimeoutError, VoiceAgentAdapter
 from .adapters import (
     ComposableVoiceAgent,
     ElevenLabsAgentAdapter,
@@ -62,6 +63,7 @@ __all__ = [
     "ElevenLabsAgentAdapter",
     "ElevenLabsSTTProvider",
     "ElevenLabsVoiceAgent",
+    "FirstChunkTimeoutError",
     "GeminiLiveAgentAdapter",
     "InterruptionConfig",
     "LatencyMetrics",

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -31,6 +31,32 @@ from .messages import create_audio_message, extract_audio
 from .recording import AudioSegment, VoiceEvent
 
 
+_FIRST_CHUNK_PHASE = "first-chunk"
+"""Phase marker for the first-chunk recv timeout (used in FirstChunkTimeoutError)."""
+
+
+class FirstChunkTimeoutError(asyncio.TimeoutError):
+    """Raised when the agent fails to send its first audio chunk within ``response_timeout``.
+
+    WHY this subclass exists: operators could not distinguish a first-chunk hang
+    (agent never spoke — wrong endpoint, VAD never fired, response_timeout too
+    short) from a tail-silence cutoff (agent finished speaking normally).  The
+    bare ``asyncio.TimeoutError`` that escaped previously had an empty ``str()``
+    and no structured attributes, so log aggregators and re-raise chains had no
+    signal.  This class embeds the phase marker (``_FIRST_CHUNK_PHASE``) in its
+    message, a machine-readable ``.timeout`` attribute, and chains the original
+    transport error via ``__cause__``.
+    """
+
+    def __init__(self, *, timeout: float, phase: str) -> None:
+        self.timeout = timeout
+        self.phase = phase
+        super().__init__(
+            f"agent did not send its first audio chunk within {timeout}s "
+            f"(phase={phase})"
+        )
+
+
 class VoiceAgentAdapter(AgentAdapter):
     """
     Abstract base for voice agents that exchange audio with the agent under test.
@@ -202,7 +228,12 @@ class VoiceAgentAdapter(AgentAdapter):
         agent.start at a real flow point rather than back-computing from
         the merged-chunk duration.
         """
-        first = await self.recv_audio(timeout=self.response_timeout)
+        try:
+            first = await self.recv_audio(timeout=self.response_timeout)
+        except asyncio.TimeoutError as err:
+            raise FirstChunkTimeoutError(
+                timeout=self.response_timeout, phase=_FIRST_CHUNK_PHASE
+            ) from err
         # First chunk arrived → agent is now speaking. Wakes anyone awaiting
         # _agent_speaking_event (the interruption path).
         if first.data and on_first_chunk is not None:

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -48,12 +48,12 @@ class FirstChunkTimeoutError(asyncio.TimeoutError):
     transport error via ``__cause__``.
     """
 
-    def __init__(self, *, timeout: float, phase: str) -> None:
+    def __init__(self, *, timeout: float) -> None:
         self.timeout = timeout
-        self.phase = phase
+        self.phase = _FIRST_CHUNK_PHASE
         super().__init__(
             f"agent did not send its first audio chunk within {timeout}s "
-            f"(phase={phase})"
+            f"(phase={_FIRST_CHUNK_PHASE})"
         )
 
 
@@ -231,9 +231,7 @@ class VoiceAgentAdapter(AgentAdapter):
         try:
             first = await self.recv_audio(timeout=self.response_timeout)
         except asyncio.TimeoutError as err:
-            raise FirstChunkTimeoutError(
-                timeout=self.response_timeout, phase=_FIRST_CHUNK_PHASE
-            ) from err
+            raise FirstChunkTimeoutError(timeout=self.response_timeout) from err
         # First chunk arrived → agent is now speaking. Wakes anyone awaiting
         # _agent_speaking_event (the interruption path).
         if first.data and on_first_chunk is not None:

--- a/python/tests/voice/test_drain_timeout_surfacing.py
+++ b/python/tests/voice/test_drain_timeout_surfacing.py
@@ -27,6 +27,13 @@ and makes ``recv_audio`` raise a bare ``asyncio.TimeoutError()`` — exactly wha
 ``pipecat.PipecatAgentAdapter.recv_audio`` / ``asyncio.wait_for`` raise on a
 real first-chunk timeout. The inherited ``_drain_agent_response`` (the line
 under test) runs unmodified.
+
+Test 2 is the falsifiable counterpart: once the first chunk *does* arrive, a
+subsequent tail-silence timeout must NOT raise — it ends the drain and returns
+the collected audio. Without this guard, "attributable first-chunk timeout"
+could be satisfied by re-raising on *every* recv timeout, which would break the
+normal end-of-turn signal. The two tests together pin "raise on first-chunk
+timeout, stay silent on tail-silence timeout."
 """
 
 from __future__ import annotations
@@ -40,6 +47,12 @@ from scenario.voice import (
     AudioChunk,
     VoiceAgentAdapter,
 )
+
+# Reach the raise site's phase marker through the MODULE, not a direct import:
+# a direct ``from ... import _FIRST_CHUNK_PHASE`` would fail at COLLECTION
+# (taking Test 2 down with it). Going through the module means a missing
+# constant fails only the test that dereferences it. The module itself exists.
+from scenario.voice import adapter as _adapter_mod
 
 # A deliberately non-default value so the assertion proves the *configured*
 # number is surfaced, not a coincidental default.
@@ -77,39 +90,136 @@ class _FirstChunkTimeoutAdapter(VoiceAgentAdapter):
         raise asyncio.TimeoutError()
 
 
+class _TailSilenceTimeoutAdapter(VoiceAgentAdapter):
+    """Real adapter where the first chunk arrives, then tail-silence times out.
+
+    First ``recv_audio`` returns one real chunk (agent started speaking); the
+    second raises ``asyncio.TimeoutError`` — the natural "agent finished
+    talking" signal. The inherited drain must absorb that and return the
+    collected audio, NOT propagate the timeout.
+    """
+
+    # One real chunk of agent audio. Non-empty data so the drain's
+    # ``first.data`` branch fires and the chunk is collected.
+    FIRST_CHUNK = AudioChunk(data=b"\x01\x02" * 600, transcript="hello")
+
+    capabilities = AdapterCapabilities(
+        streaming_transcripts=True,
+        native_vad=True,
+        dtmf=False,
+        input_formats=["pcm16/24000"],
+        output_formats=["pcm16/24000"],
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._calls = 0
+
+    async def connect(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def disconnect(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def send_audio(self, chunk: AudioChunk) -> None:  # pragma: no cover
+        pass
+
+    async def recv_audio(self, timeout: float) -> AudioChunk:
+        # Call 1: first chunk on the wire. Call 2+: tail silence (timeout).
+        self._calls += 1
+        if self._calls == 1:
+            return self.FIRST_CHUNK
+        raise asyncio.TimeoutError()
+
+
 @pytest.mark.asyncio
 async def test_first_chunk_timeout_is_attributable():
     """The error escaping the drain on a first-chunk timeout must be
-    informative — non-empty, naming the first-chunk timeout, and quoting the
-    configured ``response_timeout`` value — so an operator can attribute it.
+    attributable: non-empty body, a code-owned phase marker (not an English
+    word), a structured ``.timeout`` attribute equal to the configured value,
+    and a ``__cause__`` chaining the original transport ``TimeoutError``.
 
     RED against current code: the first-chunk ``recv_audio`` call is unwrapped,
-    so a bare ``asyncio.TimeoutError`` (``str() == ""``) escapes verbatim with
-    no context.
+    so a bare ``asyncio.TimeoutError`` (``str() == ""``, no ``.timeout``, no
+    ``__cause__``) escapes verbatim. The first assertion to fail will be the
+    phase-marker dereference (``_adapter_mod._FIRST_CHUNK_PHASE`` does not yet
+    exist) — by design, that is the coder's contract symbol.
     """
     adapter = _FirstChunkTimeoutAdapter()
     adapter.response_timeout = _SENTINEL_TIMEOUT
 
+    # We assert on ``asyncio.TimeoutError`` because that is the transport-native
+    # exception class. On Python >= 3.11 ``asyncio.TimeoutError is TimeoutError``,
+    # so the *type* alone proves nothing — the contract is the message + the
+    # ``.timeout`` attribute + the chained ``__cause__``, asserted below.
     with pytest.raises(asyncio.TimeoutError) as excinfo:
         await adapter._drain_agent_response()
 
     message = str(excinfo.value)
 
-    # 1. Body must never be blank — the whole point of the diagnostic slice.
+    # AC1 — body must never be blank: the whole point of the diagnostic slice.
     assert message.strip(), (
         "first-chunk timeout escaped with a blank body — operators get no "
         f"signal; got: {message!r}"
     )
 
-    # 2. Must distinguish the first-chunk timeout from a tail-silence cutoff.
-    assert "first" in message.lower(), (
-        "timeout message must name the *first-chunk* wait so it is "
-        f"distinguishable from a tail-silence cutoff; got: {message!r}"
+    # AC2a — phase marker is CODE-OWNED, not an English substring. Reference the
+    # constant the coder will define so the marker and the assertion cannot
+    # drift apart and a reviewer cannot satisfy it with a stray word like
+    # "first" elsewhere in the sentence. (Dereferencing the not-yet-defined
+    # constant is the intended RED point for this test.)
+    assert _adapter_mod._FIRST_CHUNK_PHASE in message, (
+        "timeout message must embed the code-owned first-chunk phase marker "
+        f"({_adapter_mod._FIRST_CHUNK_PHASE!r}) so it is distinguishable from a "
+        f"tail-silence cutoff; got: {message!r}"
     )
 
-    # 3. Must surface the configured timeout value so the operator can judge
-    #    whether the budget was simply too short for a real STT+LLM+TTS turn.
-    assert str(_SENTINEL_TIMEOUT) in message, (
-        "timeout message must quote the configured response_timeout value; "
-        f"got: {message!r}"
+    # AC2b — configured timeout surfaced as a STRUCTURED attribute, not scraped
+    # from the message. ``str(timeout) in message`` false-passes on substrings
+    # (0.05 matches "10.05") and breaks on float formatting (0.05 vs 5e-02);
+    # a typed attribute is formatting-proof and machine-readable.
+    assert excinfo.value.timeout == _SENTINEL_TIMEOUT, (  # type: ignore[attr-defined]
+        "raised error must carry a structured .timeout attribute equal to the "
+        f"configured response_timeout ({_SENTINEL_TIMEOUT}); got: "
+        f"{getattr(excinfo.value, 'timeout', '<missing>')!r}"
+    )
+
+    # AC-cause — the re-raise must CHAIN the original transport timeout
+    # (``raise ... from err``) so the underlying error is not lost.
+    assert isinstance(excinfo.value.__cause__, asyncio.TimeoutError), (
+        "re-raised error must chain the original transport TimeoutError as its "
+        f"__cause__ (raise ... from err); got: {excinfo.value.__cause__!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tail_silence_timeout_ends_drain_without_raising():
+    """Once the first chunk has arrived, a tail-silence ``recv_audio`` timeout
+    must END the drain and RETURN the collected audio — never propagate.
+
+    GREEN against current code: the tail-silence recv is already wrapped in a
+    try/except that ``break``s the loop. This is the falsifiable counterpart to
+    Test 1 — it proves the first-chunk fix must be *scoped* to the first recv
+    and not turn every recv timeout into a raise.
+
+    Return shape: with exactly one chunk collected, ``_drain_agent_response``
+    returns that chunk via ``_merge_chunks`` (single-chunk path returns the
+    chunk unchanged), so the result carries the first chunk's data verbatim.
+    """
+    adapter = _TailSilenceTimeoutAdapter()
+    # Keep the sentinel here too so a future first-chunk re-raise (if it ever
+    # leaked into this path) would be obvious — but this path must not raise.
+    adapter.response_timeout = _SENTINEL_TIMEOUT
+
+    # Must RETURN, not raise: any TimeoutError here is a regression.
+    result = await adapter._drain_agent_response()
+
+    assert isinstance(result, AudioChunk), (
+        f"drain must return a merged AudioChunk after tail silence; got: {result!r}"
+    )
+    # Single collected chunk → _merge_chunks returns it unchanged, so the data
+    # is the first chunk's data verbatim.
+    assert result.data == _TailSilenceTimeoutAdapter.FIRST_CHUNK.data, (
+        "returned audio must contain the first chunk's data after the "
+        f"tail-silence cutoff; got {len(result.data)} bytes"
     )

--- a/python/tests/voice/test_drain_timeout_surfacing.py
+++ b/python/tests/voice/test_drain_timeout_surfacing.py
@@ -48,10 +48,8 @@ from scenario.voice import (
     VoiceAgentAdapter,
 )
 
-# Reach the raise site's phase marker through the MODULE, not a direct import:
-# a direct ``from ... import _FIRST_CHUNK_PHASE`` would fail at COLLECTION
-# (taking Test 2 down with it). Going through the module means a missing
-# constant fails only the test that dereferences it. The module itself exists.
+# Import the module (not the constant directly) so a missing _FIRST_CHUNK_PHASE
+# fails only the test that dereferences it, not collection.
 from scenario.voice import adapter as _adapter_mod
 
 # A deliberately non-default value so the assertion proves the *configured*
@@ -66,21 +64,16 @@ class _FirstChunkTimeoutAdapter(VoiceAgentAdapter):
     test is inherited from ``VoiceAgentAdapter`` unchanged.
     """
 
-    capabilities = AdapterCapabilities(
-        streaming_transcripts=True,
-        native_vad=True,
-        dtmf=False,
-        input_formats=["pcm16/24000"],
-        output_formats=["pcm16/24000"],
-    )
+    # The drain/timeout path reads no capability field; bare defaults suffice.
+    capabilities = AdapterCapabilities()
 
-    async def connect(self) -> None:  # pragma: no cover - trivial
+    async def connect(self) -> None:
         pass
 
-    async def disconnect(self) -> None:  # pragma: no cover - trivial
+    async def disconnect(self) -> None:
         pass
 
-    async def send_audio(self, chunk: AudioChunk) -> None:  # pragma: no cover
+    async def send_audio(self, chunk: AudioChunk) -> None:
         pass
 
     async def recv_audio(self, timeout: float) -> AudioChunk:
@@ -103,25 +96,20 @@ class _TailSilenceTimeoutAdapter(VoiceAgentAdapter):
     # ``first.data`` branch fires and the chunk is collected.
     FIRST_CHUNK = AudioChunk(data=b"\x01\x02" * 600, transcript="hello")
 
-    capabilities = AdapterCapabilities(
-        streaming_transcripts=True,
-        native_vad=True,
-        dtmf=False,
-        input_formats=["pcm16/24000"],
-        output_formats=["pcm16/24000"],
-    )
+    # The drain/timeout path reads no capability field; bare defaults suffice.
+    capabilities = AdapterCapabilities()
 
     def __init__(self) -> None:
         super().__init__()
         self._calls = 0
 
-    async def connect(self) -> None:  # pragma: no cover - trivial
+    async def connect(self) -> None:
         pass
 
-    async def disconnect(self) -> None:  # pragma: no cover - trivial
+    async def disconnect(self) -> None:
         pass
 
-    async def send_audio(self, chunk: AudioChunk) -> None:  # pragma: no cover
+    async def send_audio(self, chunk: AudioChunk) -> None:
         pass
 
     async def recv_audio(self, timeout: float) -> AudioChunk:

--- a/python/tests/voice/test_drain_timeout_surfacing.py
+++ b/python/tests/voice/test_drain_timeout_surfacing.py
@@ -1,0 +1,115 @@
+"""When the agent under test never sends its first audio chunk, the voice
+adapter's drain loop times out — and that timeout must be *attributable*.
+
+Regression target for #498 (diagnostic-surfacing slice, creds-free half).
+
+Mechanism of the bug: ``VoiceAgentAdapter._drain_agent_response`` awaits the
+first chunk via ``recv_audio(timeout=self.response_timeout)`` (adapter.py:205).
+That call is NOT wrapped — a transport ``asyncio.TimeoutError`` propagates
+verbatim. Because ``str(asyncio.TimeoutError())`` is ``""`` and its ``.args``
+are empty, the error that escapes carries *no* signal:
+
+  - which timeout fired (the first-chunk ``response_timeout`` vs the
+    per-chunk ``response_tail_silence``), and
+  - what the configured timeout value actually was.
+
+The executor re-raise (``[{agent_name}] {error_detail}``) was already fixed
+under #500/#547 to fall back to the type name, so operators now at least see
+``[PipecatAgentAdapter] TimeoutError`` instead of ``[PipecatAgentAdapter]``.
+But "TimeoutError" alone still cannot tell a first-chunk hang (agent never
+spoke — likely wrong endpoint / VAD never fired / response_timeout too short)
+apart from a mid-response tail-silence cutoff. This test pins the *upstream*
+fix: the adapter must surface that context at the raise site.
+
+No credentials, no live transport: a dummy adapter (a real
+``VoiceAgentAdapter`` subclass) overrides only the abstract transport methods
+and makes ``recv_audio`` raise a bare ``asyncio.TimeoutError()`` — exactly what
+``pipecat.PipecatAgentAdapter.recv_audio`` / ``asyncio.wait_for`` raise on a
+real first-chunk timeout. The inherited ``_drain_agent_response`` (the line
+under test) runs unmodified.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from scenario.voice import (
+    AdapterCapabilities,
+    AudioChunk,
+    VoiceAgentAdapter,
+)
+
+# A deliberately non-default value so the assertion proves the *configured*
+# number is surfaced, not a coincidental default.
+_SENTINEL_TIMEOUT = 0.05
+
+
+class _FirstChunkTimeoutAdapter(VoiceAgentAdapter):
+    """Real adapter whose transport never yields a first chunk.
+
+    Overrides only the four abstract transport hooks; the drain logic under
+    test is inherited from ``VoiceAgentAdapter`` unchanged.
+    """
+
+    capabilities = AdapterCapabilities(
+        streaming_transcripts=True,
+        native_vad=True,
+        dtmf=False,
+        input_formats=["pcm16/24000"],
+        output_formats=["pcm16/24000"],
+    )
+
+    async def connect(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def disconnect(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def send_audio(self, chunk: AudioChunk) -> None:  # pragma: no cover
+        pass
+
+    async def recv_audio(self, timeout: float) -> AudioChunk:
+        # Mirror what `asyncio.wait_for(queue.get(), timeout)` raises in
+        # pipecat.PipecatAgentAdapter.recv_audio when no agent audio arrives:
+        # a bare, message-less TimeoutError.
+        raise asyncio.TimeoutError()
+
+
+@pytest.mark.asyncio
+async def test_first_chunk_timeout_is_attributable():
+    """The error escaping the drain on a first-chunk timeout must be
+    informative — non-empty, naming the first-chunk timeout, and quoting the
+    configured ``response_timeout`` value — so an operator can attribute it.
+
+    RED against current code: the first-chunk ``recv_audio`` call is unwrapped,
+    so a bare ``asyncio.TimeoutError`` (``str() == ""``) escapes verbatim with
+    no context.
+    """
+    adapter = _FirstChunkTimeoutAdapter()
+    adapter.response_timeout = _SENTINEL_TIMEOUT
+
+    with pytest.raises(asyncio.TimeoutError) as excinfo:
+        await adapter._drain_agent_response()
+
+    message = str(excinfo.value)
+
+    # 1. Body must never be blank — the whole point of the diagnostic slice.
+    assert message.strip(), (
+        "first-chunk timeout escaped with a blank body — operators get no "
+        f"signal; got: {message!r}"
+    )
+
+    # 2. Must distinguish the first-chunk timeout from a tail-silence cutoff.
+    assert "first" in message.lower(), (
+        "timeout message must name the *first-chunk* wait so it is "
+        f"distinguishable from a tail-silence cutoff; got: {message!r}"
+    )
+
+    # 3. Must surface the configured timeout value so the operator can judge
+    #    whether the budget was simply too short for a real STT+LLM+TTS turn.
+    assert str(_SENTINEL_TIMEOUT) in message, (
+        "timeout message must quote the configured response_timeout value; "
+        f"got: {message!r}"
+    )


### PR DESCRIPTION
## Why

Closes the **creds-free diagnostic half** of #498. When a voice agent fails to send its **first** audio chunk within `response_timeout`, the adapter's first-chunk `recv_audio` was **unwrapped** — a bare `asyncio.TimeoutError` (empty `str()`, no context) propagated. Even with the executor's #500 type-name fallback, operators only saw `[PipecatAgentAdapter] TimeoutError`: indistinguishable from a mid-response (tail-silence) cutoff, and missing the configured timeout value.

**References #498** — the *primary* root cause (**why** the 2nd Pipecat turn times out: agent hang vs `response_timeout` too short vs VAD-on-synthetic-audio vs a swallowed background-task crash) needs a **live Pipecat run** and is out of scope for this slice. #498 stays open for it.

## What changed

- New `FirstChunkTimeoutError(asyncio.TimeoutError)` in `scenario/voice/adapter.py` carrying `.timeout` (the configured budget) + `.phase` (`"first-chunk"`), with a non-empty message embedding both. It **subclasses** `asyncio.TimeoutError`, so the executor wrap (`#500`) and any existing `except asyncio.TimeoutError` are unaffected.
- `_drain_agent_response` wraps **only** the first-chunk `recv_audio` and re-raises `FirstChunkTimeoutError(...) from err` (chains the original transport timeout for an intact stack). The tail-silence recv is **untouched** — it still ends the drain silently and returns the chunks collected so far.

Before → after operator string:
`[PipecatAgentAdapter] TimeoutError` → `[PipecatAgentAdapter] agent did not send its first audio chunk within <response_timeout>s (phase=first-chunk)`

## Acceptance Criteria (creds-free diagnostic slice; ac-reviewed)

- **AC1** — first-chunk timeout escapes as a `TimeoutError` with a **non-empty** message, chaining the original transport timeout (`__cause__`). ✅ `test_first_chunk_timeout_is_attributable`
- **AC2** — the message carries a **code-owned phase marker** (`_FIRST_CHUNK_PHASE`, not an English substring) and exposes the configured timeout as a **typed `.timeout` attribute** (not a brittle string scrape). ✅ same test
- **AC3** (regression guard) — the tail-silence path is **unchanged** (returns collected chunks, does not raise). ✅ `test_tail_silence_timeout_ends_drain_without_raising`
- **Deferred (live-gated)** — primary 2nd-turn timeout root cause.

## Test plan

```
cd python && uv run pytest tests/voice/test_drain_timeout_surfacing.py
```
- `test_first_chunk_timeout_is_attributable` — RED before this change, GREEN after.
- `test_tail_silence_timeout_ends_drain_without_raising` — GREEN throughout (guards no regression).
- Local validation: target 2 passed · `test_adapter_base.py` 3 passed · voice dir collects 377 · `pyright scenario/voice/adapter.py` 0 errors.

## How I can prove it

No playable artifact — the change is an exception-surfacing diagnostic. The regression net is the two unit tests above (the first exercises the real inherited `_drain_agent_response` via a dummy adapter raising a bare `asyncio.TimeoutError`).
