### PR TITLE
feat(#660): expose context param on scenario.judge() public API

### DIFF
--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -777,8 +777,8 @@ describe("JudgeAgent", () => {
     });
   });
 
-  describe("additional context via judgmentRequest.context", () => {
-    it("includes <additional_context> in the user message when context is provided", async () => {
+  describe("additional context via judgmentRequest.additionalContext", () => {
+    it("includes <additional_context> in the user message when additionalContext is provided", async () => {
       const collector = createMockSpanCollector([]);
 
       const config: JudgeAgentConfig = {
@@ -800,7 +800,7 @@ describe("JudgeAgent", () => {
 
       const inputWithContext = createBaseInput({
         judgmentRequest: {
-          context:
+          additionalContext:
             "The agent ran `npm install -g git-orchard` which exited 0. The binary is now at /usr/local/bin/orchard.",
         },
       });
@@ -820,7 +820,7 @@ describe("JudgeAgent", () => {
       expect(userContent).toContain("</additional_context>");
     });
 
-    it("omits <additional_context> when no context is provided", async () => {
+    it("omits <additional_context> when no additionalContext is provided", async () => {
       const collector = createMockSpanCollector([]);
 
       const config: JudgeAgentConfig = {

--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -852,6 +852,82 @@ describe("JudgeAgent", () => {
           : JSON.stringify(userMessage.content);
       expect(userContent).not.toContain("<additional_context>");
     });
+
+    it("includes <additional_context> when deprecated context field is used (backward compat)", async () => {
+      const collector = createMockSpanCollector([]);
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent installed the dependency"],
+        spanCollector: collector,
+      };
+      const agent = judgeAgent(config);
+
+      let capturedParams: InvokeLLMParams | undefined;
+      agent.invokeLLM = async (params) => {
+        capturedParams = params;
+        return mockLLMResult("finish_test", {
+          criteria: { agent_installed_the_dependency: "true" },
+          reasoning: "ok",
+          verdict: "success",
+        });
+      };
+
+      const inputWithDeprecatedContext = createBaseInput({
+        judgmentRequest: {
+          context: "Legacy context string passed via deprecated field.",
+        },
+      });
+
+      await agent.call(inputWithDeprecatedContext);
+
+      const messages = capturedParams!.messages ?? [];
+      const userMessage = messages.find((m) => m.role === "user");
+      if (!userMessage) throw new Error("Expected a user message in LLM call");
+      const userContent =
+        typeof userMessage.content === "string"
+          ? userMessage.content
+          : JSON.stringify(userMessage.content);
+      expect(userContent).toContain("<additional_context>");
+      expect(userContent).toContain("Legacy context string passed via deprecated field.");
+      expect(userContent).toContain("</additional_context>");
+    });
+
+    it("additionalContext wins when both additionalContext and deprecated context are set", async () => {
+      const collector = createMockSpanCollector([]);
+      const config: JudgeAgentConfig = {
+        criteria: ["Agent responded"],
+        spanCollector: collector,
+      };
+      const agent = judgeAgent(config);
+
+      let capturedParams: InvokeLLMParams | undefined;
+      agent.invokeLLM = async (params) => {
+        capturedParams = params;
+        return mockLLMResult("finish_test", {
+          criteria: { agent_responded: "true" },
+          reasoning: "ok",
+          verdict: "success",
+        });
+      };
+
+      const inputWithBoth = createBaseInput({
+        judgmentRequest: {
+          additionalContext: "New field value.",
+          context: "Old field value.",
+        },
+      });
+
+      await agent.call(inputWithBoth);
+
+      const messages = capturedParams!.messages ?? [];
+      const userMessage = messages.find((m) => m.role === "user");
+      if (!userMessage) throw new Error("Expected a user message in LLM call");
+      const userContent =
+        typeof userMessage.content === "string"
+          ? userMessage.content
+          : JSON.stringify(userMessage.content);
+      expect(userContent).toContain("New field value.");
+      expect(userContent).not.toContain("Old field value.");
+    });
   });
 
   describe("when no criteria provided and judgment requested", () => {

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -512,7 +512,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
       messagesForTranscript,
     );
 
-    const extraContext = input.judgmentRequest?.context;
+    const extraContext = input.judgmentRequest?.additionalContext;
     const additionalContextSection = extraContext
       ? `\n    <additional_context>\n    ${extraContext}\n    </additional_context>`
       : "";

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -512,7 +512,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
       messagesForTranscript,
     );
 
-    const extraContext = input.judgmentRequest?.additionalContext;
+    const extraContext = input.judgmentRequest?.additionalContext ?? input.judgmentRequest?.context;
     const additionalContextSection = extraContext
       ? `\n    <additional_context>\n    ${extraContext}\n    </additional_context>`
       : "";

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -42,6 +42,10 @@ export interface JudgmentRequest {
    * tool-call JSON that is difficult for the judge to interpret directly.
    */
   additionalContext?: string;
+  /**
+   * @deprecated Use `additionalContext` instead.
+   */
+  context?: string;
 }
 
 /**

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -41,7 +41,7 @@ export interface JudgmentRequest {
    * `<additional_context>`. Useful when conversation messages contain raw
    * tool-call JSON that is difficult for the judge to interpret directly.
    */
-  context?: string;
+  additionalContext?: string;
 }
 
 /**

--- a/javascript/src/domain/scenarios/index.ts
+++ b/javascript/src/domain/scenarios/index.ts
@@ -197,10 +197,15 @@ export interface ScenarioExecutionLike {
   agentNonBlocking?(content?: string | ModelMessage): void;
   /**
    * Invokes the judge agent to evaluate the current state.
-   * @param options Optional options with inline criteria to evaluate as a checkpoint.
+   * @param options Optional options with inline criteria and/or additional context.
    * @returns The result of the scenario if the judge makes a final decision.
    */
-  judge(options?: { criteria?: string[] }): Promise<ScenarioResult | null>;
+  judge(options?: {
+    criteria?: string[];
+    additionalContext?: string;
+    /** @deprecated Use `additionalContext` instead. */
+    context?: string;
+  }): Promise<ScenarioResult | null>;
   /**
    * Proceeds with the scenario automatically for a number of turns.
    * @param turns The number of turns to proceed. Defaults to running until the scenario ends.

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -1281,11 +1281,16 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
    * });
    * ```
    */
-  async judge(options?: { criteria?: string[]; additionalContext?: string }): Promise<ScenarioResult | null> {
+  async judge(options?: {
+    criteria?: string[];
+    additionalContext?: string;
+    /** @deprecated Use `additionalContext` instead. */
+    context?: string;
+  }): Promise<ScenarioResult | null> {
     return await this.scriptCallAgent(
       AgentRole.JUDGE,
       undefined,
-      { criteria: options?.criteria, additionalContext: options?.additionalContext }
+      { criteria: options?.criteria, additionalContext: options?.additionalContext ?? options?.context }
     );
   }
 

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -1277,15 +1277,15 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
    * // Provide additional context for tool-call-heavy conversations
    * const result = await execution.judge({
    *   criteria: ["Agent installed the dependency"],
-   *   context: "The agent ran `npm install -g git-orchard` which exited 0.",
+   *   additionalContext: "The agent ran `npm install -g git-orchard` which exited 0.",
    * });
    * ```
    */
-  async judge(options?: { criteria?: string[]; context?: string }): Promise<ScenarioResult | null> {
+  async judge(options?: { criteria?: string[]; additionalContext?: string }): Promise<ScenarioResult | null> {
     return await this.scriptCallAgent(
       AgentRole.JUDGE,
       undefined,
-      { criteria: options?.criteria, context: options?.context }
+      { criteria: options?.criteria, additionalContext: options?.additionalContext }
     );
   }
 

--- a/javascript/src/script/index.ts
+++ b/javascript/src/script/index.ts
@@ -126,11 +126,11 @@ function isVoiceAgentOptions(
  *
  * @param options Optional options object with inline criteria and/or context to evaluate.
  *   - `criteria`: Criteria to evaluate (overrides judge's configured criteria).
- *   - `context`: Additional context for the judge, e.g. filesystem state or command output.
+ *   - `additionalContext`: Additional context for the judge, e.g. filesystem state or command output.
  *     Included in the judge's prompt under `<additional_context>`.
  * @returns A ScriptStep function that can be used in scenario scripts.
  */
-export const judge = (options?: { criteria?: string[]; context?: string }): ScriptStep => {
+export const judge = (options?: { criteria?: string[]; additionalContext?: string }): ScriptStep => {
   return async (_state, executor) => {
     await executor.judge(options);
   };

--- a/javascript/src/script/index.ts
+++ b/javascript/src/script/index.ts
@@ -128,9 +128,15 @@ function isVoiceAgentOptions(
  *   - `criteria`: Criteria to evaluate (overrides judge's configured criteria).
  *   - `additionalContext`: Additional context for the judge, e.g. filesystem state or command output.
  *     Included in the judge's prompt under `<additional_context>`.
+ *   - `context`: @deprecated Use `additionalContext` instead.
  * @returns A ScriptStep function that can be used in scenario scripts.
  */
-export const judge = (options?: { criteria?: string[]; additionalContext?: string }): ScriptStep => {
+export const judge = (options?: {
+  criteria?: string[];
+  additionalContext?: string;
+  /** @deprecated Use `additionalContext` instead. */
+  context?: string;
+}): ScriptStep => {
   return async (_state, executor) => {
     await executor.judge(options);
   };

--- a/javascript/src/script/index.ts
+++ b/javascript/src/script/index.ts
@@ -124,11 +124,10 @@ function isVoiceAgentOptions(
  * When no criteria are provided, the judge uses its own configured criteria
  * and returns a final verdict (success or failure), ending the scenario.
  *
- * @param options Optional options object with inline criteria and/or context to evaluate.
+ * @param options Optional options object with inline criteria and/or additional context.
  *   - `criteria`: Criteria to evaluate (overrides judge's configured criteria).
  *   - `additionalContext`: Additional context for the judge, e.g. filesystem state or command output.
  *     Included in the judge's prompt under `<additional_context>`.
- *   - `context`: @deprecated Use `additionalContext` instead.
  * @returns A ScriptStep function that can be used in scenario scripts.
  */
 export const judge = (options?: {

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -466,8 +466,8 @@ class JudgeAgent(AgentAdapter):
         logger.debug(f"OpenTelemetry traces built: {digest[:200]}...")
 
         extra_context = (
-            input.judgment_request.context
-            if input.judgment_request and input.judgment_request.context
+            input.judgment_request.additional_context
+            if input.judgment_request and input.judgment_request.additional_context
             else None
         )
         extra_context_section = (

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1417,11 +1417,11 @@ class ScenarioExecutor:
     async def judge(
         self,
         criteria: Optional[List[str]] = None,
-        context: Optional[str] = None,
+        additional_context: Optional[str] = None,
     ) -> Optional[ScenarioResult]:
         return await self._script_call_agent(
             AgentRole.JUDGE,
-            judgment_request=JudgmentRequest(criteria=criteria, context=context),
+            judgment_request=JudgmentRequest(criteria=criteria, context=additional_context),
         )
 
     async def proceed(

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1417,10 +1417,11 @@ class ScenarioExecutor:
     async def judge(
         self,
         criteria: Optional[List[str]] = None,
+        context: Optional[str] = None,
     ) -> Optional[ScenarioResult]:
         return await self._script_call_agent(
             AgentRole.JUDGE,
-            judgment_request=JudgmentRequest(criteria=criteria),
+            judgment_request=JudgmentRequest(criteria=criteria, context=context),
         )
 
     async def proceed(

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1421,7 +1421,7 @@ class ScenarioExecutor:
     ) -> Optional[ScenarioResult]:
         return await self._script_call_agent(
             AgentRole.JUDGE,
-            judgment_request=JudgmentRequest(criteria=criteria, context=additional_context),
+            judgment_request=JudgmentRequest(criteria=criteria, additional_context=additional_context),
         )
 
     async def proceed(

--- a/python/scenario/script.py
+++ b/python/scenario/script.py
@@ -174,7 +174,7 @@ def agent(
 
 def judge(
     criteria: Optional[List[str]] = None,
-    context: Optional[str] = None,
+    additional_context: Optional[str] = None,
 ) -> ScriptStep:
     """
     Invoke the judge agent to evaluate the current conversation state.
@@ -190,7 +190,7 @@ def judge(
     Args:
         criteria: Optional list of criteria to evaluate inline. When provided,
                  acts as a checkpoint rather than a final judgment.
-        context: Additional context for the judge, e.g. filesystem state
+        additional_context: Additional context for the judge, e.g. filesystem state
                 or command output. Included in the judge's evaluation prompt under
                 <additional_context>. Empty strings are treated as absent (no block emitted).
 
@@ -228,7 +228,7 @@ def judge(
         )
         ```
     """
-    return lambda state: state._executor.judge(criteria=criteria, context=context)
+    return lambda state: state._executor.judge(criteria=criteria, additional_context=additional_context)
 
 
 def proceed(

--- a/python/scenario/script.py
+++ b/python/scenario/script.py
@@ -174,6 +174,7 @@ def agent(
 
 def judge(
     criteria: Optional[List[str]] = None,
+    context: Optional[str] = None,
 ) -> ScriptStep:
     """
     Invoke the judge agent to evaluate the current conversation state.
@@ -189,6 +190,9 @@ def judge(
     Args:
         criteria: Optional list of criteria to evaluate inline. When provided,
                  acts as a checkpoint rather than a final judgment.
+        context: Additional context for the judge, e.g. filesystem state
+                or command output. Included in the judge's evaluation prompt under
+                <additional_context>. Empty strings are treated as absent (no block emitted).
 
     Returns:
         ScriptStep function that can be used in scenario scripts
@@ -224,7 +228,7 @@ def judge(
         )
         ```
     """
-    return lambda state: state._executor.judge(criteria=criteria)
+    return lambda state: state._executor.judge(criteria=criteria, context=context)
 
 
 def proceed(

--- a/python/scenario/types.py
+++ b/python/scenario/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from pydantic import BaseModel, SkipValidation
+from pydantic import BaseModel, SkipValidation, model_validator
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -103,15 +103,30 @@ class JudgmentRequest(BaseModel):
     Attributes:
         criteria: Optional list of criteria to evaluate. When provided, overrides
                  the judge agent's configured criteria for this evaluation.
-        context: Optional additional context for the judge, such as filesystem
-                 state, command outputs, or structured observations from custom
-                 assertion steps. Included in the judge's evaluation prompt under
-                 <additional_context>. Useful when the conversation messages
+        additional_context: Optional additional context for the judge, such as
+                 filesystem state, command outputs, or structured observations from
+                 custom assertion steps. Included in the judge's evaluation prompt
+                 under <additional_context>. Useful when the conversation messages
                  contain raw tool-call JSON that is hard for the judge to parse.
+        context: Deprecated. Use ``additional_context`` instead.
     """
 
     criteria: Optional[List[str]] = None
+    additional_context: Optional[str] = None
+    # Deprecated backward-compat alias — populated by the validator below.
     context: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _migrate_context_alias(self) -> "JudgmentRequest":
+        if self.context is not None and self.additional_context is None:
+            import warnings
+            warnings.warn(
+                "JudgmentRequest.context is deprecated; use additional_context instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.additional_context = self.context
+        return self
 
 
 class AgentInput(BaseModel):

--- a/python/scenario/types.py
+++ b/python/scenario/types.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import Enum
 from pydantic import BaseModel, SkipValidation, model_validator
 from typing import (
@@ -119,7 +120,6 @@ class JudgmentRequest(BaseModel):
     @model_validator(mode="after")
     def _migrate_context_alias(self) -> "JudgmentRequest":
         if self.context is not None and self.additional_context is None:
-            import warnings
             warnings.warn(
                 "JudgmentRequest.context is deprecated; use additional_context instead.",
                 DeprecationWarning,

--- a/python/tests/test_judge_agent.py
+++ b/python/tests/test_judge_agent.py
@@ -300,10 +300,10 @@ async def test_judge_result_messages_is_conversation_not_judge_context():
 
 @pytest.mark.asyncio
 async def test_judge_includes_additional_context_in_prompt():
-    """JudgmentRequest.context is injected into the judge's user message under <additional_context>.
+    """Deprecated JudgmentRequest.context alias is injected into the judge's user message under <additional_context>.
 
-    Test for #318: allows callers to pass structured observations (e.g. command
-    output, filesystem state) to the judge without polluting the message history.
+    Tests backward compat: callers still using the old context= field should see the value
+    forwarded to the judge prompt. See #660 for the rename to additional_context.
     """
     ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
     judge = JudgeAgent(criteria=["Agent installed the dependency"])

--- a/python/tests/test_judge_context_api.py
+++ b/python/tests/test_judge_context_api.py
@@ -56,7 +56,7 @@ def _get_system_message(mock_completion: MagicMock) -> str:
 
 
 @pytest.mark.asyncio
-async def test_executor_judge_context_forwarded_to_llm_input():
+async def test_executor_judge_additional_context_forwarded_to_llm_input():
     """executor.judge(additional_context=...) must include <additional_context> in the LLM user message."""
     ctx_text = "the agent ran npm install which exited 0"
     executor = _make_executor()
@@ -78,7 +78,7 @@ async def test_executor_judge_context_forwarded_to_llm_input():
 
 
 @pytest.mark.asyncio
-async def test_executor_judge_criteria_and_context_forwarded_independently():
+async def test_executor_judge_criteria_and_additional_context_forwarded_independently():
     """executor.judge(criteria=[...], additional_context=...) forwards both criteria and additional_context."""
     ctx_text = "exit code 0"
     executor = _make_executor()
@@ -144,7 +144,7 @@ async def test_executor_judge_no_context_no_additional_context_block_criteria_on
 
 
 @pytest.mark.asyncio
-async def test_executor_judge_empty_string_context_no_additional_context_block():
+async def test_executor_judge_empty_string_additional_context_no_additional_context_block():
     """executor.judge(additional_context='') must NOT emit <additional_context> (truthy guard)."""
     executor = _make_executor()
     mock_response = _make_mock_litellm_response()

--- a/python/tests/test_judge_context_api.py
+++ b/python/tests/test_judge_context_api.py
@@ -5,12 +5,14 @@ JudgmentRequest — to verify that the public API wires additional_context all t
 to the LLM call. See issue #660.
 """
 
+import warnings
 import pytest
 from unittest.mock import patch, MagicMock
 
 from scenario import JudgeAgent
 from scenario.config import ScenarioConfig
 from scenario.scenario_executor import ScenarioExecutor
+from scenario.types import JudgmentRequest
 
 
 def _make_mock_litellm_response(verdict: str = "success") -> MagicMock:
@@ -160,3 +162,36 @@ async def test_executor_judge_empty_string_additional_context_no_additional_cont
             assert "<additional_context>" not in content
     finally:
         ScenarioConfig.default_config = None
+
+
+# ---------------------------------------------------------------------------
+# JudgmentRequest deprecated context alias tests
+# ---------------------------------------------------------------------------
+
+
+def test_judgment_request_deprecated_context_alias_migrates_to_additional_context():
+    """JudgmentRequest(context=...) should migrate the value to additional_context and warn."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        req = JudgmentRequest(context="legacy value")
+
+    assert req.additional_context == "legacy value"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_judgment_request_additional_context_wins_over_deprecated_context():
+    """When both are set, additional_context takes precedence and no migration occurs."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        req = JudgmentRequest(additional_context="new value", context="old value")
+
+    assert req.additional_context == "new value"
+    assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_judgment_request_deprecated_context_alias_included_in_llm_prompt():
+    """JudgmentRequest built via deprecated context field should reach the judge's LLM call."""
+    ctx_text = "legacy context via deprecated field"
+    req = JudgmentRequest(context=ctx_text)
+    # After migration the field is normalised to additional_context.
+    assert req.additional_context == ctx_text

--- a/python/tests/test_judge_context_api.py
+++ b/python/tests/test_judge_context_api.py
@@ -1,0 +1,162 @@
+"""Tests for the context parameter on ScenarioExecutor.judge() and script.judge().
+
+These tests enter through ScenarioExecutor.judge() — NOT through a hand-built
+JudgmentRequest — to verify that the public API wires context all the way down
+to the LLM call. See issue #660.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from scenario import JudgeAgent
+from scenario.config import ScenarioConfig
+from scenario.scenario_executor import ScenarioExecutor
+
+
+def _make_mock_litellm_response(verdict: str = "success") -> MagicMock:
+    """Build a minimal litellm completion mock that JudgeAgent.call() accepts."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.tool_calls = [MagicMock()]
+    mock_response.choices[0].message.tool_calls[0].function.name = "finish_test"
+    mock_response.choices[0].message.tool_calls[0].function.arguments = (
+        '{"verdict": "' + verdict + '", "reasoning": "ok", "criteria": {}}'
+    )
+    return mock_response
+
+
+def _make_executor(criteria=None) -> ScenarioExecutor:
+    """Return an initialised ScenarioExecutor with a single JudgeAgent."""
+    ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
+    executor = ScenarioExecutor(
+        name="context test",
+        description="test description",
+        agents=[
+            JudgeAgent(criteria=criteria or ["agent responded"]),
+        ],
+    )
+    executor.reset()
+    return executor
+
+
+def _get_user_message(mock_completion: MagicMock) -> str:
+    """Extract the content of the first user-role message from litellm call args."""
+    call_kwargs = mock_completion.call_args.kwargs
+    messages = call_kwargs["messages"]
+    user_msg = next(m for m in messages if m["role"] == "user")
+    return user_msg["content"]
+
+
+def _get_system_message(mock_completion: MagicMock) -> str:
+    """Extract the content of the system message from litellm call args."""
+    call_kwargs = mock_completion.call_args.kwargs
+    messages = call_kwargs["messages"]
+    sys_msg = next(m for m in messages if m["role"] == "system")
+    return sys_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_executor_judge_context_forwarded_to_llm_input():
+    """executor.judge(context=...) must include <additional_context> in the LLM user message."""
+    ctx_text = "the agent ran npm install which exited 0"
+    executor = _make_executor()
+    mock_response = _make_mock_litellm_response()
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ) as mock_completion:
+            await executor.judge(context=ctx_text)
+
+            assert mock_completion.called
+            content = _get_user_message(mock_completion)
+            assert "<additional_context>" in content
+            assert ctx_text in content
+            assert "</additional_context>" in content
+    finally:
+        ScenarioConfig.default_config = None
+
+
+@pytest.mark.asyncio
+async def test_executor_judge_criteria_and_context_forwarded_independently():
+    """executor.judge(criteria=[...], context=...) forwards both criteria and context."""
+    ctx_text = "exit code 0"
+    executor = _make_executor()
+    mock_response = _make_mock_litellm_response()
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ) as mock_completion:
+            await executor.judge(
+                criteria=["agent installed dependency"], context=ctx_text
+            )
+
+            assert mock_completion.called
+            user_content = _get_user_message(mock_completion)
+            sys_content = _get_system_message(mock_completion)
+            # context block present in user message
+            assert "<additional_context>" in user_content
+            assert ctx_text in user_content
+            assert "</additional_context>" in user_content
+            # criteria present in system message (judge includes them in <criteria>)
+            assert "agent installed dependency" in sys_content
+    finally:
+        ScenarioConfig.default_config = None
+
+
+@pytest.mark.asyncio
+async def test_executor_judge_no_context_no_additional_context_block_no_args():
+    """executor.judge() with no arguments must NOT emit <additional_context>."""
+    executor = _make_executor()
+    mock_response = _make_mock_litellm_response()
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ) as mock_completion:
+            await executor.judge()
+
+            assert mock_completion.called
+            content = _get_user_message(mock_completion)
+            assert "<additional_context>" not in content
+    finally:
+        ScenarioConfig.default_config = None
+
+
+@pytest.mark.asyncio
+async def test_executor_judge_no_context_no_additional_context_block_criteria_only():
+    """executor.judge(criteria=[...]) with no context must NOT emit <additional_context>."""
+    executor = _make_executor()
+    mock_response = _make_mock_litellm_response()
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ) as mock_completion:
+            await executor.judge(criteria=["agent responded"])
+
+            assert mock_completion.called
+            content = _get_user_message(mock_completion)
+            assert "<additional_context>" not in content
+    finally:
+        ScenarioConfig.default_config = None
+
+
+@pytest.mark.asyncio
+async def test_executor_judge_empty_string_context_no_additional_context_block():
+    """executor.judge(context='') must NOT emit <additional_context> (truthy guard)."""
+    executor = _make_executor()
+    mock_response = _make_mock_litellm_response()
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ) as mock_completion:
+            await executor.judge(context="")
+
+            assert mock_completion.called
+            content = _get_user_message(mock_completion)
+            assert "<additional_context>" not in content
+    finally:
+        ScenarioConfig.default_config = None

--- a/python/tests/test_judge_context_api.py
+++ b/python/tests/test_judge_context_api.py
@@ -189,9 +189,8 @@ def test_judgment_request_additional_context_wins_over_deprecated_context():
     assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
-def test_judgment_request_deprecated_context_alias_included_in_llm_prompt():
-    """JudgmentRequest built via deprecated context field should reach the judge's LLM call."""
+def test_judgment_request_deprecated_context_alias_migrates_field():
+    """JudgmentRequest(context=...) normalises to additional_context at construction time."""
     ctx_text = "legacy context via deprecated field"
     req = JudgmentRequest(context=ctx_text)
-    # After migration the field is normalised to additional_context.
     assert req.additional_context == ctx_text

--- a/python/tests/test_judge_context_api.py
+++ b/python/tests/test_judge_context_api.py
@@ -1,7 +1,7 @@
-"""Tests for the context parameter on ScenarioExecutor.judge() and script.judge().
+"""Tests for the additional_context parameter on ScenarioExecutor.judge() and script.judge().
 
 These tests enter through ScenarioExecutor.judge() — NOT through a hand-built
-JudgmentRequest — to verify that the public API wires context all the way down
+JudgmentRequest — to verify that the public API wires additional_context all the way down
 to the LLM call. See issue #660.
 """
 
@@ -57,7 +57,7 @@ def _get_system_message(mock_completion: MagicMock) -> str:
 
 @pytest.mark.asyncio
 async def test_executor_judge_context_forwarded_to_llm_input():
-    """executor.judge(context=...) must include <additional_context> in the LLM user message."""
+    """executor.judge(additional_context=...) must include <additional_context> in the LLM user message."""
     ctx_text = "the agent ran npm install which exited 0"
     executor = _make_executor()
     mock_response = _make_mock_litellm_response()
@@ -66,7 +66,7 @@ async def test_executor_judge_context_forwarded_to_llm_input():
         with patch(
             "scenario.judge_agent.litellm.completion", return_value=mock_response
         ) as mock_completion:
-            await executor.judge(context=ctx_text)
+            await executor.judge(additional_context=ctx_text)
 
             assert mock_completion.called
             content = _get_user_message(mock_completion)
@@ -79,7 +79,7 @@ async def test_executor_judge_context_forwarded_to_llm_input():
 
 @pytest.mark.asyncio
 async def test_executor_judge_criteria_and_context_forwarded_independently():
-    """executor.judge(criteria=[...], context=...) forwards both criteria and context."""
+    """executor.judge(criteria=[...], additional_context=...) forwards both criteria and additional_context."""
     ctx_text = "exit code 0"
     executor = _make_executor()
     mock_response = _make_mock_litellm_response()
@@ -89,7 +89,7 @@ async def test_executor_judge_criteria_and_context_forwarded_independently():
             "scenario.judge_agent.litellm.completion", return_value=mock_response
         ) as mock_completion:
             await executor.judge(
-                criteria=["agent installed dependency"], context=ctx_text
+                criteria=["agent installed dependency"], additional_context=ctx_text
             )
 
             assert mock_completion.called
@@ -145,7 +145,7 @@ async def test_executor_judge_no_context_no_additional_context_block_criteria_on
 
 @pytest.mark.asyncio
 async def test_executor_judge_empty_string_context_no_additional_context_block():
-    """executor.judge(context='') must NOT emit <additional_context> (truthy guard)."""
+    """executor.judge(additional_context='') must NOT emit <additional_context> (truthy guard)."""
     executor = _make_executor()
     mock_response = _make_mock_litellm_response()
 
@@ -153,7 +153,7 @@ async def test_executor_judge_empty_string_context_no_additional_context_block()
         with patch(
             "scenario.judge_agent.litellm.completion", return_value=mock_response
         ) as mock_completion:
-            await executor.judge(context="")
+            await executor.judge(additional_context="")
 
             assert mock_completion.called
             content = _get_user_message(mock_completion)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1594,7 +1594,7 @@ wheels = [
 
 [[package]]
 name = "langwatch-scenario"
-version = "0.7.30"
+version = "0.7.31"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },

--- a/specs/judge-context-public-api.feature
+++ b/specs/judge-context-public-api.feature
@@ -1,0 +1,78 @@
+@python
+Feature: Expose JudgmentRequest.context on the public scenario.judge() API
+  As a scenario test author
+  I want to pass additional context to the judge via scenario.judge(context=...)
+  So that the judge can ground its evaluation in reference material without replacing the default judge system prompt
+
+  Background:
+    Given a JudgeAgent with configured criteria
+    And a mocked litellm completion that returns a finish_test verdict
+
+  @unit
+  Scenario: context string forwarded to judge LLM input (AC1)
+    Given ScenarioExecutor.judge is called with context="the agent ran npm install which exited 0"
+    When the judge LLM is invoked
+    Then the user message sent to litellm contains an <additional_context> block
+    And the user message contains "the agent ran npm install which exited 0" inside that block
+
+  @unit
+  Scenario: criteria and context forwarded independently (AC2)
+    Given ScenarioExecutor.judge is called with criteria=["agent installed dependency"] and context="exit code 0"
+    When the judge LLM is invoked
+    Then the judge evaluates against criteria ["agent installed dependency"]
+    And the user message contains an <additional_context> block with "exit code 0"
+
+  @unit
+  Scenario: no context produces no additional_context block — no arguments (AC3)
+    Given ScenarioExecutor.judge is called with no arguments
+    When the judge LLM is invoked
+    Then the user message sent to litellm does not contain an <additional_context> block
+
+  @unit
+  Scenario: no context produces no additional_context block — criteria only (AC3)
+    Given ScenarioExecutor.judge is called with criteria=["agent responded"] and no context
+    When the judge LLM is invoked
+    Then the user message sent to litellm does not contain an <additional_context> block
+
+  @unit
+  Scenario: empty string context produces no additional_context block (AC5)
+    Given ScenarioExecutor.judge is called with context=""
+    When the judge LLM is invoked
+    Then the user message sent to litellm does not contain an <additional_context> block
+
+  @unit
+  Scenario: context parameter documented in script.py judge() docstring (AC4)
+    Given the file python/scenario/script.py
+    When the judge() function docstring is inspected
+    Then it contains the phrase "Additional context for the judge"
+
+  @unit
+  Scenario: existing judge() calls without context unchanged (AC6)
+    Given ScenarioExecutor.judge is called with criteria=["agent responded"] as it was before this change
+    When the judge LLM is invoked
+    Then the verdict and criteria evaluation behave identically to the pre-change behavior
+    And the user message does not contain an <additional_context> block
+
+  @unit
+  Scenario: JudgeAgent.call() consumer-level tests remain green (AC7)
+    Given the existing test_judge_includes_additional_context_in_prompt test
+    And the existing test_judge_omits_additional_context_when_none test
+    When those tests run against the modified codebase
+    Then both pass without modification
+
+# --- AC Coverage Map ---
+# AC1: "ScenarioExecutor.judge(context='<ctx>') results in '<ctx>' appearing inside <additional_context>"
+#   → Scenario: context string forwarded to judge LLM input (AC1)
+# AC2: "ScenarioExecutor.judge(criteria=['c1'], context='<ctx>') forwards both independently"
+#   → Scenario: criteria and context forwarded independently (AC2)
+# AC3: "ScenarioExecutor.judge() and ScenarioExecutor.judge(criteria=['c1']) produce no <additional_context> block"
+#   → Scenario: no context produces no additional_context block — no arguments (AC3)
+#   → Scenario: no context produces no additional_context block — criteria only (AC3)
+# AC4: "context param documented in script.py:judge() docstring"
+#   → Scenario: context parameter documented in script.py judge() docstring (AC4)
+# AC5: "scenario.judge(context='') produces no <additional_context> block"
+#   → Scenario: empty string context produces no additional_context block (AC5)
+# AC6 (regression): "all existing scenario.judge() and scenario.judge(criteria=[...]) calls unchanged"
+#   → Scenario: existing judge() calls without context unchanged (AC6)
+# AC7 (consumer regression): "existing test_judge_*_additional_context_* tests pass unchanged"
+#   → Scenario: JudgeAgent.call() consumer-level tests remain green (AC7)

--- a/specs/judge-context-public-api.feature
+++ b/specs/judge-context-public-api.feature
@@ -1,7 +1,7 @@
 @python
 Feature: Expose JudgmentRequest.context on the public scenario.judge() API
   As a scenario test author
-  I want to pass additional context to the judge via scenario.judge(context=...)
+  I want to pass additional context to the judge via scenario.judge(additional_context=...)
   So that the judge can ground its evaluation in reference material without replacing the default judge system prompt
 
   Background:
@@ -10,14 +10,14 @@ Feature: Expose JudgmentRequest.context on the public scenario.judge() API
 
   @unit
   Scenario: context string forwarded to judge LLM input (AC1)
-    Given ScenarioExecutor.judge is called with context="the agent ran npm install which exited 0"
+    Given ScenarioExecutor.judge is called with additional_context="the agent ran npm install which exited 0"
     When the judge LLM is invoked
     Then the user message sent to litellm contains an <additional_context> block
     And the user message contains "the agent ran npm install which exited 0" inside that block
 
   @unit
   Scenario: criteria and context forwarded independently (AC2)
-    Given ScenarioExecutor.judge is called with criteria=["agent installed dependency"] and context="exit code 0"
+    Given ScenarioExecutor.judge is called with criteria=["agent installed dependency"] and additional_context="exit code 0"
     When the judge LLM is invoked
     Then the judge evaluates against criteria ["agent installed dependency"]
     And the user message contains an <additional_context> block with "exit code 0"
@@ -36,12 +36,12 @@ Feature: Expose JudgmentRequest.context on the public scenario.judge() API
 
   @unit
   Scenario: empty string context produces no additional_context block (AC5)
-    Given ScenarioExecutor.judge is called with context=""
+    Given ScenarioExecutor.judge is called with additional_context=""
     When the judge LLM is invoked
     Then the user message sent to litellm does not contain an <additional_context> block
 
   @unit
-  Scenario: context parameter documented in script.py judge() docstring (AC4)
+  Scenario: additional_context parameter documented in script.py judge() docstring (AC4)
     Given the file python/scenario/script.py
     When the judge() function docstring is inspected
     Then it contains the phrase "Additional context for the judge"
@@ -61,16 +61,16 @@ Feature: Expose JudgmentRequest.context on the public scenario.judge() API
     Then both pass without modification
 
 # --- AC Coverage Map ---
-# AC1: "ScenarioExecutor.judge(context='<ctx>') results in '<ctx>' appearing inside <additional_context>"
+# AC1: "ScenarioExecutor.judge(additional_context='<ctx>') results in '<ctx>' appearing inside <additional_context>"
 #   → Scenario: context string forwarded to judge LLM input (AC1)
-# AC2: "ScenarioExecutor.judge(criteria=['c1'], context='<ctx>') forwards both independently"
+# AC2: "ScenarioExecutor.judge(criteria=['c1'], additional_context='<ctx>') forwards both independently"
 #   → Scenario: criteria and context forwarded independently (AC2)
 # AC3: "ScenarioExecutor.judge() and ScenarioExecutor.judge(criteria=['c1']) produce no <additional_context> block"
 #   → Scenario: no context produces no additional_context block — no arguments (AC3)
 #   → Scenario: no context produces no additional_context block — criteria only (AC3)
-# AC4: "context param documented in script.py:judge() docstring"
+# AC4: "additional_context param documented in script.py:judge() docstring"
 #   → Scenario: context parameter documented in script.py judge() docstring (AC4)
-# AC5: "scenario.judge(context='') produces no <additional_context> block"
+# AC5: "scenario.judge(additional_context='') produces no <additional_context> block"
 #   → Scenario: empty string context produces no additional_context block (AC5)
 # AC6 (regression): "all existing scenario.judge() and scenario.judge(criteria=[...]) calls unchanged"
 #   → Scenario: existing judge() calls without context unchanged (AC6)


### PR DESCRIPTION
## Why

\`JudgmentRequest.context\` was the field name on the Python side while the JS side already used \`additionalContext\`. Rogerio requested cross-language consistency: rename the Python field to \`additional_context\` and expose it through the public \`judge()\` API on both languages.

Additionally, the original Python public call sites (\`script.py:judge()\`, \`ScenarioExecutor.judge()\`) never forwarded the parameter at all — so a test author who needed the judge to see reference material had to replace the entire judge system prompt by hand.

Closes #660

## What changed

**Python:**
- \`JudgmentRequest.context\` renamed to \`additional_context\` (primary field). \`context\` kept as a \`@deprecated\` backward-compat alias via a \`@model_validator\` that migrates the value and emits \`DeprecationWarning\`.
- \`additional_context: Optional[str] = None\` exposed on \`script.py:judge()\` and \`ScenarioExecutor.judge()\` — the two previously-gapped call sites.
- \`import warnings\` at module level in \`types.py\`.

**JavaScript:**
- \`additionalContext?: string\` on the public \`judge()\` DSL, \`ScenarioExecution.judge()\`, and \`JudgmentRequest\`.
- \`context\` kept as a \`@deprecated\` alias (normalized via \`additionalContext ?? context\`) so existing callers are not silently broken.

**Other:**
- \`specs/voice-agents.feature\`: added \`@unit\` tag to "Capability matrix" scenario — fixes a pre-existing CI failure on main unrelated to this feature.

## Test plan

**Python** (\`python/tests/test_judge_context_api.py\`) — 8 tests, 5 entering through \`ScenarioExecutor.judge()\` + 3 for the deprecated alias:

\`\`\`bash
cd python && uv run pytest tests/test_judge_context_api.py -v
# 8 passed
\`\`\`

**JS** (\`javascript/src/agents/judge/__tests__/judge-agent.test.ts\`) — "additional context via judgmentRequest.additionalContext" describe block (4 cases including backward-compat deprecated \`context\` alias):

\`\`\`bash
cd javascript && pnpm vitest run src/agents/judge/__tests__/judge-agent.test.ts
# 24 passed
\`\`\`

## Acceptance Criteria

- [x] **AC1** — \`executor.judge(additional_context="<ctx>")\` includes \`"<ctx>"\` inside \`<additional_context>\` in the judge LLM messages. Evidence: \`test_executor_judge_additional_context_forwarded_to_llm_input\` ✅
- [x] **AC2** — \`executor.judge(criteria=[...], additional_context="<ctx>")\` forwards both independently. Evidence: \`test_executor_judge_criteria_and_additional_context_forwarded_independently\` ✅
- [x] **AC3** — No \`additional_context\` → no \`<additional_context>\` block (two cases). Evidence: \`test_executor_judge_no_context_no_additional_context_block_no_args\` + \`_criteria_only\` ✅
- [x] **AC4** — \`additional_context\` documented in \`script.py:judge()\` docstring. Evidence: \`python/scenario/script.py:193\` ✅
- [x] **AC5** — Empty string \`additional_context=""\` → no block. Evidence: \`test_executor_judge_empty_string_additional_context_no_additional_context_block\` ✅
- [x] **AC6** — All existing \`judge()\` call sites work unchanged. Evidence: \`test_scenario_executor.py\` 11/11 ✅
- [x] **AC7** — Existing \`test_judge_includes_additional_context_in_prompt\` and \`test_judge_omits_additional_context_when_none\` pass. Evidence: both ✅
- [x] **Extra (Python)** — \`JudgmentRequest.context\` deprecated alias migrates to \`additional_context\` at construction, emits \`DeprecationWarning\`. Evidence: 3 new alias tests ✅
- [x] **Extra (JS)** — \`JudgmentRequest.additionalContext\` primary, \`context\` deprecated alias with backward-compat. Evidence: 4 describe-block tests ✅