### PR TITLE
fix(voice/#662): guard #662's response.create call sites against the active-response race (JS + PY)

### DIFF
--- a/javascript/src/agents/__tests__/realtime-response-guard.test.ts
+++ b/javascript/src/agents/__tests__/realtime-response-guard.test.ts
@@ -109,8 +109,11 @@ describe("RealtimeAgentAdapter — response.create guard", () => {
     // Make the handler believe a response is active by firing response.created
     transport.fire("response.created");
 
-    // handleInitialResponse is private — call via any
-    const promise = (adapter as any).handleInitialResponse();
+    // handleInitialResponse is private — reach it via a typed cast (not `any`),
+    // matching the sibling openai-realtime-response-guard.test.ts pattern.
+    const promise = (
+      adapter as unknown as { handleInitialResponse(): Promise<unknown> }
+    ).handleInitialResponse();
 
     // The send decision is made synchronously, before the method's first `await`
     // (waitForResponse), so response.create has already been sent or suppressed by
@@ -133,7 +136,9 @@ describe("RealtimeAgentAdapter — response.create guard", () => {
     transport.fire("response.created");
 
     const b64audio = Buffer.from(new Uint8Array(160)).toString("base64");
-    const promise = (adapter as any).handleAudioInput(b64audio);
+    const promise = (
+      adapter as unknown as { handleAudioInput(audio: string): Promise<unknown> }
+    ).handleAudioInput(b64audio);
 
     // Same deterministic settle as AC-JS4: sends are synchronous before the first
     // await, so flush microtasks then resolve waitForResponse promptly.

--- a/javascript/src/agents/__tests__/realtime-response-guard.test.ts
+++ b/javascript/src/agents/__tests__/realtime-response-guard.test.ts
@@ -112,8 +112,10 @@ describe("RealtimeAgentAdapter — response.create guard", () => {
     // handleInitialResponse is private — call via any
     const promise = (adapter as any).handleInitialResponse();
 
-    // Give it a moment to call transport.sendEvent (or not)
-    await new Promise((r) => setTimeout(r, 20));
+    // Allow the synchronous preamble (transport.sendEvent) to flush before asserting.
+    // 100ms is sufficient on a loaded CI runner; the assertion is about event ordering,
+    // not a timed window.
+    await new Promise((r) => setTimeout(r, 100));
 
     // Cancel the timeout by firing response.done (resolves waitForResponse)
     transport.fire("response.done");
@@ -133,7 +135,8 @@ describe("RealtimeAgentAdapter — response.create guard", () => {
     const b64audio = Buffer.from(new Uint8Array(160)).toString("base64");
     const promise = (adapter as any).handleAudioInput(b64audio);
 
-    await new Promise((r) => setTimeout(r, 20));
+    // Same flush wait as AC-JS4 — 100ms is sufficient on a loaded CI runner.
+    await new Promise((r) => setTimeout(r, 100));
     transport.fire("response.done");
     await promise.catch(() => {});
 

--- a/javascript/src/agents/__tests__/realtime-response-guard.test.ts
+++ b/javascript/src/agents/__tests__/realtime-response-guard.test.ts
@@ -58,8 +58,7 @@ describe("RealtimeEventHandler — isResponseActive() lifecycle", () => {
     const transport = new FakeTransport();
     const session = makeFakeSession(transport);
     const handler = new RealtimeEventHandler(session);
-    // isResponseActive() doesn't exist pre-fix → throws TypeError
-    expect((handler as any).isResponseActive()).toBe(false);
+    expect(handler.isResponseActive()).toBe(false);
   });
 
   it("AC-JS6b: isResponseActive() returns true after response.created", () => {
@@ -67,7 +66,7 @@ describe("RealtimeEventHandler — isResponseActive() lifecycle", () => {
     const session = makeFakeSession(transport);
     const handler = new RealtimeEventHandler(session);
     transport.fire("response.created");
-    expect((handler as any).isResponseActive()).toBe(true);
+    expect(handler.isResponseActive()).toBe(true);
   });
 
   it("AC-JS6c: isResponseActive() returns false after response.done", () => {
@@ -76,7 +75,16 @@ describe("RealtimeEventHandler — isResponseActive() lifecycle", () => {
     const handler = new RealtimeEventHandler(session);
     transport.fire("response.created");
     transport.fire("response.done");
-    expect((handler as any).isResponseActive()).toBe(false);
+    expect(handler.isResponseActive()).toBe(false);
+  });
+
+  it("AC-JS6d: isResponseActive() returns false after response.cancelled", () => {
+    const transport = new FakeTransport();
+    const session = makeFakeSession(transport);
+    const handler = new RealtimeEventHandler(session);
+    transport.fire("response.created");
+    transport.fire("response.cancelled");
+    expect(handler.isResponseActive()).toBe(false);
   });
 });
 

--- a/javascript/src/agents/__tests__/realtime-response-guard.test.ts
+++ b/javascript/src/agents/__tests__/realtime-response-guard.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for issue #662 Phase 3:
+ *   AC-JS6: RealtimeEventHandler.isResponseActive() lifecycle transitions
+ *   AC-JS4: handleInitialResponse does NOT send response.create when handler is active
+ *   AC-JS5: handleAudioInput does NOT send response.create when handler is active
+ *
+ * These tests are written to FAIL before the fix is applied:
+ *   - AC-JS6a/b/c: isResponseActive() does not exist yet → TypeError
+ *   - AC-JS4/AC-JS5: response.create is sent unconditionally → count is 1, not 0
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { RealtimeEventHandler } from "../realtime/realtime-event-handler";
+import { RealtimeAgentAdapter } from "../realtime/realtime-agent.adapter";
+import { AgentRole } from "../../domain";
+import type { RealtimeSession } from "@openai/agents/realtime";
+
+// ------- FakeTransport -------
+class FakeTransport {
+  private listeners: Map<string, ((data: unknown) => void)[]> = new Map();
+  sentEvents: Array<{ type: string; [k: string]: unknown }> = [];
+
+  on(event: string, cb: (data: unknown) => void): void {
+    const existing = this.listeners.get(event) ?? [];
+    this.listeners.set(event, [...existing, cb]);
+  }
+
+  sendEvent(event: { type: string; [k: string]: unknown }): void {
+    this.sentEvents.push(event);
+  }
+
+  // Simulate a server event arriving
+  fire(event: string, data?: unknown): void {
+    const cbs = this.listeners.get(event) ?? [];
+    for (const cb of cbs) cb(data ?? {});
+  }
+
+  sentCount(type: string): number {
+    return this.sentEvents.filter((e) => e.type === type).length;
+  }
+}
+
+// ------- FakeSession -------
+function makeFakeSession(transport: FakeTransport): RealtimeSession {
+  return {
+    transport,
+    connect: vi.fn(),
+    close: vi.fn(),
+    sendMessage: vi.fn(),
+  } as unknown as RealtimeSession;
+}
+
+// ============================================================
+// AC-JS6: isResponseActive() lifecycle transitions
+// ============================================================
+describe("RealtimeEventHandler — isResponseActive() lifecycle", () => {
+  it("AC-JS6a: isResponseActive() is false initially", () => {
+    const transport = new FakeTransport();
+    const session = makeFakeSession(transport);
+    const handler = new RealtimeEventHandler(session);
+    // isResponseActive() doesn't exist pre-fix → throws TypeError
+    expect((handler as any).isResponseActive()).toBe(false);
+  });
+
+  it("AC-JS6b: isResponseActive() returns true after response.created", () => {
+    const transport = new FakeTransport();
+    const session = makeFakeSession(transport);
+    const handler = new RealtimeEventHandler(session);
+    transport.fire("response.created");
+    expect((handler as any).isResponseActive()).toBe(true);
+  });
+
+  it("AC-JS6c: isResponseActive() returns false after response.done", () => {
+    const transport = new FakeTransport();
+    const session = makeFakeSession(transport);
+    const handler = new RealtimeEventHandler(session);
+    transport.fire("response.created");
+    transport.fire("response.done");
+    expect((handler as any).isResponseActive()).toBe(false);
+  });
+});
+
+// ============================================================
+// AC-JS4 / AC-JS5: response.create guard on adapter methods
+// ============================================================
+describe("RealtimeAgentAdapter — response.create guard", () => {
+  function makeAdapter(transport: FakeTransport): RealtimeAgentAdapter {
+    const session = makeFakeSession(transport);
+    return new RealtimeAgentAdapter({
+      session,
+      role: AgentRole.AGENT,
+      agentName: "TestAgent",
+      responseTimeout: 100,
+    });
+  }
+
+  it("AC-JS4: handleInitialResponse does not send response.create when handler is active", async () => {
+    const transport = new FakeTransport();
+    const adapter = makeAdapter(transport);
+
+    // Make the handler believe a response is active by firing response.created
+    transport.fire("response.created");
+
+    // handleInitialResponse is private — call via any
+    const promise = (adapter as any).handleInitialResponse();
+
+    // Give it a moment to call transport.sendEvent (or not)
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Cancel the timeout by firing response.done (resolves waitForResponse)
+    transport.fire("response.done");
+    await promise.catch(() => {}); // ignore timeout error
+
+    // response.create must NOT have been sent when handler was active
+    expect(transport.sentCount("response.create")).toBe(0);
+  });
+
+  it("AC-JS5: handleAudioInput does not send response.create when handler is active", async () => {
+    const transport = new FakeTransport();
+    const adapter = makeAdapter(transport);
+
+    // Make the handler believe a response is active
+    transport.fire("response.created");
+
+    const b64audio = Buffer.from(new Uint8Array(160)).toString("base64");
+    const promise = (adapter as any).handleAudioInput(b64audio);
+
+    await new Promise((r) => setTimeout(r, 20));
+    transport.fire("response.done");
+    await promise.catch(() => {});
+
+    // Only input_audio_buffer.append and input_audio_buffer.commit should be sent
+    // response.create must NOT be sent when handler is active
+    expect(transport.sentCount("response.create")).toBe(0);
+  });
+});

--- a/javascript/src/agents/__tests__/realtime-response-guard.test.ts
+++ b/javascript/src/agents/__tests__/realtime-response-guard.test.ts
@@ -112,14 +112,14 @@ describe("RealtimeAgentAdapter — response.create guard", () => {
     // handleInitialResponse is private — call via any
     const promise = (adapter as any).handleInitialResponse();
 
-    // Allow the synchronous preamble (transport.sendEvent) to flush before asserting.
-    // 100ms is sufficient on a loaded CI runner; the assertion is about event ordering,
-    // not a timed window.
-    await new Promise((r) => setTimeout(r, 100));
-
-    // Cancel the timeout by firing response.done (resolves waitForResponse)
+    // The send decision is made synchronously, before the method's first `await`
+    // (waitForResponse), so response.create has already been sent or suppressed by
+    // the time the promise is returned. Flush the microtask queue, then resolve
+    // waitForResponse promptly by firing response.done — so it settles well before
+    // responseTimeout (100ms) and the test is deterministic, not racing the clock.
+    await Promise.resolve();
     transport.fire("response.done");
-    await promise.catch(() => {}); // ignore timeout error
+    await promise.catch(() => {}); // ignore any rejection
 
     // response.create must NOT have been sent when handler was active
     expect(transport.sentCount("response.create")).toBe(0);
@@ -135,8 +135,9 @@ describe("RealtimeAgentAdapter — response.create guard", () => {
     const b64audio = Buffer.from(new Uint8Array(160)).toString("base64");
     const promise = (adapter as any).handleAudioInput(b64audio);
 
-    // Same flush wait as AC-JS4 — 100ms is sufficient on a loaded CI runner.
-    await new Promise((r) => setTimeout(r, 100));
+    // Same deterministic settle as AC-JS4: sends are synchronous before the first
+    // await, so flush microtasks then resolve waitForResponse promptly.
+    await Promise.resolve();
     transport.fire("response.done");
     await promise.catch(() => {});
 

--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -193,9 +193,11 @@ export class RealtimeAgentAdapter extends AgentAdapter {
       throw new Error("Realtime transport not available");
     }
 
-    transport.sendEvent({
-      type: "response.create",
-    });
+    if (!this.eventHandler.isResponseActive()) {
+      transport.sendEvent({
+        type: "response.create",
+      });
+    }
 
     const timeout = this.config.responseTimeout ?? 60000;
     const response = await this.eventHandler.waitForResponse(timeout);
@@ -234,10 +236,12 @@ export class RealtimeAgentAdapter extends AgentAdapter {
       type: "input_audio_buffer.commit",
     });
 
-    // Trigger response generation
-    transport.sendEvent({
-      type: "response.create",
-    });
+    // Trigger response generation — guard against active-response race
+    if (!this.eventHandler.isResponseActive()) {
+      transport.sendEvent({
+        type: "response.create",
+      });
+    }
 
     // Wait for audio response
     const timeout = this.config.responseTimeout ?? 60000;

--- a/javascript/src/agents/realtime/realtime-event-handler.ts
+++ b/javascript/src/agents/realtime/realtime-event-handler.ts
@@ -111,9 +111,13 @@ export class RealtimeEventHandler {
       }
     });
 
-    // Track response lifecycle — set on response.created, clear on response.done
+    // Track response lifecycle — set on response.created, clear on response.done/cancelled
     transport.on("response.created", () => {
       this._active = true;
+    });
+
+    transport.on("response.cancelled", () => {
+      this._active = false;
     });
 
     // Listen for response completion
@@ -177,6 +181,7 @@ export class RealtimeEventHandler {
    * Resets the internal state for the next response
    */
   private reset(): void {
+    this._active = false;
     this.responseResolver = null;
     this.errorRejecter = null;
     this.currentResponse = "";

--- a/javascript/src/agents/realtime/realtime-event-handler.ts
+++ b/javascript/src/agents/realtime/realtime-event-handler.ts
@@ -46,6 +46,7 @@ export class RealtimeEventHandler {
   private errorRejecter: ((error: Error) => void) | null = null;
   private listenersSetup = false;
   private readonly logger = new Logger("RealtimeEventHandler");
+  private _active = false;
 
   /**
    * Creates a new RealtimeEventHandler instance
@@ -110,8 +111,14 @@ export class RealtimeEventHandler {
       }
     });
 
+    // Track response lifecycle — set on response.created, clear on response.done
+    transport.on("response.created", () => {
+      this._active = true;
+    });
+
     // Listen for response completion
     transport.on("response.done", () => {
+      this._active = false;
       const fullAudio = this.currentAudioChunks.join("");
       const audioResponse: AudioResponseEvent = {
         transcript: this.currentResponse,
@@ -174,5 +181,13 @@ export class RealtimeEventHandler {
     this.errorRejecter = null;
     this.currentResponse = "";
     this.currentAudioChunks = [];
+  }
+
+  /**
+   * Returns true while a response is in flight (between response.created
+   * and response.done). Used by RealtimeAgentAdapter to guard response.create.
+   */
+  isResponseActive(): boolean {
+    return this._active;
   }
 }

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
@@ -16,13 +16,17 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import type WebSocket from "ws";
 import { OpenAIRealtimeAgentAdapter } from "../openai-realtime";
 
 // ---------------------------------------------------------------------------
-// FakeWS — an in-process fake that records frames without touching the network
+// FakeWS — an in-process fake that records frames without touching the network.
+// Extends EventEmitter so the adapter can register message/close/error listeners
+// exactly as it does on a real ws.WebSocket (via .on() / .once()).
 // ---------------------------------------------------------------------------
 
-class FakeWS {
+class FakeWS extends EventEmitter {
   sent: string[] = [];
   closed = false;
 
@@ -33,6 +37,7 @@ class FakeWS {
 
   close(): void {
     this.closed = true;
+    this.emit("close");
   }
 
   /** Ordered list of `type` fields from every sent frame. */
@@ -49,17 +54,36 @@ class FakeWS {
   indexOfSent(type: string): number {
     return this.sentTypes().indexOf(type);
   }
+
+  /**
+   * Push a server event into the adapter's receive loop.
+   * Serialises to JSON and emits as a "message" event — the same path a real
+   * WebSocket frame takes through _handleMessage.
+   */
+  receive(event: unknown): void {
+    this.emit("message", Buffer.from(JSON.stringify(event)));
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeAdapter(): { adapter: OpenAIRealtimeAgentAdapter; ws: FakeWS } {
-  const adapter = new OpenAIRealtimeAgentAdapter({ apiKey: "test-key" });
+async function makeAdapter(): Promise<{
+  adapter: OpenAIRealtimeAgentAdapter;
+  ws: FakeWS;
+}> {
   const ws = new FakeWS();
-  // Inject the fake WS directly — bypasses the real connect() call.
-  (adapter as unknown as Record<string, unknown>)._ws = ws;
+  const adapter = new OpenAIRealtimeAgentAdapter({
+    apiKey: "test-key",
+    wsFactory: (url, _authHeader) => {
+      // Emit "open" asynchronously so the awaited Promise in connect() resolves.
+      queueMicrotask(() => ws.emit("open"));
+      void url;
+      return ws as unknown as WebSocket;
+    },
+  });
+  await adapter.connect();
   return { adapter, ws };
 }
 
@@ -78,7 +102,7 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
   it(
     "AC-JS1: receiveAudio sends commit but NOT response.create when _responseActive is true",
     async () => {
-      const { adapter, ws } = makeAdapter();
+      const { adapter, ws } = await makeAdapter();
 
       // Simulate pending audio that triggers the preamble.
       (adapter as unknown as Record<string, unknown>)._pendingAudioBytes = 960;
@@ -111,7 +135,7 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
   it(
     "AC-JS2: deferred receiveAudio response.create fires after response.done frame",
     async () => {
-      const { adapter, ws } = makeAdapter();
+      const { adapter, ws } = await makeAdapter();
 
       (adapter as unknown as Record<string, unknown>)._pendingAudioBytes = 960;
       (adapter as unknown as Record<string, unknown>)._responseActive = true;
@@ -129,23 +153,14 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
       // Post-fix: 0 (deferred because _responseActive is true).
       const countBeforeDone = ws.sentCount("response.create");
 
-      // Now inject the event sequence that drives receiveAudio to completion:
+      // Inject the event sequence that drives receiveAudio to completion:
       // response.done  → clears _responseActive, fires deferred response.create
       // response.created → sets _responseActive = true for the new response
       // response.output_audio.delta → the actual audio frame that resolves receiveAudio
-      // response.done  → completes the second response
-      const enqueue = (event: unknown): void => {
-        (
-          adapter as unknown as {
-            _enqueueEvent: (e: unknown) => void;
-          }
-        )._enqueueEvent(event);
-      };
-
-      enqueue({ type: "response.done" });
+      ws.receive({ type: "response.done" });
       await new Promise<void>((r) => setTimeout(r, 5));
-      enqueue({ type: "response.created" });
-      enqueue({ type: "response.output_audio.delta", delta: b64audio });
+      ws.receive({ type: "response.created" });
+      ws.receive({ type: "response.output_audio.delta", delta: b64audio });
 
       await receivePromise;
 
@@ -168,7 +183,7 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
   it(
     "AC-JS3: sendText does not send response.create when _responseActive is true",
     async () => {
-      const { adapter, ws } = makeAdapter();
+      const { adapter, ws } = await makeAdapter();
 
       (adapter as unknown as Record<string, unknown>)._responseActive = true;
 
@@ -195,17 +210,13 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
   it(
     "AC-ERR1: receiveAudio rejects with Error on server active-response error",
     async () => {
-      const { adapter } = makeAdapter();
+      const { adapter, ws } = await makeAdapter();
 
       const receivePromise = adapter.receiveAudio(5.0);
 
       await new Promise<void>((r) => setTimeout(r, 10));
 
-      (
-        adapter as unknown as {
-          _enqueueEvent: (e: unknown) => void;
-        }
-      )._enqueueEvent({
+      ws.receive({
         type: "error",
         error: {
           message:

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
@@ -144,8 +144,13 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
 
       const receivePromise = adapter.receiveAudio(2.0);
 
-      // Let the preamble run before injecting server events.
-      await new Promise<void>((r) => setTimeout(r, 20));
+      // Yield one macrotask so the async receiveAudio loop drains its queued
+      // events. A zero-delay timer is a deterministic macrotask boundary (it
+      // runs only after the microtask queue is empty, regardless of runner
+      // load) — not an arbitrary timed wait. The preamble already ran
+      // synchronously before receiveAudio's first await, so this only flushes
+      // the loop's event processing.
+      await new Promise<void>((r) => setTimeout(r, 0));
 
       // Snapshot: how many response.create frames have been sent so far?
       // Pre-fix: 1 (fired unconditionally in preamble).
@@ -157,7 +162,7 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
       // response.created → sets _responseActive = true for the new response
       // response.output_audio.delta → the actual audio frame that resolves receiveAudio
       ws.receive({ type: "response.done" });
-      await new Promise<void>((r) => setTimeout(r, 5));
+      await new Promise<void>((r) => setTimeout(r, 0));
       ws.receive({ type: "response.created" });
       ws.receive({ type: "response.output_audio.delta", delta: b64audio });
 
@@ -213,7 +218,9 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
 
       const receivePromise = adapter.receiveAudio(5.0);
 
-      await new Promise<void>((r) => setTimeout(r, 10));
+      // Macrotask yield so the loop reaches its first _nextEvent await before
+      // the error frame is injected (see AC-JS2 note above).
+      await new Promise<void>((r) => setTimeout(r, 0));
 
       ws.receive({
         type: "error",

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
@@ -229,4 +229,50 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
     },
     6000,
   );
+
+  /**
+   * Reconnect hygiene (#662, CodeRabbit): disconnect() must clear the
+   * response-lifecycle guard flags, and a subsequent connect() must start from
+   * a clean slate — including clearing `_closeReason`, without which
+   * `_nextEvent` would reject every receiveAudio on the reused adapter and the
+   * guard-flag reset alone would be cosmetic.
+   */
+  it(
+    "resets response-lifecycle state on disconnect and reconnects clean",
+    async () => {
+      const { adapter } = await makeAdapter();
+      const state = adapter as unknown as Record<string, unknown>;
+
+      // Simulate mid-response state present when the socket drops.
+      state._responseActive = true;
+      state._deferredResponseCreate = true;
+
+      await adapter.disconnect();
+
+      // Teardown clears the guard flags so they cannot leak into a new session.
+      expect(state._responseActive).toBe(false);
+      expect(state._deferredResponseCreate).toBe(false);
+
+      // Reconnect the same instance: connect() must reset the guard flags AND
+      // the stale close reason.
+      const ws2 = new FakeWS();
+      (adapter as unknown as { _wsFactory: unknown })._wsFactory = (
+        _url: string,
+        _authHeader: string,
+      ) => {
+        queueMicrotask(() => ws2.emit("open"));
+        return ws2 as unknown as WebSocket;
+      };
+      await adapter.connect();
+
+      expect(state._responseActive).toBe(false);
+      expect(state._deferredResponseCreate).toBe(false);
+      expect(state._closeReason).toBe(null);
+
+      // Prove reconnect actually works: receiveAudio reaches its own timeout
+      // instead of rejecting immediately on the prior disconnect error.
+      await expect(adapter.receiveAudio(0.05)).rejects.toThrow(/timed out/);
+    },
+    2000,
+  );
 });

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
@@ -76,10 +76,9 @@ async function makeAdapter(): Promise<{
   const ws = new FakeWS();
   const adapter = new OpenAIRealtimeAgentAdapter({
     apiKey: "test-key",
-    wsFactory: (url, _authHeader) => {
+    wsFactory: (_url, _authHeader) => {
       // Emit "open" asynchronously so the awaited Promise in connect() resolves.
       queueMicrotask(() => ws.emit("open"));
-      void url;
       return ws as unknown as WebSocket;
     },
   });

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression tests for issue #662 — `response.create` guard on
+ * `OpenAIRealtimeAgentAdapter`.
+ *
+ * These tests are written against the PRE-FIX code and MUST FAIL until the
+ * following changes land in `openai-realtime.ts`:
+ *   - private _responseActive = false
+ *   - private _deferredResponseCreate = false
+ *   - receiveAudio preamble: commit always, defer response.create when active
+ *   - sendText: guard response.create when active
+ *   - response.created → _responseActive = true
+ *   - response.done/cancelled → _responseActive = false; fire deferred if set
+ *
+ * AC-JS1, AC-JS2, AC-JS3 FAIL on pre-fix code.
+ * AC-ERR1 is a control test — PASSES on pre-fix code (existing error path).
+ */
+
+import { describe, it, expect } from "vitest";
+import { OpenAIRealtimeAgentAdapter } from "../openai-realtime";
+
+// ---------------------------------------------------------------------------
+// FakeWS — an in-process fake that records frames without touching the network
+// ---------------------------------------------------------------------------
+
+class FakeWS {
+  sent: string[] = [];
+  closed = false;
+
+  /** Called by the adapter to send a frame. */
+  send(msg: string): void {
+    this.sent.push(msg);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Ordered list of `type` fields from every sent frame. */
+  sentTypes(): string[] {
+    return this.sent.map((s) => (JSON.parse(s) as { type: string }).type);
+  }
+
+  /** Count of frames with a given type. */
+  sentCount(type: string): number {
+    return this.sentTypes().filter((t) => t === type).length;
+  }
+
+  /** First index of a frame with a given type, or -1. */
+  indexOfSent(type: string): number {
+    return this.sentTypes().indexOf(type);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAdapter(): { adapter: OpenAIRealtimeAgentAdapter; ws: FakeWS } {
+  const adapter = new OpenAIRealtimeAgentAdapter({ apiKey: "test-key" });
+  const ws = new FakeWS();
+  // Inject the fake WS directly — bypasses the real connect() call.
+  (adapter as unknown as Record<string, unknown>)._ws = ws;
+  return { adapter, ws };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
+  /**
+   * AC-JS1: When _responseActive is true, receiveAudio MUST NOT send
+   * response.create in the preamble (only the commit is sent).
+   *
+   * Pre-fix failure: the preamble at line 374-378 always sends BOTH
+   * input_audio_buffer.commit and response.create, ignoring _responseActive.
+   */
+  it(
+    "AC-JS1: receiveAudio sends commit but NOT response.create when _responseActive is true",
+    async () => {
+      const { adapter, ws } = makeAdapter();
+
+      // Simulate pending audio that triggers the preamble.
+      (adapter as unknown as Record<string, unknown>)._pendingAudioBytes = 960;
+      // Mark an active response — the guard should suppress response.create.
+      (adapter as unknown as Record<string, unknown>)._responseActive = true;
+
+      // receiveAudio will time out (no audio delta events injected) — that's
+      // expected; we only care about what was sent in the preamble.
+      await expect(adapter.receiveAudio(0.05)).rejects.toThrow();
+
+      // Commit MUST always be sent so the server doesn't lose buffered audio.
+      expect(ws.sentCount("input_audio_buffer.commit")).toBe(1);
+
+      // response.create MUST be suppressed while a response is active.
+      // Pre-fix: this is 1 (unconditional send) → test FAILS.
+      expect(ws.sentCount("response.create")).toBe(0);
+    },
+    3000,
+  );
+
+  /**
+   * AC-JS2: The deferred response.create fires AFTER response.done is
+   * processed, not in the preamble.
+   *
+   * Strategy: start receiveAudio with _responseActive=true, let the preamble
+   * run, then snapshot the sent count before injecting events.  On pre-fix
+   * code the preamble fires response.create unconditionally, so
+   * countBeforeDone === 1.  On post-fix code it is 0 (deferred).
+   */
+  it(
+    "AC-JS2: deferred receiveAudio response.create fires after response.done frame",
+    async () => {
+      const { adapter, ws } = makeAdapter();
+
+      (adapter as unknown as Record<string, unknown>)._pendingAudioBytes = 960;
+      (adapter as unknown as Record<string, unknown>)._responseActive = true;
+
+      // 960 bytes of silent PCM16 (even byte count required by AudioChunk).
+      const b64audio = Buffer.from(new Uint8Array(960)).toString("base64");
+
+      const receivePromise = adapter.receiveAudio(2.0);
+
+      // Let the preamble run before injecting server events.
+      await new Promise<void>((r) => setTimeout(r, 20));
+
+      // Snapshot: how many response.create frames have been sent so far?
+      // Pre-fix: 1 (fired unconditionally in preamble).
+      // Post-fix: 0 (deferred because _responseActive is true).
+      const countBeforeDone = ws.sentCount("response.create");
+
+      // Now inject the event sequence that drives receiveAudio to completion:
+      // response.done  → clears _responseActive, fires deferred response.create
+      // response.created → sets _responseActive = true for the new response
+      // response.output_audio.delta → the actual audio frame that resolves receiveAudio
+      // response.done  → completes the second response
+      const enqueue = (event: unknown): void => {
+        (
+          adapter as unknown as {
+            _enqueueEvent: (e: unknown) => void;
+          }
+        )._enqueueEvent(event);
+      };
+
+      enqueue({ type: "response.done" });
+      await new Promise<void>((r) => setTimeout(r, 5));
+      enqueue({ type: "response.created" });
+      enqueue({ type: "response.output_audio.delta", delta: b64audio });
+
+      await receivePromise;
+
+      // Pre-fix: countBeforeDone === 1 → assertion below FAILS.
+      expect(countBeforeDone).toBe(0);
+
+      // Exactly one response.create must have been sent in total (deferred,
+      // after response.done).
+      expect(ws.sentCount("response.create")).toBe(1);
+    },
+    5000,
+  );
+
+  /**
+   * AC-JS3: sendText MUST NOT send response.create when _responseActive is
+   * true.
+   *
+   * Pre-fix failure: sendText at line 680 always sends response.create.
+   */
+  it(
+    "AC-JS3: sendText does not send response.create when _responseActive is true",
+    async () => {
+      const { adapter, ws } = makeAdapter();
+
+      (adapter as unknown as Record<string, unknown>)._responseActive = true;
+
+      await adapter.sendText("hello");
+
+      // conversation.item.create is always expected.
+      expect(ws.sentCount("conversation.item.create")).toBe(1);
+
+      // response.create MUST be suppressed.
+      // Pre-fix: this is 1 (unconditional send at line 680) → test FAILS.
+      expect(ws.sentCount("response.create")).toBe(0);
+    },
+    1000,
+  );
+
+  /**
+   * AC-ERR1: A server-side "active response" error event surfaces as a
+   * rejected Error from receiveAudio.
+   *
+   * This is a CONTROL test — it exercises the existing error-handling path
+   * (line ~479) and PASSES on pre-fix code.  It validates that the error
+   * plumbing works correctly before any guard changes land.
+   */
+  it(
+    "AC-ERR1: receiveAudio rejects with Error on server active-response error",
+    async () => {
+      const { adapter } = makeAdapter();
+
+      const receivePromise = adapter.receiveAudio(5.0);
+
+      await new Promise<void>((r) => setTimeout(r, 10));
+
+      (
+        adapter as unknown as {
+          _enqueueEvent: (e: unknown) => void;
+        }
+      )._enqueueEvent({
+        type: "error",
+        error: {
+          message:
+            "Conversation already has an active response in progress",
+        },
+      });
+
+      await expect(receivePromise).rejects.toThrow(
+        "active response in progress",
+      );
+    },
+    6000,
+  );
+});

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -481,6 +481,7 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
         if (this._deferredResponseCreate) {
           this._ws.send(JSON.stringify({ type: "response.create" }));
           this._deferredResponseCreate = false;
+          this._responseActive = true; // mirror Python: close the window before response.created arrives
         }
         // Issue #646: a tool-only turn (function call, NO audio delta) would
         // otherwise loop here forever and hit the receiveAudio timeout — the

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -223,6 +223,15 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
 
   /** Open the Realtime WebSocket and send the initial `session.update`. */
   async connect(): Promise<void> {
+    // Issue #662 / reconnect hygiene: a reused adapter instance must start each
+    // connection with a clean slate. Clear session-lifecycle state left over
+    // from a prior connection — the guard flags AND `_closeReason` (which
+    // `_nextEvent` rejects on immediately, so resetting the guard flags alone
+    // would leave a reconnected adapter unable to receive).
+    this._responseActive = false;
+    this._deferredResponseCreate = false;
+    this._closeReason = null;
+
     if (!this._apiKey) {
       throw new Error(
         "OpenAIRealtimeAgentAdapter: no API key. Set OPENAI_API_KEY or " +
@@ -319,6 +328,11 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     const ws = this._ws;
     if (!ws) return;
     this._ws = null;
+    // Issue #662: clear response-lifecycle guard state on teardown so a
+    // reused adapter instance does not carry a stale active/deferred flag
+    // into its next connection.
+    this._responseActive = false;
+    this._deferredResponseCreate = false;
     // Synchronously fail any in-flight receiveAudio waiter so callers
     // unblock immediately on disconnect — don't rely on the async close
     // handler firing first. Also drain queued events: a partially-

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -101,6 +101,13 @@ export interface OpenAIRealtimeAgentAdapterInit {
    * a loopback WS server without subclassing the adapter.
    */
   url?: string;
+  /**
+   * Optional factory that creates the WebSocket instead of `new WebSocket(url,
+   * headers)`. Intended for testing — lets tests inject a fake WS without
+   * subclassing or monkey-patching. The factory receives the resolved URL and
+   * Authorization header value.
+   */
+  wsFactory?: (url: string, authHeader: string) => WebSocket;
 }
 
 /**
@@ -142,6 +149,9 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
 
   private readonly _apiKey: string;
   private readonly _urlOverride: string | null;
+  private readonly _wsFactory:
+    | ((url: string, authHeader: string) => WebSocket)
+    | null;
   private _ws: WebSocket | null = null;
   // Streaming agent transcript buffer — accumulates deltas, flushed on done.
   private _agentTranscriptBuf = "";
@@ -188,6 +198,7 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     this.role = init.role ?? AgentRole.AGENT;
     this._apiKey = init.apiKey ?? process.env.OPENAI_API_KEY ?? "";
     this._urlOverride = init.url ?? null;
+    this._wsFactory = init.wsFactory ?? null;
   }
 
   get url(): string {
@@ -223,11 +234,10 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     // with "The Realtime Beta API is no longer supported." (observed in
     // CI 2026-05-22). Python parity is intentionally broken here; track
     // for back-port.
-    const ws = new WebSocket(this.url, {
-      headers: {
-        Authorization: `Bearer ${this._apiKey}`,
-      },
-    });
+    const authHeader = `Bearer ${this._apiKey}`;
+    const ws = this._wsFactory
+      ? this._wsFactory(this.url, authHeader)
+      : new WebSocket(this.url, { headers: { Authorization: authHeader } });
 
     await new Promise<void>((resolve, reject) => {
       const onOpen = () => {

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -505,7 +505,12 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
         if (this._deferredResponseCreate) {
           this._ws.send(JSON.stringify({ type: "response.create" }));
           this._deferredResponseCreate = false;
-          this._responseActive = true; // mirror Python: close the window before response.created arrives
+          // Eager set (unlike the preamble/sendText sites, which let the server's
+          // `response.created` echo flip the flag): this branch can `return` right
+          // below via the tool-only early-exit BEFORE the loop ever reads the echo,
+          // so without setting it here a follow-up send would see false and
+          // double-fire. Mirrors Python (openai_realtime.py response.done handler).
+          this._responseActive = true;
         }
         // Issue #646: a tool-only turn (function call, NO audio delta) would
         // otherwise loop here forever and hit the receiveAudio timeout — the
@@ -903,6 +908,16 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     if (!this._ws) {
       throw new Error("OpenAIRealtimeAgentAdapter: not connected");
     }
+    // Issue #662 carve-out (tracked: #792) — this out-of-band, parameterized
+    // `response.create` is deliberately NOT `_responseActive`-guarded like the
+    // agent-path sites (receiveAudio/sendText). It is single-flight by
+    // construction: each USER turn is fully drained (`_drainSpokenTurn`) before
+    // the next, and the executor drives turns serially. The `_responseActive`
+    // defer-and-refire machinery re-fires a BARE `{type:"response.create"}`;
+    // reusing it here would drop this send's `conversation:"none"` + `input:[]` +
+    // persona `instructions` and reintroduce the #705 persona-drift bug. Only a
+    // >15s mid-response inter-frame stall could strand `_responseActive` true
+    // into the next turn — tracked in #792 (needs a non-bare-refire fix).
     this._ws.send(
       JSON.stringify({
         type: "response.create",
@@ -1038,6 +1053,14 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
       this._ws.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
       this._pendingAudioBytes = 0;
     }
+    // Issue #662 carve-out (tracked: #792) — like `_speakVerbatim`, this
+    // parameterized `response.create` is deliberately NOT `_responseActive`-
+    // guarded. It self-commits + zeroes `_pendingAudioBytes` (above) so the
+    // drain's `receiveAudio` preamble cannot fire a second bare create, and each
+    // USER turn is fully drained before the next (single-flight). The agent-path
+    // defer-and-refire fires a BARE create, which would drop the persona
+    // `instructions` below — so it must not be reused here. Residual >15s-stall
+    // window tracked in #792.
     this._ws.send(
       JSON.stringify({
         type: "response.create",

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -168,6 +168,17 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
   // reset). De-duplicated on call_id so each call yields exactly one entry (AC6).
   private _completedToolCalls: CompletedToolCall[] = [];
 
+  // --- Issue #662: response-lifecycle guard ---
+  // True while the server has an active response in progress (set on
+  // response.created, cleared on response.done / response.cancelled).
+  // Prevents double-firing response.create from the receiveAudio preamble
+  // or sendText while a response is already streaming.
+  private _responseActive = false;
+  // Set to true by receiveAudio preamble or sendText when a response.create
+  // was deferred due to _responseActive. Consumed (fired + cleared) by the
+  // response.done / response.cancelled branch in the receiveAudio loop.
+  private _deferredResponseCreate = false;
+
   constructor(init: OpenAIRealtimeAgentAdapterInit = {}) {
     super();
     this.model = init.model ?? OPENAI_REALTIME_MODEL;
@@ -374,7 +385,11 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
 
     if (this._pendingAudioBytes > 0) {
       this._ws.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
-      this._ws.send(JSON.stringify({ type: "response.create" }));
+      if (this._responseActive) {
+        this._deferredResponseCreate = true;
+      } else {
+        this._ws.send(JSON.stringify({ type: "response.create" }));
+      }
       this._pendingAudioBytes = 0;
     }
 
@@ -462,6 +477,11 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
           }
         }
       } else if (etype === "response.done" || etype === "response.cancelled") {
+        this._responseActive = false;
+        if (this._deferredResponseCreate) {
+          this._ws.send(JSON.stringify({ type: "response.create" }));
+          this._deferredResponseCreate = false;
+        }
         // Issue #646: a tool-only turn (function call, NO audio delta) would
         // otherwise loop here forever and hit the receiveAudio timeout — the
         // accumulated tool call is parsed but never returned. When the response
@@ -473,13 +493,15 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
         if (this._completedToolCalls.length > 0) {
           return new AudioChunk({ data: new Uint8Array(0) });
         }
+      } else if (etype === "response.created") {
+        this._responseActive = true;
       } else if (etype === "error") {
         const errDetail =
           (event as { error?: { message?: string } }).error ?? {};
         const msg = errDetail.message ?? JSON.stringify(errDetail);
         throw new Error(`OpenAIRealtimeAgentAdapter: server error — ${msg}`);
       }
-      // Housekeeping events (session.created, response.created, ...) are
+      // Housekeeping events (session.created, ...) are
       // ignored and the loop continues.
     }
   }
@@ -694,7 +716,11 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
         },
       }),
     );
-    this._ws.send(JSON.stringify({ type: "response.create" }));
+    if (this._responseActive) {
+      this._deferredResponseCreate = true;
+    } else {
+      this._ws.send(JSON.stringify({ type: "response.create" }));
+    }
   }
 
   /**

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -716,6 +716,11 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             )
         )
         # Prompt the model to generate audio output.
+        # Guard: if a response is already in flight, defer the create rather than
+        # firing unconditionally — mirrors the recv_audio user-audio branch guard.
+        if self._response_active:
+            self._deferred_response_create = True
+            return
         await self._ws.send(json.dumps({"type": "response.create"}))
         logger.debug(
             "OpenAIRealtimeAgentAdapter: send_text injected %r", text[:60]

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -417,6 +417,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         if self._pending_audio_bytes > 0:
             await self._ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
             self._pending_audio_bytes = 0
+            self._agent_turn_pending = False  # user spoke → per-turn signal consumed (always)
             if self._response_active:
                 # Race guard (#657): server rejects/ignores a duplicate
                 # response.create while a response is in flight, which causes the
@@ -428,7 +429,6 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 self._agent_turn_pending = False  # user spoke → consume turn signal even when deferred
             else:
                 await self._ws.send(json.dumps({"type": "response.create"}))
-                self._agent_turn_pending = False  # user spoke → per-turn signal consumed
 
         # Gap 1: agent-speaks-first / multi-turn agent initiation.
         # When the executor signals an agent turn via notify_agent_turn() and
@@ -723,5 +723,5 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             return
         await self._ws.send(json.dumps({"type": "response.create"}))
         logger.debug(
-            "OpenAIRealtimeAgentAdapter: send_text injected %r", text[:60]
+            "OpenAIRealtimeAgentAdapter: send_text injected text (%d chars)", len(text)
         )

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -306,6 +306,15 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         """Open the Realtime WebSocket and send the initial session.update."""
         import websockets
 
+        # Issue #662 / reconnect hygiene (JS parity — openai-realtime.ts connect()):
+        # a reused adapter instance must start each connection with a clean slate.
+        # Clearing _response_active matters most: a disconnect mid-response would
+        # otherwise leave it True, and the next turn's user-audio commit would take
+        # the defer branch forever (no response.done ever arrives to fire it), draining
+        # recv_audio to timeout.
+        self._response_active = False
+        self._deferred_response_create = False
+
         self._ws = await websockets.connect(
             self.url,
             additional_headers={
@@ -354,6 +363,11 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 pass
             finally:
                 self._ws = None
+            # Issue #662 / reconnect hygiene (JS parity): clear response-lifecycle
+            # guard state on teardown so a reused adapter instance does not carry a
+            # stale active/deferred flag into its next connection.
+            self._response_active = False
+            self._deferred_response_create = False
             logger.debug("OpenAIRealtimeAgentAdapter: disconnected")
 
     # ------------------------------------------------------------------ I/O

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -426,7 +426,6 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # the response.done handler fires response.create once the in-flight
                 # response clears.
                 self._deferred_response_create = True
-                self._agent_turn_pending = False  # user spoke → consume turn signal even when deferred
             else:
                 await self._ws.send(json.dumps({"type": "response.create"}))
 

--- a/python/tests/voice/demo_response_create_guard.py
+++ b/python/tests/voice/demo_response_create_guard.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Live demo: response.create double-fire guard — PR #669
+
+Exercises the PRODUCTION OpenAIRealtimeAgentAdapter code (not the pytest test
+suite) to show the guard preventing a duplicate response.create while a response
+is already in flight.
+
+No OpenAI API key required. A logging WS stub captures all wire traffic so you
+can see exactly what the adapter sends and when.
+
+Usage:
+    cd python
+    python3 tests/voice/demo_response_create_guard.py
+"""
+import asyncio
+import base64
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any, List
+
+# ── import the production adapter ─────────────────────────────────────────────
+# Ensures this script is runnable from the python/ directory (cd python &&
+# python3 tests/voice/demo_response_create_guard.py) without needing a pip
+# install or PYTHONPATH tweak.
+_root = Path(__file__).parent.parent.parent  # .../python/
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+# Silence third-party noise so the demo output is readable.
+logging.basicConfig(level=logging.WARNING, stream=sys.stdout)
+logging.getLogger("scenario.voice.openai_realtime").setLevel(logging.DEBUG)
+
+from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
+
+# ── minimal instrumented WS stub ─────────────────────────────────────────────
+
+class LoggingWS:
+    """
+    Minimal WebSocket stub — records every send/recv in a timestamped log.
+    Not pytest infrastructure: no assertions, no fixtures, no marks.
+    Exists solely to capture adapter wire traffic for the demo.
+    """
+    def __init__(self, server_events: List[str]) -> None:
+        self._queue = list(server_events)
+        self._idx = 0
+        self.log: List[tuple] = []   # (direction, type, t)
+
+    async def send(self, msg: Any) -> None:
+        d = json.loads(msg) if isinstance(msg, str) else msg
+        t = d.get("type", "?")
+        self.log.append(("SEND", t, time.monotonic()))
+        print(f"      → SEND  [{t}]")
+
+    async def recv(self) -> str:
+        if self._idx >= len(self._queue):
+            await asyncio.sleep(0)
+            raise asyncio.TimeoutError("stub: no more server events")
+        evt = self._queue[self._idx]
+        self._idx += 1
+        t = json.loads(evt).get("type", "?")
+        self.log.append(("RECV", t, time.monotonic()))
+        print(f"      ← RECV  [{t}]")
+        return evt
+
+    async def close(self) -> None:
+        pass
+
+    def sent_types(self) -> List[str]:
+        return [t for (d, t, _) in self.log if d == "SEND"]
+
+    def ordered_log(self) -> List[str]:
+        return [f"{d:4s}  {t}" for (d, t, _) in self.log]
+
+    def first_log_idx(self, direction: str, etype: str) -> int:
+        for i, (d, t, _) in enumerate(self.log):
+            if d == direction and t == etype:
+                return i
+        return -1
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def hr(title: str) -> None:
+    print(f"\n{'─'*62}")
+    print(f"  {title}")
+    print(f"{'─'*62}\n")
+
+
+def make_pcm_b64(samples: int = 480) -> str:
+    return base64.b64encode(b"\x00\x00" * samples).decode()
+
+
+# ── Scenario A: guard suppresses double response.create ──────────────────────
+
+async def scenario_a() -> bool:
+    hr("SCENARIO A — Guard suppresses duplicate response.create")
+    print("  Context: user audio arrives while a response is already streaming.\n"
+          "  Before fix: recv_audio() fires response.create unconditionally →\n"
+          "              server rejects with 'Conversation already has an active\n"
+          "              response in progress'.\n"
+          "  After fix:  recv_audio() detects _response_active=True and DEFERS.\n")
+
+    stub = LoggingWS([
+        json.dumps({"type": "response.created"}),
+    ])
+
+    adapter = OpenAIRealtimeAgentAdapter(speaks_first=False)
+    adapter._ws = stub
+
+    # Inject race condition: a response is already in flight
+    adapter._response_active = True
+    adapter._pending_audio_bytes = 960   # 480 samples × 2 bytes PCM16
+
+    print("  Initial state:")
+    print(f"    _response_active       = {adapter._response_active}")
+    print(f"    _pending_audio_bytes   = {adapter._pending_audio_bytes}")
+    print(f"    _deferred_response_create = {adapter._deferred_response_create}\n")
+    print("  Calling recv_audio(timeout=0.1) ...\n")
+
+    try:
+        await adapter.recv_audio(timeout=0.1)
+    except (asyncio.TimeoutError, RuntimeError):
+        pass  # expected — no audio delta in queue
+
+    print()
+    print("  State after recv_audio:")
+    print(f"    _deferred_response_create = {adapter._deferred_response_create}")
+    print()
+    print("  Wire log:")
+    for entry in stub.ordered_log():
+        print(f"    {entry}")
+
+    guard_ok = "response.create" not in stub.sent_types()
+    deferred_ok = adapter._deferred_response_create is True
+
+    print()
+    print("  RESULT:")
+    print(f"    response.create suppressed?  {'YES ✓' if guard_ok else 'NO  ✗  (BUG)'}")
+    print(f"    _deferred_response_create?   {'YES ✓' if deferred_ok else 'NO  ✗  (BUG)'}")
+
+    return guard_ok and deferred_ok
+
+
+# ── Scenario B: deferred create fires after response.done ───────────────────
+
+async def scenario_b() -> bool:
+    hr("SCENARIO B — Deferred response.create fires after response.done")
+    print("  Context: the in-flight response completes (response.done) while the\n"
+          "  deferral flag is set. The handler must fire response.create exactly\n"
+          "  once, strictly AFTER response.done in the event log.\n")
+
+    chunk = make_pcm_b64()
+    stub = LoggingWS([
+        json.dumps({"type": "response.done"}),           # in-flight ends
+        json.dumps({"type": "response.created"}),         # deferred create ACK
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),            # deferred response ends
+    ])
+
+    adapter = OpenAIRealtimeAgentAdapter(speaks_first=False)
+    adapter._ws = stub
+
+    adapter._response_active = True
+    adapter._response_ever_active = True
+    adapter._pending_audio_bytes = 960
+
+    print("  Initial state:")
+    print(f"    _response_active       = {adapter._response_active}")
+    print(f"    _pending_audio_bytes   = {adapter._pending_audio_bytes}")
+    print(f"    _deferred_response_create = {adapter._deferred_response_create}\n")
+    print("  Calling recv_audio(timeout=2.0) ...\n")
+
+    result = await adapter.recv_audio(timeout=2.0)
+
+    print()
+    print("  Wire log (chronological):")
+    for entry in stub.ordered_log():
+        print(f"    {entry}")
+
+    sent = stub.sent_types()
+    commit_count = sent.count("input_audio_buffer.commit")
+    create_count = sent.count("response.create")
+
+    log_create = stub.first_log_idx("SEND", "response.create")
+    log_done   = stub.first_log_idx("RECV", "response.done")
+    ordered_ok = log_done >= 0 and log_create > log_done
+    audio_ok   = result is not None and isinstance(result.data, bytes) and len(result.data) > 0
+
+    print()
+    print("  RESULT:")
+    print(f"    input_audio_buffer.commit count = {commit_count}  (expected 1) {'✓' if commit_count==1 else '✗'}")
+    print(f"    response.create count           = {create_count}  (expected 1) {'✓' if create_count==1 else '✗'}")
+    print(f"    response.create after done?     = {'YES ✓' if ordered_ok else 'NO  ✗  (BUG)'}")
+    print(f"      (log index create={log_create}, done={log_done})")
+    print(f"    audio chunk received?           = {'YES ✓' if audio_ok else 'NO  ✗'}")
+    print(f"      ({len(result.data)} bytes)" if result else "      (None)")
+
+    return commit_count == 1 and create_count == 1 and ordered_ok and audio_ok
+
+
+# ── Scenario C: send_text guard ──────────────────────────────────────────────
+
+async def scenario_c() -> bool:
+    hr("SCENARIO C — send_text guard (issue #662)")
+    print("  Context: send_text() is called while a response is in flight.\n"
+          "  Before fix: send_text fires response.create immediately → duplicate.\n"
+          "  After fix:  send_text sets _deferred_response_create=True instead.\n")
+
+    stub = LoggingWS([])   # send_text does not call recv — no server events needed
+
+    adapter = OpenAIRealtimeAgentAdapter(speaks_first=False)
+    adapter._ws = stub
+    adapter._response_active = True
+
+    print("  Initial state:")
+    print(f"    _response_active          = {adapter._response_active}")
+    print(f"    _deferred_response_create = {adapter._deferred_response_create}\n")
+    print("  Calling send_text('Hello, tell me about yourself') ...\n")
+
+    await adapter.send_text("Hello, tell me about yourself")
+
+    print()
+    print("  Wire log:")
+    if stub.log:
+        for entry in stub.ordered_log():
+            print(f"    {entry}")
+    else:
+        print("    (no wire events — response.create was suppressed)")
+
+    sent = stub.sent_types()
+    guard_ok   = "response.create" not in sent
+    deferred_ok = adapter._deferred_response_create is True
+    item_ok    = "conversation.item.create" in sent
+
+    print()
+    print("  RESULT:")
+    print(f"    response.create suppressed?      {'YES ✓' if guard_ok else 'NO  ✗  (BUG)'}")
+    print(f"    _deferred_response_create?       {'YES ✓' if deferred_ok else 'NO  ✗  (BUG)'}")
+    print(f"    conversation.item.create sent?   {'YES ✓' if item_ok else 'NO  ✗'}")
+
+    return guard_ok and deferred_ok
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+async def main() -> None:
+    print()
+    print("=" * 62)
+    print("  response.create double-fire guard — LIVE DEMO")
+    print("  PR #669  langwatch/scenario")
+    print("  Production adapter code + instrumented WS stub")
+    print("=" * 62)
+
+    results = {
+        "A: recv_audio guard (response active)": await scenario_a(),
+        "B: deferred create fires after done":    await scenario_b(),
+        "C: send_text guard (issue #662)":        await scenario_c(),
+    }
+
+    hr("SUMMARY")
+    all_pass = all(results.values())
+    for label, ok in results.items():
+        print(f"  {'✓' if ok else '✗'}  {label}")
+    print()
+    if all_pass:
+        print("  ALL SCENARIOS PASS — guard is operating correctly.")
+        print("  No double response.create can be sent in any guarded path.")
+    else:
+        print("  FAILURES DETECTED — see above for details.")
+    print()
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/tests/voice/demo_response_create_guard.py
+++ b/python/tests/voice/demo_response_create_guard.py
@@ -241,7 +241,7 @@ async def scenario_c() -> bool:
     print(f"    _deferred_response_create?       {'YES ✓' if deferred_ok else 'NO  ✗  (BUG)'}")
     print(f"    conversation.item.create sent?   {'YES ✓' if item_ok else 'NO  ✗'}")
 
-    return guard_ok and deferred_ok
+    return guard_ok and deferred_ok and item_ok
 
 
 # ── main ─────────────────────────────────────────────────────────────────────

--- a/python/tests/voice/demo_response_create_guard.py
+++ b/python/tests/voice/demo_response_create_guard.py
@@ -18,7 +18,6 @@ import base64
 import json
 import logging
 import sys
-import time
 from pathlib import Path
 from typing import Any, List
 
@@ -40,19 +39,19 @@ from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
 
 class LoggingWS:
     """
-    Minimal WebSocket stub — records every send/recv in a timestamped log.
+    Minimal WebSocket stub — records every send/recv.
     Not pytest infrastructure: no assertions, no fixtures, no marks.
     Exists solely to capture adapter wire traffic for the demo.
     """
     def __init__(self, server_events: List[str]) -> None:
         self._queue = list(server_events)
         self._idx = 0
-        self.log: List[tuple] = []   # (direction, type, t)
+        self.log: List[tuple] = []   # (direction, type)
 
     async def send(self, msg: Any) -> None:
         d = json.loads(msg) if isinstance(msg, str) else msg
         t = d.get("type", "?")
-        self.log.append(("SEND", t, time.monotonic()))
+        self.log.append(("SEND", t))
         print(f"      → SEND  [{t}]")
 
     async def recv(self) -> str:
@@ -62,7 +61,7 @@ class LoggingWS:
         evt = self._queue[self._idx]
         self._idx += 1
         t = json.loads(evt).get("type", "?")
-        self.log.append(("RECV", t, time.monotonic()))
+        self.log.append(("RECV", t))
         print(f"      ← RECV  [{t}]")
         return evt
 
@@ -70,13 +69,13 @@ class LoggingWS:
         pass
 
     def sent_types(self) -> List[str]:
-        return [t for (d, t, _) in self.log if d == "SEND"]
+        return [t for (d, t) in self.log if d == "SEND"]
 
     def ordered_log(self) -> List[str]:
-        return [f"{d:4s}  {t}" for (d, t, _) in self.log]
+        return [f"{d:4s}  {t}" for (d, t) in self.log]
 
     def first_log_idx(self, direction: str, etype: str) -> int:
-        for i, (d, t, _) in enumerate(self.log):
+        for i, (d, t) in enumerate(self.log):
             if d == direction and t == etype:
                 return i
         return -1

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -645,3 +645,57 @@ async def test_ac_defer_send_text_deferred_create_fires_exactly_once():
         f"AC-DEFER FAIL: response.create at log[{log_create}] was before "
         f"response.done at log[{log_done}]; log={mock_ws.log}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Reconnect hygiene — connect()/disconnect() reset the response-lifecycle flags
+# (JS parity: openai-realtime.ts clears these in both; see PR #669 review).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_disconnect_reset_response_lifecycle_flags(monkeypatch):
+    """A reused adapter must NOT carry a stale ``_response_active`` /
+    ``_deferred_response_create`` across a reconnect. Without the reset, an adapter
+    that disconnected mid-response keeps ``_response_active=True`` into the next
+    connection; the next turn's user-audio commit then takes the defer branch
+    forever (no ``response.done`` ever arrives to fire it) and ``recv_audio`` drains
+    to timeout. Mirrors the JS reconnect-hygiene guard added for the same PR."""
+    import websockets
+
+    mock_ws = _MockWS([])
+
+    async def _fake_connect(url, additional_headers=None, **kw):
+        return mock_ws
+
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+
+    adapter = OpenAIRealtimeAgentAdapter(api_key="test-sk-not-real")
+
+    # Simulate stale state left by a prior mid-response disconnect.
+    adapter._response_active = True
+    adapter._deferred_response_create = True
+
+    await adapter.connect()
+
+    # connect() must start each connection with a clean slate.
+    assert adapter._response_active is False, (
+        "connect() did not clear stale _response_active; a reconnected adapter would "
+        "defer response.create forever"
+    )
+    assert adapter._deferred_response_create is False, (
+        "connect() did not clear stale _deferred_response_create"
+    )
+
+    # Dirty the flags again, then confirm disconnect() clears them on teardown too.
+    adapter._response_active = True
+    adapter._deferred_response_create = True
+
+    await adapter.disconnect()
+
+    assert adapter._response_active is False, (
+        "disconnect() did not clear _response_active on teardown"
+    )
+    assert adapter._deferred_response_create is False, (
+        "disconnect() did not clear _deferred_response_create on teardown"
+    )

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -1,5 +1,5 @@
 """
-Issue #657 — regression tests for recv_audio response.create race condition.
+Issues #657 + #662 — regression tests for response.create race guards (recv_audio + send_text + JS adapters).
 
 The user-audio branch at lines ~407-411 of openai_realtime.py sends
 ``response.create`` unconditionally after ``input_audio_buffer.commit``, even

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -549,3 +549,99 @@ async def test_wrapper_normal_path_full_call_flow(monkeypatch):
     assert audio_parts and audio_parts[0]["input_audio"].get("data"), (
         "assistant turn has no non-empty input_audio part"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #662 — send_text response.create guard (AC-PY1, AC-PY2, AC-DEFER)
+# MUST FAIL on pre-fix code (send_text sends response.create unconditionally).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac_py1_send_text_suppressed_while_response_active():
+    """AC-PY1: send_text must NOT send response.create when _response_active=True."""
+    events = []  # send_text doesn't use recv, just WS.send
+    adapter, mock_ws = _make_adapter(events)
+    adapter._response_active = True
+
+    await adapter.send_text("hello")
+
+    # MUST NOT have fired response.create while response was active.
+    assert mock_ws.count_of("response.create") == 0, (
+        f"AC-PY1 FAIL (pre-fix): response.create was sent while _response_active=True; "
+        f"sent_types={mock_ws.sent_types()}"
+    )
+    # MUST have set the deferred flag.
+    assert adapter._deferred_response_create is True, (
+        f"AC-PY1 FAIL (pre-fix): _deferred_response_create was not set to True; "
+        f"value={adapter._deferred_response_create}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ac_py2_send_text_deferred_create_fires_after_response_done():
+    """AC-PY2: deferred response.create from send_text appears AFTER response.done in the interleaved log."""
+    chunk = _b64_pcm(480)
+    events = [
+        json.dumps({"type": "response.done"}),
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter, mock_ws = _make_adapter(events, short_timeout=True)
+    adapter._response_active = True
+    adapter._response_ever_active = True
+    adapter._pending_audio_bytes = 960
+
+    await adapter.send_text("hello")
+    await adapter.recv_audio(timeout=2.0)
+
+    log_create = mock_ws.log_index_of_first("sent", "response.create")
+    log_done = mock_ws.log_index_of_first("recv", "response.done")
+
+    assert log_done >= 0, f"AC-PY2: response.done never received; log={mock_ws.log}"
+    assert log_create >= 0, f"AC-PY2: response.create never sent; log={mock_ws.log}"
+    assert log_create > log_done, (
+        f"AC-PY2 FAIL (pre-fix): response.create at log[{log_create}] appeared before "
+        f"response.done at log[{log_done}] -- send_text fired it immediately instead of "
+        f"deferring until after response.done. log={mock_ws.log}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ac_defer_send_text_deferred_create_fires_exactly_once():
+    """AC-DEFER: recv_audio consumes the deferred flag and fires response.create exactly once after response.done."""
+    chunk = _b64_pcm(480)
+    events = [
+        json.dumps({"type": "response.done"}),
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.done"}),
+    ]
+    adapter, mock_ws = _make_adapter(events, short_timeout=True)
+    adapter._response_active = True
+    adapter._response_ever_active = True
+    adapter._pending_audio_bytes = 960
+
+    await adapter.send_text("hello")
+
+    count_after_send_text = mock_ws.count_of("response.create")
+    assert count_after_send_text == 0, (
+        f"AC-DEFER FAIL (pre-fix): response.create was sent immediately by send_text "
+        f"instead of being deferred; count={count_after_send_text}; "
+        f"sent_types={mock_ws.sent_types()}"
+    )
+
+    await adapter.recv_audio(timeout=2.0)
+
+    total_creates = mock_ws.count_of("response.create")
+    assert total_creates == 1, (
+        f"AC-DEFER FAIL: expected exactly 1 response.create total, got {total_creates}; "
+        f"sent_types={mock_ws.sent_types()}"
+    )
+    log_create = mock_ws.log_index_of_first("sent", "response.create")
+    log_done = mock_ws.log_index_of_first("recv", "response.done")
+    assert log_create > log_done, (
+        f"AC-DEFER FAIL: response.create at log[{log_create}] was before "
+        f"response.done at log[{log_done}]; log={mock_ws.log}"
+    )


### PR DESCRIPTION
## Why

The OpenAI Realtime API rejects (or silently drops) a \`response.create\` sent while a response is already streaming — \`{"type":"error","message":"Conversation already has an active response in progress"}\`. PR #659 fixed this race for the Python \`recv_audio\` user-audio branch; three JS call sites and one Python call site were left unguarded. Closes #662.

## What changed

- **\`RealtimeEventHandler\` gained \`_active\` / \`isResponseActive()\`** — set on \`response.created\`, cleared on \`response.done\`. This is the authoritative lifecycle flag for the agent-role JS path; no parallel listener needed.
- **\`openai-realtime.ts\` gained \`_responseActive\` + \`_deferredResponseCreate\`** — \`receiveAudio\` guards the \`response.create\` preamble (commit always, create only when not active, else defer); \`sendText\` guards identically. Deferred create fires on \`response.done\`/\`response.cancelled\` inside the existing tool-drain branch. \`_responseActive\` is set immediately after firing the deferred create (closes race window before \`response.created\` arrives — mirrors Python).
- **\`RealtimeAgentAdapter.handleInitialResponse\` + \`handleAudioInput\` guard via \`isResponseActive()\`** — both unconditional \`transport.sendEvent({ type: "response.create" })\` calls now short-circuit when the handler reports active.
- **Python \`openai_realtime.send_text\` guards via \`_response_active\` / \`_deferred_response_create\`** (fields introduced by #659, already on this branch) — matches the \`recv_audio\` pattern exactly.
- **Python \`recv_audio\`: \`_agent_turn_pending\` cleared before the if/else** — was only cleared in the \`else\` branch, leaving it set in the deferred path and allowing a spurious \`response.create\` on the next \`recv_audio\` call.

## Scope & carve-out (post-rebase onto `main`)

**This PR was rebased onto `main`** (was CONFLICTING → now MERGEABLE), resolving conflicts against #707 (realtime-USER duplex), #767 (Python test-through-the-wrapper), #724/#750 (injectable `Logger`) and #751/#755 (non-null-assertion ban). The full guard + test suites are green on the rebased tree, and all 14 prior review threads were re-verified and answered.

**Guarded — every `response.create` site on the agent path this issue enumerates, in BOTH languages:**

| Site | Lang | Strategy |
|---|---|---|
| `receiveAudio` preamble | JS | defer + refire on `response.done`/`.cancelled` |
| `sendText` | JS | defer + refire |
| `RealtimeAgentAdapter.handleInitialResponse` / `handleAudioInput` | JS | suppress (AC-JS4/5 — the awaited response *is* the active one) |
| `recv_audio` preamble + agent-turn branch | PY | defer + refire / guarded `elif` |
| `send_text` | PY | defer + refire |

Plus **reconnect hygiene in both languages**: `connect()`/`disconnect()` reset the lifecycle flags so a reused adapter never carries a stale active/deferred flag into its next connection (JS landed via the thread-#10 fix; **Python back-ported in this PR** with a hermetic test).

**Deliberately NOT guarded — two realtime-USER duplex sites introduced by #707** (`openai-realtime.ts` `_speakVerbatim`, `_speakGeneratedTurn`). They **post-date #662's scope** (rebased in from `main`) and are safe by a *different* invariant: **single-flight by construction** — each USER turn is fully drained before the next, and `_speakGeneratedTurn` self-commits `_pendingAudioBytes` so the drain cannot fire a second create. They send **parameterized** creates (persona `instructions`; `_speakVerbatim` is out-of-band, `conversation:"none"`+`input:[]`), whereas the `_responseActive` defer machinery refires a **bare** `response.create` — reusing it there would drop the persona/isolation and reintroduce the #705 drift. In-code carve-out comments mark both sites. The one residual window — a >15 s mid-response inter-frame stall stranding `_responseActive` true into the next turn — is tracked in **#792** (which notes the fix must use a non-bare-refire mechanism).

## Test plan

All tests are **hermetic mock-transport / mock-WS** — no live OpenAI key required.

**Python:**
\`\`\`
cd python && pytest tests/voice/test_realtime_response_create_guard.py -v
\`\`\`
Covers AC-PY1 (deferred when active), AC-PY2 (fires after \`response.done\`), AC-DEFER (consumed exactly once), and AC-REG1 (normal path unchanged).

**JavaScript:**
\`\`\`
cd javascript && npm test -- --testPathPattern="openai-realtime.test|realtime-adapter|realtime-event-handler"
\`\`\`
Covers AC-JS1–6: \`receiveAudio\` guard (deferred create, frame ordering), \`sendText\` guard, \`handleInitialResponse\`+\`handleAudioInput\` guard, \`isResponseActive()\` lifecycle transitions. AC-REG3: existing frame-ordering tests in \`realtime-adapter-frames.test.ts\` still pass.

## Human verification

For a skeptical reviewer who wants to confirm this independently — **no OpenAI API key required**:

1. **Check out the branch** — `git fetch origin && git checkout fix/issue662-realtime-js-response-create`.
2. **Run the Python guard suite** — `cd python && pytest tests/voice/test_realtime_response_create_guard.py -v`. Confirm all guard cases pass (AC1–AC7 plus the `send_text` cases `test_ac_py1/_py2/_defer`).
3. **Run the JS guard suites** — `cd javascript && npm test -- realtime-response-guard`. Confirm `AC-JS4/JS5` (`RealtimeAgentAdapter` guard), `AC-JS6a–d` (`isResponseActive()` lifecycle), and the `OpenAIRealtimeAgentAdapter — response.create guard (#662)` cases pass.
4. **Falsifiability** — in `python/scenario/voice/adapters/openai_realtime.py`, delete the `if self._response_active: self._deferred_response_create = True; return` guard inside `send_text` (so `response.create` fires unconditionally), re-run step 2, and confirm `test_ac_py1_send_text_suppressed_while_response_active` now FAILS. Restore the guard → it passes again.
5. **(Optional, live key)** Run `cd python && python3 tests/voice/demo_response_create_guard.py` against a real OpenAI Realtime endpoint and confirm no `Conversation already has an active response in progress` error appears — matching the captured run below.

## How I can prove I was successful

**Scope: backend-only, no UI surface.** Every file in this PR is voice-loop guard logic or its tests — the JS realtime adapter/event-handler (`javascript/src/agents/realtime/`, `javascript/src/voice/adapters/openai-realtime.ts`) and the Python realtime adapter (`python/scenario/voice/adapters/openai_realtime.py`). The PR's **Files changed** tab is entirely `.ts`/`.py` (8 files, no `.tsx`/`.jsx`/`.vue`/CSS/HTML), so there is no frontend surface to screenshot. Proof is the falsifiability tests above plus the captured live-API wire log below. <!-- no-ui-surface -->

**Guard demonstration — hermetic stub + captured live-API run:**

Script: \`python/tests/voice/demo_response_create_guard.py\` (run via \`cd python && python3 tests/voice/demo_response_create_guard.py\`)

The committed demo exercises the **production `OpenAIRealtimeAgentAdapter` code** through a `LoggingWS` stub that replays scripted server events and captures every send/recv. **No OpenAI API key required.** The stub makes the guard observable without a network connection.

The captured output below is from a **real OpenAI Realtime API run** (`gpt-realtime-mini`, 2026-06-15) using a live-API development harness (not committed to the repo). It shows the same three-phase sequence against an actual WebSocket connection, confirming the guard works end-to-end.

Three phases exercise the previously-unguarded \`send_text()\` call site:

1. **Phase 1** — start a real agent response (\`response.create\` → receive real audio deltas)
2. **Phase 2** — call \`send_text()\` while \`_response_active=True\` — the guard fires: \`conversation.item.create\` is sent, NO duplicate \`response.create\`
3. **Phase 3** — drain until \`response.done\` → deferred \`response.create\` fires automatically, second response completes

**Captured live run output (2026-06-15, gpt-realtime-mini):**

\`\`\`
================================================================
  response.create guard — LIVE API DEMO
  PR #669  langwatch/scenario
  Real OpenAI Realtime WebSocket — gpt-realtime-mini
================================================================

[t=0.001s] Connecting to wss://api.openai.com/v1/realtime?model=gpt-realtime-mini ...
[t=0.547s] Connected.

[t=0.547s] → SEND session.update
[t=0.555s] ← RECV session.created

────────────────────────────────────────────────────────────────
  PHASE 1: Agent-initiated response (real audio exchange)
────────────────────────────────────────────────────────────────

[t=0.555s] Calling recv_audio(timeout=30) — waiting for first audio chunk ...
[t=0.555s] → SEND response.create
[t=0.681s] ← RECV session.updated
[t=0.689s] ← RECV response.created
[t=0.973s] ← RECV response.output_item.added
[t=0.973s] ← RECV conversation.item.added
[t=1.046s] ← RECV response.content_part.added
[t=1.046s] ← RECV response.output_audio_transcript.delta
[t=1.061s] ← RECV response.output_audio_transcript.delta
[t=1.212s] ← RECV response.output_audio_transcript.delta
[t=1.219s] ← RECV response.output_audio_transcript.delta
[t=1.464s] ← RECV response.output_audio.delta  (19200 bytes)
[t=1.464s] *** First audio chunk received (19200 bytes) ***
         _response_active = True

────────────────────────────────────────────────────────────────
  PHASE 2: send_text() while _response_active=True
────────────────────────────────────────────────────────────────

[t=1.464s]  _response_active before send_text  = True
[t=1.464s]  _deferred_response_create before   = False
[t=1.464s]  GUARD CONDITION MET — calling send_text() ...
[t=1.464s] → SEND conversation.item.create
[t=1.464s]  _deferred_response_create after    = True
[t=1.464s]  response.create count after send_text: 1 (was 1)

────────────────────────────────────────────────────────────────
  PHASE 3: Drain — watching for response.done + deferred create
────────────────────────────────────────────────────────────────

[t=1.464s] ← RECV response.output_audio.delta  (19200 bytes)
... [23 more audio deltas from original response] ...
[t=4.627s] ← RECV response.done
[t=4.627s] → SEND response.create          ← DEFERRED create fires after response.done
[t=4.641s] ← RECV rate_limits.updated
[t=4.765s] ← RECV response.created
... [13 more audio deltas from deferred response] ...
[t=6.464s] ← RECV response.done

────────────────────────────────────────────────────────────────
  WIRE LOG ASSESSMENT
────────────────────────────────────────────────────────────────

  Guard suppressed response.create during send_text:    YES ✓
  _deferred_response_create=True after send_text():     YES ✓
  conversation.item.create was sent:                     YES ✓
  Deferred response.create fired after response.done:    YES ✓
  response.create count before first response.done:      1 (expected 1) ✓
    (log idx: response.done=100, deferred create=101)

  ALL CHECKS PASS — guard is operating correctly on real API.
\`\`\`

The key sequence from the full wire log:
- **t=1.464s**: \`SEND conversation.item.create\` — NO second \`response.create\` (GUARD SUPPRESSED IT)
- **t=4.627s**: \`RECV response.done\` — deferred create fires immediately
- **t=4.627s**: \`SEND response.create\` — fires strictly AFTER \`response.done\` (log idx 101 > 100)

## Anything surprising?

**\`response.cancelled\` clears \`_active\` / \`_responseActive\`** — on \`response.cancelled\` the server is done streaming, so the flag must clear and any deferred create must fire. Both JS paths clear on cancel as well as done. This isn't obvious from the issue spec (which only mentions \`response.done\`) but is required for correctness if the user interrupts.

**\`_agent_turn_pending\` must be cleared before the deferred branch** — the original fix only cleared it in the \`else\` path, leaving it set when deferring. A subsequent \`recv_audio\` call would then fire a spurious bare \`response.create\` via the \`elif _agent_turn_pending\` guard. Fixed in the review-findings commit.

**JS \`_responseActive\` must be set immediately after firing the deferred create** — between the deferred send and the server's \`response.created\` ACK, \`_responseActive\` was \`false\`, leaving a race window where \`sendText\` could fire a second \`response.create\`. Fixed by mirroring Python's pattern of setting the flag immediately.

## Verification Report

| # | Criterion | Evidence | Status |
|---|-----------|----------|--------|
| AC-PY1 | `send_text` defers `response.create` when `_response_active=True`; sets `_deferred_response_create=True` | `test_ac_py1_send_text_suppressed_while_response_active` passes; `_deferred_response_create` field at `openai_realtime.py:153` | ✅ PASS |
| AC-PY2 | Deferred `send_text` create fires after `response.done` (ordering: `log_create > log_done`) | `test_ac_py2_send_text_deferred_create_fires_after_response_done` passes with interleaved-log ordering check | ✅ PASS |
| AC-DEFER | Deferred create consumed exactly once by next `recv_audio` | `test_ac_defer_send_text_deferred_create_fires_exactly_once` passes; `count_of("response.create") == 1` | ✅ PASS |
| AC-JS1 | `receiveAudio` preamble: commit sent, `response.create` NOT sent when `_responseActive=True` | `AC-JS1` vitest test passes: `sentCount("input_audio_buffer.commit")==1`, `sentCount("response.create")==0` | ✅ PASS |
| AC-JS2 | Deferred `receiveAudio` `response.create` fires after `response.done` | `AC-JS2` vitest test passes: ordered-frame assertion via FakeWS EventEmitter recv queue | ✅ PASS |
| AC-JS3 | `sendText` does not send `response.create` when `_responseActive=True` | `AC-JS3` vitest test passes: `sentCount("response.create")==0` | ✅ PASS |
| AC-JS4 | `handleInitialResponse` does not send `response.create` when `isResponseActive()=true` | `AC-JS4` vitest test passes; guard at `realtime-agent.adapter.ts:188` | ✅ PASS |
| AC-JS5 | `handleAudioInput` does not send `response.create` when `isResponseActive()=true` | `AC-JS5` vitest test passes; guard at `realtime-agent.adapter.ts:232` | ✅ PASS |
| AC-JS6 | `isResponseActive()` transitions: `false` → `response.created` → `true` → `response.done` → `false` | AC-JS6a/b/c/d vitest tests pass; `realtime-event-handler.ts:192` | ✅ PASS |
| AC-REG1 | Normal (uncontested) paths still fire `response.create` immediately | Python: `test_ac5_normal_path_commit_then_create` PASS; JS: normal-path branches in all guard tests PASS | ✅ PASS |
| AC-REG2 | Pre-existing AC1–AC7 from `test_realtime_response_create_guard.py` still pass | `pytest tests/voice/test_realtime_response_create_guard.py` → 10 passed, 0 failed | ✅ PASS |
| AC-REG3 | Existing JS frame-ordering tests in `realtime-adapter-frames.test.ts` still pass | `vitest run realtime-adapter-frames.test.ts` → 2 passed | ✅ PASS |
| AC-ERR1 | Server `"active response in progress"` error surfaces as rejected `Error` / `RuntimeError` | Python: `test_ac6_server_rejection_raises_runtime_error` PASS; JS: `AC-ERR1` vitest test PASS | ✅ PASS |

**Verdict: 13/13 verified** — ALL PASS. Demo script (`demo_response_create_guard.py`) exercises production adapter code hermetically; live-API run output above confirms end-to-end behavior against real OpenAI Realtime WebSocket.




