### PR TITLE
fix(voice/#648): terminal drain on non-audio completion (EL + WebSocket)

### DIFF
--- a/javascript/src/voice/adapters/__tests__/elevenlabs.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs.test.ts
@@ -631,10 +631,31 @@ describe("ElevenLabsAgentAdapter wire-protocol (onMessage branches)", () => {
     const { adapter, socket } = await makeConnected();
     emit(socket, { type: "interruption" });
     emit(socket, { type: "vad_score", vad_event: { score: 0.5 } });
-    emit(socket, { type: "client_tool_call", payload: {} });
-    // No throw, no mutation visible to callers.
+    emit(socket, { type: "agent_response_metadata", metadata: {} });
+    // No throw, no mutation visible to callers. (`client_tool_call` is NOT here:
+    // it is a non-audio terminal, covered by its own test below — issue #648.)
     expect(adapter.lastAgentTranscript).toBeNull();
     expect(adapter.lastUserTranscript).toBeNull();
+    await adapter.disconnect();
+  });
+
+  it("client_tool_call (tool-only turn) resolves the receiver with an empty chunk (#648)", async () => {
+    const { adapter, socket } = await makeConnected();
+    const recv = adapter.receiveAudio(2);
+    emit(socket, {
+      type: "client_tool_call",
+      client_tool_call: {
+        tool_name: "lookup_order",
+        tool_call_id: "call_1",
+        parameters: { order_id: "42" },
+      },
+    });
+    const chunk = await recv;
+    // A tool-only turn yields no spoken audio (this adapter has no
+    // client_tool_result path). The drain must exit cleanly with an empty chunk
+    // rather than swallowing the event and hanging to the receiveAudio timeout.
+    expect(chunk).toBeInstanceOf(AudioChunk);
+    expect(chunk.data.length).toBe(0);
     await adapter.disconnect();
   });
 

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -494,10 +494,18 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
       // / non-audio terminal turn. Resolve the active `receiveAudio` waiter with
       // an empty chunk so the base drain (`drainAgentResponse`) exits cleanly
       // instead of hanging to the `receiveAudio` timeout. Mirrors the #646/PR647
-      // reference fix and the Python parity in `elevenlabs.py`. If no receive is
-      // in flight there is nothing to unblock — drop it (the close/error
-      // handlers use the same active-waiters-only semantics via
-      // `drainPendingWaiters`).
+      // reference fix and the Python parity in `elevenlabs.py`.
+      //
+      // If no receive is in flight we DROP the terminal rather than queue it
+      // (unlike the `audio` branch above, which buffers onto `audioQueue`). Safe
+      // because: (1) a terminal carries no payload to preserve, so nothing is
+      // lost; (2) the drain always parks a waiter before the agent acts
+      // (call -> drain -> receiveAudio awaits), so a mid-turn tool call always
+      // finds one. Queuing an empty sentinel would be WORSE — it would surface as
+      // the NEXT turn's first `receiveAudio` result, a spurious empty turn. This
+      // matches the active-waiters-only semantics of onSocketClose / onSocketError
+      // (`drainPendingWaiters`). Python differs only because its pull-loop
+      // `recv_audio` hands the terminal to whichever call asks next.
       const waiter = this.waiters.shift();
       if (waiter) waiter(new AudioChunk({ data: new Uint8Array(0) }));
       return;

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -17,8 +17,14 @@
  *      `lastAgentTranscript`
  *    - `audio` — decoded base64 PCM16 and returned from `receiveAudio`
  *    - `ping` — replied with `{"type": "pong", "event_id": <id>}`
+ *    - `client_tool_call` — tool-only / non-audio terminal turn: resolves the
+ *      drain with an empty `AudioChunk` (issue #648) instead of hanging to the
+ *      `receiveAudio` timeout (no `client_tool_result` path → no follow-up audio)
  *    - `interruption` — swallowed
  *    - Anything else — silently skipped
+ *
+ * A socket close mid-receive is likewise terminal: `onSocketClose` resolves
+ * pending waiters with an empty `AudioChunk` so the drain exits cleanly (#648).
  *
  * {@link ElevenLabsVoiceAgent} — the typed *local* composable preset (distinct
  * responsibility, same vendor): you compose {@link ElevenLabsSTTProvider} + any
@@ -478,6 +484,22 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
             `from advertised pcm16/24000 capability; the agent may not understand audio we send.`,
         );
       }
+      return;
+    }
+
+    if (etype === "client_tool_call") {
+      // Issue #648: EL ConvAI emits `client_tool_call` when the agent invokes a
+      // CLIENT-side tool. This adapter has no `client_tool_result` path, so the
+      // agent will never produce spoken audio for this turn — it is a tool-only
+      // / non-audio terminal turn. Resolve the active `receiveAudio` waiter with
+      // an empty chunk so the base drain (`drainAgentResponse`) exits cleanly
+      // instead of hanging to the `receiveAudio` timeout. Mirrors the #646/PR647
+      // reference fix and the Python parity in `elevenlabs.py`. If no receive is
+      // in flight there is nothing to unblock — drop it (the close/error
+      // handlers use the same active-waiters-only semantics via
+      // `drainPendingWaiters`).
+      const waiter = this.waiters.shift();
+      if (waiter) waiter(new AudioChunk({ data: new Uint8Array(0) }));
       return;
     }
 

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -28,10 +28,16 @@ Wire protocol:
     ``last_agent_transcript`` (post-barge-in update)
   - ``audio`` — decoded and returned from ``recv_audio``
   - ``ping`` — replied to with ``{"type": "pong", "event_id": <id>}``
+  - ``client_tool_call`` — tool-only / non-audio terminal turn: ends the
+    drain with an empty ``AudioChunk`` (issue #648) instead of hanging to
+    the ``response_timeout`` deadline. The adapter has no
+    ``client_tool_result`` path, so the agent cannot follow up with audio.
   - ``interruption`` — swallowed
-  - Other documented events (``vad_score``, ``client_tool_call``,
-    ``agent_response_metadata``, etc.) — silently skipped; the
-    provisioned test agent doesn't trigger them.
+  - Other documented events (``vad_score``, ``agent_response_metadata``,
+    etc.) — silently skipped; the provisioned test agent doesn't trigger them.
+
+A socket close mid-receive is also treated as a terminal: ``recv_audio``
+returns an empty ``AudioChunk`` so the drain exits cleanly (issue #648).
 """
 
 from __future__ import annotations
@@ -297,8 +303,14 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         deadline, so this returns when an ``audio`` event arrives and raises
         :class:`asyncio.TimeoutError` only after ``timeout`` seconds elapse
         with **no message of any kind**. Pings are replied to inline;
-        transcript events update instance attributes for observability; all
+        transcript events update instance attributes for observability; most
         other event types are swallowed without error.
+
+        Terminal (non-audio) completions return an **empty** ``AudioChunk``
+        rather than hanging to the deadline (issue #648): a ``client_tool_call``
+        (tool-only turn — this adapter has no ``client_tool_result`` path) and a
+        socket close mid-receive both end the drain cleanly, mirroring the
+        #646/PR647 reference fix and the Gemini Live / Pipecat idiom.
 
         Design decision (issue #493 — intentional, not an oversight): because
         a received ping is treated as proof of liveness, a hosted agent that
@@ -311,6 +323,8 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         (An absolute caller-side backstop for the wedged-agent case is tracked
         as a separate follow-up; it is intentionally not implemented here.)
         """
+        import websockets  # for the ConnectionClosed terminal (issue #648)
+
         if self._ws is None:
             raise RuntimeError("ElevenLabsAgentAdapter: not connected")
 
@@ -320,7 +334,21 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             if remaining <= 0:
                 raise asyncio.TimeoutError("ElevenLabsAgentAdapter: recv_audio timed out")
 
-            raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            try:
+                raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            except websockets.exceptions.ConnectionClosed:
+                # Issue #648: the hosted agent finished its turn and the server
+                # closed the socket WITHOUT a trailing audio frame (a silent /
+                # tool-only turn). Mirror the #646/PR647 reference pattern (and
+                # the Gemini Live / Pipecat idiom): return an empty AudioChunk so
+                # the base ``_drain_agent_response`` loop exits cleanly, instead
+                # of letting ConnectionClosed propagate — the drain only catches
+                # asyncio.TimeoutError, so an unhandled close would crash the turn.
+                logger.debug(
+                    "ElevenLabsAgentAdapter: socket closed during recv; "
+                    "ending turn with empty chunk"
+                )
+                return AudioChunk(data=b"")
             # A received message (ping included) proves the socket is alive, so
             # re-arm the idle deadline. Placed BEFORE json.loads so ANY frame —
             # even a non-JSON/malformed one — counts as a liveness signal.
@@ -413,6 +441,22 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
                         "the agent may not understand audio we send.",
                         in_fmt,
                     )
+
+            elif etype == "client_tool_call":
+                # Issue #648: EL ConvAI emits ``client_tool_call`` when the agent
+                # invokes a CLIENT-side tool. This adapter is a black-box test
+                # harness and does NOT send ``client_tool_result`` back, so the
+                # hosted agent will never produce spoken audio for this turn — it
+                # is a tool-only / non-audio terminal turn. Mirror the #646/PR647
+                # reference pattern: return an empty AudioChunk so the drain exits
+                # cleanly instead of looping to the ``response_timeout`` deadline
+                # and raising. The tool call is observable on the wire; we surface
+                # the turn's completion, not its payload.
+                logger.debug(
+                    "ElevenLabsAgentAdapter: client_tool_call (tool-only turn); "
+                    "ending turn with empty chunk"
+                )
+                return AudioChunk(data=b"")
 
             elif etype == "interruption":
                 pass  # documented non-audio event, no action needed

--- a/python/scenario/voice/adapters/websocket.py
+++ b/python/scenario/voice/adapters/websocket.py
@@ -68,13 +68,30 @@ class WebSocketAgentAdapter(VoiceAgentAdapter):
         await self._ws.send(payload)
 
     async def recv_audio(self, timeout: float) -> AudioChunk:
+        """Loop inbound frames until the protocol decodes an audio chunk.
+
+        A clean server close (end of stream) with no final audio frame is a
+        terminal, not an error: ``recv_audio`` returns an empty ``AudioChunk``
+        so the base ``_drain_agent_response`` loop exits cleanly (issue #648),
+        mirroring the #646/PR647 reference pattern and the Gemini Live / Pipecat
+        idiom. ``asyncio.TimeoutError`` is still raised on inter-message silence.
+        """
+        import websockets  # for the ConnectionClosed terminal (issue #648)
+
         if self._ws is None:
             raise RuntimeError(f"{type(self).__name__}: not connected")
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         while True:
             remaining = max(0.0, deadline - loop.time())
-            message = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            try:
+                message = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            except websockets.exceptions.ConnectionClosed:
+                # End of stream: the server closed without a trailing audio
+                # frame. Surface a clean terminal rather than letting
+                # ConnectionClosed propagate — the drain only catches
+                # asyncio.TimeoutError, so an unhandled close crashes the turn.
+                return AudioChunk(data=b"")
             chunk = self.protocol.decode_response(message)
             if chunk is not None:
                 return chunk

--- a/python/tests/voice/test_audio_gated_drain.py
+++ b/python/tests/voice/test_audio_gated_drain.py
@@ -29,10 +29,11 @@ immediately and stays well under the ceiling.
 import asyncio
 import base64
 import json
+from typing import Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from websockets.exceptions import ConnectionClosedOK
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 from scenario.voice import AudioChunk, ElevenLabsAgentAdapter
 from scenario.voice.adapters.websocket import (
@@ -48,16 +49,16 @@ RECV_TIMEOUT = 30.0
 OUTER_CEILING = 2.0
 
 
-def _scripted_ws(frames: list, *, then_close: bool = False) -> AsyncMock:
+def _scripted_ws(frames: list, *, close_with: Optional[Exception] = None) -> AsyncMock:
     """A mock WS whose ``recv()`` serves ``frames`` in order.
 
-    After the programmed frames are exhausted it either raises
-    ``ConnectionClosedOK`` (``then_close=True``, modelling a clean server close)
-    or blocks indefinitely (modelling a silent-but-open socket). The
-    block-forever tail is what makes the terminal-case tests RED on an un-fixed
-    adapter: without the empty-chunk return, ``recv_audio`` loops past the
-    swallowed non-audio frame into the blocking ``recv()`` and only the outer
-    ceiling unwinds it.
+    After the programmed frames are exhausted it either raises ``close_with`` (a
+    ``ConnectionClosed*`` instance, modelling a server close) or — when
+    ``close_with is None`` — blocks indefinitely (modelling a silent-but-open
+    socket). The block-forever tail is what makes the terminal-case tests RED on
+    an un-fixed adapter: without the empty-chunk return, ``recv_audio`` loops
+    past the swallowed non-audio frame into the blocking ``recv()`` and only the
+    outer ceiling unwinds it.
     """
     idx = 0
 
@@ -67,8 +68,8 @@ def _scripted_ws(frames: list, *, then_close: bool = False) -> AsyncMock:
             msg = frames[idx]
             idx += 1
             return msg
-        if then_close:
-            raise ConnectionClosedOK(None, None)
+        if close_with is not None:
+            raise close_with
         await asyncio.sleep(3600)  # silent-but-open socket
         raise AssertionError("unreachable")  # pragma: no cover
 
@@ -77,6 +78,12 @@ def _scripted_ws(frames: list, *, then_close: bool = False) -> AsyncMock:
     ws.send = AsyncMock()
     ws.close = AsyncMock()
     return ws
+
+
+# Production catches the base ``ConnectionClosed``; both a clean close
+# (``ConnectionClosedOK``) and an abnormal one (``ConnectionClosedError``) must
+# terminate the drain cleanly, so the socket-close tests run against both.
+_CLOSE_CLASSES = [ConnectionClosedOK, ConnectionClosedError]
 
 
 # --------------------------------------------------------------------- ElevenLabs
@@ -116,14 +123,18 @@ async def test_elevenlabs_client_tool_call_terminates_drain():
 
 
 @pytest.mark.asyncio
-async def test_elevenlabs_socket_close_terminates_drain():
-    """A clean server close mid-receive returns an empty chunk, not an error.
+@pytest.mark.parametrize("close_cls", _CLOSE_CLASSES)
+async def test_elevenlabs_socket_close_terminates_drain(close_cls):
+    """A server close mid-receive returns an empty chunk, not an error.
 
-    Pre-fix, the unhandled ``ConnectionClosed`` propagated out of ``recv_audio``
-    (the drain only catches ``asyncio.TimeoutError``) and crashed the turn.
+    Runs against both a clean close (``ConnectionClosedOK``) and an abnormal one
+    (``ConnectionClosedError``): production catches the base ``ConnectionClosed``,
+    so both subclasses must terminate the drain cleanly. Pre-fix, the unhandled
+    ``ConnectionClosed`` propagated out of ``recv_audio`` (the drain only catches
+    ``asyncio.TimeoutError``) and crashed the turn.
     """
     adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
-    mock_ws = _scripted_ws([], then_close=True)
+    mock_ws = _scripted_ws([], close_with=close_cls(None, None))
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
@@ -170,15 +181,17 @@ class _BytesAudioProtocol(WebSocketProtocol):
 
 
 @pytest.mark.asyncio
-async def test_websocket_socket_close_terminates_drain():
-    """Generic WebSocket: a clean server close (end of stream) returns empty.
+@pytest.mark.parametrize("close_cls", _CLOSE_CLASSES)
+async def test_websocket_socket_close_terminates_drain(close_cls):
+    """Generic WebSocket: a server close (end of stream) returns empty.
 
-    Pre-fix, the ``while True`` loop returned only on a decoded audio chunk and
-    had no end-of-stream path, so a clean close raised an unhandled
-    ``ConnectionClosed``.
+    Runs against both clean (``ConnectionClosedOK``) and abnormal
+    (``ConnectionClosedError``) closes. Pre-fix, the ``while True`` loop returned
+    only on a decoded audio chunk and had no end-of-stream path, so a close
+    raised an unhandled ``ConnectionClosed``.
     """
     adapter = WebSocketAgentAdapter(url="ws://x", protocol=_BytesAudioProtocol())
-    mock_ws = _scripted_ws([], then_close=True)
+    mock_ws = _scripted_ws([], close_with=close_cls(None, None))
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()

--- a/python/tests/voice/test_audio_gated_drain.py
+++ b/python/tests/voice/test_audio_gated_drain.py
@@ -90,8 +90,8 @@ _CLOSE_CLASSES = [ConnectionClosedOK, ConnectionClosedError]
 
 
 @pytest.mark.asyncio
-async def test_elevenlabs_client_tool_call_terminates_drain():
-    """A tool-only turn (``client_tool_call``, no audio) returns an empty chunk.
+async def test_elevenlabs_client_tool_call_returns_empty_chunk():
+    """Unit: a tool-only turn (``client_tool_call``, no audio) returns empty.
 
     EL ConvAI emits ``client_tool_call`` when the agent invokes a client-side
     tool. This adapter never sends ``client_tool_result``, so the agent produces
@@ -124,8 +124,8 @@ async def test_elevenlabs_client_tool_call_terminates_drain():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("close_cls", _CLOSE_CLASSES)
-async def test_elevenlabs_socket_close_terminates_drain(close_cls):
-    """A server close mid-receive returns an empty chunk, not an error.
+async def test_elevenlabs_socket_close_returns_empty_chunk(close_cls):
+    """Unit: a server close mid-receive returns an empty chunk, not an error.
 
     Runs against both a clean close (``ConnectionClosedOK``) and an abnormal one
     (``ConnectionClosedError``): production catches the base ``ConnectionClosed``,
@@ -165,6 +165,45 @@ async def test_elevenlabs_normal_audio_still_returned():
     assert result.data == pcm_payload  # real audio, non-empty
 
 
+@pytest.mark.asyncio
+async def test_elevenlabs_tool_only_turn_drain_exits_cleanly():
+    """Drain-level: a tool-only turn makes ``_drain_agent_response`` exit cleanly.
+
+    This is the end-to-end guard for the bug as reported — a *drain*-level hang —
+    above the unit tests that pin ``recv_audio`` alone. With a ``client_tool_call``
+    and no audio: the first ``recv_audio`` returns an empty chunk; the drain marks
+    no first-chunk, enters its tail loop, and breaks on the next recv (the now-
+    silent socket times out at ``response_tail_silence``), returning an empty
+    merged turn. Pre-fix, the first ``recv_audio`` looped to ``response_timeout``
+    and the drain raised :class:`FirstChunkTimeoutError`.
+    """
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    # After the empty first chunk the drain does one more recv that must time out
+    # fast against the now-silent socket — keep the tail-silence wait tiny.
+    adapter.response_tail_silence = 0.1
+    tool_call = json.dumps(
+        {
+            "type": "client_tool_call",
+            "client_tool_call": {
+                "tool_name": "lookup_order",
+                "tool_call_id": "call_1",
+                "parameters": {},
+            },
+        }
+    )
+    mock_ws = _scripted_ws([tool_call])  # then blocks (silent-but-open) socket
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        merged = await asyncio.wait_for(
+            adapter._drain_agent_response(), timeout=OUTER_CEILING
+        )
+
+    # Drain returned an empty merged turn instead of raising FirstChunkTimeoutError.
+    assert isinstance(merged, AudioChunk)
+    assert merged.data == b""
+
+
 # ----------------------------------------------------------------- WebSocket (generic)
 
 
@@ -182,8 +221,8 @@ class _BytesAudioProtocol(WebSocketProtocol):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("close_cls", _CLOSE_CLASSES)
-async def test_websocket_socket_close_terminates_drain(close_cls):
-    """Generic WebSocket: a server close (end of stream) returns empty.
+async def test_websocket_socket_close_returns_empty_chunk(close_cls):
+    """Unit: generic WebSocket server close (end of stream) returns empty.
 
     Runs against both clean (``ConnectionClosedOK``) and abnormal
     (``ConnectionClosedError``) closes. Pre-fix, the ``while True`` loop returned

--- a/python/tests/voice/test_audio_gated_drain.py
+++ b/python/tests/voice/test_audio_gated_drain.py
@@ -1,0 +1,207 @@
+"""
+Issue #648 — audio-gated drain must terminate cleanly on a non-audio completion.
+
+The ElevenLabs (hosted ConvAI) and generic WebSocket adapters share an
+audio-gated receive loop: historically each returned ONLY on an audio frame, so
+a turn that completed WITHOUT producing audio drained to the ``response_timeout``
+deadline and raised (a latent hang surfaced by ``/sweep`` during PR #647, which
+fixed the same anti-pattern in the OpenAI Realtime adapter for issue #646).
+
+The fix mirrors the #646/PR647 reference pattern (and the Gemini Live /
+Pipecat idiom): on a non-audio terminal — a socket close, or an ElevenLabs
+``client_tool_call`` (a tool-only turn that never yields spoken audio because
+this adapter has no ``client_tool_result`` path) — ``recv_audio`` returns an
+**empty** ``AudioChunk`` so the base ``_drain_agent_response`` loop exits
+cleanly instead of hanging.
+
+These tests pin that behaviour and guard against regressing the normal
+audio path. No real network: ``websockets.connect`` is patched to a mock whose
+``recv()`` serves programmed frames (or raises ``ConnectionClosedOK`` to model a
+clean server close).
+
+Each terminal-case assertion gives ``recv_audio`` a generous ``timeout`` (the
+budget it would otherwise hang for) and wraps the call in a short outer
+``asyncio.wait_for`` ceiling, so an un-fixed adapter that loops to its deadline
+fails fast instead of stalling the suite — the empty-chunk fix returns
+immediately and stays well under the ceiling.
+"""
+
+import asyncio
+import base64
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from websockets.exceptions import ConnectionClosedOK
+
+from scenario.voice import AudioChunk, ElevenLabsAgentAdapter
+from scenario.voice.adapters.websocket import (
+    WebSocketAgentAdapter,
+    WebSocketProtocol,
+)
+
+
+# recv_audio is handed a long nominal budget (what an un-fixed adapter would
+# hang for); the outer ceiling fails the test fast if the empty-chunk terminal
+# is missing. The fix returns instantly, far under the ceiling.
+RECV_TIMEOUT = 30.0
+OUTER_CEILING = 2.0
+
+
+def _scripted_ws(frames: list, *, then_close: bool = False) -> AsyncMock:
+    """A mock WS whose ``recv()`` serves ``frames`` in order.
+
+    After the programmed frames are exhausted it either raises
+    ``ConnectionClosedOK`` (``then_close=True``, modelling a clean server close)
+    or blocks indefinitely (modelling a silent-but-open socket). The
+    block-forever tail is what makes the terminal-case tests RED on an un-fixed
+    adapter: without the empty-chunk return, ``recv_audio`` loops past the
+    swallowed non-audio frame into the blocking ``recv()`` and only the outer
+    ceiling unwinds it.
+    """
+    idx = 0
+
+    async def fake_recv():
+        nonlocal idx
+        if idx < len(frames):
+            msg = frames[idx]
+            idx += 1
+            return msg
+        if then_close:
+            raise ConnectionClosedOK(None, None)
+        await asyncio.sleep(3600)  # silent-but-open socket
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    ws = AsyncMock()
+    ws.recv = fake_recv
+    ws.send = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+# --------------------------------------------------------------------- ElevenLabs
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_client_tool_call_terminates_drain():
+    """A tool-only turn (``client_tool_call``, no audio) returns an empty chunk.
+
+    EL ConvAI emits ``client_tool_call`` when the agent invokes a client-side
+    tool. This adapter never sends ``client_tool_result``, so the agent produces
+    no spoken audio for the turn — pre-fix, ``recv_audio`` swallowed the event
+    and looped to the deadline. The fix surfaces the completion as an empty
+    ``AudioChunk``.
+    """
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    tool_call = json.dumps(
+        {
+            "type": "client_tool_call",
+            "client_tool_call": {
+                "tool_name": "lookup_order",
+                "tool_call_id": "call_1",
+                "parameters": {"order_id": "42"},
+            },
+        }
+    )
+    mock_ws = _scripted_ws([tool_call])  # then blocks forever
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        result = await asyncio.wait_for(
+            adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+        )
+
+    assert isinstance(result, AudioChunk)
+    assert result.data == b""  # empty terminal, not a hang
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_socket_close_terminates_drain():
+    """A clean server close mid-receive returns an empty chunk, not an error.
+
+    Pre-fix, the unhandled ``ConnectionClosed`` propagated out of ``recv_audio``
+    (the drain only catches ``asyncio.TimeoutError``) and crashed the turn.
+    """
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    mock_ws = _scripted_ws([], then_close=True)
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        result = await asyncio.wait_for(
+            adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+        )
+
+    assert isinstance(result, AudioChunk)
+    assert result.data == b""
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_normal_audio_still_returned():
+    """No regression: a normal ``audio`` frame is still decoded and returned."""
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    pcm_payload = b"\x12\x34" * 8  # 16 bytes of dummy PCM16
+    b64 = base64.b64encode(pcm_payload).decode()
+    audio_frame = json.dumps({"type": "audio", "audio_event": {"audio_base_64": b64}})
+    mock_ws = _scripted_ws([audio_frame])
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        result = await asyncio.wait_for(
+            adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+        )
+
+    assert isinstance(result, AudioChunk)
+    assert result.data == pcm_payload  # real audio, non-empty
+
+
+# ----------------------------------------------------------------- WebSocket (generic)
+
+
+class _BytesAudioProtocol(WebSocketProtocol):
+    """Minimal protocol: binary frames are PCM16 audio; everything else is non-audio."""
+
+    def encode_audio(self, audio: bytes):
+        return audio
+
+    def decode_response(self, message):
+        if isinstance(message, (bytes, bytearray)):
+            return AudioChunk(data=bytes(message))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_websocket_socket_close_terminates_drain():
+    """Generic WebSocket: a clean server close (end of stream) returns empty.
+
+    Pre-fix, the ``while True`` loop returned only on a decoded audio chunk and
+    had no end-of-stream path, so a clean close raised an unhandled
+    ``ConnectionClosed``.
+    """
+    adapter = WebSocketAgentAdapter(url="ws://x", protocol=_BytesAudioProtocol())
+    mock_ws = _scripted_ws([], then_close=True)
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        result = await asyncio.wait_for(
+            adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+        )
+
+    assert isinstance(result, AudioChunk)
+    assert result.data == b""
+
+
+@pytest.mark.asyncio
+async def test_websocket_normal_audio_still_returned():
+    """No regression: a decoded audio frame is still returned from the loop."""
+    adapter = WebSocketAgentAdapter(url="ws://x", protocol=_BytesAudioProtocol())
+    pcm_payload = b"\xab\xcd" * 8
+    mock_ws = _scripted_ws([pcm_payload])
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        result = await asyncio.wait_for(
+            adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+        )
+
+    assert isinstance(result, AudioChunk)
+    assert result.data == pcm_payload


### PR DESCRIPTION
## Why

The ElevenLabs (hosted ConvAI) and generic WebSocket adapters shared an audio-gated receive loop that returned ONLY on an audio frame, so a turn completing without audio drained to the `response_timeout` deadline and raised — a latent hang surfaced by `/sweep` during PR #647 (which fixed the same anti-pattern in the OpenAI Realtime adapter for #646).

Closes #648

## What changed

- Reused the #646/PR647 empty-`AudioChunk` terminal pattern (proven for OpenAI Realtime; same idiom as Gemini Live / Pipecat) rather than inventing a new signal: `recv_audio` returns an empty chunk on a non-audio terminal, so the base `_drain_agent_response` loop exits through its existing empty-chunk break.
- ElevenLabs (`elevenlabs.py` `recv_audio` / `elevenlabs.ts` `onMessage`): treat `client_tool_call` as a tool-only terminal — this adapter has no `client_tool_result` path, so the hosted agent can never follow up with spoken audio. PY now also catches `ConnectionClosed`; the TS socket-close terminal was already handled by `onSocketClose`.
- Generic WebSocket (`websocket.py` `recv_audio`): a clean server close (end of stream) returns empty instead of letting `ConnectionClosed` propagate — the drain only catches `asyncio.TimeoutError`, so an unhandled close crashed the turn.
- Narrowest correct change per adapter; the normal audio path is untouched.

## Test plan

- `python/tests/voice/test_audio_gated_drain.py` (new) — `cd python && PYTHONPATH=. uv run pytest tests/voice/test_audio_gated_drain.py` → **7 passed**. Covers EL `client_tool_call`→empty, EL socket-close→empty, WebSocket socket-close→empty (each socket-close case parametrized over both `ConnectionClosedOK` and `ConnectionClosedError`, since production catches the base `ConnectionClosed`), plus normal-audio no-regression for both adapters. Terminal cases give `recv_audio` a long budget under a short outer `asyncio.wait_for` ceiling, so the un-fixed adapter fails fast (hang→timeout / propagated `ConnectionClosed`) instead of stalling the suite.
- `javascript/src/voice/adapters/__tests__/elevenlabs.test.ts` — added a `client_tool_call`→empty terminal test (red without the fix: `receiveAudio` rejects with a timeout); `client_tool_call` removed from the "swallows unknown events" case since it is now a terminal. `cd javascript && pnpm exec vitest run src/voice/adapters/__tests__/` → **140 passed / 1 skipped**.
- `cd javascript && pnpm typecheck` → clean.

## Human verification

`backend-only, no UI surface` — this is a pure library/transport fix in the voice adapter drain logic (`python/scenario/voice/adapters/{elevenlabs,websocket}.py`, `javascript/src/voice/adapters/elevenlabs.ts`); there is no front-end, route, or visual surface to exercise, so there is no screenshot/recording to attach. <!-- no-ui-surface -->

To verify by hand:

1. **Green at HEAD (both languages).**
   - `cd python && PYTHONPATH=. uv run pytest tests/voice/test_audio_gated_drain.py` → **7 passed**.
   - `cd javascript && pnpm exec vitest run src/voice/adapters/__tests__/` → **140 passed / 1 skipped**; `pnpm typecheck` → clean.
2. **Red without the fix (the discriminating check).** Revert only the source files and re-run the suites above:
   ```
   git checkout origin/main -- python/scenario/voice/adapters/elevenlabs.py python/scenario/voice/adapters/websocket.py javascript/src/voice/adapters/elevenlabs.ts
   ```
   The terminal-case tests then FAIL (Python: `3 failed, 2 passed`; TS: the `#648 client_tool_call` test times out after ~2s), confirming the tests gate the bug rather than passing vacuously. Restore with `git checkout HEAD -- <same paths>`.

## How I can prove I was successful

No playable artifact — this is a pure library/transport fix. AC1's gating surface is the base drain loop (`_drain_agent_response` / `drainAgentResponse`) exiting on an empty chunk, which the unit tests sit directly on (they assert the returned `AudioChunk(data=b"")`, not a code-path trace). The proof is falsifiability:

- **Hand-verified red-without-fix → green-with-fix (both languages).** Against `origin/main` source the terminal-case tests FAIL — Python: `3 failed, 2 passed`; TS: the `#648 client_tool_call` test fails on a ~2s `receiveAudio timed out`. With the fix, all pass. (Note: CI only ever runs HEAD, which is all-green, so the discriminating red-state is not visible from CI alone — it was verified locally by reverting just the source files and re-running.)
- A full scenario run against a live tool-only EL turn is not cheaply reproducible — the provisioned test agent never emits `client_tool_call` (per the issue body) — so the transport-layer unit proof on the gating contract is the correct surface.

## Anything surprising?

`#567` (post-interrupt re-engage on EL hosted) is a separate follow-up that also touches the EL adapter; per the plan it should be driven AFTER this lands to avoid conflicts. Local `pnpm lint` reports a large pre-existing import-order/eslint-disable baseline across many untouched files (identical count with and without this diff) — not introduced here.

