### PR TITLE
fix(voice/#623): reframe realtime agent audio turns so the voiced sim does not echo them

### DIFF
--- a/javascript/src/agents/__tests__/realtime-adapter-frames.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-frames.test.ts
@@ -1,0 +1,222 @@
+/**
+ * AC-JS3' (agent-first) + AC-JS4' (user-first no-double-fire) — outbound-frame
+ * regression locks for the realtime adapter (`RealtimeAgentAdapter`), issue #623.
+ *
+ * These assert on the ARTIFACT the double-fire / hang bugs actually produce —
+ * the sequence of events written to the realtime transport — NOT on
+ * result-message counts. A `response.create` storm or a missing initial
+ * `response.create` is invisible at the message layer but obvious on the wire.
+ *
+ *  - AC-JS3' (agent-first, locks `handleInitialResponse`): a leading
+ *    `scenario.agent()` with NO prior user message must fire exactly ONE
+ *    `response.create` BEFORE any user-audio commit, and yield exactly one
+ *    non-empty assistant turn carrying both a `text` and an `audio/pcm16` `file`
+ *    part. The run must not hang.
+ *  - AC-JS4' (user-first no-double-fire): for a script of N user-audio turns the
+ *    transport must receive EXACTLY N `response.create` frames, and ZERO before
+ *    the first `input_audio_buffer.commit`. (The double-fire bug shows up as
+ *    > N frames.)
+ *
+ * Creds-free mock strategy (no OpenAI key, no network):
+ *  - A fake transport (an `on`/`sendEvent` object) records every outbound event
+ *    AND, on receiving `response.create`, asynchronously emits the
+ *    transcript-delta + audio-delta + `response.done` events the real
+ *    `RealtimeEventHandler` listens for — so `waitForResponse` resolves exactly
+ *    as it would against the live API. The adapter drives the REAL
+ *    `RealtimeEventHandler` / `MessageProcessor` / `ResponseFormatter`.
+ *  - A fake session exposes that transport (the only session surface
+ *    `RealtimeAgentAdapter` touches for these paths is `session.transport`).
+ */
+
+import type { ModelMessage } from "ai";
+import { describe, it, expect } from "vitest";
+
+import { RealtimeAgentAdapter } from "../realtime/realtime-agent.adapter";
+import { AgentRole } from "../../domain";
+import type { AgentInput } from "../../domain";
+
+const AGENT_TRANSCRIPT = "thanks for joining, tell me about your background";
+
+/** One PCM16 audio-delta frame (base64) the fake "model" streams back. */
+const AUDIO_DELTA_B64 = Buffer.from(
+  "\x10\x00\x20\x00",
+  "binary",
+).toString("base64");
+
+interface OutboundEvent {
+  type: string;
+  [k: string]: unknown;
+}
+
+/**
+ * A fake realtime transport: an `on`/`sendEvent` surface that (1) records every
+ * outbound event, and (2) on `response.create`, asynchronously streams back the
+ * transcript-delta + audio-delta + `response.done` the real
+ * `RealtimeEventHandler` consumes. Mirrors the live transport's event names
+ * (`response.output_audio_transcript.delta`, `response.output_audio.delta`,
+ * `response.done`) so the adapter's REAL handler resolves `waitForResponse`.
+ */
+class FakeTransport {
+  readonly outbound: OutboundEvent[] = [];
+  private listeners = new Map<string, Array<(data: unknown) => void>>();
+
+  on(event: string, callback: (data: unknown) => void): void {
+    const arr = this.listeners.get(event) ?? [];
+    arr.push(callback);
+    this.listeners.set(event, arr);
+  }
+
+  private emit(event: string, data: unknown): void {
+    for (const cb of this.listeners.get(event) ?? []) cb(data);
+  }
+
+  sendEvent(event: OutboundEvent): void {
+    this.outbound.push(event);
+    if (event.type === "response.create") {
+      // Resolve on a later macrotask so the adapter's `waitForResponse`
+      // resolver is registered before `response.done` fires (the live API is
+      // likewise strictly async after `response.create`).
+      setTimeout(() => {
+        this.emit("response.output_audio_transcript.delta", {
+          delta: AGENT_TRANSCRIPT,
+        });
+        this.emit("response.output_audio.delta", { delta: AUDIO_DELTA_B64 });
+        this.emit("response.done", {});
+      }, 0);
+    }
+  }
+
+  /** Count of a given outbound event type. */
+  count(type: string): number {
+    return this.outbound.filter((e) => e.type === type).length;
+  }
+
+  /** First index of an outbound event type (or -1). */
+  indexOf(type: string): number {
+    return this.outbound.findIndex((e) => e.type === type);
+  }
+}
+
+/** A fake RealtimeSession exposing only the surface the adapter touches. */
+function makeFakeSession(transport: FakeTransport) {
+  return {
+    transport,
+    connect: async () => undefined,
+    close: () => undefined,
+    sendMessage: () => undefined,
+  } as unknown as ConstructorParameters<
+    typeof RealtimeAgentAdapter
+  >[0]["session"];
+}
+
+function makeAdapter(transport: FakeTransport): RealtimeAgentAdapter {
+  return new RealtimeAgentAdapter({
+    session: makeFakeSession(transport),
+    role: AgentRole.AGENT,
+    agentName: "Realtime Agent Under Test",
+    responseTimeout: 2000,
+  });
+}
+
+/** A user audio turn (the shape the adapter routes to `handleAudioInput`). */
+function userAudioTurn(): ModelMessage {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "file",
+        mediaType: "audio/pcm16",
+        data: Buffer.from("\x00\x00".repeat(160), "binary").toString("base64"),
+      },
+    ],
+  } as ModelMessage;
+}
+
+function makeInput(newMessages: ModelMessage[]): AgentInput {
+  return {
+    threadId: "realtime-frames-thread",
+    messages: newMessages,
+    newMessages,
+    requestedRole: AgentRole.AGENT,
+    scenarioState: {} as unknown as AgentInput["scenarioState"],
+    scenarioConfig: {
+      name: "realtime-frames",
+      description: "Voice interview.",
+    } as unknown as AgentInput["scenarioConfig"],
+  } as AgentInput;
+}
+
+/** Pull text + audio parts out of a returned assistant turn. */
+function partsOf(msg: unknown): Array<{ type?: string; text?: string; mediaType?: string }> {
+  const content = (msg as { content?: unknown }).content;
+  return Array.isArray(content)
+    ? (content as Array<{ type?: string; text?: string; mediaType?: string }>)
+    : [];
+}
+
+describe("RealtimeAgentAdapter agent-first (AC-JS3' — locks handleInitialResponse)", () => {
+  it("fires exactly one response.create before any user-audio commit and yields one non-empty assistant turn", async () => {
+    const transport = new FakeTransport();
+    const adapter = makeAdapter(transport);
+
+    // Leading scenario.agent() with NO prior user message → newMessages empty →
+    // handleInitialResponse. Must resolve (not hang) via the fake's async
+    // response.done.
+    const result = await adapter.call(makeInput([]));
+
+    // Exactly ONE response.create was sent...
+    expect(transport.count("response.create")).toBe(1);
+    // ...and NO user-audio was ever appended/committed for an agent-first open.
+    expect(transport.count("input_audio_buffer.commit")).toBe(0);
+    expect(transport.count("input_audio_buffer.append")).toBe(0);
+
+    // The resulting assistant turn is non-empty and carries BOTH a text part
+    // (the transcript) and an audio/pcm16 file part.
+    expect((result as { role?: string }).role).toBe("assistant");
+    const parts = partsOf(result);
+    const text = parts.find((p) => p.type === "text");
+    const file = parts.find((p) => p.type === "file");
+    expect(text?.text).toBe(AGENT_TRANSCRIPT);
+    expect(file?.mediaType).toBe("audio/pcm16");
+
+    // Run-shape: >= 1 assistant turn, non-empty.
+    const assistantTurns = [result].filter(
+      (m) => (m as { role?: string }).role === "assistant",
+    );
+    expect(assistantTurns.length).toBeGreaterThanOrEqual(1);
+    expect((text?.text ?? "").length).toBeGreaterThan(0);
+  });
+});
+
+describe("RealtimeAgentAdapter user-first (AC-JS4' — no double-fire, outbound frames)", () => {
+  it("sends exactly N response.create frames for N user turns, none before the first audio commit", async () => {
+    const N = 3;
+    const transport = new FakeTransport();
+    const adapter = makeAdapter(transport);
+
+    let sawUserRole = false;
+    for (let i = 0; i < N; i++) {
+      const userTurn = userAudioTurn();
+      sawUserRole = sawUserRole || userTurn.role === "user";
+      // Each user-audio turn drives handleAudioInput: append → commit →
+      // response.create → waitForResponse (resolved by the fake).
+      const reply = await adapter.call(makeInput([userTurn]));
+      expect((reply as { role?: string }).role).toBe("assistant");
+    }
+
+    // EXACTLY N response.create frames — not 2N (the double-fire signature).
+    expect(transport.count("response.create")).toBe(N);
+    // One commit per user turn.
+    expect(transport.count("input_audio_buffer.commit")).toBe(N);
+
+    // ZERO response.create before the FIRST user-audio commit: the commit must
+    // precede the very first response.create on the wire.
+    const firstCommit = transport.indexOf("input_audio_buffer.commit");
+    const firstResponseCreate = transport.indexOf("response.create");
+    expect(firstCommit).toBeGreaterThanOrEqual(0);
+    expect(firstResponseCreate).toBeGreaterThan(firstCommit);
+
+    // Run-shape: at least one user-role turn was present in the script.
+    expect(sawUserRole).toBe(true);
+  });
+});

--- a/javascript/src/agents/__tests__/realtime-echo-noleak.test.ts
+++ b/javascript/src/agents/__tests__/realtime-echo-noleak.test.ts
@@ -1,0 +1,213 @@
+/**
+ * AC-JS2' (no-leak) + AC-JS7 (scenario-rerun arm) — the echo reframe for issue
+ * #623 must live ONLY in the copy fed to the LLM, never in the persisted /
+ * caller-visible conversation.
+ *
+ * The fix (`user-simulator-agent.ts:stripAudioContent`) reframes a voiced agent
+ * turn's transcript as `[the agent said: <transcript>]` so the role-reversed
+ * simulator reads it as the OTHER party's line, not its own (breaking the echo
+ * — locked by AC-JS1' in `realtime-echo-safe.test.ts`). This file locks the
+ * COMPLEMENT: the reframe is simulator-view-only.
+ *
+ *  - AC-JS2'(a): the persisted assistant turn is UNCHANGED — its text part is
+ *    the RAW `response.transcript` verbatim, with NO `[the agent said:` wrapper.
+ *    (`stripAudioContent` maps to a NEW array via spread; the input objects are
+ *    never mutated. This test locks that against future refactors.)
+ *  - AC-JS2'(b): the wrapper `[the agent said:` IS present in the messages the
+ *    simulator actually hands to `invokeLLM` — captured via a spy stub.
+ *  - AC-JS7 (scenario-rerun arm): re-run the same free-running echo path with an
+ *    EMPTY transcript. The reframe is a no-op (no text part to wrap → no
+ *    `[the agent said:` injected), the candidate answer is unaffected (the
+ *    parrot cannot echo a transcript that was never surfaced), and the run does
+ *    not error.
+ *
+ * Mock strategy mirrors AC-JS1' (creds-free):
+ *  - the agent turn is built by the REAL `ResponseFormatter.formatAudioResponse`
+ *    (exact realtime wire shape);
+ *  - `invokeLLM` is a spy that BOTH records the messages it received AND parrots
+ *    the last user-role message's text (so an un-reframed transcript would echo).
+ */
+
+import type { ModelMessage } from "ai";
+import { describe, it, expect, vi } from "vitest";
+
+import { userSimulatorAgent } from "../user-simulator-agent";
+import type { InvokeLLMParams, InvokeLLMResult } from "../types";
+import { ResponseFormatter } from "../realtime/response-formatter";
+import type { AudioResponseEvent } from "../realtime/realtime-event-handler";
+import { AgentRole } from "../../domain";
+import type { AgentInput } from "../../domain";
+
+vi.mock("../../config", () => ({
+  getProjectConfig: vi.fn().mockResolvedValue({
+    defaultModel: { model: "openai/gpt-4.1-mini", temperature: 0 },
+  }),
+}));
+
+const QUESTION = "what was your role on the payments team";
+const REFRAME_PREFIX = "[the agent said:";
+
+/** Plain-text of a message's content (string or content-part array). */
+function contentToText(content: ModelMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (part && typeof part === "object" && "type" in part) {
+          const p = part as { type?: string; text?: string };
+          if (p.type === "text" && typeof p.text === "string") return p.text;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join(" ");
+  }
+  return "";
+}
+
+/** The raw `text` of the first text part of an assistant message. */
+function firstTextPart(msg: ModelMessage): string | undefined {
+  const content = msg.content;
+  if (!Array.isArray(content)) return undefined;
+  for (const part of content as Array<{ type?: string; text?: string }>) {
+    if (part?.type === "text" && typeof part.text === "string") return part.text;
+  }
+  return undefined;
+}
+
+/** A realtime agent turn as surfaced by the REAL response formatter. */
+function realtimeAgentTurn(transcript: string): ModelMessage {
+  const audioEvent: AudioResponseEvent = {
+    transcript,
+    audio: Buffer.from("\x00\x00".repeat(240), "binary").toString("base64"),
+  };
+  return new ResponseFormatter().formatAudioResponse(
+    audioEvent,
+  ) as unknown as ModelMessage;
+}
+
+function makeSimulatorInput(agentTurn: ModelMessage): AgentInput {
+  return {
+    threadId: "echo-noleak-thread",
+    messages: [agentTurn],
+    newMessages: [agentTurn],
+    requestedRole: AgentRole.USER,
+    scenarioState: { currentTurn: 1 } as unknown as AgentInput["scenarioState"],
+    scenarioConfig: {
+      name: "echo-noleak",
+      description:
+        "Candidate answers an interviewer's opening question about their experience.",
+    } as unknown as AgentInput["scenarioConfig"],
+  } as AgentInput;
+}
+
+/**
+ * Spy invokeLLM: records every `messages` array it is handed, then parrots the
+ * LAST user-role message's text (the echo-prone path — an un-reframed transcript
+ * lands here verbatim and would be echoed back).
+ */
+function makeSpyParrot() {
+  const seen: ModelMessage[][] = [];
+  const fn = (params: InvokeLLMParams): Promise<InvokeLLMResult> => {
+    const messages = (params.messages ?? []) as ModelMessage[];
+    seen.push(messages);
+    let lastUserText = "";
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === "user") {
+        lastUserText = contentToText(messages[i]!.content);
+        break;
+      }
+    }
+    return Promise.resolve({
+      text: lastUserText,
+      content: [],
+      toolCalls: [],
+      toolResults: [],
+    } as unknown as InvokeLLMResult);
+  };
+  return { fn, seen };
+}
+
+describe("realtime echo reframe is simulator-view-only (AC-JS2')", () => {
+  it("persists the RAW transcript (no wrapper) while the LLM-input copy carries the reframe", async () => {
+    const agentTurn = realtimeAgentTurn(QUESTION);
+
+    // Snapshot the persisted turn's text part BEFORE the sim runs.
+    const persistedTextBefore = firstTextPart(agentTurn);
+    expect(persistedTextBefore).toBe(QUESTION);
+
+    const input = makeSimulatorInput(agentTurn);
+    const sim = userSimulatorAgent();
+    const spy = makeSpyParrot();
+    sim.invokeLLM = spy.fn;
+
+    const reply = await sim.call(input);
+
+    // --- AC-JS2'(a): the PERSISTED assistant turn is unchanged ---------------
+    // The fix maps to a NEW array (spread), so neither the agentTurn object nor
+    // the caller's `input.messages` is mutated: its text part is still the RAW
+    // transcript, with NO `[the agent said:` wrapper.
+    const persistedTextAfter = firstTextPart(agentTurn);
+    expect(persistedTextAfter).toBe(QUESTION);
+    expect(persistedTextAfter).not.toContain(REFRAME_PREFIX);
+    // Same object identity preserved in the caller's message history.
+    expect(input.messages[0]).toBe(agentTurn);
+    expect(firstTextPart(input.messages[0]!)).toBe(QUESTION);
+
+    // --- AC-JS2'(b): the LLM-input copy DOES carry the reframe ---------------
+    expect(spy.seen.length).toBeGreaterThanOrEqual(1);
+    const llmInput = spy.seen[0]!;
+    const reframedTurn = llmInput.find(
+      (m) =>
+        typeof m.content === "string" && m.content.includes(REFRAME_PREFIX),
+    );
+    expect(reframedTurn).toBeDefined();
+    expect(reframedTurn!.content).toContain(QUESTION); // wraps, not drops, the text
+
+    // The reframe must NOT have leaked into the persisted message history.
+    const persistedHasWrapper = input.messages.some(
+      (m) => contentToText(m.content).includes(REFRAME_PREFIX),
+    );
+    expect(persistedHasWrapper).toBe(false);
+
+    // Run-shape: the simulated exchange has the agent turn + a non-empty reply.
+    const exchange: ModelMessage[] = [agentTurn, reply];
+    expect(exchange.length).toBeGreaterThanOrEqual(2);
+    expect(contentToText(reply.content).length).toBeGreaterThan(0);
+  });
+});
+
+describe("echo reframe is a no-op for a degraded/empty transcript (AC-JS7, scenario-rerun arm)", () => {
+  it("empty-transcript agent turn → no reframe injected, candidate answer unaffected, no error", async () => {
+    // With the AC-JS7 formatter guard, an empty transcript surfaces ONLY the
+    // audio file part (no text part) — so the simulator has no transcript text
+    // to reframe and none to echo.
+    const agentTurn = realtimeAgentTurn("");
+    // Sanity: the degraded turn carries no surfaced transcript text.
+    expect(firstTextPart(agentTurn)).toBeUndefined();
+
+    const input = makeSimulatorInput(agentTurn);
+    const sim = userSimulatorAgent();
+    const spy = makeSpyParrot();
+    sim.invokeLLM = spy.fn;
+
+    const reply = await sim.call(input); // must not throw
+
+    // No `[the agent said:` wrapper anywhere in the LLM-input copy: there was
+    // no transcript text to wrap, so the reframe is a no-op.
+    const llmInput = spy.seen[0]!;
+    const anyReframe = llmInput.some(
+      (m) => typeof m.content === "string" && m.content.includes(REFRAME_PREFIX),
+    );
+    expect(anyReframe).toBe(false);
+
+    // The candidate answer is unaffected by the (absent) transcript: the parrot
+    // sees the audio placeholder, never the verbatim question, so it cannot echo
+    // QUESTION (which was never surfaced for this empty-transcript turn).
+    const answer = contentToText(reply.content);
+    expect(answer).not.toContain("payments team");
+
+    // Run-shape: a reply was produced for the rerun.
+    expect(answer.length).toBeGreaterThan(0);
+  });
+});

--- a/javascript/src/agents/__tests__/realtime-echo-safe.test.ts
+++ b/javascript/src/agents/__tests__/realtime-echo-safe.test.ts
@@ -1,0 +1,223 @@
+/**
+ * AC-JS1' — Echo-safety for the free-running JS user simulator facing the
+ * realtime adapter.
+ *
+ * LATENT BUG (issue #623): when a free-running `userSimulatorAgent` faces the
+ * realtime agent adapter, the agent's voiced turn is surfaced as
+ *   [{ type: "text", text: transcript }, { type: "file", mediaType: "audio/pcm16", ... }]
+ * (see `ResponseFormatter.formatAudioResponse`). `messageRoleReversal` swaps
+ * that assistant turn to a `user` turn but passes its content through UNCHANGED
+ * — so the transcript text lands on the reversed `user` turn, the LLM reads it
+ * as its own prior words, and parrots it back as the candidate's answer (echo).
+ *
+ * Python has `_strip_audio_content`, which — before role-reversal — reframes a
+ * voiced agent turn's text as `[the agent said: <transcript>]` so the simulator
+ * reads it as the OTHER party's utterance, not its own line. JS has no
+ * equivalent. This test is the creds-free repro of that gap.
+ *
+ * Mock strategy (no live key):
+ * - The assistant turn the simulator sees is built by the REAL
+ *   `ResponseFormatter.formatAudioResponse(...)` — i.e. the exact realtime
+ *   adapter wire shape, not a hand-rolled stand-in.
+ * - `agent.invokeLLM` is stubbed to a PARROT that returns the text of the last
+ *   user-role message it is handed. After reversal the agent's audio turn is the
+ *   last `user` message; if its transcript flows through verbatim, the parrot
+ *   echoes the agent's question back as the candidate answer.
+ *
+ * Two arms IN THE SAME TEST:
+ *   - post-fix = drive the REAL `userSimulatorAgent.call(...)` (the production
+ *     path the coder will fix). Today there is no reframe, so this currently
+ *     behaves like the naive arm (echo) and the `< 0.8` assertion FAILS → RED.
+ *   - naive   = feed the same realtime assistant turn through the production
+ *     `messageRoleReversal` directly (verbatim pass-through, no reframe) and
+ *     parrot the result. This is the red-capability control: echo IS present.
+ *
+ * Contract (mirrors the Python echo test):
+ *   Q = the agent's spoken question (the surfaced transcript)
+ *   U = the simulator's generated reply (candidate answer)
+ *   post-fix:        jaccard(U, Q) <  0.8   (reframe breaks verbatim echo)
+ *   naive (control): jaccard(U, Q) >= 0.8   (metric is red-capable at the JS layer)
+ *   margin:          jaccard_naive - jaccard_postfix >= 0.3
+ *
+ * Until the reframe exists, post-fix == naive (both echo) → all three
+ * assertions fail. The RED lands on the ECHO/Jaccard assertion, NOT a
+ * compile/import error.
+ */
+
+import type { ModelMessage } from "ai";
+import { describe, it, expect, vi } from "vitest";
+
+import { userSimulatorAgent } from "../user-simulator-agent";
+import { messageRoleReversal } from "../utils";
+import type { InvokeLLMParams, InvokeLLMResult } from "../types";
+import { ResponseFormatter } from "../realtime/response-formatter";
+import type { AudioResponseEvent } from "../realtime/realtime-event-handler";
+import { AgentRole } from "../../domain";
+import type { AgentInput } from "../../domain";
+
+// Mock getProjectConfig so no real model config / filesystem is needed and the
+// stubbed invokeLLM is never bypassed (mirrors judge-agent.test.ts).
+vi.mock("../../config", () => ({
+  getProjectConfig: vi.fn().mockResolvedValue({
+    defaultModel: { model: "openai/gpt-4.1-mini", temperature: 0 },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const QUESTION = "what was your role on the payments team";
+
+/** Jaccard word overlap — mirrors the Python `jaccard` helper. */
+function jaccard(a: string, b: string): number {
+  const wa = new Set(a.toLowerCase().split(/\s+/).filter(Boolean));
+  const wb = new Set(b.toLowerCase().split(/\s+/).filter(Boolean));
+  if (wa.size === 0 && wb.size === 0) return 1.0;
+  const intersection = new Set([...wa].filter((w) => wb.has(w)));
+  const union = new Set([...wa, ...wb]);
+  return intersection.size / union.size;
+}
+
+/**
+ * Pull the plain-text of a message's content, whether it is a string or an
+ * array of content parts. Mirrors how the simulator's prompt is read by an
+ * LLM: text parts are concatenated; non-text parts (audio/file) contribute
+ * nothing on their own.
+ */
+function contentToText(content: ModelMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (part && typeof part === "object" && "type" in part) {
+          const p = part as { type?: string; text?: string };
+          if (p.type === "text" && typeof p.text === "string") return p.text;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join(" ");
+  }
+  return "";
+}
+
+/**
+ * Parrot LLM stub: returns the text of the LAST user-role message it is handed.
+ *
+ * After `messageRoleReversal` the agent's audio turn becomes a `user` message.
+ * If its transcript flowed through verbatim, the last-user text IS the agent's
+ * question Q — so the parrot echoes Q. With the reframe applied, the last-user
+ * text is `[the agent said: Q]`, so the parrot returns that framing, not Q.
+ */
+function parrotInvokeLLM(params: InvokeLLMParams): Promise<InvokeLLMResult> {
+  const messages = (params.messages ?? []) as ModelMessage[];
+  let lastUserText = "";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") {
+      lastUserText = contentToText(messages[i]!.content);
+      break;
+    }
+  }
+  return Promise.resolve({
+    text: lastUserText,
+    content: [],
+    toolCalls: [],
+    toolResults: [],
+  } as unknown as InvokeLLMResult);
+}
+
+/** A realtime agent turn as surfaced by the REAL response formatter. */
+function realtimeAgentTurn(transcript: string = QUESTION): ModelMessage {
+  const formatter = new ResponseFormatter();
+  const audioEvent: AudioResponseEvent = {
+    transcript,
+    // Minimal silent PCM16 stand-in, base64 — the bytes are irrelevant to the
+    // echo metric; only that an audio `file` part rides alongside the text part.
+    audio: Buffer.from("\x00\x00".repeat(240), "binary").toString("base64"),
+  };
+  return formatter.formatAudioResponse(audioEvent) as unknown as ModelMessage;
+}
+
+/** AgentInput the free-running simulator consumes (it reads scenarioConfig + messages). */
+function makeSimulatorInput(agentTurn: ModelMessage): AgentInput {
+  return {
+    threadId: "echo-safe-thread",
+    messages: [agentTurn],
+    newMessages: [agentTurn],
+    requestedRole: AgentRole.USER,
+    scenarioState: { currentTurn: 1 } as unknown as AgentInput["scenarioState"],
+    scenarioConfig: {
+      name: "echo-safe",
+      description:
+        "Candidate answers an interviewer's opening question about their experience.",
+    } as unknown as AgentInput["scenarioConfig"],
+  } as AgentInput;
+}
+
+// ---------------------------------------------------------------------------
+// AC-JS1' — main echo test (post-fix arm + naive red-capability control)
+// ---------------------------------------------------------------------------
+
+describe("realtime echo-safety (AC-JS1')", () => {
+  it("free-running sim must NOT echo the realtime agent transcript back as its answer", async () => {
+    const agentTurn = realtimeAgentTurn(QUESTION);
+
+    // --- post-fix arm: drive the REAL production simulator path ---
+    // This is the path the coder will fix (reframe inside `messageRoleReversal`
+    // or a strip step ahead of it). Until then it echoes.
+    const sim = userSimulatorAgent();
+    sim.invokeLLM = parrotInvokeLLM;
+    const postFixReply = await sim.call(makeSimulatorInput(agentTurn));
+    const postFixAnswer = contentToText(postFixReply.content);
+    const jPostFix = jaccard(postFixAnswer, QUESTION);
+
+    // --- naive control arm: verbatim pass-through (no reframe) ---
+    // Reproduces today's behaviour explicitly so the metric is provably
+    // red-capable at the JS layer: the realtime turn goes straight through the
+    // production reversal, and the parrot sees the agent's transcript verbatim.
+    const naiveReversed = messageRoleReversal([
+      { role: "system", content: "you are pretending to be a user" },
+      { role: "assistant", content: "Hello, how can I help you today" },
+      agentTurn,
+    ]);
+    const naiveResult = await parrotInvokeLLM({
+      messages: naiveReversed,
+    } as unknown as InvokeLLMParams);
+    const naiveAnswer = naiveResult.text ?? "";
+    const jNaive = jaccard(naiveAnswer, QUESTION);
+
+    // Run-shape floor (AC-JS1'): the simulated exchange has >= 3 messages
+    // (system + agent turn + simulator reply) and at least one user-role turn.
+    const exchange: ModelMessage[] = [
+      { role: "system", content: "you are pretending to be a user" },
+      agentTurn,
+      postFixReply,
+    ];
+    expect(exchange.length).toBeGreaterThanOrEqual(3);
+    expect(exchange.some((m) => m.role === "user")).toBe(true);
+
+    // Diagnostics (visible on failure).
+    // eslint-disable-next-line no-console
+    console.log(`[POST-FIX] Q=${JSON.stringify(QUESTION)}`);
+    // eslint-disable-next-line no-console
+    console.log(`[POST-FIX] U=${JSON.stringify(postFixAnswer)}`);
+    // eslint-disable-next-line no-console
+    console.log(`[POST-FIX] Jaccard=${jPostFix.toFixed(3)}`);
+    // eslint-disable-next-line no-console
+    console.log(`[NAIVE]    U=${JSON.stringify(naiveAnswer)}`);
+    // eslint-disable-next-line no-console
+    console.log(`[NAIVE]    Jaccard=${jNaive.toFixed(3)}`);
+
+    // Naive control: the echo metric IS red-capable at the JS layer.
+    expect(jNaive).toBeGreaterThanOrEqual(0.8);
+
+    // Post-fix: the reframe must break the verbatim echo. RED until the coder
+    // adds the reframe to the production simulator path.
+    expect(jPostFix).toBeLessThan(0.8);
+
+    // Margin floor: the reframe must move the metric by a real amount, not just
+    // squeak under an absolute line.
+    expect(jNaive - jPostFix).toBeGreaterThanOrEqual(0.3);
+  });
+});

--- a/javascript/src/agents/__tests__/realtime-response-formatter.test.ts
+++ b/javascript/src/agents/__tests__/realtime-response-formatter.test.ts
@@ -1,0 +1,125 @@
+/**
+ * AC-JS5 / AC-JS7 (formatter arm) — transcript surfacing + degraded-transcript
+ * safety for the realtime adapter's `ResponseFormatter`.
+ *
+ * Context (issue #623): the realtime adapter surfaces a voiced agent turn as a
+ * two-part assistant message —
+ *   [{ type: "text", text: transcript }, { type: "file", mediaType: "audio/pcm16", ... }]
+ * The `text` part is what the user simulator reads (and, pre-fix, parroted back
+ * as an echo). Two properties must hold at this formatter boundary:
+ *
+ *  - AC-JS5: a REAL transcript is surfaced verbatim as the `text` part, riding
+ *    alongside the `audio/pcm16` `file` part. This is the surface the whole
+ *    echo chain depends on — if the transcript were dropped here, there would
+ *    be nothing to (mis)read downstream.
+ *  - AC-JS7 (formatter arm): a DEGRADED transcript (empty string or undefined —
+ *    silence, dropped ASR) must NOT produce a `text: undefined` part nor the
+ *    literal string `"undefined"`. The formatter either omits the text part or
+ *    emits an empty string. (The production guard added for #623 omits it.)
+ *
+ * Pure-function unit assertions — no run-shape, no creds, no transport.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { ResponseFormatter } from "../realtime/response-formatter";
+import type { AudioResponseEvent } from "../realtime/realtime-event-handler";
+
+/** Minimal base64 PCM16 stand-in (bytes are irrelevant to these assertions). */
+const AUDIO_B64 = Buffer.from("\x00\x00".repeat(8), "binary").toString("base64");
+
+interface TextPart {
+  type: "text";
+  text: string;
+}
+interface FilePart {
+  type: "file";
+  mediaType: string;
+  data: string;
+}
+type Part = TextPart | FilePart | { type?: string; [k: string]: unknown };
+
+function partsOf(msg: { content: unknown }): Part[] {
+  expect(Array.isArray(msg.content)).toBe(true);
+  return msg.content as Part[];
+}
+function textParts(parts: Part[]): TextPart[] {
+  return parts.filter((p): p is TextPart => p.type === "text");
+}
+function filePart(parts: Part[]): FilePart | undefined {
+  return parts.find((p): p is FilePart => p.type === "file");
+}
+
+describe("ResponseFormatter.formatAudioResponse — transcript surfacing (AC-JS5)", () => {
+  it("surfaces a real transcript as a text part alongside an audio/pcm16 file part", () => {
+    const transcript = "what was your role on the payments team";
+    const event: AudioResponseEvent = { transcript, audio: AUDIO_B64 };
+
+    const msg = new ResponseFormatter().formatAudioResponse(event);
+    expect(msg.role).toBe("assistant");
+
+    const parts = partsOf(msg);
+
+    // Exactly one text part, carrying the transcript VERBATIM (=== the event's
+    // transcript — this is the value the echo chain reads downstream).
+    const texts = textParts(parts);
+    expect(texts).toHaveLength(1);
+    expect(texts[0]!.text).toBe(transcript);
+    expect(texts[0]!.text).toBe(event.transcript);
+
+    // The audio rides alongside as a pcm16 file part with the same bytes.
+    const file = filePart(parts);
+    expect(file).toBeDefined();
+    expect(file!.mediaType).toBe("audio/pcm16");
+    expect(file!.data).toBe(AUDIO_B64);
+
+    // formatInitialResponse is the agent-first entry; same surfaced shape.
+    const initial = new ResponseFormatter().formatInitialResponse(event);
+    const initialTexts = textParts(partsOf(initial));
+    expect(initialTexts).toHaveLength(1);
+    expect(initialTexts[0]!.text).toBe(transcript);
+  });
+});
+
+describe("ResponseFormatter.formatAudioResponse — degraded transcript (AC-JS7, formatter arm)", () => {
+  // Both degraded shapes a live RealtimeEventHandler can hand the formatter:
+  //   ""        — handler initialises currentResponse = "" and no delta arrived
+  //   undefined — a malformed / partial event with no transcript field
+  const degraded: Array<[string, string | undefined]> = [
+    ["empty string", ""],
+    ["undefined", undefined],
+  ];
+
+  it.each(degraded)(
+    "never emits text:undefined or the literal \"undefined\" for a %s transcript",
+    (_label, transcript) => {
+      const event = {
+        transcript,
+        audio: AUDIO_B64,
+      } as unknown as AudioResponseEvent;
+
+      const msg = new ResponseFormatter().formatAudioResponse(event);
+      const parts = partsOf(msg);
+
+      // The audio is ALWAYS surfaced — a degraded transcript never drops audio.
+      const file = filePart(parts);
+      expect(file).toBeDefined();
+      expect(file!.mediaType).toBe("audio/pcm16");
+      expect(file!.data).toBe(AUDIO_B64);
+
+      // Contract: omit the text part OR emit an empty string — but NEVER a
+      // `text: undefined` part and NEVER the literal "undefined".
+      const texts = textParts(parts);
+      for (const t of texts) {
+        expect(t.text).not.toBeUndefined();
+        expect(t.text).not.toBe("undefined");
+        expect(t.text).toBe(""); // if a text part survives, it must be empty
+      }
+      // And the serialized form (what an LLM/transport would see) must not
+      // carry the literal "undefined" anywhere in the text channel.
+      const serialized = JSON.stringify(parts);
+      expect(serialized).not.toContain('"text":"undefined"');
+      expect(serialized).not.toContain('"text":undefined');
+    },
+  );
+});

--- a/javascript/src/agents/realtime/response-formatter.ts
+++ b/javascript/src/agents/realtime/response-formatter.ts
@@ -1,6 +1,11 @@
 import type { AssistantModelMessage } from "ai";
 import type { AudioResponseEvent } from "./realtime-event-handler.js";
 
+/** A content part of an assistant message (text or audio file). */
+type AssistantContentPart =
+  | { type: "text"; text: string }
+  | { type: "file"; mediaType: string; data: string };
+
 /**
  * Formats responses for the Scenario framework
  *
@@ -11,16 +16,37 @@ export class ResponseFormatter {
   /**
    * Formats an audio response event into Scenario framework format
    *
+   * The audio `file` part is always present. The transcript `text` part is
+   * included ONLY when the transcript is a non-empty string — a degraded /
+   * empty / undefined transcript (AC-JS7) omits the text part rather than
+   * emitting `text: undefined` (a malformed part the AI SDK would coerce to
+   * the literal `"undefined"` downstream). Callers that read text parts (the
+   * user simulator's `stripAudioContent`, the role-reversal echo reframe) then
+   * see no spurious text to surface or parrot.
+   *
    * @param audioEvent - The audio response event from the Realtime API
-   * @returns Formatted assistant message with audio and text content
+   * @returns Formatted assistant message with audio and (when present) text content
    */
   formatAudioResponse(audioEvent: AudioResponseEvent): AssistantModelMessage {
+    const content: AssistantContentPart[] = [];
+
+    // Surface the transcript only when it is a real, non-empty string. Empty /
+    // undefined transcripts (degraded ASR, silence) contribute no text part —
+    // never `text: undefined` / the literal `"undefined"`. (AC-JS5 / AC-JS7)
+    const transcript = audioEvent.transcript;
+    if (typeof transcript === "string" && transcript.length > 0) {
+      content.push({ type: "text", text: transcript });
+    }
+
+    content.push({
+      type: "file",
+      mediaType: "audio/pcm16",
+      data: audioEvent.audio,
+    });
+
     return {
       role: "assistant",
-      content: [
-        { type: "text", text: audioEvent.transcript },
-        { type: "file", mediaType: "audio/pcm16", data: audioEvent.audio },
-      ],
+      content,
     } as AssistantModelMessage;
   }
 

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -80,13 +80,27 @@ ${personaBlock}`.trim();
 }
 
 /**
- * Remove audio content blocks from messages before sending to a text-only LLM.
+ * Remove audio content blocks from messages before sending to a text-only LLM,
+ * and apply echo-safety reframing for voiced agent turns.
  *
  * Voice turns carry the canonical AI-SDK audio `file` part (`{ type: "file",
  * mediaType: "audio/pcm16", … }`, see `voice/messages.ts`) which text-only
  * models like `gpt-4.1-mini` reject. This helper keeps `text` parts as-is and
  * replaces audio-only messages with an `[audio message]` placeholder so the
  * LLM still has a structural turn in the right position.
+ *
+ * Echo-safety (AC-JS1'): when an **assistant** message carries BOTH an audio
+ * part AND a text part, it is a voiced agent turn whose transcript was
+ * auto-surfaced by the realtime adapter. The simulator must NOT receive that
+ * text verbatim — after `messageRoleReversal` the assistant turn becomes a
+ * `user` turn, which the LLM reads as its own prior words and parrots back as
+ * the candidate's answer. Instead we reframe the text as third-person context
+ * (`[the agent said: Q]`) so the simulator understands it as the OTHER party's
+ * utterance to respond to, not its own line.
+ *
+ * This reframing applies ONLY to the copy passed into `invokeLLM`. The
+ * original messages (and `result.messages`) are never mutated — a new array
+ * is built via spread (`{ ...msg, content: … }`), satisfying AC-JS2'.
  *
  * Port of `python/scenario/user_simulator_agent.py:_strip_audio_content`.
  */
@@ -96,12 +110,30 @@ function stripAudioContent(messages: ModelMessage[]): ModelMessage[] {
     if (!Array.isArray(content)) return msg;
 
     const parts = content as Array<Record<string, unknown>>;
+
+    const hasAudio = parts.some(
+      (p) =>
+        p?.type === "input_audio" ||
+        p?.type === "audio" ||
+        (p?.type === "file" &&
+          typeof p["mediaType"] === "string" &&
+          p["mediaType"].startsWith("audio/")),
+    );
+
     const textParts = parts
       .filter((p) => p?.type === "text" && typeof p["text"] === "string")
       .map((p) => p["text"] as string);
 
     if (textParts.length > 0) {
-      return { ...msg, content: textParts.join(" ") } as ModelMessage;
+      let joined = textParts.join(" ");
+      // Echo-safety: an assistant turn with BOTH audio and text parts is a
+      // voiced agent turn (transcript auto-surfaced by the realtime adapter).
+      // Reframe as third-person context so the simulator sees it as the
+      // agent's utterance to answer, not its own words to repeat. (AC-JS1')
+      if (hasAudio && msg.role === "assistant") {
+        joined = `[the agent said: ${joined}]`;
+      }
+      return { ...msg, content: joined } as ModelMessage;
     }
     return { ...msg, content: "[audio message]" } as ModelMessage;
   });

--- a/python/tests/voice/test_gemini_live_echo_safe.py
+++ b/python/tests/voice/test_gemini_live_echo_safe.py
@@ -1,0 +1,533 @@
+"""
+AC-PY1' — Echo-safety REGRESSION test for GeminiLiveAgentAdapter.
+
+This test LOCKS already-correct behaviour. Gemini Live is ALREADY echo-safe:
+its ``recv_audio`` sets ``transcript=`` on the assistant ``AudioChunk`` (from
+the server's ``output_transcription``), which the shared base
+``VoiceAgentAdapter.call`` turns into an assistant turn carrying BOTH an
+``input_audio`` part AND a ``text`` part. That voiced-agent turn then hits the
+SHARED reframe in ``UserSimulatorAgent._strip_audio_content`` — the same code
+path that makes the OpenAI Realtime adapter echo-safe (see
+``test_realtime_agent_echo_safe.py``). So the post-fix arm is GREEN now and NO
+production change is expected. If the post-fix arm comes out RED, Gemini is NOT
+actually echo-safe — that is a finding, not something to force green.
+
+Mock strategy (creds-free, no API key, no ``google-genai`` SDK):
+- The Gemini Live SDK session (``AsyncSession``) is replaced by a duck-typed
+  ``_FakeSession`` whose ``receive()`` yields ``LiveServerMessage``-shaped
+  objects (``server_content.output_transcription`` + ``server_content.model_turn``
+  + ``turn_complete``). ``connect``/``disconnect``/``send_audio`` are overridden
+  to be creds-free — they are the ONLY methods that import ``google.genai``
+  (``recv_audio`` does not), so the REAL ``recv_audio`` runs and exercises the
+  genuine transcript-surfacing path (gemini_live.py lines ~403-423).
+- ``litellm.completion`` is stubbed to a "parrot" returning the most-recent
+  user-role content VERBATIM. After ``reverse_roles`` the agent's turn becomes
+  a "user" message; WITHOUT the reframe the parrot would echo the raw question
+  Q back as the candidate's answer (Jaccard >= 0.8). WITH the reframe the text
+  is ``[the agent said: Q]`` so the parrot cannot echo Q verbatim (< 0.8).
+
+Kept REAL (code under test — do NOT monkeypatch):
+- ``_strip_audio_content`` (the shared reframe)
+- ``reverse_roles``
+- ``create_audio_message`` (transcript -> text part)
+- ``GeminiLiveAgentAdapter.recv_audio`` (sets transcript on the AudioChunk)
+
+AC-PY1' contract (both arms, SAME test):
+  Q = the agent's spoken question (the fake session's output_transcription)
+  U = the user-sim's generated reply (parrot stub via REAL _generate_text)
+  post-fix:     jaccard(U, Q) <  0.8   (shared reframe breaks verbatim echo)
+  naive arm:    jaccard(U, Q) >= 0.8   (reframe disabled -> parrot echoes Q)
+  margin floor: naive - postfix >= 0.3 (proves the metric is red-capable here)
+
+Run-shape floor (mirrors the OpenAI reference's run-shape assertions):
+  messageCount >= 3, >= 1 user-role turn, >= 1 assistant-role turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, List, Optional
+
+from litellm.files.main import ModelResponse as _LiteLLMModelResponse
+
+import pytest
+
+import scenario
+from scenario.config import ScenarioConfig
+from scenario.voice.adapters.gemini_live import GeminiLiveAgentAdapter
+from scenario.user_simulator_agent import UserSimulatorAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+QUESTION = "what was your role on the payments team"
+
+
+def _make_pcm(n_samples: int = 2400) -> bytes:
+    """Minimal silent PCM16 mono @ 24 kHz."""
+    return b"\x00\x00" * n_samples
+
+
+def jaccard(a: str, b: str) -> float:
+    """Word-set Jaccard overlap — ported verbatim from the OpenAI reference."""
+    wa = set(a.lower().split())
+    wb = set(b.lower().split())
+    if not wa and not wb:
+        return 1.0
+    return len(wa & wb) / len(wa | wb)
+
+
+# ---------------------------------------------------------------------------
+# Duck-typed Gemini Live server-message shapes (no google-genai dependency)
+# ---------------------------------------------------------------------------
+#
+# The real recv_audio reads:
+#   message.go_away
+#   message.server_content (sc)
+#     sc.interrupted
+#     sc.output_transcription.text
+#     sc.model_turn.parts[].inline_data.data
+#     sc.turn_complete
+# We provide just those attributes — the SDK's concrete LiveServerMessage type
+# is never imported.
+
+
+class _FakePart:
+    def __init__(self, data: Optional[bytes]) -> None:
+        self.inline_data = _FakeInlineData(data) if data is not None else None
+
+
+class _FakeInlineData:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+
+class _FakeModelTurn:
+    def __init__(self, parts: List[_FakePart]) -> None:
+        self.parts = parts
+
+
+class _FakeTranscription:
+    def __init__(self, text: Optional[str]) -> None:
+        self.text = text
+
+
+class _FakeServerContent:
+    def __init__(
+        self,
+        *,
+        output_transcription: Optional[_FakeTranscription] = None,
+        model_turn: Optional[_FakeModelTurn] = None,
+        turn_complete: bool = False,
+        interrupted: bool = False,
+    ) -> None:
+        self.output_transcription = output_transcription
+        self.model_turn = model_turn
+        self.turn_complete = turn_complete
+        self.interrupted = interrupted
+
+
+class _FakeLiveServerMessage:
+    def __init__(self, server_content: Optional[_FakeServerContent]) -> None:
+        self.go_away = None
+        self.server_content = server_content
+
+
+def _agent_turn_messages(question: str = QUESTION) -> List[_FakeLiveServerMessage]:
+    """One Gemini Live agent turn: transcript+audio, then turn_complete.
+
+    The output_transcription rides the SAME message as the audio part so that
+    when recv_audio returns the audio chunk it carries ``transcript=question``
+    (recv_audio accumulates transcription into ``pending_delta`` BEFORE
+    inspecting ``model_turn`` within the loop body, then returns the chunk with
+    ``transcript=pending_delta``). A trailing ``turn_complete`` message ends the
+    turn so the base ``_drain_agent_response`` sees the empty chunk and exits.
+    """
+    return [
+        _FakeLiveServerMessage(
+            _FakeServerContent(
+                output_transcription=_FakeTranscription(question),
+                model_turn=_FakeModelTurn([_FakePart(_make_pcm(2400))]),
+            )
+        ),
+        _FakeLiveServerMessage(
+            _FakeServerContent(turn_complete=True),
+        ),
+    ]
+
+
+class _FakeSession:
+    """Duck-typed stand-in for the google-genai ``AsyncSession``.
+
+    ``receive()`` returns a FRESH async generator each call that yields ONE
+    agent turn's messages then stops (StopAsyncIteration) — matching the real
+    SDK, whose ``session.receive()`` generator yields one model turn then
+    completes. The real ``recv_audio`` caches this iterator on ``_recv_iter``
+    and re-creates it per user turn, so a fresh generator per ``receive()`` call
+    is the faithful contract.
+
+    ``send_realtime_input`` is recorded but never reached here (send_audio is
+    overridden creds-free in the test), kept for completeness.
+    """
+
+    def __init__(self, turns: List[List[_FakeLiveServerMessage]]) -> None:
+        self._turns = list(turns)
+        self._turn_idx = 0
+        self.sent: List[Any] = []
+
+    def receive(self):
+        # Pick the next turn's message list; an exhausted schedule yields an
+        # immediately-completing (empty) generator so any extra recv settles
+        # to end-of-turn rather than hanging.
+        if self._turn_idx < len(self._turns):
+            msgs = self._turns[self._turn_idx]
+            self._turn_idx += 1
+        else:
+            msgs = []
+
+        async def _gen():
+            for m in msgs:
+                await asyncio.sleep(0)
+                yield m
+
+        return _gen()
+
+    async def send_realtime_input(self, **kwargs: Any) -> None:
+        self.sent.append(kwargs)
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Parrot LLM stub (ported from the OpenAI reference)
+# ---------------------------------------------------------------------------
+
+def _make_parrot_response(text: str) -> _LiteLLMModelResponse:
+    """Build a real litellm ModelResponse so langwatch tracing can serialize it."""
+    return _LiteLLMModelResponse(
+        id="parrot-stub",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        model="gpt-4.1-mini",
+        object="chat.completion",
+    )
+
+
+def _parrot_completion(**kwargs):
+    """Return the content of the last user-role message in the prompt VERBATIM.
+
+    After reverse_roles the agent's turn becomes a "user" message. Without the
+    reframe the text is the raw question Q — the parrot echoes Q back. With the
+    fix the text is ``[the agent said: Q]`` — the parrot echoes that framing,
+    not Q verbatim.
+    """
+    messages = kwargs.get("messages", [])
+    last_user = None
+    for m in reversed(messages):
+        if m.get("role") == "user":
+            last_user = m.get("content", "")
+            break
+    parrot_text = last_user or ""
+    return _make_parrot_response(parrot_text)
+
+
+# ---------------------------------------------------------------------------
+# Naive-strip contrast control (reframe disabled) — ported from OpenAI ref
+# ---------------------------------------------------------------------------
+
+def _naive_strip_audio_content(messages: list) -> list:
+    """Old (pre-fix) behaviour: assistant text parts pass through VERBATIM.
+
+    Identical audio-stripping to the real helper, but WITHOUT the
+    ``[the agent said: ...]`` reframe on voiced assistant turns — so after
+    reverse_roles the raw question Q flows into the reversed user turn and the
+    parrot echoes it. This is the red-capability control proving the Jaccard
+    metric fires on Gemini's message shape.
+    """
+    result = []
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            text_parts = [
+                p["text"]
+                for p in content
+                if isinstance(p, dict) and p.get("type") == "text"
+            ]
+            if text_parts:
+                result.append({**msg, "content": " ".join(text_parts)})
+            else:
+                result.append({**msg, "content": "[audio message]"})
+        else:
+            result.append(msg)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fixture: configure ScenarioConfig + hermetic floor (ported from OpenAI ref)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _configure_scenario(monkeypatch):
+    """Minimal ScenarioConfig + suppress LangWatch network calls.
+
+    Mirrors the OpenAI reference's hermetic floor: unset LangWatch env, provide
+    dummy OpenAI keys so any un-mocked client construction does not raise, and
+    no-op the event reporter so no HTTP escapes.
+    """
+    monkeypatch.delenv("LANGWATCH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGWATCH_ENDPOINT", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-sk-not-a-real-key")
+    monkeypatch.setenv("OPENAI_ADMIN_KEY", "test-sk-not-a-real-key")
+    # No GEMINI_API_KEY needed — connect() is overridden creds-free below.
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    try:
+        from langwatch.client import Client
+
+        monkeypatch.setattr(Client, "_api_key", "", raising=False)
+    except ImportError:
+        pass  # langwatch SDK not importable — hermetic floor is best-effort
+    try:
+        from scenario._events.event_reporter import EventReporter
+
+        async def _noop_post_event(self, event):
+            return {}
+
+        monkeypatch.setattr(EventReporter, "post_event", _noop_post_event)
+    except ImportError:
+        pass  # event reporter not importable — no-op floor is best-effort
+
+    prev = ScenarioConfig.default_config
+    ScenarioConfig.default_config = ScenarioConfig(
+        default_model="openai/gpt-4.1-mini",
+        verbose=False,
+    )
+    yield
+    ScenarioConfig.default_config = prev
+
+
+# ---------------------------------------------------------------------------
+# Wire the Gemini adapter creds-free and run the echo scenario
+# ---------------------------------------------------------------------------
+
+def _wire_creds_free(adapter: GeminiLiveAgentAdapter, session: _FakeSession) -> None:
+    """Override the ONLY google.genai-importing methods so no SDK/key is needed.
+
+    ``connect``/``disconnect``/``send_audio`` are the sole methods that
+    ``from google.genai import types`` (or construct ``genai.Client``).
+    ``recv_audio`` imports nothing google — it stays REAL so the genuine
+    transcript-surfacing path runs against the fake session.
+    """
+
+    async def _fake_connect() -> None:
+        adapter._session = session
+        adapter._recv_iter = None
+
+    async def _fake_disconnect() -> None:
+        adapter._session = None
+        adapter._recv_iter = None
+
+    async def _fake_send_audio(chunk) -> None:
+        # Real send_audio resamples + emits google ActivityStart/Blob/ActivityEnd
+        # — all google-genai-typed and irrelevant to the echo path (it only ships
+        # USER audio to Google). We reproduce only the framework-visible side
+        # effect: reset the per-turn transcript + receive iterator so the next
+        # recv_audio enters session.receive() fresh for the new turn.
+        adapter._reset_turn_transcript()
+        adapter._recv_iter = None
+
+    adapter.connect = _fake_connect  # type: ignore[method-assign]
+    adapter.disconnect = _fake_disconnect  # type: ignore[method-assign]
+    adapter.send_audio = _fake_send_audio  # type: ignore[method-assign]
+
+
+async def _run_echo_test(
+    *,
+    with_reframe: bool,
+    question: str = QUESTION,
+) -> tuple:
+    """Run the Gemini echo scenario; return (result, sim_reply, jaccard_value).
+
+    ``with_reframe=True``  -> REAL _strip_audio_content (echo-safe; GREEN now).
+    ``with_reframe=False`` -> _strip_audio_content patched to the naive
+                              (pre-fix) surfacing so the parrot echoes Q.
+    """
+    from unittest.mock import patch
+
+    # Two agent turns scheduled so [agent(), user(), agent()] each read a turn.
+    session = _FakeSession([_agent_turn_messages(question), _agent_turn_messages(question)])
+
+    adapter = GeminiLiveAgentAdapter(
+        system_instruction="You are an interviewer. Ask about the candidate's experience.",
+    )
+    _wire_creds_free(adapter, session)
+
+    # User simulator WITH voice so _generate_text runs (free-running, no script text).
+    user_sim = UserSimulatorAgent(
+        model="openai/gpt-4.1-mini",
+        voice="openai/nova",
+    )
+
+    # Neutralise real TTS — no live synth key needed.
+    async def _fake_synthesize(text: str, voice: str):
+        from scenario.voice.audio_chunk import AudioChunk
+        return AudioChunk(data=_make_pcm(2400), transcript=text)
+
+    script = [
+        scenario.agent(),
+        scenario.user(),
+        scenario.agent(),
+        scenario.succeed("done"),
+    ]
+
+    with patch("scenario.voice.synthesize", side_effect=_fake_synthesize):
+        with patch(
+            "scenario.user_simulator_agent.litellm.completion",
+            side_effect=_parrot_completion,
+        ):
+            if with_reframe:
+                result = await scenario.arun(
+                    name="gemini-echo-safe",
+                    description="Candidate answers an interviewer's opening question",
+                    agents=[adapter, user_sim],
+                    script=script,
+                )
+            else:
+                with patch(
+                    "scenario.user_simulator_agent._strip_audio_content",
+                    side_effect=_naive_strip_audio_content,
+                ):
+                    result = await scenario.arun(
+                        name="gemini-echo-naive",
+                        description="Candidate answers an interviewer's opening question",
+                        agents=[adapter, user_sim],
+                        script=script,
+                    )
+
+    # Extract the simulator's reply: the first user-role text after the agent's
+    # opening turn (mirrors the OpenAI reference's extraction).
+    sim_reply = ""
+    for msg in result.messages:
+        if msg.get("role") == "user":
+            content = msg.get("content")
+            if isinstance(content, str):
+                sim_reply = content
+                break
+            elif isinstance(content, list):
+                text_parts = [
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                if text_parts:
+                    sim_reply = " ".join(text_parts)
+                    break
+
+    return result, sim_reply, jaccard(sim_reply, question)
+
+
+# ---------------------------------------------------------------------------
+# AC-PY1' — Gemini echo-safety regression: post-fix GREEN + naive red-capable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_gemini_echo_safe_regression_both_arms():
+    """AC-PY1' (regression): Gemini Live is ALREADY echo-safe via the shared
+    _strip_audio_content reframe.
+
+    Both arms in ONE test:
+      post-fix:     jaccard(U, Q) <  0.8   (GREEN now — reframe breaks echo)
+      naive:        jaccard(U, Q) >= 0.8   (red-capability control)
+      margin floor: naive - postfix >= 0.3 (metric is red-capable on Gemini)
+
+    Run-shape floor: messageCount >= 3, >= 1 user-role, >= 1 assistant-role.
+    """
+    # --- Post-fix arm (real shared reframe; already echo-safe) ---
+    result, sim_reply, j_post = await _run_echo_test(with_reframe=True)
+
+    print(f"\n[GEMINI POST-FIX] Q={QUESTION!r}")
+    print(f"[GEMINI POST-FIX] U={sim_reply!r}")
+    print(f"[GEMINI POST-FIX] Jaccard={j_post:.3f}")
+
+    # Run-shape floor (mirrors OpenAI reference's run-shape assertions).
+    assert len(result.messages) >= 3, (
+        f"Expected >= 3 messages for [agent(), user(), agent()], "
+        f"got {len(result.messages)}: {result.messages}"
+    )
+    user_roles = [m for m in result.messages if m.get("role") == "user"]
+    assert user_roles, "Expected at least one user-role message in result.messages"
+    assistant_roles = [m for m in result.messages if m.get("role") == "assistant"]
+    assert assistant_roles, "Expected at least one assistant-role message in result.messages"
+
+    # Echo-safety: the reframe must break the verbatim echo.
+    assert j_post < 0.8, (
+        f"Post-fix Jaccard {j_post:.3f} >= 0.8 — Gemini is NOT echo-safe; the "
+        f"shared reframe did not break the echo. This is a FINDING. "
+        f"Q={QUESTION!r}, U={sim_reply!r}"
+    )
+
+    # --- Naive arm (reframe disabled; red-capability control) ---
+    _, sim_reply_naive, j_naive = await _run_echo_test(with_reframe=False)
+
+    print(f"\n[GEMINI NAIVE]    Q={QUESTION!r}")
+    print(f"[GEMINI NAIVE]    U={sim_reply_naive!r}")
+    print(f"[GEMINI NAIVE]    Jaccard={j_naive:.3f}")
+
+    assert j_naive >= 0.8, (
+        f"Naive Jaccard {j_naive:.3f} < 0.8 — the red-capability control did "
+        f"not detect the echo on Gemini's message shape. The metric may not be "
+        f"red-capable here. Q={QUESTION!r}, U={sim_reply_naive!r}"
+    )
+
+    # --- Margin floor: the metric meaningfully separates the two arms ---
+    margin = j_naive - j_post
+    print(f"[GEMINI MARGIN]   naive - postfix = {margin:.3f}")
+    assert margin >= 0.3, (
+        f"Margin {margin:.3f} < 0.3 — the echo metric does not separate the "
+        f"reframed vs naive arms enough to prove it is red-capable on Gemini. "
+        f"naive={j_naive:.3f}, postfix={j_post:.3f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural: Gemini's transcript surfaces as an assistant text part, and the
+# shared reframe is what protects it (no marker key leaks — AC11 parallel).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_gemini_transcript_surfaces_as_assistant_text_part():
+    """The Gemini adapter's recv_audio transcript lands as a text part on the
+    assistant turn in result.messages (this is the part the shared reframe
+    protects). Also: no 'scenario_origin' marker key leaks into messages.
+    """
+    result, _, _ = await _run_echo_test(with_reframe=True)
+
+    found_text = False
+    for msg in result.messages:
+        if msg.get("role") == "assistant":
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for part in content:
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") == "text"
+                        and QUESTION in (part.get("text") or "")
+                    ):
+                        found_text = True
+    assert found_text, (
+        f"Expected the Gemini assistant turn to surface transcript text "
+        f"{QUESTION!r} as a text part. Messages: {result.messages}"
+    )
+
+    dumped = json.dumps([dict(m) for m in result.messages])
+    assert "scenario_origin" not in dumped, (
+        "Marker key 'scenario_origin' leaked into result.messages"
+    )


### PR DESCRIPTION
## Why

Closes the **JS echo-safety gap** of #623 — the one real net-new fix the investigation surfaced (the rest of #623's premise was mostly moot: Gemini Live already inherits echo-safety, other adapters are audio-only or transport stubs) — and adds the full #623 creds-free regression coverage. A free-running voiced `userSimulatorAgent` faced with the realtime adapter **echoed the agent's surfaced transcript** as the candidate answer (`messageRoleReversal` passed audio-turn text through verbatim; the JS analogue of Python `_strip_audio_content` was absent). **Reproduced**: Jaccard 1.000.

**References #623.** Remaining #623 work (live-gated real-transport agent-first; the transport-stub adapters LiveKit/Vapi/WebRTC) is tracked as follow-up.

## What changed

- **Fix (AC-JS1'):** `stripAudioContent` (`javascript/src/agents/user-simulator-agent.ts`) reframes audio assistant turns to `[the agent said: <text>]` (mirroring Python `_strip_audio_content`) when `hasAudio && role==="assistant"`, on the **copy** fed to `invokeLLM` only — the persisted `result.messages` is never mutated.
- **Degraded-transcript guard (AC-JS7):** `javascript/src/agents/realtime/response-formatter.ts` now omits the text part for an empty/undefined transcript (it was emitting `text: undefined` → the literal `"undefined"` downstream); non-empty behavior is byte-identical.

## Test coverage (all creds-free, all GREEN)

| AC | Test | Asserts |
|----|------|---------|
| **AC-JS1'** | `realtime-echo-safe.test.ts` | the fix: free-running sim does not echo (post-fix Jaccard `<0.8`, naive `≥0.8`, margin `≥0.3`) |
| **AC-JS2'** | `realtime-echo-noleak.test.ts` | reframe is LLM-input-only; the persisted assistant turn stays raw |
| **AC-JS3'** | `realtime-adapter-frames.test.ts` | agent-first fires one non-empty turn (locks `handleInitialResponse`) |
| **AC-JS4'** | `realtime-adapter-frames.test.ts` | user-first sends exactly N `response.create` frames (no double-fire) |
| **AC-JS5** | `realtime-response-formatter.test.ts` | transcript surfaces as `{type:"text"}` + audio part |
| **AC-JS7** | `realtime-response-formatter.test.ts` + echo rerun | empty transcript → no `"undefined"` text; reframe is a no-op |
| **AC-PY1'** | `python/tests/voice/test_gemini_live_echo_safe.py` | **Gemini Live already echo-safe** (NO production change) via the shared `_strip_audio_content` — post-fix 0.583 / naive 1.000 / margin 0.417 |

## Test plan

- JS (nvm): `pnpm vitest run src/agents/` → 356 passed; `src/voice/` → 322 passed / 1 pre-existing skip; `pnpm typecheck` clean.
- Python: `uv run pytest tests/voice/test_gemini_live_echo_safe.py tests/voice/test_realtime_agent_echo_safe.py` → 11 passed; pyright clean.

## How I can prove it

The echo before/after: pre-fix the candidate is the agent's question verbatim (Jaccard 1.000); post-fix the sim sees `[the agent said: …]` and answers as a user (Jaccard ~0.5). The Gemini test confirms the shared `_strip_audio_content` path already protects non-OpenAI adapters with no per-adapter work — resolving #623's central open question.
