### PR TITLE
feat(voice): realtime_langwatch_session context manager for live OpenAI Realtime apps (#673)

### DIFF
--- a/docs/docs/pages/voice/happy-path-openai-realtime.mdx
+++ b/docs/docs/pages/voice/happy-path-openai-realtime.mdx
@@ -219,6 +219,54 @@ This is the thing you can't do with a hosted agent — you're configuring the ag
 
 ---
 
+## Getting LangWatch traces from your live app
+
+Scenario tests give you rich LangWatch traces automatically — each `scenario.run()` call sets up the OTLP exporter and emits per-turn spans. Your **live / production** app gets nothing by default; the test scaffolding stays in the test runner.
+
+Use `realtime_langwatch_session` to wrap your production Realtime session in the same span shape:
+
+```python
+import os
+import asyncio
+import websockets
+from scenario import realtime_langwatch_session
+
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+LANGWATCH_API_KEY = os.environ["LANGWATCH_API_KEY"]
+
+async def run_realtime_session():
+    async with realtime_langwatch_session(
+        name="my-production-session",
+        model="gpt-4o-realtime-preview",
+        api_key=LANGWATCH_API_KEY,
+    ) as session:
+        # Open your raw Realtime WebSocket here.
+        # After each agent turn, call session.log_turn() with the
+        # transcripts you receive from the Realtime event stream.
+        async with websockets.connect(
+            "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview",
+            additional_headers={"Authorization": f"Bearer {OPENAI_API_KEY}"},
+        ) as ws:
+            # ... send/receive events as normal ...
+            # When the agent finishes a turn:
+            await session.log_turn(
+                user_transcript="I want to cancel my subscription",
+                agent_transcript="Of course, I can help with that.",
+                model="gpt-4o-realtime-preview",
+                latency_ms=430,
+            )
+
+asyncio.run(run_realtime_session())
+```
+
+**What `log_turn` records**: a child LLM span with `input` (user transcript), `output` (agent transcript), `model`, and `latency_ms` — the same fields LangWatch renders in the trace explorer. Traces land at your LangWatch project and are queryable alongside your scenario-test traces.
+
+**When `LANGWATCH_API_KEY` is absent** the context manager is a no-op — no error, no side effects. Safe to ship in environments without a key set.
+
+**If you already call `langwatch.setup()` in your app** (e.g. to instrument other LLM calls), `realtime_langwatch_session` detects the existing provider and attaches to it — no duplicate initialization.
+
+---
+
 ## Next
 
 - **ElevenLabs (hosted provider)** happy path: [/voice/happy-path-elevenlabs](/voice/happy-path-elevenlabs)

--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -107,6 +107,7 @@ from .config import ScenarioConfig
 
 # Tracing public API
 from ._tracing import setup_scenario_tracing, scenario_only, with_custom_scopes
+from ._tracing.live import RealtimeLangWatchSession as realtime_langwatch_session
 
 # Then import modules with dependencies
 from .scenario_executor import run, arun
@@ -222,6 +223,7 @@ __all__ = [
     "setup_scenario_tracing",
     "scenario_only",
     "with_custom_scopes",
+    "realtime_langwatch_session",
     # Types
     "ScenarioResult",
     "AgentInput",

--- a/python/scenario/_tracing/live.py
+++ b/python/scenario/_tracing/live.py
@@ -132,7 +132,6 @@ class RealtimeLangWatchSession:
         self._api_key = api_key or os.environ.get("LANGWATCH_API_KEY")
 
         # Lifecycle flags.
-        self._entered = False  # has __aenter__ run at least once?
         self._active = False  # is the context currently open (guards log_turn)?
         self._noop = False  # no key → emit nothing, but still guard log_turn
 
@@ -144,8 +143,6 @@ class RealtimeLangWatchSession:
         self._ctx_token = None
 
     async def __aenter__(self) -> "RealtimeLangWatchSession":
-        self._entered = True
-
         if not self._api_key:
             # No-op mode: the context is "active" (so log_turn does not raise the
             # not-active RuntimeError), but it emits nothing.
@@ -170,6 +167,8 @@ class RealtimeLangWatchSession:
 
             self._tracer = trace.get_tracer("scenario.realtime")
             self._root_span = self._tracer.start_span(self._name)
+            if self._model is not None:
+                self._root_span.set_attribute("model", self._model)
             self._ctx_token = context.attach(
                 trace.set_span_in_context(self._root_span)
             )
@@ -226,7 +225,7 @@ class RealtimeLangWatchSession:
                 exc_info=True,
             )
 
-    async def __aexit__(self, exc_type, exc, tb) -> bool:
+    async def __aexit__(self, exc_type, exc, tb) -> None:
         # Guard first so log_turn raises if called after exit.
         self._active = False
 
@@ -255,5 +254,3 @@ class RealtimeLangWatchSession:
                 "Failed to flush realtime_langwatch_session provider.", exc_info=True
             )
 
-        # Never suppress an exception raised inside the with-block.
-        return False

--- a/python/scenario/_tracing/live.py
+++ b/python/scenario/_tracing/live.py
@@ -1,0 +1,259 @@
+"""LangWatch tracing for live (production) OpenAI Realtime apps.
+
+Scenario tests get rich LangWatch traces automatically via ``scenario.run()``,
+but a production Realtime app gets nothing by default. ``RealtimeLangWatchSession``
+(exported as ``realtime_langwatch_session``) wraps a live Realtime session in the
+same per-turn span shape so live traffic lands in the same LangWatch project,
+queryable alongside scenario-test traces.
+
+Design constraints (issue #673):
+
+- This module MUST NOT import from ``scenario._tracing.setup``. The setup module
+  is the test-runner's lazy initialization path; the live helper has to stand on
+  its own so it works in a process where ``scenario.run()`` was never called. The
+  two small helpers it needs (``_get_concrete_provider`` /
+  ``_add_langwatch_exporter``) are therefore intentionally duplicated inline.
+- Importing ``scenario`` must NOT create a ``TracerProvider`` — all OTel work
+  happens inside ``__aenter__``, never at import time.
+- Nothing in the live path may raise into the host application. Export failures
+  are swallowed and logged at WARNING.
+"""
+
+import logging
+import os
+from typing import Optional
+
+from opentelemetry import context, trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SpanExporter
+
+logger = logging.getLogger("scenario.tracing")
+
+
+def _get_concrete_provider(provider) -> Optional[TracerProvider]:
+    """Return the concrete ``TracerProvider`` if one exists, else ``None``.
+
+    Checks the provider itself and one level of delegation (the
+    ``ProxyTracerProvider`` pattern OTel uses before any provider is set).
+
+    NOTE: intentionally duplicated from ``scenario._tracing.setup`` — see the
+    module docstring for why this file must not import from setup.
+    """
+    if isinstance(provider, TracerProvider):
+        return provider
+
+    delegate = None
+    if hasattr(provider, "get_delegate"):
+        delegate = provider.get_delegate()
+    elif hasattr(provider, "_delegate"):
+        delegate = provider._delegate
+
+    if isinstance(delegate, TracerProvider):
+        return delegate
+
+    return None
+
+
+def _add_langwatch_exporter(provider: TracerProvider, api_key: str) -> None:
+    """Attach the LangWatch OTLP exporter to ``provider``.
+
+    Best-effort: if the OTLP HTTP exporter dependency is missing we log a
+    warning and return rather than raising into the host app.
+
+    NOTE: intentionally duplicated/simplified from ``scenario._tracing.setup``
+    — see the module docstring for why this file must not import from setup.
+    """
+    endpoint = os.environ.get("LANGWATCH_ENDPOINT", "https://app.langwatch.ai")
+
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    except ImportError:
+        logger.warning(
+            "opentelemetry-exporter-otlp-proto-http not installed. "
+            "LangWatch span export disabled for realtime_langwatch_session."
+        )
+        return
+
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    exporter: SpanExporter = OTLPSpanExporter(
+        endpoint=f"{endpoint}/api/otel/v1/traces",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+
+
+class RealtimeLangWatchSession:
+    """Async context manager that traces a live OpenAI Realtime session.
+
+    Wrap your production Realtime loop in ``async with`` and call
+    :meth:`log_turn` after each agent turn::
+
+        from scenario import realtime_langwatch_session
+
+        async with realtime_langwatch_session(
+            name="my-production-session",
+            model="gpt-4o-realtime-preview",
+        ) as session:
+            ...  # drive your raw Realtime WebSocket
+            await session.log_turn(
+                user_transcript="I want to cancel my subscription",
+                agent_transcript="Of course, I can help with that.",
+                model="gpt-4o-realtime-preview",
+                latency_ms=430,
+            )
+
+    Behavior:
+
+    - **No key → no-op.** If ``LANGWATCH_API_KEY`` is absent (and no ``api_key``
+      is passed), entering the context and calling :meth:`log_turn` produce zero
+      spans and never raise. Safe to ship in keyless environments.
+    - **Fresh process.** If no concrete ``TracerProvider`` exists yet, one is
+      created, wired to LangWatch, and installed globally; it is force-flushed on
+      exit so spans are exported before the block returns.
+    - **Existing provider.** If ``langwatch.setup()`` (or anything else) already
+      installed a concrete provider, the helper attaches its exporter to that
+      provider and leaves it in place — no duplicate initialization.
+    - **Never raises into the host app.** Per-turn span failures are caught and
+      logged at WARNING; ``__aexit__`` never raises.
+    """
+
+    def __init__(
+        self,
+        name: str = "realtime_session",
+        *,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> None:
+        self._name = name
+        self._model = model
+        self._api_key = api_key or os.environ.get("LANGWATCH_API_KEY")
+
+        # Lifecycle flags.
+        self._entered = False  # has __aenter__ run at least once?
+        self._active = False  # is the context currently open (guards log_turn)?
+        self._noop = False  # no key → emit nothing, but still guard log_turn
+
+        # OTel handles, populated in __aenter__.
+        self._provider: Optional[TracerProvider] = None
+        self._own_provider = False  # did WE create/install the provider?
+        self._tracer = None
+        self._root_span = None
+        self._ctx_token = None
+
+    async def __aenter__(self) -> "RealtimeLangWatchSession":
+        self._entered = True
+
+        if not self._api_key:
+            # No-op mode: the context is "active" (so log_turn does not raise the
+            # not-active RuntimeError), but it emits nothing.
+            self._noop = True
+            self._active = True
+            return self
+
+        try:
+            concrete = _get_concrete_provider(trace.get_tracer_provider())
+            if concrete is None:
+                # Fresh process — build and install our own provider.
+                provider = TracerProvider()
+                _add_langwatch_exporter(provider, self._api_key)
+                trace.set_tracer_provider(provider)
+                self._provider = provider
+                self._own_provider = True
+            else:
+                # Attach to the provider someone else already installed.
+                _add_langwatch_exporter(concrete, self._api_key)
+                self._provider = concrete
+                self._own_provider = False
+
+            self._tracer = trace.get_tracer("scenario.realtime")
+            self._root_span = self._tracer.start_span(self._name)
+            self._ctx_token = context.attach(
+                trace.set_span_in_context(self._root_span)
+            )
+        except Exception:  # noqa: BLE001 - never raise into the host app
+            logger.warning(
+                "Failed to start realtime_langwatch_session root span; "
+                "continuing as a no-op.",
+                exc_info=True,
+            )
+            self._noop = True
+
+        self._active = True
+        return self
+
+    async def log_turn(
+        self,
+        user_transcript: str,
+        agent_transcript: str,
+        model: str,
+        latency_ms: float,
+    ) -> None:
+        """Record one agent turn as a child LLM span under the root span.
+
+        Raises:
+            RuntimeError: if called before ``__aenter__`` or after ``__aexit__``.
+                In no-op mode (no API key) this is a silent no-op instead.
+        """
+        if not self._active:
+            raise RuntimeError(
+                "realtime_langwatch_session context is not active — call "
+                "async with realtime_langwatch_session() as session first"
+            )
+
+        if self._noop:
+            return
+
+        try:
+            assert self._tracer is not None  # for type-checkers; guarded by _noop
+            ctx = (
+                trace.set_span_in_context(self._root_span)
+                if self._root_span is not None
+                else None
+            )
+            span = self._tracer.start_span("realtime_turn", context=ctx)
+            span.set_attribute("type", "llm")
+            span.set_attribute("input", user_transcript)
+            span.set_attribute("output", agent_transcript)
+            span.set_attribute("model", model)
+            span.set_attribute("latency_ms", latency_ms)
+            span.end()
+        except Exception:  # noqa: BLE001 - export/processor failures must not propagate
+            logger.warning(
+                "Failed to record realtime turn span; dropping it.",
+                exc_info=True,
+            )
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        # Guard first so log_turn raises if called after exit.
+        self._active = False
+
+        try:
+            if self._root_span is not None:
+                self._root_span.end()
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to end realtime_langwatch_session root span.", exc_info=True
+            )
+
+        try:
+            if self._ctx_token is not None:
+                context.detach(self._ctx_token)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to detach realtime_langwatch_session context.", exc_info=True
+            )
+
+        # Force-flush only the provider WE own, so spans export before returning.
+        try:
+            if self._own_provider and self._provider is not None:
+                self._provider.force_flush()
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to flush realtime_langwatch_session provider.", exc_info=True
+            )
+
+        # Never suppress an exception raised inside the with-block.
+        return False

--- a/python/scenario/_tracing/live.py
+++ b/python/scenario/_tracing/live.py
@@ -57,12 +57,18 @@ def _get_concrete_provider(provider) -> Optional[TracerProvider]:
 def _add_langwatch_exporter(provider: TracerProvider, api_key: str) -> None:
     """Attach the LangWatch OTLP exporter to ``provider``.
 
+    Idempotent: does nothing if a LangWatch exporter is already attached to
+    this provider instance (prevents duplicate processors on sequential sessions).
+
     Best-effort: if the OTLP HTTP exporter dependency is missing we log a
     warning and return rather than raising into the host app.
 
     NOTE: intentionally duplicated/simplified from ``scenario._tracing.setup``
     — see the module docstring for why this file must not import from setup.
     """
+    if getattr(provider, "_scenario_langwatch_exporter_attached", False):
+        return
+
     endpoint = os.environ.get("LANGWATCH_ENDPOINT", "https://app.langwatch.ai")
 
     try:
@@ -83,6 +89,7 @@ def _add_langwatch_exporter(provider: TracerProvider, api_key: str) -> None:
         headers={"Authorization": f"Bearer {api_key}"},
     )
     provider.add_span_processor(BatchSpanProcessor(exporter))
+    setattr(provider, "_scenario_langwatch_exporter_attached", True)
 
 
 class RealtimeLangWatchSession:

--- a/python/scenario/_tracing/live.py
+++ b/python/scenario/_tracing/live.py
@@ -179,11 +179,11 @@ class RealtimeLangWatchSession:
             self._ctx_token = context.attach(
                 trace.set_span_in_context(self._root_span)
             )
-        except Exception:  # noqa: BLE001 - never raise into the host app
+        except Exception as exc:  # noqa: BLE001 - never raise into the host app
             logger.warning(
                 "Failed to start realtime_langwatch_session root span; "
-                "continuing as a no-op.",
-                exc_info=True,
+                "continuing as a no-op. (error type: %s)",
+                type(exc).__name__,
             )
             self._noop = True
 

--- a/python/tests/test_live_tracing.py
+++ b/python/tests/test_live_tracing.py
@@ -1,0 +1,517 @@
+"""Unit tests for ``scenario._tracing.live.RealtimeLangWatchSession``.
+
+Covers AC1-AC14 from ``specs/realtime-live-tracing.feature``.
+
+OTel global-provider state is process-global AND set-once-guarded, so every
+test runs against a fully reset provider via the autouse ``reset_otel`` fixture.
+The reset MUST clear both ``trace._TRACER_PROVIDER`` and the
+``trace._TRACER_PROVIDER_SET_ONCE`` guard — otherwise the second
+``set_tracer_provider()`` across the whole test session is silently dropped with
+an "Overriding of current TracerProvider is not allowed" warning, which would
+make every test after the first attach to a stale provider.
+"""
+
+import logging
+import pathlib
+
+import pytest
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import ProxyTracerProvider
+from opentelemetry.util._once import Once
+
+import scenario._tracing.setup as setup_mod
+from scenario._tracing.setup import (
+    ensure_tracing_initialized,
+    _reset_tracing_for_tests,
+)
+from scenario import realtime_langwatch_session
+from scenario._tracing.live import RealtimeLangWatchSession
+
+
+API_KEY = "test-key-123"
+
+
+@pytest.fixture(autouse=True)
+def reset_otel():
+    """Reset OTel global provider state (and the set-once guard) around each test."""
+
+    def _reset() -> None:
+        trace._TRACER_PROVIDER = None
+        # Without resetting the Once guard, only the FIRST set_tracer_provider
+        # in the whole process takes effect; every later one is dropped.
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+        _reset_tracing_for_tests()
+
+    _reset()
+    yield
+    _reset()
+
+
+@pytest.fixture(autouse=True)
+def clear_langwatch_key(monkeypatch: pytest.MonkeyPatch):
+    """Start every test with LANGWATCH_API_KEY absent.
+
+    Tests that need a key set it explicitly via ``set_key`` / monkeypatch so the
+    no-op vs active branch is never decided by ambient environment.
+    """
+    monkeypatch.delenv("LANGWATCH_API_KEY", raising=False)
+    yield
+
+
+def _install_in_memory_provider() -> InMemorySpanExporter:
+    """Install a concrete TracerProvider with an InMemorySpanExporter and return it.
+
+    The helper, on entry, detects this concrete provider and attaches to it (the
+    "existing provider" branch) rather than creating its own — so spans it emits
+    are recorded by the returned exporter.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+# --- AC1, AC9 ---------------------------------------------------------------
+
+
+def test_ac1_importable_from_scenario_package():
+    """AC1: realtime_langwatch_session is importable from the scenario package."""
+    import scenario
+
+    assert hasattr(scenario, "realtime_langwatch_session")
+    assert scenario.realtime_langwatch_session is RealtimeLangWatchSession
+    assert "realtime_langwatch_session" in scenario.__all__
+
+
+def test_ac9_importing_scenario_does_not_create_tracer_provider():
+    """AC9: importing scenario alone leaves a ProxyTracerProvider (no concrete one)."""
+    # reset_otel has just reset to a fresh proxy. Merely having imported scenario
+    # (done at module load) must not have installed a concrete provider.
+    provider = trace.get_tracer_provider()
+    assert isinstance(provider, ProxyTracerProvider)
+
+
+# --- AC2 --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac2_log_turn_emits_child_llm_span_with_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC2: log_turn emits exactly one 'realtime_turn' LLM span with all attributes."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    exporter = _install_in_memory_provider()
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        await session.log_turn(
+            user_transcript="Hello",
+            agent_transcript="Hi there",
+            model="gpt-4o-realtime-preview",
+            latency_ms=450,
+        )
+
+    spans = exporter.get_finished_spans()
+    turn_spans = [s for s in spans if s.name == "realtime_turn"]
+    assert len(turn_spans) == 1
+    span = turn_spans[0]
+    assert span.name == "realtime_turn"
+    assert span.attributes["type"] == "llm"
+    assert span.attributes["input"] == "Hello"
+    assert span.attributes["output"] == "Hi there"
+    assert span.attributes["model"] == "gpt-4o-realtime-preview"
+    assert span.attributes["latency_ms"] == 450
+
+
+# --- AC3 --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac3_no_op_when_api_key_absent():
+    """AC3: with no key, enter + log_turn raise nothing and record zero spans."""
+    # clear_langwatch_key already removed the env var.
+    exporter = _install_in_memory_provider()
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        await session.log_turn(
+            user_transcript="anything",
+            agent_transcript="anything back",
+            model="gpt-4o-realtime-preview",
+            latency_ms=123,
+        )
+
+    spans = exporter.get_finished_spans()
+    turn_spans = [s for s in spans if s.name == "realtime_turn"]
+    assert turn_spans == []
+
+
+# --- AC4 --------------------------------------------------------------------
+
+
+def test_ac4_no_import_from_tracing_setup():
+    """AC4: live.py exists and has no import line from scenario._tracing.setup."""
+    live_path = (
+        pathlib.Path(__file__).parent.parent / "scenario" / "_tracing" / "live.py"
+    )
+    assert live_path.exists()
+
+    import re
+
+    src = live_path.read_text()
+    offending = [
+        line
+        for line in src.splitlines()
+        if re.match(r"^(from|import) .*_tracing\.setup", line)
+    ]
+    assert offending == [], f"live.py must not import from _tracing.setup: {offending}"
+
+
+@pytest.mark.asyncio
+async def test_ac4_usable_without_scenario_run_ever_called(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC4: the helper works in a process where scenario.run() / setup was never called.
+
+    ensure_tracing_initialized() is the function run() calls; we assert it was
+    never triggered (setup remains uninitialized) yet the helper still functions.
+    """
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    exporter = _install_in_memory_provider()
+
+    assert setup_mod._initialized is False
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        await session.log_turn(
+            user_transcript="u",
+            agent_transcript="a",
+            model="gpt-4o-realtime-preview",
+            latency_ms=10,
+        )
+
+    # Helper did its own setup; the run()-path init flag was never flipped.
+    assert setup_mod._initialized is False
+    turn_spans = [s for s in exporter.get_finished_spans() if s.name == "realtime_turn"]
+    assert len(turn_spans) == 1
+
+
+# --- AC5a -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac5a_creates_new_tracer_provider_when_none_exists(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC5a: fresh ProxyTracerProvider + key → entering installs a concrete TracerProvider."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    # reset_otel leaves a fresh proxy; do NOT install a concrete one here.
+    assert isinstance(trace.get_tracer_provider(), ProxyTracerProvider)
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+        provider = trace.get_tracer_provider()
+        assert isinstance(provider, TracerProvider)
+        assert not isinstance(provider, ProxyTracerProvider)
+
+
+# --- AC5b -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac5b_attaches_to_existing_provider_without_replacing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC5b: an existing concrete provider is reused (same object) and captures the span."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    exporter = _install_in_memory_provider()
+    existing = trace.get_tracer_provider()
+    existing_id = id(existing)
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        assert id(trace.get_tracer_provider()) == existing_id
+        await session.log_turn(
+            user_transcript="hi",
+            agent_transcript="hello",
+            model="gpt-4o-realtime-preview",
+            latency_ms=42,
+        )
+
+    assert id(trace.get_tracer_provider()) == existing_id
+    turn_spans = [s for s in exporter.get_finished_spans() if s.name == "realtime_turn"]
+    assert len(turn_spans) == 1
+
+
+# --- AC6 --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac6_export_failure_does_not_propagate_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """AC6: a processor whose on_end raises is swallowed; a WARNING is logged."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+
+    # Concrete provider whose span processor raises on span end.
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+
+    def boom(_span):
+        raise RuntimeError("simulated export failure")
+
+    monkeypatch.setattr(processor, "on_end", boom)
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+
+    with caplog.at_level(logging.WARNING, logger="scenario.tracing"):
+        async with realtime_langwatch_session(
+            model="gpt-4o-realtime-preview"
+        ) as session:
+            # Must not raise out of log_turn even though on_end blows up.
+            await session.log_turn(
+                user_transcript="hi",
+                agent_transcript="hello",
+                model="gpt-4o-realtime-preview",
+                latency_ms=42,
+            )
+        # Must not raise out of the async-with block either.
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and r.name == "scenario.tracing"
+    ]
+    assert warnings, "expected at least one WARNING from scenario.tracing"
+
+
+# --- AC7 --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac7_log_turn_before_enter_raises_runtimeerror(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC7: calling log_turn before __aenter__ raises RuntimeError naming the helper."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    session = RealtimeLangWatchSession(model="gpt-4o-realtime-preview")
+
+    with pytest.raises(RuntimeError, match="realtime_langwatch_session"):
+        await session.log_turn(
+            user_transcript="hi",
+            agent_transcript="hello",
+            model="gpt-4o-realtime-preview",
+            latency_ms=42,
+        )
+
+
+@pytest.mark.asyncio
+async def test_ac7_log_turn_after_exit_raises_runtimeerror(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC7: calling log_turn after __aexit__ raises RuntimeError naming the helper."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    _install_in_memory_provider()
+
+    session = RealtimeLangWatchSession(model="gpt-4o-realtime-preview")
+    async with session:
+        pass
+
+    with pytest.raises(RuntimeError, match="realtime_langwatch_session"):
+        await session.log_turn(
+            user_transcript="hi",
+            agent_transcript="hello",
+            model="gpt-4o-realtime-preview",
+            latency_ms=42,
+        )
+
+
+# --- AC8 --------------------------------------------------------------------
+
+
+def _doc_path() -> pathlib.Path:
+    return (
+        pathlib.Path(__file__).parent.parent.parent
+        / "docs/docs/pages/voice/happy-path-openai-realtime.mdx"
+    )
+
+
+def test_ac8_doc_has_live_app_tracing_section():
+    """AC8: the realtime doc has the live-app tracing heading + code block."""
+    doc = _doc_path()
+    assert doc.exists(), f"doc not found at {doc}"
+    text = doc.read_text()
+
+    heading = "## Getting LangWatch traces from your live app"
+    assert heading in text, "live-app tracing heading missing from doc"
+
+    # Code block under the heading must show the async-with usage.
+    after_heading = text.split(heading, 1)[1]
+    # bound the section at the next top-level heading
+    section = after_heading.split("\n## ", 1)[0]
+    assert "async with realtime_langwatch_session(" in section
+
+
+def test_ac8_doc_section_only_references_two_keys():
+    """AC8: the section's *_KEY env var names are exactly OPENAI_API_KEY + LANGWATCH_API_KEY."""
+    import re
+
+    text = _doc_path().read_text()
+    heading = "## Getting LangWatch traces from your live app"
+    section = text.split(heading, 1)[1].split("\n## ", 1)[0]
+
+    keys = sorted(set(re.findall(r"[A-Z_]+_KEY", section)))
+    assert keys == ["LANGWATCH_API_KEY", "OPENAI_API_KEY"], keys
+
+
+# --- AC10 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac10_run_then_helper_no_duplicate_provider(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC10: after ensure_tracing_initialized() (simulating run()), the helper reuses the provider."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+
+    # Simulate scenario.run() having initialized tracing already.
+    ensure_tracing_initialized()
+    provider_before = trace.get_tracer_provider()
+    provider_id = id(provider_before)
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+        assert id(trace.get_tracer_provider()) == provider_id
+
+    assert id(trace.get_tracer_provider()) == provider_id
+
+
+# --- AC11 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac11_helper_then_run_coexistence(monkeypatch: pytest.MonkeyPatch):
+    """AC11: after the helper exits, ensure_tracing_initialized() runs cleanly and flips _initialized."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        await session.log_turn(
+            user_transcript="u",
+            agent_transcript="a",
+            model="gpt-4o-realtime-preview",
+            latency_ms=10,
+        )
+
+    # run()'s init path must proceed without an OTel conflict.
+    ensure_tracing_initialized()
+    assert setup_mod._initialized is True
+
+
+# --- AC12 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac12_empty_transcripts_and_zero_latency(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC12: empty transcripts and zero latency still produce exactly one span, no error."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    exporter = _install_in_memory_provider()
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        await session.log_turn(
+            user_transcript="",
+            agent_transcript="",
+            model="gpt-4o-realtime-preview",
+            latency_ms=0,
+        )
+
+    turn_spans = [s for s in exporter.get_finished_spans() if s.name == "realtime_turn"]
+    assert len(turn_spans) == 1
+    span = turn_spans[0]
+    assert span.attributes["input"] == ""
+    assert span.attributes["output"] == ""
+    assert span.attributes["latency_ms"] == 0
+
+
+# --- AC13 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac13_multiple_sequential_turns_emit_independent_spans(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC13: two log_turn calls produce two independent spans with their own attributes."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    exporter = _install_in_memory_provider()
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        await session.log_turn(
+            user_transcript="Turn 1 user",
+            agent_transcript="Turn 1 agent",
+            model="gpt-4o-realtime-preview",
+            latency_ms=100,
+        )
+        await session.log_turn(
+            user_transcript="Turn 2 user",
+            agent_transcript="Turn 2 agent",
+            model="gpt-4o-realtime-preview",
+            latency_ms=200,
+        )
+
+    turn_spans = [s for s in exporter.get_finished_spans() if s.name == "realtime_turn"]
+    assert len(turn_spans) == 2
+
+    by_input = {s.attributes["input"]: s for s in turn_spans}
+    assert by_input["Turn 1 user"].attributes["output"] == "Turn 1 agent"
+    assert by_input["Turn 1 user"].attributes["latency_ms"] == 100
+    assert by_input["Turn 2 user"].attributes["output"] == "Turn 2 agent"
+    assert by_input["Turn 2 user"].attributes["latency_ms"] == 200
+
+
+# --- AC14 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac14_aexit_flushes_span_visible_after_block(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC14: the span emitted inside the block is present in finished spans after exit."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    exporter = _install_in_memory_provider()
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+        await session.log_turn(
+            user_transcript="hi",
+            agent_transcript="hello",
+            model="gpt-4o-realtime-preview",
+            latency_ms=42,
+        )
+
+    # Observed strictly AFTER the with-block exits.
+    turn_spans = [s for s in exporter.get_finished_spans() if s.name == "realtime_turn"]
+    assert len(turn_spans) == 1
+
+
+@pytest.mark.asyncio
+async def test_ac14_aexit_does_not_raise_with_no_turns(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """AC14: exiting without logging any turn does not raise."""
+    monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
+    _install_in_memory_provider()
+
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+        pass  # no turns logged
+
+    # Reaching here without an exception is the assertion.
+
+
+@pytest.mark.asyncio
+async def test_ac14_aexit_does_not_raise_with_no_key():
+    """AC14 (no-op branch): exiting a keyless session with no turns does not raise."""
+    # clear_langwatch_key removed the key.
+    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+        pass

--- a/python/tests/test_live_tracing.py
+++ b/python/tests/test_live_tracing.py
@@ -25,11 +25,8 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 from opentelemetry.trace import ProxyTracerProvider
 from opentelemetry.util._once import Once
 
+import scenario
 import scenario._tracing.setup as setup_mod
-from scenario._tracing.setup import (
-    ensure_tracing_initialized,
-    _reset_tracing_for_tests,
-)
 from scenario import realtime_langwatch_session
 from scenario._tracing.live import RealtimeLangWatchSession
 
@@ -46,7 +43,7 @@ def reset_otel():
         # Without resetting the Once guard, only the FIRST set_tracer_provider
         # in the whole process takes effect; every later one is dropped.
         trace._TRACER_PROVIDER_SET_ONCE = Once()
-        _reset_tracing_for_tests()
+        setup_mod._reset_tracing_for_tests()
 
     _reset()
     yield
@@ -83,8 +80,6 @@ def _install_in_memory_provider() -> InMemorySpanExporter:
 
 def test_ac1_importable_from_scenario_package():
     """AC1: realtime_langwatch_session is importable from the scenario package."""
-    import scenario
-
     assert hasattr(scenario, "realtime_langwatch_session")
     assert scenario.realtime_langwatch_session is RealtimeLangWatchSession
     assert "realtime_langwatch_session" in scenario.__all__
@@ -178,7 +173,7 @@ async def test_ac4_usable_without_scenario_run_ever_called(
 ):
     """AC4: the helper works in a process where scenario.run() / setup was never called.
 
-    ensure_tracing_initialized() is the function run() calls; we assert it was
+    setup_mod.ensure_tracing_initialized() is the function run() calls; we assert it was
     never triggered (setup remains uninitialized) yet the helper still functions.
     """
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
@@ -378,7 +373,7 @@ async def test_ac10_run_then_helper_no_duplicate_provider(
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
 
     # Simulate scenario.run() having initialized tracing already.
-    ensure_tracing_initialized()
+    setup_mod.ensure_tracing_initialized()
     provider_before = trace.get_tracer_provider()
     provider_id = id(provider_before)
 
@@ -405,7 +400,7 @@ async def test_ac11_helper_then_run_coexistence(monkeypatch: pytest.MonkeyPatch)
         )
 
     # run()'s init path must proceed without an OTel conflict.
-    ensure_tracing_initialized()
+    setup_mod.ensure_tracing_initialized()
     assert setup_mod._initialized is True
 
 

--- a/python/tests/test_live_tracing.py
+++ b/python/tests/test_live_tracing.py
@@ -124,8 +124,11 @@ async def test_ac2_log_turn_emits_child_llm_span_with_attributes(
     # AC2 requires the turn span to be a *child* of the root span — verify the link
     root_spans = [s for s in spans if s.name != "realtime_turn"]
     assert len(root_spans) >= 1, "expected a root span"
-    assert span.parent is not None, "turn span should have a parent"
-    assert span.parent.span_id == root_spans[0].context.span_id
+    parent_ctx = span.parent
+    assert parent_ctx is not None, "turn span should have a parent"
+    root_ctx = root_spans[0].context
+    assert root_ctx is not None, "root span should have a context"
+    assert parent_ctx.span_id == root_ctx.span_id
 
 
 # --- AC3 --------------------------------------------------------------------

--- a/python/tests/test_live_tracing.py
+++ b/python/tests/test_live_tracing.py
@@ -121,7 +121,6 @@ async def test_ac2_log_turn_emits_child_llm_span_with_attributes(
     turn_spans = [s for s in spans if s.name == "realtime_turn"]
     assert len(turn_spans) == 1
     span = turn_spans[0]
-    assert span.name == "realtime_turn"
     assert span.attributes["type"] == "llm"
     assert span.attributes["input"] == "Hello"
     assert span.attributes["output"] == "Hi there"

--- a/python/tests/test_live_tracing.py
+++ b/python/tests/test_live_tracing.py
@@ -121,6 +121,7 @@ async def test_ac2_log_turn_emits_child_llm_span_with_attributes(
     turn_spans = [s for s in spans if s.name == "realtime_turn"]
     assert len(turn_spans) == 1
     span = turn_spans[0]
+    assert span.attributes is not None
     assert span.attributes["type"] == "llm"
     assert span.attributes["input"] == "Hello"
     assert span.attributes["output"] == "Hi there"
@@ -430,6 +431,7 @@ async def test_ac12_empty_transcripts_and_zero_latency(
     turn_spans = [s for s in exporter.get_finished_spans() if s.name == "realtime_turn"]
     assert len(turn_spans) == 1
     span = turn_spans[0]
+    assert span.attributes is not None
     assert span.attributes["input"] == ""
     assert span.attributes["output"] == ""
     assert span.attributes["latency_ms"] == 0
@@ -463,9 +465,13 @@ async def test_ac13_multiple_sequential_turns_emit_independent_spans(
     turn_spans = [s for s in exporter.get_finished_spans() if s.name == "realtime_turn"]
     assert len(turn_spans) == 2
 
-    by_input = {s.attributes["input"]: s for s in turn_spans}
+    for s in turn_spans:
+        assert s.attributes is not None
+    by_input = {s.attributes["input"]: s for s in turn_spans if s.attributes is not None}
+    assert by_input["Turn 1 user"].attributes is not None
     assert by_input["Turn 1 user"].attributes["output"] == "Turn 1 agent"
     assert by_input["Turn 1 user"].attributes["latency_ms"] == 100
+    assert by_input["Turn 2 user"].attributes is not None
     assert by_input["Turn 2 user"].attributes["output"] == "Turn 2 agent"
     assert by_input["Turn 2 user"].attributes["latency_ms"] == 200
 

--- a/python/tests/test_live_tracing.py
+++ b/python/tests/test_live_tracing.py
@@ -27,7 +27,6 @@ from opentelemetry.util._once import Once
 
 import scenario
 import scenario._tracing.setup as setup_mod
-from scenario import realtime_langwatch_session
 from scenario._tracing.live import RealtimeLangWatchSession
 
 
@@ -104,7 +103,7 @@ async def test_ac2_log_turn_emits_child_llm_span_with_attributes(
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
     exporter = _install_in_memory_provider()
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         await session.log_turn(
             user_transcript="Hello",
             agent_transcript="Hi there",
@@ -133,7 +132,7 @@ async def test_ac3_no_op_when_api_key_absent():
     # clear_langwatch_key already removed the env var.
     exporter = _install_in_memory_provider()
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         await session.log_turn(
             user_transcript="anything",
             agent_transcript="anything back",
@@ -181,7 +180,7 @@ async def test_ac4_usable_without_scenario_run_ever_called(
 
     assert setup_mod._initialized is False
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         await session.log_turn(
             user_transcript="u",
             agent_transcript="a",
@@ -207,7 +206,7 @@ async def test_ac5a_creates_new_tracer_provider_when_none_exists(
     # reset_otel leaves a fresh proxy; do NOT install a concrete one here.
     assert isinstance(trace.get_tracer_provider(), ProxyTracerProvider)
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview"):
         provider = trace.get_tracer_provider()
         assert isinstance(provider, TracerProvider)
         assert not isinstance(provider, ProxyTracerProvider)
@@ -226,7 +225,7 @@ async def test_ac5b_attaches_to_existing_provider_without_replacing(
     existing = trace.get_tracer_provider()
     existing_id = id(existing)
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         assert id(trace.get_tracer_provider()) == existing_id
         await session.log_turn(
             user_transcript="hi",
@@ -264,7 +263,7 @@ async def test_ac6_export_failure_does_not_propagate_and_warns(
     trace.set_tracer_provider(provider)
 
     with caplog.at_level(logging.WARNING, logger="scenario.tracing"):
-        async with realtime_langwatch_session(
+        async with scenario.realtime_langwatch_session(
             model="gpt-4o-realtime-preview"
         ) as session:
             # Must not raise out of log_turn even though on_end blows up.
@@ -377,7 +376,7 @@ async def test_ac10_run_then_helper_no_duplicate_provider(
     provider_before = trace.get_tracer_provider()
     provider_id = id(provider_before)
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview"):
         assert id(trace.get_tracer_provider()) == provider_id
 
     assert id(trace.get_tracer_provider()) == provider_id
@@ -391,7 +390,7 @@ async def test_ac11_helper_then_run_coexistence(monkeypatch: pytest.MonkeyPatch)
     """AC11: after the helper exits, ensure_tracing_initialized() runs cleanly and flips _initialized."""
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         await session.log_turn(
             user_transcript="u",
             agent_transcript="a",
@@ -415,7 +414,7 @@ async def test_ac12_empty_transcripts_and_zero_latency(
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
     exporter = _install_in_memory_provider()
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         await session.log_turn(
             user_transcript="",
             agent_transcript="",
@@ -443,7 +442,7 @@ async def test_ac13_multiple_sequential_turns_emit_independent_spans(
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
     exporter = _install_in_memory_provider()
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         await session.log_turn(
             user_transcript="Turn 1 user",
             agent_transcript="Turn 1 agent",
@@ -482,7 +481,7 @@ async def test_ac14_aexit_flushes_span_visible_after_block(
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
     exporter = _install_in_memory_provider()
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview") as session:
         await session.log_turn(
             user_transcript="hi",
             agent_transcript="hello",
@@ -503,7 +502,7 @@ async def test_ac14_aexit_does_not_raise_with_no_turns(
     monkeypatch.setenv("LANGWATCH_API_KEY", API_KEY)
     _install_in_memory_provider()
 
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview"):
         pass  # no turns logged
 
     # Reaching here without an exception is the assertion.
@@ -513,5 +512,5 @@ async def test_ac14_aexit_does_not_raise_with_no_turns(
 async def test_ac14_aexit_does_not_raise_with_no_key():
     """AC14 (no-op branch): exiting a keyless session with no turns does not raise."""
     # clear_langwatch_key removed the key.
-    async with realtime_langwatch_session(model="gpt-4o-realtime-preview"):
+    async with scenario.realtime_langwatch_session(model="gpt-4o-realtime-preview"):
         pass

--- a/python/tests/test_live_tracing.py
+++ b/python/tests/test_live_tracing.py
@@ -121,6 +121,11 @@ async def test_ac2_log_turn_emits_child_llm_span_with_attributes(
     assert span.attributes["output"] == "Hi there"
     assert span.attributes["model"] == "gpt-4o-realtime-preview"
     assert span.attributes["latency_ms"] == 450
+    # AC2 requires the turn span to be a *child* of the root span — verify the link
+    root_spans = [s for s in spans if s.name != "realtime_turn"]
+    assert len(root_spans) >= 1, "expected a root span"
+    assert span.parent is not None, "turn span should have a parent"
+    assert span.parent.span_id == root_spans[0].context.span_id
 
 
 # --- AC3 --------------------------------------------------------------------

--- a/specs/realtime-live-tracing.feature
+++ b/specs/realtime-live-tracing.feature
@@ -1,0 +1,180 @@
+Feature: LangWatch tracing for live OpenAI Realtime apps
+  As a developer who uses OpenAI Realtime in production
+  I want a packaged helper that wraps my Realtime session in LangWatch spans
+  So that I get the same observability story in my live app as I do in scenario tests
+
+  # --- AC1, AC9 ---
+  @unit
+  Scenario: realtime_langwatch_session is importable from scenario
+    Given the scenario package is installed
+    When `from scenario import realtime_langwatch_session` is executed
+    Then the import succeeds without error
+    And importing scenario alone does not create a TracerProvider (provider type is ProxyTracerProvider)
+
+  # --- AC2 ---
+  @unit
+  Scenario: log_turn emits a child LLM span with correct attributes and name
+    Given an InMemorySpanExporter is installed on the current TracerProvider
+    And LANGWATCH_API_KEY is set in the environment
+    When realtime_langwatch_session is entered as an async context manager
+    And log_turn is called with user_transcript "Hello", agent_transcript "Hi there", model "gpt-4o-realtime-preview", latency_ms 450
+    Then the InMemorySpanExporter records exactly 1 finished span
+    And that span has name "realtime_turn"
+    And that span has attribute type = "llm"
+    And that span has attribute input = "Hello"
+    And that span has attribute output = "Hi there"
+    And that span has attribute model = "gpt-4o-realtime-preview"
+    And that span has attribute latency_ms = 450
+
+  # --- AC3 ---
+  @unit
+  Scenario: no-op when LANGWATCH_API_KEY is absent
+    Given LANGWATCH_API_KEY is not set in the environment
+    And an InMemorySpanExporter is installed on the current TracerProvider
+    When realtime_langwatch_session is entered as an async context manager
+    And log_turn is called with any transcripts
+    Then no exception is raised
+    And the InMemorySpanExporter records 0 finished spans
+
+  # --- AC4 ---
+  @unit
+  Scenario: helper module has no import from scenario._tracing.setup
+    When the source of scenario/_tracing/live.py is inspected
+    Then the file exists (test -f scenario/_tracing/live.py exits 0)
+    And it contains no line matching "^from.*_tracing.setup" or "^import.*_tracing.setup"
+    And realtime_langwatch_session can be used in a process where scenario.run() was never called
+
+  # --- AC5a ---
+  @unit
+  Scenario: creates new TracerProvider when no prior setup exists
+    Given OTel state is reset to a fresh ProxyTracerProvider
+    And LANGWATCH_API_KEY is set in the environment
+    When realtime_langwatch_session is entered as an async context manager
+    Then trace.get_tracer_provider() returns an instance of TracerProvider (not ProxyTracerProvider)
+
+  # --- AC5b ---
+  @unit
+  Scenario: attaches to existing TracerProvider without replacing it
+    Given langwatch.setup() has already been called (existing concrete TracerProvider)
+    And the existing provider id is captured
+    And an InMemorySpanExporter is added to the existing provider
+    When realtime_langwatch_session is entered as an async context manager
+    Then trace.get_tracer_provider() id is unchanged (same object)
+    And log_turn emits a span captured by the InMemorySpanExporter on the existing provider
+
+  # --- AC6 ---
+  @unit
+  Scenario: OTLP export failure does not propagate to the live app
+    Given LANGWATCH_API_KEY is set in the environment
+    And the span processor's on_end method is mocked to raise RuntimeError
+    When realtime_langwatch_session is entered as an async context manager
+    And log_turn is called
+    Then no exception propagates out of the async with block or log_turn call
+    And at least one WARNING record is emitted from logger "scenario.tracing"
+
+  # --- AC7 ---
+  @unit
+  Scenario: log_turn before entering context raises RuntimeError
+    Given a realtime_langwatch_session instance
+    When log_turn is called before __aenter__ is called
+    Then RuntimeError is raised with message containing "realtime_langwatch_session"
+
+  @unit
+  Scenario: log_turn after exiting context raises RuntimeError
+    Given a realtime_langwatch_session instance
+    And the context has been entered and exited
+    When log_turn is called after __aexit__ returns
+    Then RuntimeError is raised with message containing "realtime_langwatch_session"
+
+  # --- AC8 ---
+  @unit
+  Scenario: happy-path-openai-realtime doc contains live app tracing section
+    When docs/docs/pages/voice/happy-path-openai-realtime.mdx is read
+    Then it contains a "## Getting LangWatch traces from your live app" heading
+    And the code block immediately under that heading contains "async with realtime_langwatch_session("
+    And the awk-extracted block under that heading contains only OPENAI_API_KEY and LANGWATCH_API_KEY as *_KEY env var names (grep -oE '[A-Z_]+_KEY' returns exactly those two, sorted)
+
+  # --- AC9 (covered in first scenario above) ---
+
+  # --- AC10 ---
+  @unit
+  Scenario: run-then-helper coexistence — no duplicate TracerProvider
+    Given ensure_tracing_initialized() has been called (simulating scenario.run())
+    And the provider id is captured
+    When realtime_langwatch_session is entered as an async context manager
+    Then no exception is raised
+    And trace.get_tracer_provider() id is unchanged (same object as before)
+
+  # --- AC11 ---
+  @unit
+  Scenario: helper-then-run coexistence — run() proceeds after helper exits
+    Given realtime_langwatch_session has been entered and exited
+    When ensure_tracing_initialized() is called
+    Then no exception is raised
+    And _initialized from scenario._tracing.setup is True
+    And a subsequent scenario.run() call does not raise an OTel conflict (returns a ScenarioResult or completes the run() call body without raising)
+
+  # --- AC12 ---
+  @unit
+  Scenario: log_turn accepts empty transcripts and zero latency without error
+    Given LANGWATCH_API_KEY is set in the environment
+    And an InMemorySpanExporter is installed
+    When realtime_langwatch_session is entered as an async context manager
+    And log_turn is called with user_transcript="", agent_transcript="", model="gpt-4o-realtime-preview", latency_ms=0
+    Then no exception is raised
+    And the InMemorySpanExporter records exactly 1 finished span
+
+  # --- AC13 ---
+  @unit
+  Scenario: multiple sequential log_turn calls each emit one independent span
+    Given LANGWATCH_API_KEY is set in the environment
+    And an InMemorySpanExporter is installed on the current TracerProvider
+    When realtime_langwatch_session is entered as an async context manager
+    And log_turn is called with user_transcript "Turn 1 user", agent_transcript "Turn 1 agent", model "gpt-4o-realtime-preview", latency_ms 100
+    And log_turn is called again with user_transcript "Turn 2 user", agent_transcript "Turn 2 agent", model "gpt-4o-realtime-preview", latency_ms 200
+    Then the InMemorySpanExporter records exactly 2 finished spans
+    And the first span has attribute input = "Turn 1 user" and output = "Turn 1 agent" and latency_ms = 100
+    And the second span has attribute input = "Turn 2 user" and output = "Turn 2 agent" and latency_ms = 200
+
+  # --- AC14 ---
+  @unit
+  Scenario: __aexit__ flushes spans and leaves no half-configured provider
+    Given LANGWATCH_API_KEY is set in the environment
+    And an InMemorySpanExporter is installed
+    When realtime_langwatch_session is entered and log_turn is called inside it
+    And the async context is exited (__aexit__ completes)
+    Then the span emitted by log_turn is present in InMemorySpanExporter.get_finished_spans() after the with block (not only mid-block)
+    And __aexit__ does not raise even if no turns were logged
+
+# --- AC Coverage Map ---
+# AC1:  "scenario.realtime_langwatch_session is the public importable name"
+#       → Scenario: realtime_langwatch_session is importable from scenario
+# AC2:  "log_turn emits child LLM span with correct attributes and name"
+#       → Scenario: log_turn emits a child LLM span with correct attributes and name
+# AC3:  "no-op when LANGWATCH_API_KEY is absent"
+#       → Scenario: no-op when LANGWATCH_API_KEY is absent
+# AC4:  "no import from scenario._tracing.setup"
+#       → Scenario: helper module has no import from scenario._tracing.setup
+# AC5a: "creates new TracerProvider when no prior setup exists"
+#       → Scenario: creates new TracerProvider when no prior setup exists
+# AC5b: "attaches to existing TracerProvider without replacing it"
+#       → Scenario: attaches to existing TracerProvider without replacing it
+# AC6:  "OTLP export failure does not propagate to the live app"
+#       → Scenario: OTLP export failure does not propagate to the live app
+# AC7:  "log_turn outside context raises RuntimeError"
+#       → Scenario: log_turn before entering context raises RuntimeError
+#       → Scenario: log_turn after exiting context raises RuntimeError
+# AC8:  "happy-path-openai-realtime.mdx gains live app tracing section"
+#       → Scenario: happy-path-openai-realtime doc contains live app tracing section
+# AC9:  "importing scenario does not create TracerProvider at import time"
+#       → Scenario: realtime_langwatch_session is importable from scenario (second Then)
+# AC10: "run-then-helper coexistence — no duplicate TracerProvider"
+#       → Scenario: run-then-helper coexistence — no duplicate TracerProvider
+# AC11: "helper-then-run coexistence — run() proceeds after helper exits"
+#       → Scenario: helper-then-run coexistence — run() proceeds after helper exits
+# AC12: "log_turn accepts empty transcripts and zero latency without error"
+#       → Scenario: log_turn accepts empty transcripts and zero latency without error
+# AC13: "multiple sequential log_turn calls each emit one independent span"
+#       → Scenario: multiple sequential log_turn calls each emit one independent span
+# AC14: "__aexit__ flushes spans and leaves no half-configured provider"
+#       → Scenario: __aexit__ flushes spans and leaves no half-configured provider


### PR DESCRIPTION
## Why

Production OpenAI Realtime apps have no path into LangWatch today — `scenario.run()` handles test-time tracing, but live calls fly blind. Closes #673.

## What changed

- **`RealtimeLangWatchSession` (exported as `realtime_langwatch_session`)** — async context manager that wraps a live Realtime session and records one child LLM span per `log_turn()` call, matching the per-turn shape scenario tests already produce.
- **No-op when keyless** — if `LANGWATCH_API_KEY` is absent the context manager is a safe no-op (no raise, no spans); safe to ship in keyless envs without a conditional.
- **Attaches to existing provider, doesn't clobber** — if `langwatch.setup()` or `scenario.run()` already installed a `TracerProvider`, the helper attaches to it; idempotent guard prevents duplicate `BatchSpanProcessor` registration across sequential sessions.
- **Spec-first, unit-tested** — 14 ACs in `specs/realtime-live-tracing.feature`, covered by 20 unit tests in `tests/test_live_tracing.py`; no live API calls needed.

## How it works

```
scenario/
  __init__.py              ← exports realtime_langwatch_session
  _tracing/
    live.py                ← RealtimeLangWatchSession + helpers (_get_concrete_provider, _add_langwatch_exporter)
specs/
  realtime-live-tracing.feature   ← 14 ACs
tests/
  test_live_tracing.py            ← 20 unit tests
```

`__aenter__` checks the global OTel provider: fresh → builds + installs its own `TracerProvider`; existing → attaches an OTLP exporter. A root span is opened for the session; `log_turn()` creates a child `realtime_turn` span with `type=llm`, `input`, `output`, `model`, `latency_ms`. `__aexit__` ends the root span and force-flushes only provider it owns.

## Test plan

```bash
cd python
uv run pytest tests/test_live_tracing.py -v
# → 20 passed
uv run pyright tests/test_live_tracing.py scenario/_tracing/live.py
# → 0 errors
```

## How I can prove I was successful

No playable artifact — see Test plan. 20 unit tests pass covering all 14 ACs; pyright clean; all CI checks green.

## Anything surprising?

The live module intentionally duplicates two small helpers from `scenario._tracing.setup` (`_get_concrete_provider`, `_add_langwatch_exporter`). The design constraint is that `scenario._tracing.setup` is the test-runner's lazy-init path — importing it from a production context would be wrong. The duplication is documented in both files.
