### PR TITLE
fix(voice): terminate wait=False test drain on end-of-turn, re-enable in CI

### DIFF
--- a/python/tests/voice/test_agent_wait_false.py
+++ b/python/tests/voice/test_agent_wait_false.py
@@ -4,25 +4,22 @@ Unit tests for the ``agent(wait=False)`` async primitive (§4.4 L369-382).
 Verifies the concurrency contract: control returns before the agent turn
 finishes, and subsequent blocking steps await the pending turn.
 
-These tests drive ``scenario.run`` end-to-end. They pass deterministically
-locally (~2s total) with no external services, but hang indefinitely in
-the project's python-ci workflow for reasons we haven't been able to
-reproduce outside CI. Skipped under ``CI=true`` until that's fixed;
-local development still exercises them on every run.
+These tests drive ``scenario.run`` end-to-end with no external services
+(~1s total). The earlier ``skipif(CI)`` guard masked an unrealistic fixture:
+``_SlowAdapter`` returned audio on *every* ``recv_audio`` call, so the base
+``_drain_agent_response`` loop never tail-silenced and ran to
+``response_max_duration`` (~90s of wall-clock for this cadence) — tripping
+CI's 60s timeout while squeaking under it on faster local machines. The
+fixture now emits one chunk then an end-of-turn empty chunk, the contract
+every real adapter honors, so the turn terminates promptly.
 """
 
 import asyncio
-import os
 
 import pytest
 
 import scenario
 from scenario.voice import AdapterCapabilities, AudioChunk, VoiceAgentAdapter
-
-pytestmark = pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="scenario.run hangs in GitHub-Actions python-ci; runs fine locally",
-)
 
 
 class _SlowAdapter(VoiceAgentAdapter):
@@ -32,6 +29,7 @@ class _SlowAdapter(VoiceAgentAdapter):
         super().__init__()
         self.recv_delay = recv_delay
         self.recv_returned_at: float | None = None
+        self._spoke: bool = False
 
     async def connect(self):
         pass
@@ -43,6 +41,15 @@ class _SlowAdapter(VoiceAgentAdapter):
         pass
 
     async def recv_audio(self, timeout):
+        # Speak one slow chunk, then signal end-of-turn with an empty chunk so
+        # the base ``_drain_agent_response`` loop terminates on tail silence —
+        # the contract every real adapter honors. Returning audio on *every*
+        # call (the previous behavior) never tail-silences, so the drain runs
+        # to ``response_max_duration`` (~90s of wall-clock for this cadence),
+        # which is what wedged the turn in CI.
+        if self._spoke:
+            return AudioChunk(data=b"")
+        self._spoke = True
         await asyncio.sleep(self.recv_delay)
         self.recv_returned_at = asyncio.get_event_loop().time()
         return AudioChunk(data=b"\x00\x00" * 2400)
@@ -55,9 +62,15 @@ class _CannedUser(scenario.AgentAdapter):
         return "hi"
 
 
+@pytest.mark.timeout(30)
 @pytest.mark.asyncio
 async def test_agent_wait_false_returns_before_turn_finishes():
-    """A wait=False agent step must not block until the slow recv completes."""
+    """A wait=False agent step must not block until the slow recv completes.
+
+    The ``timeout`` guards the regression this fixture once caused: an adapter
+    that never tail-silences makes the drain run to ``response_max_duration``
+    (~90s), so a stuck turn fails fast and loud here instead of wedging CI.
+    """
     slow = _SlowAdapter(recv_delay=0.3)
 
     returned_at: float | None = None


### PR DESCRIPTION
## Why

The `agent(wait=False)` voice tests in `tests/voice/test_agent_wait_false.py` were skipped in CI via `@pytest.mark.skipif(CI=="true")` with the note "hangs in python-ci, can't reproduce locally." The hang isn't infinite — it's a ~90s turn. The test's `_SlowAdapter.recv_audio` returns a non-empty audio chunk on *every* call, so the base `_drain_agent_response` loop (`scenario/voice/adapter.py`) never tail-silences and runs until `accumulated_audio >= response_max_duration` (30s of audio ≈ 90s of wall-clock at this cadence). That trips CI's 60s timeout reliably under load while squeaking under it on faster local machines — a textbook timing flake. This restores the lost CI coverage of the `wait=False` concurrency primitive.

Relates to #648 (same audio-gated-drain class; this PR fixes the *test fixture* side, not the product-side adapter terminal path).

## What changed

- **Fixed the test fixture to honor the real adapter end-of-turn contract.** `_SlowAdapter` now emits one real chunk, then a terminal empty `AudioChunk(data=b"")` — the same end-of-turn signal real adapters send (OpenAI Realtime, Gemini Live, Composable) so the base drain loop exits on tail silence instead of running to `response_max_duration`. Chose fixing the unrealistic mock over adding a wall-clock cap to the base loop, because #647 establishes that the drain terminates on an audio-terminal event, deliberately keeping `response_timeout` as the only time-guard.
- **Removed the `skipif(CI)` workaround** (and the now-unused `import os`). With the fixture fixed, the tests run in CI again — closing the coverage gap the skip created.
- **Added `@pytest.mark.timeout(30)`** to `test_agent_wait_false_returns_before_turn_finishes` so any regression of the ~90s drain fails fast and loud instead of wedging the runner.

## Test plan

```bash
# from python/
CI=true uv run pytest tests/voice/test_agent_wait_false.py -p no:cacheprovider -v
# → 3 passed in ~1.2s
```

- Reproduced the original hang cross-platform before the fix: Windows + Linux (WSL2 Ubuntu), Python 3.12 — `scenario.run()` with the `wait=False` script ran ~90s (measured: `RETURNED after 90.3s success=True`) and exceeded the 60s pytest-timeout.
- After the fix, the full file passes in ~1.2s on both platforms with `CI=true` set (the condition that previously skipped it).
- The non-blocking assertion is unchanged and still meaningful: `_stamp` fires before `slow.recv_returned_at` (the `wait=False` step returns control before the slow recv completes). The sibling `test_double_wait_false_in_flight_raises` race is preserved (the fixture change only affects calls *after* the first chunk).

## How I can prove I was successful

No playable artifact — see Test plan. This is a test-fixture/control-flow change; the demonstration is the suite going from skipped-in-CI (~90s drain on the parent commit when the skip is removed) to `3 passed in ~1.2s` on this branch with `CI=true`.
