### PR TITLE
fix(voice): guard response.create on active response in recv_audio

### DIFF
--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -425,6 +425,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # the response.done handler fires response.create once the in-flight
                 # response clears.
                 self._deferred_response_create = True
+                self._agent_turn_pending = False  # user spoke → consume turn signal even when deferred
             else:
                 await self._ws.send(json.dumps({"type": "response.create"}))
                 self._agent_turn_pending = False  # user spoke → per-turn signal consumed

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -623,6 +623,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         """
         # Reset per-turn tool-call state so a prior turn's calls don't bleed
         # through (mirrors the transcript reset in _drain_agent_response).
+        self._deferred_response_create = False
         self._completed_tool_calls = []
         self._tool_call_accumulators = {}
 

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -406,9 +406,17 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         # If send_audio was called since last recv, commit and request response.
         if self._pending_audio_bytes > 0:
             await self._ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
-            await self._ws.send(json.dumps({"type": "response.create"}))
             self._pending_audio_bytes = 0
-            self._agent_turn_pending = False  # user spoke → per-turn signal consumed
+            if self._response_active:
+                # Race guard (#657): server rejects/ignores a duplicate
+                # response.create while a response is in flight, which causes the
+                # recv loop to drain to timeout instead of completing.  Defer by
+                # re-arming _agent_turn_pending so the response.done handler below
+                # fires response.create as soon as the in-flight response clears.
+                self._agent_turn_pending = True
+            else:
+                await self._ws.send(json.dumps({"type": "response.create"}))
+                self._agent_turn_pending = False  # user spoke → per-turn signal consumed
 
         # Gap 1: agent-speaks-first / multi-turn agent initiation.
         # When the executor signals an agent turn via notify_agent_turn() and
@@ -499,6 +507,13 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # Response finished or was cancelled — mark it so the next
                 # drain re-entry returns an empty chunk (clean exit).
                 self._response_active = False
+                # Issue #657: if user audio was committed while a response was
+                # in flight, _agent_turn_pending was set as a deferral flag.
+                # Now that _response_active is cleared, fire the deferred create.
+                if self._agent_turn_pending:
+                    await self._ws.send(json.dumps({"type": "response.create"}))
+                    self._agent_turn_pending = False
+                    self._response_active = True
                 # Issue #646: a tool-only turn (function call, NO audio delta) would
                 # otherwise loop here to the deadline and raise — the accumulated tool
                 # call is parsed but never returned. When the response is done and at

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -142,6 +142,16 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         # proceed()/resume). Consumed (cleared) when the kick fires.
         self._agent_turn_pending: bool = speaks_first  # first turn armed if speaks_first
 
+        # Issue #657: distinct deferral flag for the user-audio race guard.
+        # Set when user audio arrives while a response is in flight; cleared and
+        # consumed in the response.done/cancelled handler to fire the deferred
+        # response.create.  Kept separate from _agent_turn_pending so each flag
+        # retains its single original meaning.
+        # Known limitation: a second user-audio commit while one create is already
+        # deferred collapses into this single boolean.  Manual-VAD single-turn flow
+        # makes that path unreachable in practice; FSM refactor tracked as follow-up.
+        self._deferred_response_create: bool = False
+
         # --- Issue #630: realtime function-call (tool-call) surfacing ---
         # In-progress function calls keyed by call_id. Each value is a dict
         # {"name": str|None, "arguments": str} assembled from the streaming
@@ -410,10 +420,11 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             if self._response_active:
                 # Race guard (#657): server rejects/ignores a duplicate
                 # response.create while a response is in flight, which causes the
-                # recv loop to drain to timeout instead of completing.  Defer by
-                # re-arming _agent_turn_pending so the response.done handler below
-                # fires response.create as soon as the in-flight response clears.
-                self._agent_turn_pending = True
+                # recv loop to drain to timeout instead of completing.  Defer via
+                # _deferred_response_create (distinct from _agent_turn_pending) so
+                # the response.done handler fires response.create once the in-flight
+                # response clears.
+                self._deferred_response_create = True
             else:
                 await self._ws.send(json.dumps({"type": "response.create"}))
                 self._agent_turn_pending = False  # user spoke → per-turn signal consumed
@@ -508,11 +519,11 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # drain re-entry returns an empty chunk (clean exit).
                 self._response_active = False
                 # Issue #657: if user audio was committed while a response was
-                # in flight, _agent_turn_pending was set as a deferral flag.
+                # in flight, _deferred_response_create was set as a deferral flag.
                 # Now that _response_active is cleared, fire the deferred create.
-                if self._agent_turn_pending:
+                if self._deferred_response_create:
                     await self._ws.send(json.dumps({"type": "response.create"}))
-                    self._agent_turn_pending = False
+                    self._deferred_response_create = False
                     self._response_active = True
                 # Issue #646: a tool-only turn (function call, NO audio delta) would
                 # otherwise loop here to the deadline and raise — the accumulated tool

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -424,3 +424,47 @@ async def test_ac7_race_sequence_returns_audio_chunk_not_timeout():
         "Post-fix: guard defers response.create until response.done is processed, "
         "then the audio-delta sequence completes with a non-empty chunk."
     )
+
+
+# ---------------------------------------------------------------------------
+# Deferred path also consumes the agent-turn signal: when user audio is
+# committed while a response is in flight, recv_audio takes the deferral
+# branch (_deferred_response_create=True) and MUST also clear
+# _agent_turn_pending (openai_realtime.py line 428) — the user spoke, so the
+# pending agent-turn signal is consumed even though the create is deferred.
+# Without that clear, a later drain re-entry would fire a spurious
+# response.create off the still-pending agent-turn flag.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deferred_path_clears_agent_turn_pending():
+    """Deferred branch clears _agent_turn_pending (line 428) when user audio is committed mid-response."""
+    # response.created fires, but no response.done — response stays active and
+    # no audio delta arrives, so the drain terminates via TimeoutError from the
+    # MockWS (same shape as AC1). The flag clear happens in the preamble before
+    # the recv loop, so the timeout does not affect what we assert.
+    events = [
+        json.dumps({"type": "response.created"}),
+    ]
+    adapter, _mock_ws = _make_adapter(events, short_timeout=True)
+
+    # Both flags set: an agent turn is pending AND a response is already in
+    # flight. User audio committed below → preamble takes the deferral branch.
+    adapter._agent_turn_pending = True
+    adapter._response_active = True
+    adapter._pending_audio_bytes = 960  # 480 samples × 2 bytes
+
+    # recv_audio times out (no audio delta, no response.done) — expected.
+    with pytest.raises((asyncio.TimeoutError, RuntimeError)):
+        await adapter.recv_audio(timeout=0.2)
+
+    # The deferral branch must have consumed the agent-turn signal (line 428).
+    assert adapter._agent_turn_pending is False, (
+        "deferred path did not clear _agent_turn_pending; a later drain "
+        "re-entry would fire a spurious response.create off the stale flag"
+    )
+    # Sanity: it really was the deferral branch (flag set), not the else branch.
+    assert adapter._deferred_response_create is True, (
+        "expected the deferral branch (_deferred_response_create=True) to be taken"
+    )

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -1,0 +1,507 @@
+"""
+Issue #657 — regression tests for recv_audio response.create race condition.
+
+The user-audio branch at lines ~407-411 of openai_realtime.py sends
+``response.create`` unconditionally after ``input_audio_buffer.commit``, even
+while ``self._response_active`` is True (set on response.created, cleared on
+response.done/response.cancelled).  The agent-turn elif at ~line 423 already
+guards on ``not self._response_active``.
+
+Fix (NOT in this file): add the same guard to the user-audio branch and defer
+the create by setting ``_agent_turn_pending=True`` so it fires after
+response.done clears ``_response_active``.
+
+Test layout
+-----------
+AC1 — guard present: response.create suppressed while response is active.
+AC2 — deferred response.create fires AFTER response.done (ordering asserted).
+AC3 — single commit + single create across the full guarded sequence.
+AC4 — control: agent-turn branch unaffected (should PASS now).
+AC5 — control: normal path (no active response) sends commit then create (should PASS now).
+AC6 — explicit server rejection raises RuntimeError.
+AC7 — pre-fix timeout face resolves to a valid AudioChunk post-fix.
+
+AC1/AC2/AC3/AC7 MUST FAIL on current (pre-fix) code.
+AC4/AC5 MUST PASS on current code.
+AC6 MUST PASS if the adapter already surfaces error events as RuntimeError.
+
+Mock strategy: hermetic _MockWS from test_realtime_tool_calls.py — queue-based,
+no live API key required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from typing import Any, List
+
+import pytest
+
+from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pcm(n_samples: int = 480) -> bytes:
+    """Minimal silent PCM16 mono @ 24 kHz."""
+    return b"\x00\x00" * n_samples
+
+
+def _b64_pcm(n_samples: int = 480) -> str:
+    return base64.b64encode(_make_pcm(n_samples)).decode()
+
+
+class _MockWS:
+    """Queue-backed WebSocket mock.
+
+    ``recv()`` pops pre-loaded JSON event strings in order; once exhausted it
+    raises asyncio.TimeoutError (tail silence).  ``send()`` is recorded in
+    ``self.sent`` as a list of parsed dicts so callers can inspect event types.
+    """
+
+    def __init__(self, events: List[str]) -> None:
+        self._events = list(events)
+        self._idx = 0
+        self.sent: List[Any] = []
+        # Also track raw send order as (index, parsed_dict) for AC2 ordering.
+        self.sent_indexed: List[tuple[int, dict]] = []
+        self._send_counter = 0
+
+    async def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+        try:
+            parsed = json.loads(msg) if isinstance(msg, str) else msg
+        except Exception:
+            parsed = {"_raw": msg}
+        self.sent_indexed.append((self._send_counter, parsed))
+        self._send_counter += 1
+
+    async def recv(self) -> str:
+        if self._idx >= len(self._events):
+            await asyncio.sleep(0)
+            raise asyncio.TimeoutError("mock WS: no more events")
+        evt = self._events[self._idx]
+        self._idx += 1
+        return evt
+
+    async def close(self) -> None:
+        pass
+
+    # --- helpers for assertions ---
+
+    def sent_types(self) -> List[str]:
+        """Ordered list of ``type`` values from sent messages."""
+        types = []
+        for msg in self.sent:
+            try:
+                d = json.loads(msg) if isinstance(msg, str) else msg
+                types.append(d.get("type", ""))
+            except Exception:
+                types.append("")
+        return types
+
+    def first_index_of(self, event_type: str) -> int:
+        """Index of the first send with the given type, or -1."""
+        for i, t in enumerate(self.sent_types()):
+            if t == event_type:
+                return i
+        return -1
+
+    def count_of(self, event_type: str) -> int:
+        return self.sent_types().count(event_type)
+
+
+def _audio_delta_events() -> List[str]:
+    """Normal audio-delta sequence ending with response.done."""
+    chunk = _b64_pcm(480)
+    return [
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+
+
+def _make_adapter(events: List[str], *, short_timeout: bool = False) -> tuple[OpenAIRealtimeAgentAdapter, _MockWS]:
+    """Build an adapter wired to a _MockWS pre-loaded with ``events``."""
+    adapter = OpenAIRealtimeAgentAdapter(speaks_first=False)
+    mock_ws = _MockWS(events)
+    adapter._ws = mock_ws
+    if short_timeout:
+        adapter.response_timeout = 0.2  # keep tests fast
+    return adapter, mock_ws
+
+
+# ---------------------------------------------------------------------------
+# AC1 — guard present: response.create suppressed while response is active
+# (MUST FAIL on pre-fix code)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac1_response_create_suppressed_while_response_active():
+    """
+    AC1: when _response_active is True (mock pre-loaded with response.created,
+    no response.done) and _pending_audio_bytes > 0, recv_audio must send
+    ``input_audio_buffer.commit`` but NOT ``response.create``.
+
+    Pre-fix: the user-audio branch fires response.create unconditionally.
+    Post-fix: the guard prevents it.
+    """
+    # response.created fires, but no response.done — response stays active.
+    # Tail silence terminates the recv loop via TimeoutError from MockWS.
+    events = [
+        json.dumps({"type": "response.created"}),
+        # no audio delta, no response.done → drain times out
+    ]
+    adapter, mock_ws = _make_adapter(events, short_timeout=True)
+
+    # Simulate user audio having been queued.
+    adapter._pending_audio_bytes = 960  # 480 samples × 2 bytes
+    # response.created has not fired yet at recv call time — but will fire
+    # mid-loop. Pre-fix sends response.create before seeing response.created.
+    # Post-fix: if response is already active at call time, guard applies.
+    # Inject _response_active=True to replicate the race (response created
+    # from a previous still-in-flight response).
+    adapter._response_active = True
+
+    # recv_audio will time out (no audio delta) — that's expected.
+    with pytest.raises((asyncio.TimeoutError, Exception)):
+        await adapter.recv_audio(timeout=0.2)
+
+    # MUST have committed audio.
+    assert mock_ws.count_of("input_audio_buffer.commit") >= 1, (
+        "AC1: input_audio_buffer.commit was not sent"
+    )
+    # MUST NOT have fired response.create while response was already active.
+    assert mock_ws.count_of("response.create") == 0, (
+        f"AC1 FAIL (pre-fix): response.create was sent while _response_active=True; "
+        f"sent_types={mock_ws.sent_types()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC2 — deferred response.create fires AFTER response.done (ordering)
+# (MUST FAIL on pre-fix code)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac2_deferred_response_create_fires_after_response_done():
+    """
+    AC2: After the guard fires (response active during commit), once the mock
+    yields response.done, response.create must NOT have been sent before the
+    recv loop processed response.done.
+
+    Pre-fix: response.create fires IMMEDIATELY in the user-audio branch preamble
+    (before the event loop starts) — so response.create count is already 1 when
+    the loop begins.
+
+    Post-fix: response.create count is 0 until after response.done is processed.
+    We detect the pre-fix shape by asserting response.create count == 0 at the
+    preamble boundary, proxied by: if _response_active=True pre-fix sends it
+    unconditionally, then the loop sees another response.created + audio delta
+    and also the agent-turn branch would fire ANOTHER one — giving count==2.
+    Post-fix: exactly 1 deferred create.
+
+    Simpler proxy: pre-fix fires response.create at index 1 (right after commit at
+    index 0) — before the event loop begins (index 0=commit, 1=create). Post-fix:
+    response.create appears at index >= 1 but ONLY after response.done was received,
+    meaning the recv loop ran first. We assert: if response.create appears at sent
+    index position 1 (immediately after commit, preamble), that's the pre-fix shape.
+    """
+    chunk = _b64_pcm(480)
+    # Sequence: response.done clears in-flight, then audio delta from deferred create.
+    events = [
+        # In-flight response completes.
+        json.dumps({"type": "response.done"}),
+        # Deferred create fires → second response.created + audio.
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter, mock_ws = _make_adapter(events, short_timeout=True)
+
+    # In-flight response: _response_active=True, pending audio.
+    adapter._response_active = True
+    adapter._response_ever_active = True
+    adapter._pending_audio_bytes = 960
+
+    result = await adapter.recv_audio(timeout=2.0)
+
+    sent = mock_ws.sent_types()
+
+    # Post-fix: response.create IS sent (deferred, not dropped).
+    assert "response.create" in sent, (
+        f"AC2 FAIL: response.create never sent; sent={sent}"
+    )
+
+    commit_idx = mock_ws.first_index_of("input_audio_buffer.commit")
+    create_idx = mock_ws.first_index_of("response.create")
+
+    assert commit_idx >= 0, "AC2: input_audio_buffer.commit not sent"
+
+    # Pre-fix shape: response.create fired in preamble (sent index 1, immediately
+    # after commit at sent index 0) — before the event loop ran at all.
+    # Post-fix: response.create deferred; must NOT be at position commit_idx+1
+    # with no recv events between them.
+    assert create_idx != commit_idx + 1, (
+        f"AC2 FAIL (pre-fix): response.create at sent[{create_idx}] is immediately "
+        f"after input_audio_buffer.commit at sent[{commit_idx}], indicating it was "
+        f"fired in the preamble (before the event loop processed response.done). "
+        f"Post-fix: it should be deferred until after response.done is received. "
+        f"sent_types={sent}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3 — exactly one commit and zero response.create in the preamble when
+# _response_active=True, plus exactly one response.create total after the
+# full guarded sequence.
+# (MUST FAIL on pre-fix code — pre-fix fires response.create in preamble)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac3_exactly_one_commit_and_one_create():
+    """
+    AC3: across the full guarded sequence (guard fires, response.done received,
+    deferred send fires), mock_ws.sent contains input_audio_buffer.commit
+    exactly once and response.create exactly once.
+
+    Pre-fix: response.create fires in the user-audio branch preamble (count=1
+    before the event loop even starts). After the loop processes response.done
+    and response.created and audio delta, count is still 1 — but the preamble
+    create came BEFORE response.done was received.
+
+    The pre-fix falsification: after the preamble, count_of("response.create")==1
+    already. We assert this equals 0 at that point (proxy: total count must
+    equal 1 AND the only create must appear AFTER response.done was received,
+    i.e., not at index commit_idx+1).
+
+    Combined assertion: count==1 AND create is NOT at preamble position.
+    This mirrors AC1 + AC2 but proves the FULL sequence property.
+    """
+    chunk = _b64_pcm(480)
+    events = [
+        # In-flight response completes.
+        json.dumps({"type": "response.done"}),
+        # Deferred create fires → second response + audio.
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter, mock_ws = _make_adapter(events, short_timeout=True)
+
+    adapter._response_active = True
+    adapter._response_ever_active = True
+    adapter._pending_audio_bytes = 960
+
+    await adapter.recv_audio(timeout=2.0)
+
+    commit_count = mock_ws.count_of("input_audio_buffer.commit")
+    create_count = mock_ws.count_of("response.create")
+    commit_idx = mock_ws.first_index_of("input_audio_buffer.commit")
+    create_idx = mock_ws.first_index_of("response.create")
+
+    assert commit_count == 1, (
+        f"AC3 FAIL: expected exactly 1 input_audio_buffer.commit, got {commit_count}; "
+        f"sent_types={mock_ws.sent_types()}"
+    )
+    assert create_count == 1, (
+        f"AC3 FAIL: expected exactly 1 response.create, got {create_count}; "
+        f"sent_types={mock_ws.sent_types()}"
+    )
+    # The create must NOT be at the preamble position (immediately after commit).
+    # Pre-fix fires it at commit_idx+1 (before the event loop ran).
+    assert create_idx != commit_idx + 1, (
+        f"AC3 FAIL (pre-fix): response.create at sent[{create_idx}] is immediately "
+        f"after commit at sent[{commit_idx}] — fired in the preamble before "
+        f"response.done was processed. Post-fix: deferred until after response.done. "
+        f"sent_types={mock_ws.sent_types()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4 — control: agent-turn branch unaffected (SHOULD PASS NOW)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac4_agent_turn_branch_still_fires_response_create():
+    """
+    AC4 (control — should PASS on current code): recv_audio with
+    _agent_turn_pending=True and _response_active=False must still fire
+    response.create exactly once. The guard must not bleed into the
+    agent-turn branch.
+    """
+    chunk = _b64_pcm(480)
+    events = [
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter, mock_ws = _make_adapter(events)
+
+    adapter._agent_turn_pending = True
+    adapter._response_active = False
+
+    await adapter.recv_audio(timeout=2.0)
+
+    create_count = mock_ws.count_of("response.create")
+    assert create_count == 1, (
+        f"AC4: expected exactly 1 response.create from agent-turn branch, "
+        f"got {create_count}; sent_types={mock_ws.sent_types()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5 — control: normal path (no active response) sends commit then create
+# (SHOULD PASS NOW)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac5_normal_path_commit_then_create():
+    """
+    AC5 (control — should PASS on current code): _pending_audio_bytes > 0
+    and _response_active=False (uncontested path). Both commit and create must
+    fire, and commit must appear before create.
+    """
+    chunk = _b64_pcm(480)
+    events = [
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter, mock_ws = _make_adapter(events)
+
+    adapter._pending_audio_bytes = 960
+    adapter._response_active = False
+
+    await adapter.recv_audio(timeout=2.0)
+
+    sent = mock_ws.sent_types()
+    assert "input_audio_buffer.commit" in sent, (
+        f"AC5: input_audio_buffer.commit not sent; sent={sent}"
+    )
+    assert "response.create" in sent, (
+        f"AC5: response.create not sent; sent={sent}"
+    )
+    commit_idx = mock_ws.first_index_of("input_audio_buffer.commit")
+    create_idx = mock_ws.first_index_of("response.create")
+    assert commit_idx < create_idx, (
+        f"AC5: expected commit (idx={commit_idx}) before create (idx={create_idx})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC6 — explicit server rejection raises RuntimeError
+# (SHOULD PASS if current adapter already surfaces error events)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac6_server_rejection_raises_runtime_error():
+    """
+    AC6: a mock that emits the server error event
+    "Conversation already has an active response in progress" must surface as
+    RuntimeError, not be swallowed.
+    """
+    error_msg = "Conversation already has an active response in progress: resp_abc123"
+    events = [
+        json.dumps({"type": "error", "error": {"message": error_msg}}),
+    ]
+    adapter, _mock_ws = _make_adapter(events)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await adapter.recv_audio(timeout=2.0)
+
+    assert "Conversation already has an active response in progress" in str(exc_info.value), (
+        f"AC6: RuntimeError raised but message doesn't contain expected text; "
+        f"got: {exc_info.value}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC7 — pre-fix race: response.create count in sent equals 2 when
+# _response_active=True; post-fix: exactly 1.
+# (MUST FAIL on pre-fix code)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac7_race_sequence_returns_audio_chunk_not_timeout():
+    """
+    AC7: with a two-call sequence through call() that exercises the drain loop,
+    the pre-fix fires response.create twice (preamble + agent-turn branch),
+    post-fix fires exactly once (deferred after response.done).
+
+    We exercise this via two sequential recv_audio calls on the same adapter +
+    mock: call 1 has the race (_response_active=True + pending audio), call 2
+    is the drain re-entry. Pre-fix: call 1 preamble fires response.create
+    immediately; call 2 (agent-turn branch) fires it again → total == 2.
+    Post-fix: call 1 defers; call 2 fires exactly the deferred create → total == 1.
+
+    Actually: the simplest falsifiable shape is that pre-fix fires response.create
+    with count=1 on call 1 preamble (before the loop), then the loop reads events
+    and the test can observe that create happened before recv events were consumed.
+    We prove this via: after recv_audio returns, check that the number of sends
+    before the first recv event was processed is already 2 (commit + create in
+    preamble), proving it fired pre-loop.
+
+    Since we cannot observe "before first recv" post-hoc, we proxy this via AC1's
+    assertion: count_of("response.create") == 0 when _response_active=True. AC7
+    adds the "full sequence resolves to non-empty AudioChunk" assertion so that
+    both the guard AND the deferred firing are proven together.
+    """
+    chunk = _b64_pcm(480)
+    # Events: in-flight completes, deferred create acknowledged, audio delta.
+    events = [
+        json.dumps({"type": "response.done"}),
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter, mock_ws = _make_adapter(events, short_timeout=True)
+
+    adapter._response_active = True
+    adapter._response_ever_active = True
+    adapter._pending_audio_bytes = 960
+
+    result = await adapter.recv_audio(timeout=2.0)
+
+    # AC7a: the guard held (no premature create) — count == 0 pre-loop means pre-fix.
+    # On pre-fix, this assertion matches AC1: count == 1 here → fails.
+    # We assert it a different way: total sent before recv events = 2 on pre-fix.
+    # Proxy: sent_types list starts with ['input_audio_buffer.commit', 'response.create']
+    # on pre-fix (both fired before recv loop). Post-fix starts with
+    # ['input_audio_buffer.commit'] only (create deferred to after response.done recv).
+    sent = mock_ws.sent_types()
+    assert sent[0] == "input_audio_buffer.commit", (
+        f"AC7: expected first sent to be commit, got {sent[0]}"
+    )
+    # Pre-fix: sent[1] == "response.create" (preamble fire). Post-fix: sent[1] is absent
+    # or is the deferred create that appeared after response.done was received.
+    # Falsify pre-fix: assert sent does NOT have response.create at index 1
+    # (the preamble position immediately after commit).
+    if len(sent) > 1:
+        assert sent[1] != "response.create", (
+            f"AC7 FAIL (pre-fix): response.create at sent[1] was fired in the "
+            f"preamble (before any recv event). Post-fix: deferred until after "
+            f"response.done is processed. sent_types={sent}"
+        )
+
+    # AC7b: the full sequence resolved to a non-empty AudioChunk (not timeout/empty).
+    assert result is not None, "AC7 FAIL: recv_audio returned None"
+    assert isinstance(result.data, bytes), (
+        f"AC7 FAIL: result.data is not bytes: {type(result.data)}"
+    )
+    assert len(result.data) > 0, (
+        "AC7 FAIL: recv_audio returned an empty AudioChunk. "
+        "Post-fix: guard defers response.create until response.done is processed, "
+        "then the audio-delta sequence completes with a non-empty chunk."
+    )

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -61,24 +61,29 @@ class _MockWS:
     ``recv()`` pops pre-loaded JSON event strings in order; once exhausted it
     raises asyncio.TimeoutError (tail silence).  ``send()`` is recorded in
     ``self.sent`` as a list of parsed dicts so callers can inspect event types.
+
+    ``log`` is a single interleaved chronological sequence of
+    ``("sent", type_str)`` and ``("recv", type_str)`` tuples — one entry per
+    adapter send and one per mock yield.  This allows true ordering assertions
+    (e.g. "response.create was not sent before response.done was received")
+    without relying on send-only position proxies.
     """
 
     def __init__(self, events: List[str]) -> None:
         self._events = list(events)
         self._idx = 0
         self.sent: List[Any] = []
-        # Also track raw send order as (index, parsed_dict) for AC2 ordering.
-        self.sent_indexed: List[tuple[int, dict]] = []
-        self._send_counter = 0
+        # Interleaved chronological log: ("sent"|"recv", type_str)
+        self.log: List[tuple[str, str]] = []
 
     async def send(self, msg: Any) -> None:
         self.sent.append(msg)
         try:
-            parsed = json.loads(msg) if isinstance(msg, str) else msg
+            d = json.loads(msg) if isinstance(msg, str) else msg
+            t = d.get("type", "")
         except Exception:
-            parsed = {"_raw": msg}
-        self.sent_indexed.append((self._send_counter, parsed))
-        self._send_counter += 1
+            t = ""
+        self.log.append(("sent", t))
 
     async def recv(self) -> str:
         if self._idx >= len(self._events):
@@ -86,6 +91,11 @@ class _MockWS:
             raise asyncio.TimeoutError("mock WS: no more events")
         evt = self._events[self._idx]
         self._idx += 1
+        try:
+            t = json.loads(evt).get("type", "")
+        except Exception:
+            t = ""
+        self.log.append(("recv", t))
         return evt
 
     async def close(self) -> None:
@@ -95,17 +105,10 @@ class _MockWS:
 
     def sent_types(self) -> List[str]:
         """Ordered list of ``type`` values from sent messages."""
-        types = []
-        for msg in self.sent:
-            try:
-                d = json.loads(msg) if isinstance(msg, str) else msg
-                types.append(d.get("type", ""))
-            except Exception:
-                types.append("")
-        return types
+        return [t for (kind, t) in self.log if kind == "sent"]
 
     def first_index_of(self, event_type: str) -> int:
-        """Index of the first send with the given type, or -1."""
+        """Index of the first send with the given type in sent_types(), or -1."""
         for i, t in enumerate(self.sent_types()):
             if t == event_type:
                 return i
@@ -113,6 +116,13 @@ class _MockWS:
 
     def count_of(self, event_type: str) -> int:
         return self.sent_types().count(event_type)
+
+    def log_index_of_first(self, kind: str, event_type: str) -> int:
+        """Index in the interleaved log of the first entry matching (kind, event_type), or -1."""
+        for i, entry in enumerate(self.log):
+            if entry == (kind, event_type):
+                return i
+        return -1
 
 
 def _audio_delta_events() -> List[str]:
@@ -239,21 +249,23 @@ async def test_ac2_deferred_response_create_fires_after_response_done():
         f"AC2 FAIL: response.create never sent; sent={sent}"
     )
 
-    commit_idx = mock_ws.first_index_of("input_audio_buffer.commit")
-    create_idx = mock_ws.first_index_of("response.create")
+    assert mock_ws.first_index_of("input_audio_buffer.commit") >= 0, (
+        "AC2: input_audio_buffer.commit not sent"
+    )
 
-    assert commit_idx >= 0, "AC2: input_audio_buffer.commit not sent"
+    # True ordering assertion using the interleaved log: the first
+    # ("sent","response.create") entry must appear AFTER the first
+    # ("recv","response.done") entry.  Pre-fix fires response.create in the
+    # preamble before the recv loop starts, so it precedes every recv entry.
+    log_create = mock_ws.log_index_of_first("sent", "response.create")
+    log_done   = mock_ws.log_index_of_first("recv", "response.done")
 
-    # Pre-fix shape: response.create fired in preamble (sent index 1, immediately
-    # after commit at sent index 0) — before the event loop ran at all.
-    # Post-fix: response.create deferred; must NOT be at position commit_idx+1
-    # with no recv events between them.
-    assert create_idx != commit_idx + 1, (
-        f"AC2 FAIL (pre-fix): response.create at sent[{create_idx}] is immediately "
-        f"after input_audio_buffer.commit at sent[{commit_idx}], indicating it was "
-        f"fired in the preamble (before the event loop processed response.done). "
-        f"Post-fix: it should be deferred until after response.done is received. "
-        f"sent_types={sent}"
+    assert log_done >= 0, f"AC2: response.done never received; log={mock_ws.log}"
+    assert log_create > log_done, (
+        f"AC2 FAIL (pre-fix): response.create appeared at log[{log_create}] "
+        f"before or at response.done at log[{log_done}], indicating it was fired "
+        f"in the preamble (before the event loop processed response.done). "
+        f"Post-fix: deferred until after response.done is received. log={mock_ws.log}"
     )
 
 
@@ -304,8 +316,6 @@ async def test_ac3_exactly_one_commit_and_one_create():
 
     commit_count = mock_ws.count_of("input_audio_buffer.commit")
     create_count = mock_ws.count_of("response.create")
-    commit_idx = mock_ws.first_index_of("input_audio_buffer.commit")
-    create_idx = mock_ws.first_index_of("response.create")
 
     assert commit_count == 1, (
         f"AC3 FAIL: expected exactly 1 input_audio_buffer.commit, got {commit_count}; "
@@ -315,13 +325,17 @@ async def test_ac3_exactly_one_commit_and_one_create():
         f"AC3 FAIL: expected exactly 1 response.create, got {create_count}; "
         f"sent_types={mock_ws.sent_types()}"
     )
-    # The create must NOT be at the preamble position (immediately after commit).
-    # Pre-fix fires it at commit_idx+1 (before the event loop ran).
-    assert create_idx != commit_idx + 1, (
-        f"AC3 FAIL (pre-fix): response.create at sent[{create_idx}] is immediately "
-        f"after commit at sent[{commit_idx}] — fired in the preamble before "
-        f"response.done was processed. Post-fix: deferred until after response.done. "
-        f"sent_types={mock_ws.sent_types()}"
+    # True ordering assertion: response.create must appear after response.done
+    # in the interleaved log.  Pre-fix fires response.create in the preamble,
+    # which always precedes any recv entry.
+    log_create = mock_ws.log_index_of_first("sent", "response.create")
+    log_done   = mock_ws.log_index_of_first("recv", "response.done")
+    assert log_done >= 0, f"AC3: response.done never received; log={mock_ws.log}"
+    assert log_create > log_done, (
+        f"AC3 FAIL (pre-fix): response.create at log[{log_create}] appeared before "
+        f"response.done at log[{log_done}] — fired in the preamble before the event "
+        f"loop processed response.done. Post-fix: deferred until after response.done. "
+        f"log={mock_ws.log}"
     )
 
 
@@ -474,26 +488,21 @@ async def test_ac7_race_sequence_returns_audio_chunk_not_timeout():
 
     result = await adapter.recv_audio(timeout=2.0)
 
-    # AC7a: the guard held (no premature create) — count == 0 pre-loop means pre-fix.
-    # On pre-fix, this assertion matches AC1: count == 1 here → fails.
-    # We assert it a different way: total sent before recv events = 2 on pre-fix.
-    # Proxy: sent_types list starts with ['input_audio_buffer.commit', 'response.create']
-    # on pre-fix (both fired before recv loop). Post-fix starts with
-    # ['input_audio_buffer.commit'] only (create deferred to after response.done recv).
-    sent = mock_ws.sent_types()
-    assert sent[0] == "input_audio_buffer.commit", (
-        f"AC7: expected first sent to be commit, got {sent[0]}"
+    # AC7a: true ordering — response.create must appear after response.done in
+    # the interleaved log.  Pre-fix fires response.create in the preamble before
+    # any recv event, so log_create < log_done on pre-fix code.
+    log_create = mock_ws.log_index_of_first("sent", "response.create")
+    log_done   = mock_ws.log_index_of_first("recv", "response.done")
+
+    assert "response.create" in mock_ws.sent_types(), (
+        f"AC7 FAIL: response.create never sent; log={mock_ws.log}"
     )
-    # Pre-fix: sent[1] == "response.create" (preamble fire). Post-fix: sent[1] is absent
-    # or is the deferred create that appeared after response.done was received.
-    # Falsify pre-fix: assert sent does NOT have response.create at index 1
-    # (the preamble position immediately after commit).
-    if len(sent) > 1:
-        assert sent[1] != "response.create", (
-            f"AC7 FAIL (pre-fix): response.create at sent[1] was fired in the "
-            f"preamble (before any recv event). Post-fix: deferred until after "
-            f"response.done is processed. sent_types={sent}"
-        )
+    assert log_done >= 0, f"AC7: response.done never received; log={mock_ws.log}"
+    assert log_create > log_done, (
+        f"AC7 FAIL (pre-fix): response.create at log[{log_create}] appeared before "
+        f"response.done at log[{log_done}] — fired in the preamble before any recv "
+        f"event. Post-fix: deferred until after response.done. log={mock_ws.log}"
+    )
 
     # AC7b: the full sequence resolved to a non-empty AudioChunk (not timeout/empty).
     assert result is not None, "AC7 FAIL: recv_audio returned None"

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -202,7 +202,7 @@ async def test_ac2_deferred_response_create_fires_after_response_done():
     adapter._response_ever_active = True
     adapter._pending_audio_bytes = 960
 
-    result = await adapter.recv_audio(timeout=2.0)
+    await adapter.recv_audio(timeout=2.0)
 
     sent = mock_ws.sent_types()
 

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -8,7 +8,7 @@ response.done/response.cancelled).  The agent-turn elif at ~line 423 already
 guards on ``not self._response_active``.
 
 Fix (NOT in this file): add the same guard to the user-audio branch and defer
-the create by setting ``_agent_turn_pending=True`` so it fires after
+the create by setting ``_deferred_response_create=True`` so it fires after
 response.done clears ``_response_active``.
 
 Test layout
@@ -125,16 +125,6 @@ class _MockWS:
         return -1
 
 
-def _audio_delta_events() -> List[str]:
-    """Normal audio-delta sequence ending with response.done."""
-    chunk = _b64_pcm(480)
-    return [
-        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
-        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
-        json.dumps({"type": "response.done"}),
-    ]
-
-
 def _make_adapter(events: List[str], *, short_timeout: bool = False) -> tuple[OpenAIRealtimeAgentAdapter, _MockWS]:
     """Build an adapter wired to a _MockWS pre-loaded with ``events``."""
     adapter = OpenAIRealtimeAgentAdapter(speaks_first=False)
@@ -153,14 +143,7 @@ def _make_adapter(events: List[str], *, short_timeout: bool = False) -> tuple[Op
 
 @pytest.mark.asyncio
 async def test_ac1_response_create_suppressed_while_response_active():
-    """
-    AC1: when _response_active is True (mock pre-loaded with response.created,
-    no response.done) and _pending_audio_bytes > 0, recv_audio must send
-    ``input_audio_buffer.commit`` but NOT ``response.create``.
-
-    Pre-fix: the user-audio branch fires response.create unconditionally.
-    Post-fix: the guard prevents it.
-    """
+    """AC1: recv_audio sends commit but NOT response.create when _response_active=True."""
     # response.created fires, but no response.done — response stays active.
     # Tail silence terminates the recv loop via TimeoutError from MockWS.
     events = [
@@ -179,7 +162,7 @@ async def test_ac1_response_create_suppressed_while_response_active():
     adapter._response_active = True
 
     # recv_audio will time out (no audio delta) — that's expected.
-    with pytest.raises((asyncio.TimeoutError, Exception)):
+    with pytest.raises((asyncio.TimeoutError, RuntimeError)):
         await adapter.recv_audio(timeout=0.2)
 
     # MUST have committed audio.
@@ -201,28 +184,7 @@ async def test_ac1_response_create_suppressed_while_response_active():
 
 @pytest.mark.asyncio
 async def test_ac2_deferred_response_create_fires_after_response_done():
-    """
-    AC2: After the guard fires (response active during commit), once the mock
-    yields response.done, response.create must NOT have been sent before the
-    recv loop processed response.done.
-
-    Pre-fix: response.create fires IMMEDIATELY in the user-audio branch preamble
-    (before the event loop starts) — so response.create count is already 1 when
-    the loop begins.
-
-    Post-fix: response.create count is 0 until after response.done is processed.
-    We detect the pre-fix shape by asserting response.create count == 0 at the
-    preamble boundary, proxied by: if _response_active=True pre-fix sends it
-    unconditionally, then the loop sees another response.created + audio delta
-    and also the agent-turn branch would fire ANOTHER one — giving count==2.
-    Post-fix: exactly 1 deferred create.
-
-    Simpler proxy: pre-fix fires response.create at index 1 (right after commit at
-    index 0) — before the event loop begins (index 0=commit, 1=create). Post-fix:
-    response.create appears at index >= 1 but ONLY after response.done was received,
-    meaning the recv loop ran first. We assert: if response.create appears at sent
-    index position 1 (immediately after commit, preamble), that's the pre-fix shape.
-    """
+    """AC2: deferred response.create appears in the interleaved log AFTER response.done is received."""
     chunk = _b64_pcm(480)
     # Sequence: response.done clears in-flight, then audio delta from deferred create.
     events = [
@@ -279,24 +241,7 @@ async def test_ac2_deferred_response_create_fires_after_response_done():
 
 @pytest.mark.asyncio
 async def test_ac3_exactly_one_commit_and_one_create():
-    """
-    AC3: across the full guarded sequence (guard fires, response.done received,
-    deferred send fires), mock_ws.sent contains input_audio_buffer.commit
-    exactly once and response.create exactly once.
-
-    Pre-fix: response.create fires in the user-audio branch preamble (count=1
-    before the event loop even starts). After the loop processes response.done
-    and response.created and audio delta, count is still 1 — but the preamble
-    create came BEFORE response.done was received.
-
-    The pre-fix falsification: after the preamble, count_of("response.create")==1
-    already. We assert this equals 0 at that point (proxy: total count must
-    equal 1 AND the only create must appear AFTER response.done was received,
-    i.e., not at index commit_idx+1).
-
-    Combined assertion: count==1 AND create is NOT at preamble position.
-    This mirrors AC1 + AC2 but proves the FULL sequence property.
-    """
+    """AC3: full guarded sequence produces exactly one commit and one response.create, ordered after response.done."""
     chunk = _b64_pcm(480)
     events = [
         # In-flight response completes.
@@ -346,12 +291,7 @@ async def test_ac3_exactly_one_commit_and_one_create():
 
 @pytest.mark.asyncio
 async def test_ac4_agent_turn_branch_still_fires_response_create():
-    """
-    AC4 (control — should PASS on current code): recv_audio with
-    _agent_turn_pending=True and _response_active=False must still fire
-    response.create exactly once. The guard must not bleed into the
-    agent-turn branch.
-    """
+    """AC4 (control): agent-turn branch fires response.create exactly once; guard does not bleed into it."""
     chunk = _b64_pcm(480)
     events = [
         json.dumps({"type": "response.created"}),
@@ -380,11 +320,7 @@ async def test_ac4_agent_turn_branch_still_fires_response_create():
 
 @pytest.mark.asyncio
 async def test_ac5_normal_path_commit_then_create():
-    """
-    AC5 (control — should PASS on current code): _pending_audio_bytes > 0
-    and _response_active=False (uncontested path). Both commit and create must
-    fire, and commit must appear before create.
-    """
+    """AC5 (control): normal uncontested path sends commit then response.create in order."""
     chunk = _b64_pcm(480)
     events = [
         json.dumps({"type": "response.created"}),
@@ -420,11 +356,7 @@ async def test_ac5_normal_path_commit_then_create():
 
 @pytest.mark.asyncio
 async def test_ac6_server_rejection_raises_runtime_error():
-    """
-    AC6: a mock that emits the server error event
-    "Conversation already has an active response in progress" must surface as
-    RuntimeError, not be swallowed.
-    """
+    """AC6: server error event "Conversation already has an active response in progress" surfaces as RuntimeError."""
     error_msg = "Conversation already has an active response in progress: resp_abc123"
     events = [
         json.dumps({"type": "error", "error": {"message": error_msg}}),
@@ -449,29 +381,7 @@ async def test_ac6_server_rejection_raises_runtime_error():
 
 @pytest.mark.asyncio
 async def test_ac7_race_sequence_returns_audio_chunk_not_timeout():
-    """
-    AC7: with a two-call sequence through call() that exercises the drain loop,
-    the pre-fix fires response.create twice (preamble + agent-turn branch),
-    post-fix fires exactly once (deferred after response.done).
-
-    We exercise this via two sequential recv_audio calls on the same adapter +
-    mock: call 1 has the race (_response_active=True + pending audio), call 2
-    is the drain re-entry. Pre-fix: call 1 preamble fires response.create
-    immediately; call 2 (agent-turn branch) fires it again → total == 2.
-    Post-fix: call 1 defers; call 2 fires exactly the deferred create → total == 1.
-
-    Actually: the simplest falsifiable shape is that pre-fix fires response.create
-    with count=1 on call 1 preamble (before the loop), then the loop reads events
-    and the test can observe that create happened before recv events were consumed.
-    We prove this via: after recv_audio returns, check that the number of sends
-    before the first recv event was processed is already 2 (commit + create in
-    preamble), proving it fired pre-loop.
-
-    Since we cannot observe "before first recv" post-hoc, we proxy this via AC1's
-    assertion: count_of("response.create") == 0 when _response_active=True. AC7
-    adds the "full sequence resolves to non-empty AudioChunk" assertion so that
-    both the guard AND the deferred firing are proven together.
-    """
+    """AC7: race sequence that pre-fix timed out now returns a non-empty AudioChunk; response.create ordered after response.done."""
     chunk = _b64_pcm(480)
     # Events: in-flight completes, deferred create acknowledged, audio delta.
     events = [

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "langwatch-scenario"
-version = "0.7.30"
+version = "0.7.31"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },

--- a/specs/realtime-response-create-guard.feature
+++ b/specs/realtime-response-create-guard.feature
@@ -13,7 +13,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # Root cause: the user-audio branch at line 407–411 lacks the
   # `not self._response_active` guard already present on the agent-turn branch
   # at line 423.  The fix adds the guard and defers response.create by setting
-  # _agent_turn_pending=True so the agent-turn branch fires it after
+  # _deferred_response_create=True so the response.done handler fires it after
   # response.done clears _response_active.
   #
   # Scope guard (documented here, not a test scenario):
@@ -34,7 +34,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # AC1 — guard present: response.create suppressed while response is active
   # ======================================================================
 
-  @unit
+  @integration
   Scenario: Guard suppresses response.create when a response is already active
     # AC1: _response_active is True (mock pre-loaded with response.created, no
     # response.done yet).  Calling recv_audio with pending audio bytes must send
@@ -49,7 +49,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # AC2 — deferred response.create fires after response.done (ordering)
   # ======================================================================
 
-  @unit
+  @integration
   Scenario: Deferred response.create fires after response.done is yielded, with ordering asserted
     # AC2: after the guard fires (response active), the mock then yields
     # response.done.  response.create must appear in mock_ws.sent AFTER the
@@ -65,7 +65,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # AC3 — single commit, single create across the full event sequence
   # ======================================================================
 
-  @unit
+  @integration
   Scenario: Exactly one commit and one response.create appear across the full guarded sequence
     # AC3: across the full sequence (guard fires, response.done received, deferred
     # send fires), mock_ws.sent contains input_audio_buffer.commit exactly once
@@ -80,7 +80,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # AC4 — agent-turn branch unaffected
   # ======================================================================
 
-  @unit
+  @integration
   Scenario: Agent-turn branch still sends response.create exactly once when no response is active
     # AC4: recv_audio with _agent_turn_pending=True and _response_active=False
     # must still fire response.create exactly once — the guard must not bleed
@@ -94,7 +94,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # AC5 — no regression on normal path (no active response)
   # ======================================================================
 
-  @unit
+  @integration
   Scenario: Normal path sends commit then response.create when no response is active
     # AC5: _pending_audio_bytes > 0 and _response_active=False — the common
     # uncontested path.  Both commit and create must fire as before.
@@ -109,7 +109,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # AC6 — explicit rejection face raises RuntimeError (falsifiable)
   # ======================================================================
 
-  @unit
+  @integration
   Scenario: Explicit server rejection event raises RuntimeError
     # AC6: a _MockWS test that bypasses the guard (or runs against pre-fix code)
     # and injects the server error event "Conversation already has an active
@@ -125,7 +125,7 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   #        now returns a valid AudioChunk
   # ======================================================================
 
-  @unit
+  @integration
   Scenario: Previously-timing-out sequence resolves to a valid AudioChunk after the fix
     # AC7: construct the exact race that pre-fix caused asyncio.TimeoutError:
     # response.created is yielded (response in flight), user audio arrives
@@ -145,32 +145,32 @@ Feature: OpenAI Realtime adapter guards response.create against in-flight respon
   # --- AC Coverage Map ---
   # AC1 — guard present: recv_audio does NOT send response.create when
   #        _response_active is True and _pending_audio_bytes > 0 ->
-  #   Scenario: Guard suppresses response.create when a response is already active (@unit)
+  #   Scenario: Guard suppresses response.create when a response is already active (@integration)
   #
   # AC2 — response.create deferred, not dropped (ordering): after response.done
   #        clears _response_active, response.create IS sent, ordering asserted
   #        on mock_ws.sent index positions ->
-  #   Scenario: Deferred response.create fires after response.done is yielded, with ordering asserted (@unit)
+  #   Scenario: Deferred response.create fires after response.done is yielded, with ordering asserted (@integration)
   #
   # AC3 — single commit, single create: mock_ws.sent contains
   #        input_audio_buffer.commit exactly once and response.create exactly once ->
-  #   Scenario: Exactly one commit and one response.create appear across the full guarded sequence (@unit)
+  #   Scenario: Exactly one commit and one response.create appear across the full guarded sequence (@integration)
   #
   # AC4 — agent-turn branch unaffected: recv_audio with _agent_turn_pending=True
   #        and _response_active=False still sends response.create exactly once ->
-  #   Scenario: Agent-turn branch still sends response.create exactly once when no response is active (@unit)
+  #   Scenario: Agent-turn branch still sends response.create exactly once when no response is active (@integration)
   #
   # AC5 — no regression on normal path: _pending_audio_bytes > 0 and
   #        _response_active=False still sends commit then response.create as before ->
-  #   Scenario: Normal path sends commit then response.create when no response is active (@unit)
+  #   Scenario: Normal path sends commit then response.create when no response is active (@integration)
   #
   # AC6 — explicit rejection face (falsifiable): injected server error event
   #        raises RuntimeError; pytest.raises assertion ->
-  #   Scenario: Explicit server rejection event raises RuntimeError (@unit)
+  #   Scenario: Explicit server rejection event raises RuntimeError (@integration)
   #
   # AC7 — timeout face eliminated: sequence that pre-fix triggers
   #        asyncio.TimeoutError post-fix returns a valid AudioChunk without timing out ->
-  #   Scenario: Previously-timing-out sequence resolves to a valid AudioChunk after the fix (@unit)
+  #   Scenario: Previously-timing-out sequence resolves to a valid AudioChunk after the fix (@integration)
   #
   # AC-scope — manual VAD only: server-VAD sessions are OUT OF SCOPE.
   #        No scenario exercises server-VAD behaviour. Documented as a scope

--- a/specs/realtime-response-create-guard.feature
+++ b/specs/realtime-response-create-guard.feature
@@ -1,0 +1,179 @@
+Feature: OpenAI Realtime adapter guards response.create against in-flight responses
+  As a developer testing a voice agent with the OpenAIRealtimeAgentAdapter
+  I want recv_audio to suppress the premature response.create when a response is already active
+  So that user audio arriving during an in-flight agent response does not race the server
+  into a rejection or drain timeout
+
+  # Issue #657 — recv_audio fires response.create unconditionally after
+  # input_audio_buffer.commit, racing an active agent response into either a
+  # server rejection ("Conversation already has an active response in progress")
+  # or a silent-ignore that causes the drain loop to hit its deadline
+  # (RuntimeError: TimeoutError).
+  #
+  # Root cause: the user-audio branch at line 407–411 lacks the
+  # `not self._response_active` guard already present on the agent-turn branch
+  # at line 423.  The fix adds the guard and defers response.create by setting
+  # _agent_turn_pending=True so the agent-turn branch fires it after
+  # response.done clears _response_active.
+  #
+  # Scope guard (documented here, not a test scenario):
+  #   AC-scope — manual-VAD only: this fix targets manual-VAD sessions
+  #   (turn_detection: None, line 316). Server-VAD mode is explicitly OUT OF
+  #   SCOPE.  No scenario exercises server-VAD behaviour; the PR must not claim
+  #   correctness for server-VAD sessions.
+  #
+  # All scenarios use the hermetic _MockWS pattern from
+  #   python/tests/voice/test_realtime_tool_calls.py — no live API key needed.
+
+  Background:
+    Given an OpenAIRealtimeAgentAdapter under test with a mock WebSocket (no live API key)
+    And the adapter is in manual-VAD mode (turn_detection: None)
+    And the adapter's response_timeout is set to a short value so tests complete quickly
+
+  # ======================================================================
+  # AC1 — guard present: response.create suppressed while response is active
+  # ======================================================================
+
+  @unit
+  Scenario: Guard suppresses response.create when a response is already active
+    # AC1: _response_active is True (mock pre-loaded with response.created, no
+    # response.done yet).  Calling recv_audio with pending audio bytes must send
+    # input_audio_buffer.commit but NOT response.create.
+    Given the mock WebSocket has yielded "response.created" (no "response.done" yet)
+    And the adapter's _pending_audio_bytes is greater than zero
+    When recv_audio is called
+    Then "input_audio_buffer.commit" IS present in mock_ws.sent
+    And "response.create" is NOT present in mock_ws.sent
+
+  # ======================================================================
+  # AC2 — deferred response.create fires after response.done (ordering)
+  # ======================================================================
+
+  @unit
+  Scenario: Deferred response.create fires after response.done is yielded, with ordering asserted
+    # AC2: after the guard fires (response active), the mock then yields
+    # response.done.  response.create must appear in mock_ws.sent AFTER the
+    # index position of the response.done processing — ordering is asserted on
+    # index positions, not mere presence.
+    Given the mock WebSocket has yielded "response.created" then "response.done"
+    And the adapter's _pending_audio_bytes is greater than zero
+    When recv_audio is called and processes through "response.done"
+    Then "response.create" IS present in mock_ws.sent
+    And the index of "response.create" in mock_ws.sent is greater than the index of the send that follows "response.done" processing
+
+  # ======================================================================
+  # AC3 — single commit, single create across the full event sequence
+  # ======================================================================
+
+  @unit
+  Scenario: Exactly one commit and one response.create appear across the full guarded sequence
+    # AC3: across the full sequence (guard fires, response.done received, deferred
+    # send fires), mock_ws.sent contains input_audio_buffer.commit exactly once
+    # and response.create exactly once — no double-fire.
+    Given the mock WebSocket has yielded "response.created" then "response.done"
+    And the adapter's _pending_audio_bytes is greater than zero
+    When recv_audio processes the full event sequence
+    Then mock_ws.sent contains "input_audio_buffer.commit" exactly 1 time
+    And mock_ws.sent contains "response.create" exactly 1 time
+
+  # ======================================================================
+  # AC4 — agent-turn branch unaffected
+  # ======================================================================
+
+  @unit
+  Scenario: Agent-turn branch still sends response.create exactly once when no response is active
+    # AC4: recv_audio with _agent_turn_pending=True and _response_active=False
+    # must still fire response.create exactly once — the guard must not bleed
+    # into the sibling branch.
+    Given the adapter has _agent_turn_pending set to True
+    And the adapter has _response_active set to False
+    When recv_audio is called
+    Then mock_ws.sent contains "response.create" exactly 1 time
+
+  # ======================================================================
+  # AC5 — no regression on normal path (no active response)
+  # ======================================================================
+
+  @unit
+  Scenario: Normal path sends commit then response.create when no response is active
+    # AC5: _pending_audio_bytes > 0 and _response_active=False — the common
+    # uncontested path.  Both commit and create must fire as before.
+    Given the adapter's _pending_audio_bytes is greater than zero
+    And the adapter has _response_active set to False
+    When recv_audio is called
+    Then mock_ws.sent contains "input_audio_buffer.commit"
+    And mock_ws.sent contains "response.create"
+    And "input_audio_buffer.commit" appears before "response.create" in mock_ws.sent
+
+  # ======================================================================
+  # AC6 — explicit rejection face raises RuntimeError (falsifiable)
+  # ======================================================================
+
+  @unit
+  Scenario: Explicit server rejection event raises RuntimeError
+    # AC6: a _MockWS test that bypasses the guard (or runs against pre-fix code)
+    # and injects the server error event "Conversation already has an active
+    # response in progress" must surface as RuntimeError — not swallowed.
+    # Evidence: pytest.raises(RuntimeError) assertion.
+    Given the mock WebSocket will emit an error event with message "Conversation already has an active response in progress: resp_abc123"
+    When the adapter processes the event
+    Then a RuntimeError is raised
+    And the RuntimeError message contains "Conversation already has an active response in progress"
+
+  # ======================================================================
+  # AC7 — timeout face eliminated: sequence that pre-fix triggers TimeoutError
+  #        now returns a valid AudioChunk
+  # ======================================================================
+
+  @unit
+  Scenario: Previously-timing-out sequence resolves to a valid AudioChunk after the fix
+    # AC7: construct the exact race that pre-fix caused asyncio.TimeoutError:
+    # response.created is yielded (response in flight), user audio arrives
+    # (_pending_audio_bytes > 0), then the mock yields response.done followed
+    # by the normal audio-delta sequence.  Pre-fix: response.create fires
+    # immediately, the server's response.done never arrives in time, TimeoutError.
+    # Post-fix: response.create is deferred until after response.done, then the
+    # subsequent audio-delta sequence completes, and recv_audio returns a
+    # non-empty AudioChunk without raising.
+    Given the mock WebSocket has yielded "response.created" (simulating an in-flight response)
+    And the adapter's _pending_audio_bytes is greater than zero
+    And the mock WebSocket will subsequently yield "response.done" then audio delta events then a final "response.done"
+    When recv_audio is called and the full sequence is processed
+    Then recv_audio returns a non-empty AudioChunk
+    And asyncio.TimeoutError is NOT raised
+
+  # --- AC Coverage Map ---
+  # AC1 — guard present: recv_audio does NOT send response.create when
+  #        _response_active is True and _pending_audio_bytes > 0 ->
+  #   Scenario: Guard suppresses response.create when a response is already active (@unit)
+  #
+  # AC2 — response.create deferred, not dropped (ordering): after response.done
+  #        clears _response_active, response.create IS sent, ordering asserted
+  #        on mock_ws.sent index positions ->
+  #   Scenario: Deferred response.create fires after response.done is yielded, with ordering asserted (@unit)
+  #
+  # AC3 — single commit, single create: mock_ws.sent contains
+  #        input_audio_buffer.commit exactly once and response.create exactly once ->
+  #   Scenario: Exactly one commit and one response.create appear across the full guarded sequence (@unit)
+  #
+  # AC4 — agent-turn branch unaffected: recv_audio with _agent_turn_pending=True
+  #        and _response_active=False still sends response.create exactly once ->
+  #   Scenario: Agent-turn branch still sends response.create exactly once when no response is active (@unit)
+  #
+  # AC5 — no regression on normal path: _pending_audio_bytes > 0 and
+  #        _response_active=False still sends commit then response.create as before ->
+  #   Scenario: Normal path sends commit then response.create when no response is active (@unit)
+  #
+  # AC6 — explicit rejection face (falsifiable): injected server error event
+  #        raises RuntimeError; pytest.raises assertion ->
+  #   Scenario: Explicit server rejection event raises RuntimeError (@unit)
+  #
+  # AC7 — timeout face eliminated: sequence that pre-fix triggers
+  #        asyncio.TimeoutError post-fix returns a valid AudioChunk without timing out ->
+  #   Scenario: Previously-timing-out sequence resolves to a valid AudioChunk after the fix (@unit)
+  #
+  # AC-scope — manual VAD only: server-VAD sessions are OUT OF SCOPE.
+  #        No scenario exercises server-VAD behaviour. Documented as a scope
+  #        note in the feature header comment above, not as a runnable scenario,
+  #        because no test can assert the absence of a claim across all VAD modes
+  #        in a hermetic mock. The PR must not claim correctness for server-VAD.


### PR DESCRIPTION
## Why

The OpenAI Realtime API silently drops a `response.create` sent while a response is already in flight. In multi-turn voice scenarios this caused `recv_audio` to hang until timeout — the committed user audio had no response kicked off, so the recv loop drained forever instead of producing a chunk. Closes #657.

## What changed

- **`_deferred_response_create` flag (separate from `_agent_turn_pending`)** — when user audio arrives while `_response_active` is true, defer the `response.create` via this flag instead of sending it immediately (which the server ignores). Keeping the flags separate preserves each flag's single meaning.
- **`response.done` / `response.cancelled` handler fires the deferred create** — once `_response_active` clears, the handler sends `response.create` and re-arms `_response_active`, so the next recv iteration picks up the response for the committed audio.
- **`_agent_turn_pending` cleared in deferred path** — the deferred path now clears `_agent_turn_pending` so a stale flag cannot fire a spurious second `response.create` after the deferred one completes.
- **`_deferred_response_create` reset in `call()` turn-start block** — prevents a turn interrupted mid-deferral from leaking the flag into the next turn's `response.done` handler.

## Test plan

Regression tests in `python/tests/voice/test_realtime_response_create_guard.py`:

```bash
cd python && uv run pytest tests/voice/test_realtime_response_create_guard.py -v
```

| Test | What it asserts |
|---|---|
| `test_ac1_response_create_suppressed_while_response_active` | guard suppresses `response.create` when `_response_active=True`; only commit sent |
| `test_ac2_deferred_response_create_fires_after_response_done` | deferred create appears in the send log *after* `response.done` is received |
| `test_ac3_exactly_one_commit_and_one_create` | exactly 1 commit + 1 create across the full race sequence |
| `test_ac4_agent_turn_branch_still_fires_response_create` | agent-turn branch unaffected by the guard (control) |
| `test_ac5_normal_path_commit_then_create` | normal (non-race) path still fires `response.create` immediately |
| `test_ac6_server_rejection_raises_runtime_error` | explicit server rejection of `response.create` raises `RuntimeError` |
| `test_ac7_race_sequence_returns_audio_chunk_not_timeout` | race sequence returns `AudioChunk` instead of timing out |
| `test_deferred_path_clears_agent_turn_pending` | deferred path clears `_agent_turn_pending` (line 428); mutation-test-confirmed |

All 8 pass locally. CI green on `4e2e858d`.

Feature file: `specs/realtime-response-create-guard.feature`

## Prove-it 2.7 — live demo output

Guard demonstrated on the **real** OpenAI Realtime API (`gpt-realtime-mini`), with no mock WebSocket. Key excerpt from the live wire log:

```
[   1.633s]     STATE  _deferred_response_create: False -> True  <<< GUARD FIRES
             (user audio committed while response in flight)

[105] RECV <- response.done
[106] SEND -> response.create   *** deferred response.create ON THE WIRE ***
[108] RECV <- response.created  (new response started — deferred turn picked up)

GUARD PROOF: PASS
[PASS] DEFERRED response.create sent AFTER response.done received
       first RECV response.done at log[105], last SEND response.create at log[106]
[PASS] Exactly 2 response.create on the wire (1 normal + 1 deferred)
[PASS] Two input_audio_buffer.commit on the wire (one per user turn)
[PASS] At least 2 response.done received (original + deferred response)
```

Full 311-line output: `/tmp/demo_659_guard_proof_output.txt` (run at commit `82d6c52c`; guard code unchanged in subsequent commits).