### PR TITLE
fix(voice/#491): diagnose + resolve multi-turn @e2e suite-wedge + tighten VAD tests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Run tests
         # `-m "not integration"` deselects voice e2e tests (auto-marked by
-        # tests/voice/conftest.py). Those hit live providers and run nightly
+        # tests/voice/conftest.py). Those hit live providers and run on-demand
         # via voice-integration.yml.
         run: uv run pytest tests/ -v --tb=short -m "not integration"
         working-directory: python

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,7 +44,7 @@ jobs:
       # `-m "not integration"` deselects voice e2e tests (auto-marked by
       # tests/voice/conftest.py). Those hit live providers, require API
       # key secrets we don't expose to the publish workflow, and run
-      # nightly via voice-integration.yml. Mirrors python-ci.yml.
+      # on-demand via voice-integration.yml. Mirrors python-ci.yml.
       - name: Run tests
         run: |
           uv run pytest tests -m "not integration"

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -35,7 +35,13 @@ concurrency:
 jobs:
   integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 90, not 45: the isolated multi-turn step caps each of its 6 demos at
+    # `timeout 600`, so that step alone has a 60-min worst case — a 45-min job cap
+    # would fire mid-loop and cancel the run, which is exactly what the per-demo
+    # cap exists to prevent ("cap one bad demo instead of letting it ride the job
+    # timeout"). 60 min for the isolated step + headroom for install and the three
+    # bulk steps.
+    timeout-minutes: 90
     env:
       CI: true
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
@@ -218,11 +224,28 @@ jobs:
           rc=0
           for f in "${files[@]}"; do
             echo "::group::${f} (isolated process)"
-            # External per-file wall-clock cap. pytest-timeout's signal/thread
-            # methods can't interrupt these asyncio teardown hangs (see
-            # pyproject.toml note), so if the drain wedge ever recurs, this caps
-            # one bad demo at 10 min instead of letting it ride the job timeout.
-            timeout 600 uv run pytest -p no:cacheprovider -x "$f" -v --tb=short || rc=1
+            # TWO nested caps, and `--timeout=540` is NOT optional:
+            #
+            # pytest.ini sets `timeout = 60` for the unit suite, and pytest.ini
+            # WINS over pyproject.toml — pytest says so out loud: "configfile:
+            # pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)".
+            # So pyproject's "@e2e voice tests can legitimately take 5+ min /
+            # per-test timeout deliberately NOT set" note is DEAD CONFIG, and
+            # without an override these demos inherit the 60s cap. They blow
+            # through it structurally — long_hold alone does a 15s wall-clock
+            # scenario.sleep(15) before 8 live LLM+TTS+STT turns — so un-skipping
+            # them under a 60s cap would just trade "asserted but never run" for
+            # "shot at 60s, red". Same idiom as python-ci's Examples step, which
+            # overrides to --timeout=300 for exactly this reason.
+            #
+            # Inner (pytest-timeout, 540s, thread method): fires FIRST and dumps
+            # every thread's stack — that thread-dump IS the #491 diagnostic (it
+            # is how the event_bus.drain() -> queue.join() wedge was root-caused),
+            # so a recurrence arrives as a readable traceback, not a silent kill.
+            # Outer (`timeout 600`): hard backstop for a hang pytest cannot
+            # interrupt at all, capping one bad demo at 10 min rather than letting
+            # it ride the job timeout.
+            timeout 600 uv run pytest -p no:cacheprovider -x "$f" -v --tb=short --timeout=540 || rc=1
             echo "::endgroup::"
           done
           exit $rc

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -22,8 +22,16 @@ name: voice-integration
 #     TWILIO_PHONE_NUMBER_2 — two Twilio-owned numbers for fully automated
 #     inbound/outbound demos
 #
-# If a secret is absent the relevant tests FAIL with a clear diagnosis message.
-# The workflow stays green as long as the tests that DID run passed.
+# If a secret is absent the relevant tests FAIL with a clear diagnosis message
+# (`_require_env` -> pytest.fail, deliberately: "e2e tests fail on missing
+# infrastructure, not skip"). A failed test fails its step, and a failed step fails
+# the JOB — this workflow does NOT go green just because the tests that ran passed.
+#
+# Consequence worth knowing (issue #491): the TWILIO_* secrets are not configured on
+# this repo, so the marker-tagged step always fails. The test steps below therefore
+# carry a reachability gate (`steps.stub_bot.outcome == 'success'`) so ONE missing
+# secret family cannot silence every other test in the suite. They still report
+# honestly and the job still fails — the gate buys visibility, not a green.
 
 on:
   workflow_dispatch:
@@ -79,6 +87,7 @@ jobs:
       # e2e tests stop skipping.
       # ---------------------------------------------------------------
       - name: Start bundled Pipecat stub bot
+        id: stub_bot
         run: |
           uv run python examples/voice/_bot/bot.py \
             >> /tmp/voice-pipecat-bot.log 2>&1 &
@@ -149,6 +158,22 @@ jobs:
           TWILIO_PHONE_NUMBER_2: ${{ secrets.TWILIO_PHONE_NUMBER_2 }}
 
       - name: Run example-suite voice integration tests
+        # Reachability gate (issue #491). Without this, the demos this PR exists to
+        # un-skip can NEVER run: the step above collects three Twilio-gated tests
+        # (test_twilio_inbound/outbound/dtmf_ivr_e2e.py) whose fixtures pytest.FAIL —
+        # by design — when TWILIO_* env is absent, and those secrets are not configured
+        # on this repo. A failed step aborts the job, so every step below it is skipped.
+        # That is why voice-integration is 30/30 red and the isolated step has 0 runs.
+        # Un-skipping the demos while leaving them unreachable would just trade
+        # "@pytest.mark.skip" for "step never executes" — the same asserted-but-never-run
+        # hole in a new costume.
+        #
+        # So: run whenever the stub bot came up, regardless of an unrelated step's
+        # failure. This does NOT hide anything — a failed step still fails the JOB, so
+        # there is no hollow green; it only stops one missing secret from silencing
+        # every other test in the suite. Gated on the bot rather than always() so a
+        # bot-startup failure doesn't spawn 6 doomed 10-minute demo runs.
+        if: ${{ !cancelled() && steps.stub_bot.outcome == 'success' }}
         run: uv run pytest examples/test_audio_to_audio.py examples/test_audio_to_text.py -v --tb=short
         working-directory: python
         env:
@@ -162,6 +187,8 @@ jobs:
       # each (issue #491); those run in the dedicated isolated step below.
       # ---------------------------------------------------------------
       - name: Run @e2e voice demos
+        # Reachability gate — see the first occurrence above (issue #491).
+        if: ${{ !cancelled() && steps.stub_bot.outcome == 'success' }}
         # CI honesty (#708): `tee` masks pytest's exit without `pipefail` (same
         # class of bug as the vitest step). Set it so a failing demo fails the
         # step instead of being swallowed by tee's exit 0.
@@ -194,6 +221,8 @@ jobs:
       # `voice_multiturn` marker so this list never drifts from the test files.
       # ---------------------------------------------------------------
       - name: Run multi-turn voice @e2e demos (isolated — one process each)
+        # Reachability gate — see the first occurrence above (issue #491).
+        if: ${{ !cancelled() && steps.stub_bot.outcome == 'success' }}
         run: |
           set -uo pipefail
           # Capture collection output AND exit code (stderr merged in). A NON-zero

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -131,6 +131,14 @@ jobs:
         # also hid real test failures. Tolerate exit 5 only; propagate every
         # other non-zero so a genuine failure fails the step and the workflow.
         #
+        # `--timeout=540` is NOT optional (issue #491). pytest.ini sets `timeout = 60`
+        # and WINS over pyproject.toml, and `timeout_method = thread` kills the ENTIRE
+        # pytest process — not just the slow test. In THIS workflow LANGWATCH_API_KEY is
+        # set, so every scenario.run() pays a telemetry drain of ~30s PER EVENT, serial
+        # (measured: +153s on a 27.6s demo). Without an override that drain pushes tests
+        # past 60s and the step dies mid-suite. PROVEN in run 29231496466: this step's
+        # sibling ("Run @e2e voice demos") had no override and was killed twice by the
+        # cap, while the isolated step — which does override — took zero kills.
         # `not voice_multiturn` keeps the multi-turn @e2e demos out of this
         # single-process run — they wedge when collected together (issue #491)
         # and are exercised one-process-each by the isolated step below.
@@ -140,7 +148,7 @@ jobs:
           # `--reruns 1` (pytest-rerunfailures, already a dep): absorb a single
           # ambient hosted-EL flake (#708) while a genuine failure that fails
           # both attempts still propagates.
-          uv run pytest tests/voice -m "integration and not voice_multiturn" -v --tb=short --reruns 1 || rc=$?
+          uv run pytest tests/voice -m "integration and not voice_multiturn" -v --tb=short --reruns 1 --timeout=540 || rc=$?
           if [ "$rc" -eq 5 ]; then
             echo "No integration-marked tests collected — treating as pass."
             exit 0
@@ -174,7 +182,7 @@ jobs:
         # every other test in the suite. Gated on the bot rather than always() so a
         # bot-startup failure doesn't spawn 6 doomed 10-minute demo runs.
         if: ${{ !cancelled() && steps.stub_bot.outcome == 'success' }}
-        run: uv run pytest examples/test_audio_to_audio.py examples/test_audio_to_text.py -v --tb=short
+        run: uv run pytest examples/test_audio_to_audio.py examples/test_audio_to_text.py -v --tb=short --timeout=300
         working-directory: python
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -198,7 +206,7 @@ jobs:
           # `--reruns 1` (pytest-rerunfailures): absorb a single ambient
           # hosted-EL flake (#708); a genuine failure that fails both attempts
           # still propagates through `pipefail` and fails the step.
-          uv run pytest tests/voice/ -m "not voice_multiturn" -v --tb=short -q --reruns 1 2>&1 | tee /tmp/e2e-voice-results.log
+          uv run pytest tests/voice/ -m "not voice_multiturn" -v --tb=short -q --reruns 1 --timeout=540 2>&1 | tee /tmp/e2e-voice-results.log
         working-directory: python
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -193,6 +193,13 @@ jobs:
           files=$(uv run pytest tests/voice/ -m voice_multiturn --collect-only -q 2>/dev/null \
             | grep '::' | cut -d: -f1 | sort -u)
           echo "Isolated multi-turn demos:"; echo "$files"
+          # Fail loudly rather than silently passing if discovery returns nothing
+          # (e.g. a collection/import error, or the marker getting renamed) — an
+          # empty list must not look like "all multi-turn demos passed".
+          if [ -z "$files" ]; then
+            echo "ERROR: no voice_multiturn demos discovered — collection error or marker drift." >&2
+            exit 1
+          fi
           rc=0
           for f in $files; do
             echo "::group::${f} (isolated process)"

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -190,18 +190,27 @@ jobs:
       - name: Run multi-turn voice @e2e demos (isolated — one process each)
         run: |
           set -uo pipefail
-          files=$(uv run pytest tests/voice/ -m voice_multiturn --collect-only -q 2>/dev/null \
-            | grep '::' | cut -d: -f1 | sort -u)
-          echo "Isolated multi-turn demos:"; echo "$files"
-          # Fail loudly rather than silently passing if discovery returns nothing
-          # (e.g. a collection/import error, or the marker getting renamed) — an
-          # empty list must not look like "all multi-turn demos passed".
-          if [ -z "$files" ]; then
-            echo "ERROR: no voice_multiturn demos discovered — collection error or marker drift." >&2
+          # Capture collection output AND exit code (stderr merged in). A NON-zero
+          # exit means collection failed — including a PARTIAL failure where one
+          # demo errors on import while others collect: pytest exits non-zero and
+          # we must fail, not silently run the subset (that would re-introduce the
+          # very "asserted-but-never-run" hole this step closes).
+          collect_out=$(uv run pytest tests/voice/ -m voice_multiturn --collect-only -q 2>&1)
+          collect_rc=$?
+          if [ "$collect_rc" -ne 0 ]; then
+            echo "ERROR: collecting voice_multiturn demos failed (pytest exit $collect_rc):" >&2
+            printf '%s\n' "$collect_out" >&2
+            exit 1
+          fi
+          # Discover the demo set by marker so it can't drift from the test files.
+          mapfile -t files < <(printf '%s\n' "$collect_out" | grep '::' | cut -d: -f1 | sort -u)
+          echo "Isolated multi-turn demos:"; printf '  %s\n' "${files[@]:-}"
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "ERROR: no voice_multiturn demos discovered — marker drift or rename." >&2
             exit 1
           fi
           rc=0
-          for f in $files; do
+          for f in "${files[@]}"; do
             echo "::group::${f} (isolated process)"
             uv run pytest -p no:cacheprovider -x "$f" -v --tb=short || rc=1
             echo "::endgroup::"

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -195,8 +195,14 @@ jobs:
           # demo errors on import while others collect: pytest exits non-zero and
           # we must fail, not silently run the subset (that would re-introduce the
           # very "asserted-but-never-run" hole this step closes).
-          collect_out=$(uv run pytest tests/voice/ -m voice_multiturn --collect-only -q 2>&1)
-          collect_rc=$?
+          #
+          # `|| collect_rc=$?` is load-bearing: this step runs under GitHub's
+          # default `bash -e {0}`, so a bare `collect_out=$(...)` assignment would
+          # abort the step the instant pytest exits non-zero — before `$?` is read,
+          # discarding the diagnostics we just captured into the variable and
+          # failing with NO output. The `||` suppresses errexit so we can report.
+          collect_rc=0
+          collect_out=$(uv run pytest tests/voice/ -m voice_multiturn --collect-only -q 2>&1) || collect_rc=$?
           if [ "$collect_rc" -ne 0 ]; then
             echo "ERROR: collecting voice_multiturn demos failed (pytest exit $collect_rc):" >&2
             printf '%s\n' "$collect_out" >&2

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -212,7 +212,11 @@ jobs:
           rc=0
           for f in "${files[@]}"; do
             echo "::group::${f} (isolated process)"
-            uv run pytest -p no:cacheprovider -x "$f" -v --tb=short || rc=1
+            # External per-file wall-clock cap. pytest-timeout's signal/thread
+            # methods can't interrupt these asyncio teardown hangs (see
+            # pyproject.toml note), so if the drain wedge ever recurs, this caps
+            # one bad demo at 10 min instead of letting it ride the job timeout.
+            timeout 600 uv run pytest -p no:cacheprovider -x "$f" -v --tb=short || rc=1
             echo "::endgroup::"
           done
           exit $rc

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -115,13 +115,17 @@ jobs:
         # to tolerate "no tests matched the marker" (pytest exit 5) — but it
         # also hid real test failures. Tolerate exit 5 only; propagate every
         # other non-zero so a genuine failure fails the step and the workflow.
+        #
+        # `not voice_multiturn` keeps the multi-turn @e2e demos out of this
+        # single-process run — they wedge when collected together (issue #491)
+        # and are exercised one-process-each by the isolated step below.
         shell: bash
         run: |
           rc=0
           # `--reruns 1` (pytest-rerunfailures, already a dep): absorb a single
           # ambient hosted-EL flake (#708) while a genuine failure that fails
           # both attempts still propagates.
-          uv run pytest tests/voice -m integration -v --tb=short --reruns 1 || rc=$?
+          uv run pytest tests/voice -m "integration and not voice_multiturn" -v --tb=short --reruns 1 || rc=$?
           if [ "$rc" -eq 5 ]; then
             echo "No integration-marked tests collected — treating as pass."
             exit 0
@@ -148,6 +152,8 @@ jobs:
 
       # ---------------------------------------------------------------
       # Run the @e2e voice demos (fail-fast on missing infrastructure).
+      # `not voice_multiturn` excludes the demos that must run one-process-
+      # each (issue #491); those run in the dedicated isolated step below.
       # ---------------------------------------------------------------
       - name: Run @e2e voice demos
         # CI honesty (#708): `tee` masks pytest's exit without `pipefail` (same
@@ -159,7 +165,41 @@ jobs:
           # `--reruns 1` (pytest-rerunfailures): absorb a single ambient
           # hosted-EL flake (#708); a genuine failure that fails both attempts
           # still propagates through `pipefail` and fails the step.
-          uv run pytest tests/voice/ -v --tb=short -q --reruns 1 2>&1 | tee /tmp/e2e-voice-results.log
+          uv run pytest tests/voice/ -m "not voice_multiturn" -v --tb=short -q --reruns 1 2>&1 | tee /tmp/e2e-voice-results.log
+        working-directory: python
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_PHONE_NUMBER: ${{ secrets.TWILIO_PHONE_NUMBER }}
+          TWILIO_PHONE_NUMBER_2: ${{ secrets.TWILIO_PHONE_NUMBER_2 }}
+
+      # ---------------------------------------------------------------
+      # Multi-turn @e2e demos — one pytest process EACH.
+      #
+      # These wedge when collected together in a single process (issue #491;
+      # see TESTING.md "Voice @e2e suite — isolation requirement"). Rather than
+      # paper over an unverifiable contract with @pytest.mark.skip, we run each
+      # in a fresh process so a leaked background task / socket / subprocess in
+      # one demo cannot wedge the next. The demo set is discovered by the
+      # `voice_multiturn` marker so this list never drifts from the test files.
+      # ---------------------------------------------------------------
+      - name: Run multi-turn voice @e2e demos (isolated — one process each)
+        run: |
+          set -uo pipefail
+          files=$(uv run pytest tests/voice/ -m voice_multiturn --collect-only -q 2>/dev/null \
+            | grep '::' | cut -d: -f1 | sort -u)
+          echo "Isolated multi-turn demos:"; echo "$files"
+          rc=0
+          for f in $files; do
+            echo "::group::${f} (isolated process)"
+            uv run pytest -p no:cacheprovider -x "$f" -v --tb=short || rc=1
+            echo "::endgroup::"
+          done
+          exit $rc
         working-directory: python
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -217,6 +217,11 @@ jobs:
           # Discover the demo set by marker so it can't drift from the test files.
           mapfile -t files < <(printf '%s\n' "$collect_out" | grep '::' | cut -d: -f1 | sort -u)
           echo "Isolated multi-turn demos:"; printf '  %s\n' "${files[@]:-}"
+          # Belt-and-braces, and deliberately kept though currently UNREACHABLE: pytest
+          # exits 5 when a marker collects nothing and 2 on a collection error, so the
+          # rc check above already catches every path that would leave `files` empty.
+          # Retained because "silently ran zero demos" is the exact hole this step exists
+          # to close — if a future pytest ever returns 0 with no matches, this is the net.
           if [ "${#files[@]}" -eq 0 ]; then
             echo "ERROR: no voice_multiturn demos discovered — marker drift or rename." >&2
             exit 1

--- a/TESTING.md
+++ b/TESTING.md
@@ -108,24 +108,65 @@ between function-scoped event loops, and the `ffmpeg` playback subprocess in
 `python/scenario/voice/playback.py` not always exiting cleanly on `.stop()`.
 
 A narrower SDK-level fix — bounding `event_bus.drain()` so telemetry can never
-block test teardown indefinitely — is recommended as a follow-up. It changes the
-shared event-bus delivery guarantee for *every* `scenario.run()` caller, so it is
-tracked separately from this process-isolation resolution.
+block test teardown indefinitely — is recommended as a follow-up (#791). It changes
+the shared event-bus delivery guarantee for *every* `scenario.run()` caller, so it
+is tracked separately from this process-isolation resolution.
+
+### Reproducing the drain — creds-free, ~3 minutes
+
+You do not need a LangWatch account. Point the endpoint at a socket that **accepts
+but never responds**; any dummy key works, because nothing ever answers.
+
+```python
+# blackhole.py — accepts TCP, swallows the request, never writes a response.
+import socket, threading, time
+s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", 9099)); s.listen(128)
+def handle(c):
+    c.recv(65536)
+    while True: time.sleep(3600)   # hold it open, never respond
+while True:
+    c, _ = s.accept(); threading.Thread(target=handle, args=(c,), daemon=True).start()
+```
+
+```bash
+python3 blackhole.py &
+export LANGWATCH_ENDPOINT=http://127.0.0.1:9099
+export LANGWATCH_API_KEY=sk-lw-blackhole-not-a-real-key
+pytest -p no:cacheprovider -x python/tests/voice/test_multi_intent_e2e.py --timeout=540
+```
+
+**Measured:** that demo takes **27.6s** with telemetry off and **181s** against the
+black hole — **+153s of pure teardown**. A stack dump mid-teardown parks at
+`event_bus.drain()` → `_event_queue.join()` → `all_tasks_done.wait()`, and the POST
+`ReadTimeout`s land **exactly 30s apart**. So: **teardown ≈ `events × 30s`**, serial,
+unbounded. That is the number #791 needs.
 
 ### Running the multi-turn demos
 
+**Always pass an explicit `--timeout`.** `pytest.ini` sets `timeout = 60` and it
+**wins over** `pyproject.toml` (pytest says so: `configfile: pytest.ini (WARNING:
+ignoring pytest config in pyproject.toml!)`). Worse, `timeout_method = thread` kills
+the **entire pytest process**, not just the slow test — so one demo over the cap
+takes the whole suite down with a thread dump, which looks exactly like a hang. Three
+of these demos exceed 60s even with telemetry off, and the drain above adds far more.
+
 ```bash
 # Supported: one process per demo (what voice-integration.yml does).
-pytest -p no:cacheprovider -x python/tests/voice/test_long_hold_e2e.py
-pytest -p no:cacheprovider -x python/tests/voice/test_emotional_escalation_e2e.py
+pytest -p no:cacheprovider -x python/tests/voice/test_long_hold_e2e.py --timeout=540
 
 # …or discover the whole set by marker and loop, one process each:
 for f in $(pytest python/tests/voice -m voice_multiturn --collect-only -q \
             | grep '::' | cut -d: -f1 | sort -u); do
-  pytest -p no:cacheprovider -x "$f"
+  timeout 600 pytest -p no:cacheprovider -x "$f" --timeout=540
 done
 
-# NOT supported: collecting them together in one process — will wedge.
+# Collecting them together in ONE process is not supported — but be precise about
+# why: it is not intrinsic. With the cap lifted and telemetry off they complete
+# together in ~424s. What kills a shared run is the drain pushing a demo past the
+# 60s cap, at which point the thread method destroys the whole process. Per-process
+# isolation is defence-in-depth (it caps a pathological drain at one demo instead of
+# the suite) — the load-bearing fix is the timeout override.
 pytest -m voice_multiturn python/tests/voice/
 ```
 ## WAV / Recording File Policy

--- a/TESTING.md
+++ b/TESTING.md
@@ -70,33 +70,63 @@ This keeps the suite lean while ensuring real failures never recur.
 The voice `@e2e` demos under `python/tests/voice/test_*_e2e.py` are auto-marked
 `integration` by `python/tests/voice/conftest.py:pytest_collection_modifyitems`
 and the default `python-ci` job deselects them with `-m "not integration"`.
-They only run via the nightly `voice-integration.yml` dispatch.
+They only run via the on-demand `voice-integration.yml` dispatch.
 
-Several multi-turn demos additionally carry a `@pytest.mark.skip` marker
-(reason: *"Hangs in full suite (not in isolation) — multi-turn max_turns demos
-wedge pytest process"*). The wedge is reproducible only when the full voice
-e2e suite is run in a single pytest process. Likely contributors (not yet
-isolated):
+Several **multi-turn** demos additionally carry the `voice_multiturn` marker.
+They MUST run one pytest process each: collecting them together in a single
+process wedges the run (issue #491). The marker lets `voice-integration.yml`
+deselect them from the bulk run (`-m "not voice_multiturn"`) and execute each in
+a fresh process — replacing the earlier `@pytest.mark.skip` markers that left
+the `@e2e` contract asserted-but-never-run.
 
-- Background tasks (`asyncio.create_task`) spawned by adapters
-  (Gemini Live `_session_lifetime`, Twilio webhook server, Cloudflare tunnel
-  subprocess) that aren't fully reaped between function-scoped event loops.
-- The `ffmpeg` playback subprocess in `python/scenario/voice/playback.py`
-  not always exiting cleanly when `.stop()` runs.
-- `max_turns` runaway in demos that should converge in 2-3 turns but spin
-  against a quota when judged in batch.
+### Root cause (diagnosed in #491)
 
-Until the wedge is diagnosed (tracked in issue #491), run the multi-turn
-demos with one process per cluster:
+`scenario.run()` offloads each scenario to a worker thread with a private event
+loop and, in that thread's `finally`, calls `event_bus.drain()` synchronously
+(`python/scenario/_events/event_bus.py`). `drain()` does an **unbounded**
+`self._event_queue.join()` that only returns once the event-bus worker thread
+has POSTed every scenario event to the LangWatch telemetry endpoint. Each POST
+has a 30s httpx timeout (`event_reporter.py`) and the worker drains events
+**serially**, so teardown cost scales with `event_count × up-to-30s` whenever the
+endpoint is reachable-but-slow. Multi-turn voice demos emit the most events (one
+per turn, plus base64 audio snapshots), so their teardown is the most exposed;
+running several in one process compounds it past the 60s per-test timeout and the
+process appears wedged.
+
+Confirmed creds-free: point `LANGWATCH_ENDPOINT` at a socket that accepts but
+never responds and run any `scenario.run()` — the worker blocks in
+`socket.recv_into` (awaiting the HTTP response) while the calling thread blocks in
+`event_bus.drain()` → `queue.join()`. Locally the default endpoint fast-refuses,
+so the drain returns immediately — which is why the wedge is invisible in
+isolation and on a developer box but bites in the integration workflow, where
+`LANGWATCH_API_KEY` is set and telemetry actually posts.
+
+Other contributors that per-process isolation also neutralises: background
+`asyncio.create_task`s spawned by adapters (Gemini Live `_session_lifetime`,
+Twilio webhook server, Cloudflare tunnel subprocess) that aren't fully reaped
+between function-scoped event loops, and the `ffmpeg` playback subprocess in
+`python/scenario/voice/playback.py` not always exiting cleanly on `.stop()`.
+
+A narrower SDK-level fix — bounding `event_bus.drain()` so telemetry can never
+block test teardown indefinitely — is recommended as a follow-up. It changes the
+shared event-bus delivery guarantee for *every* `scenario.run()` caller, so it is
+tracked separately from this process-isolation resolution.
+
+### Running the multi-turn demos
 
 ```bash
-# OK — fresh process per demo cluster.
+# Supported: one process per demo (what voice-integration.yml does).
 pytest -p no:cacheprovider -x python/tests/voice/test_long_hold_e2e.py
 pytest -p no:cacheprovider -x python/tests/voice/test_emotional_escalation_e2e.py
-# …etc.
 
-# NOT OK — runs the whole suite in one process, will wedge.
-pytest -m integration python/tests/voice/
+# …or discover the whole set by marker and loop, one process each:
+for f in $(pytest python/tests/voice -m voice_multiturn --collect-only -q \
+            | grep '::' | cut -d: -f1 | sort -u); do
+  pytest -p no:cacheprovider -x "$f"
+done
+
+# NOT supported: collecting them together in one process — will wedge.
+pytest -m voice_multiturn python/tests/voice/
 ```
 ## WAV / Recording File Policy
 

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -7,5 +7,5 @@ asyncio_default_fixture_loop_scope=function
 timeout = 60
 timeout_method = thread
 markers =
-    integration: hits live providers / external services — requires API keys, run via the nightly voice-integration workflow, not on every PR.
+    integration: hits live providers / external services — requires API keys, run via the on-demand voice-integration workflow, not on every PR.
     voice_multiturn: multi-turn voice @e2e demo that must run in its own pytest process. Several of these wedge the process if run together in one suite (see issue #491 / TESTING.md "Voice @e2e suite — isolation requirement"). The voice-integration workflow deselects them from the bulk run and runs each in a fresh process.

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -8,3 +8,4 @@ timeout = 60
 timeout_method = thread
 markers =
     integration: hits live providers / external services — requires API keys, run via the nightly voice-integration workflow, not on every PR.
+    voice_multiturn: multi-turn voice @e2e demo that must run in its own pytest process. Several of these wedge the process if run together in one suite (see issue #491 / TESTING.md "Voice @e2e suite — isolation requirement"). The voice-integration workflow deselects them from the bulk run and runs each in a fresh process.

--- a/python/tests/voice/conftest.py
+++ b/python/tests/voice/conftest.py
@@ -390,7 +390,7 @@ def pytest_collection_modifyitems(config, items):
     """Auto-mark *_e2e.py tests with `integration`.
 
     Why: voice e2e tests hit live providers (OpenAI, ElevenLabs, Twilio,
-    Gemini) and fail-fast on missing infrastructure. They run nightly via
+    Gemini) and fail-fast on missing infrastructure. They run on-demand via
     voice-integration.yml, not on every PR. python-ci uses
     `-m "not integration"` to deselect them.
     """

--- a/python/tests/voice/test_accent_loop_e2e.py
+++ b/python/tests/voice/test_accent_loop_e2e.py
@@ -15,7 +15,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice"))
 
 
-@pytest.mark.skip(reason="Hangs in full suite (not in isolation) — multi-turn max_turns demos wedge pytest process. Same pattern as 6.3, 6.7. Scoped to follow-up per #350 narrowing decision (cut from narrowed PR).")
+@pytest.mark.voice_multiturn  # runs in its own process; see TESTING.md (issue #491)
 @pytest.mark.asyncio
 async def test_pain_accent_loop_e2e_success(requires_llm, requires_pipecat_bot):
     """Agent offers alternative input after repeated accent misunderstandings."""

--- a/python/tests/voice/test_emotional_escalation_e2e.py
+++ b/python/tests/voice/test_emotional_escalation_e2e.py
@@ -15,7 +15,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice"))
 
 
-@pytest.mark.skip(reason="Hangs in full suite (not in isolation) — multi-turn max_turns demos wedge pytest process. Same pattern as 6.3, 6.7. Scoped to follow-up per #350 narrowing decision (cut from narrowed PR).")
+@pytest.mark.voice_multiturn  # runs in its own process; see TESTING.md (issue #491)
 @pytest.mark.asyncio
 async def test_pain_emotional_escalation_e2e_success(requires_llm, requires_pipecat_bot):
     """Agent detects emotional escalation and responds with empathy."""

--- a/python/tests/voice/test_long_hold_e2e.py
+++ b/python/tests/voice/test_long_hold_e2e.py
@@ -14,7 +14,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice"))
 
 
-@pytest.mark.skip(reason="Hangs in full suite (not in isolation) — multi-turn max_turns demos wedge pytest process. Same pattern as 6.3, 6.7. Scoped to follow-up per #350 narrowing decision (cut from narrowed PR).")
+@pytest.mark.voice_multiturn  # runs in its own process; see TESTING.md (issue #491)
 @pytest.mark.asyncio
 async def test_pain_long_hold_e2e_success(requires_llm, requires_pipecat_bot):
     """Agent provides feedback during a 15s simulated hold; scenario succeeds."""

--- a/python/tests/voice/test_multi_intent_e2e.py
+++ b/python/tests/voice/test_multi_intent_e2e.py
@@ -15,7 +15,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice"))
 
 
-@pytest.mark.skip(reason="Hangs in full suite (not in isolation) — multi-turn max_turns demos wedge pytest process. Same pattern as 6.3, 6.7. Scoped to follow-up per #350 narrowing decision (cut from narrowed PR).")
+@pytest.mark.voice_multiturn  # runs in its own process; see TESTING.md (issue #491)
 @pytest.mark.asyncio
 async def test_pain_multi_intent_e2e_success(requires_llm, requires_pipecat_bot):
     """Agent addresses both intents in a single user turn."""

--- a/python/tests/voice/test_openai_realtime_agent_e2e.py
+++ b/python/tests/voice/test_openai_realtime_agent_e2e.py
@@ -1,7 +1,7 @@
 """
 E2E check — OpenAI Realtime adapter (AGENT role) against the GA Realtime API.
 
-Integration / nightly, key-gated (``requires_llm``).  Runs the
+Integration / on-demand, key-gated (``requires_llm``).  Runs the
 ``openai_realtime_agent`` demo script end-to-end against the real OpenAI
 Realtime WebSocket API and asserts ``result.success`` is True.
 """

--- a/python/tests/voice/test_openai_realtime_user_e2e.py
+++ b/python/tests/voice/test_openai_realtime_user_e2e.py
@@ -1,7 +1,7 @@
 """
 E2E check — OpenAI Realtime adapter (USER role) against the GA Realtime API.
 
-Integration / nightly, key-gated (``requires_llm``).  Runs the
+Integration / on-demand, key-gated (``requires_llm``).  Runs the
 ``openai_realtime_user`` demo script end-to-end against the real OpenAI
 Realtime WebSocket API and asserts ``result.success`` is True.  Verifies that
 scripted ``user("text")`` lines are delivered via the text-input channel

--- a/python/tests/voice/test_pain_patterns.py
+++ b/python/tests/voice/test_pain_patterns.py
@@ -3,7 +3,7 @@ Unit-level mechanism probes for the five §8 pain patterns.
 
 These are the user-value scenarios that justify the voice feature. Each
 pain-pattern scenario in ``specs/voice-agents.feature`` is tagged
-``@integration`` (full end-to-end exercise runs under the nightly voice
+``@integration`` (full end-to-end exercise runs under the on-demand voice
 workflow). The tests here probe the *mechanisms* that enable each pattern,
 on mocked adapters, so the implementation seam is regression-guarded even
 without live providers.

--- a/python/tests/voice/test_random_interruptions_e2e.py
+++ b/python/tests/voice/test_random_interruptions_e2e.py
@@ -16,13 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="Example 6.7 hangs in the suite (not in isolation) — suite-level "
-    "test isolation bug same pattern as 6.3. Passes via "
-    "`pytest tests/voice/test_example_6_7_random_interruptions_e2e.py` alone "
-    "but wedges the pytest process when executed as part of the full voice "
-    "suite. Scoped to follow-up."
-)
+@pytest.mark.voice_multiturn  # runs in its own process; see TESTING.md (issue #491)
 async def test_example_6_7_random_interruptions_e2e(requires_llm, requires_pipecat_bot):
     """Scenario with interrupt_probability=0.4 over 5 turns.
 

--- a/python/tests/voice/test_random_interruptions_e2e.py
+++ b/python/tests/voice/test_random_interruptions_e2e.py
@@ -15,8 +15,8 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice"))
 
 
-@pytest.mark.asyncio
 @pytest.mark.voice_multiturn  # runs in its own process; see TESTING.md (issue #491)
+@pytest.mark.asyncio
 async def test_example_6_7_random_interruptions_e2e(requires_llm, requires_pipecat_bot):
     """Scenario with interrupt_probability=0.4 over 5 turns.
 

--- a/python/tests/voice/test_silence_handling_e2e.py
+++ b/python/tests/voice/test_silence_handling_e2e.py
@@ -14,7 +14,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice"))
 
 
-@pytest.mark.skip(reason="Hangs in full suite (not in isolation) — multi-turn max_turns demos wedge pytest process. Same pattern as 6.3, 6.7. Scoped to follow-up per #350 narrowing decision (cut from narrowed PR).")
+@pytest.mark.voice_multiturn  # runs in its own process; see TESTING.md (issue #491)
 @pytest.mark.asyncio
 async def test_example_6_8_silence_handling_e2e_success(requires_llm, requires_pipecat_bot):
     """Silence injection scenario completes with result.success True."""

--- a/python/tests/voice/test_vad.py
+++ b/python/tests/voice/test_vad.py
@@ -50,8 +50,13 @@ class _ScriptedVad:
         return self._verdicts.pop(0) if self._verdicts else False
 
 
-def _vad_with_scripted_verdicts(verdicts: list[bool]):
-    """Build a fallback whose classifier is scripted; return (vad, stub, starts, ends)."""
+def _vad_with_scripted_verdicts(monkeypatch: pytest.MonkeyPatch, verdicts: list[bool]):
+    """Build a fallback whose classifier is scripted; return (vad, stub, starts, ends).
+
+    ``monkeypatch`` (rather than a direct ``vad._vad = stub``) because the real
+    ``_vad`` is nominally a ``webrtcvad.Vad`` — a C-extension class the stub cannot
+    subclass — so a plain assignment is a pyright ``reportAttributeAccessIssue``.
+    """
     WebRTCVadFallback.reset_warnings()
     starts: list[bool] = []
     ends: list[bool] = []
@@ -61,11 +66,11 @@ def _vad_with_scripted_verdicts(verdicts: list[bool]):
         on_speech_end=lambda: ends.append(True),
     )
     stub = _ScriptedVad(verdicts)
-    vad._vad = stub  # noqa: SLF001 — pin the state machine, not webrtcvad's acoustics
+    monkeypatch.setattr(vad, "_vad", stub)
     return vad, stub, starts, ends
 
 
-def test_vad_fires_one_event_per_transition_not_per_frame():
+def test_vad_fires_one_event_per_transition_not_per_frame(monkeypatch: pytest.MonkeyPatch):
     """Callbacks are **edge**-triggered: one event per speech *run*, not per frame.
 
     The transition tests above assert ``>= 1`` start/end because the real
@@ -76,7 +81,7 @@ def test_vad_fires_one_event_per_transition_not_per_frame():
     surrounded by silence yields exactly ONE start and exactly ONE end.
     """
     verdicts = [False, True, True, True, True, True, False, False]
-    vad, stub, starts, ends = _vad_with_scripted_verdicts(verdicts)
+    vad, stub, starts, ends = _vad_with_scripted_verdicts(monkeypatch, verdicts)
 
     vad.process(AudioChunk(data=_frames(len(verdicts))))
 
@@ -86,7 +91,7 @@ def test_vad_fires_one_event_per_transition_not_per_frame():
     assert not vad.is_speaking
 
 
-def test_vad_buffers_partial_frames_across_chunks():
+def test_vad_buffers_partial_frames_across_chunks(monkeypatch: pytest.MonkeyPatch):
     """A frame split across chunks is reassembled — the residual is not dropped.
 
     ``process()`` keeps a partial frame in ``self._buf`` and completes it from the
@@ -95,7 +100,7 @@ def test_vad_buffers_partial_frames_across_chunks():
     unnoticed. Streaming transports hand us arbitrarily-sized chunks, so this is
     the class's normal operating mode, not an edge case.
     """
-    vad, stub, starts, _ends = _vad_with_scripted_verdicts([True])
+    vad, stub, starts, _ends = _vad_with_scripted_verdicts(monkeypatch, [True])
     payload = _frames(1)
     third = len(payload) // 3
 

--- a/python/tests/voice/test_vad.py
+++ b/python/tests/voice/test_vad.py
@@ -22,6 +22,95 @@ def _silence_pcm(duration_s: float) -> bytes:
     return b"\x00\x00" * int(duration_s * SR)
 
 
+def _frames(n: int) -> bytes:
+    """``n`` whole VAD frames of arbitrary PCM.
+
+    Content is irrelevant wherever a :class:`_ScriptedVad` is installed — the
+    classification is scripted, so these bytes only have to be the right *length*.
+    """
+    return b"\x01\x00" * (WebRTCVadFallback.SAMPLES_PER_FRAME * n)
+
+
+class _ScriptedVad:
+    """Deterministic stand-in for ``webrtcvad.Vad``.
+
+    The real classifier's verdicts depend on the acoustic content, so tests that
+    drive it with noise can only assert ``>= 1`` transition (it legitimately
+    flickers at the boundary). That fuzziness is exactly what lets a
+    level-triggered regression hide. Scripting the per-frame verdicts makes the
+    transition contract *exactly* assertable.
+    """
+
+    def __init__(self, verdicts: list[bool]):
+        self._verdicts = list(verdicts)
+        self.calls = 0
+
+    def is_speech(self, frame: bytes, rate: int) -> bool:
+        self.calls += 1
+        return self._verdicts.pop(0) if self._verdicts else False
+
+
+def _vad_with_scripted_verdicts(verdicts: list[bool]):
+    """Build a fallback whose classifier is scripted; return (vad, stub, starts, ends)."""
+    WebRTCVadFallback.reset_warnings()
+    starts: list[bool] = []
+    ends: list[bool] = []
+    vad = WebRTCVadFallback(
+        "TestAdapter",
+        on_speech_start=lambda: starts.append(True),
+        on_speech_end=lambda: ends.append(True),
+    )
+    stub = _ScriptedVad(verdicts)
+    vad._vad = stub  # noqa: SLF001 — pin the state machine, not webrtcvad's acoustics
+    return vad, stub, starts, ends
+
+
+def test_vad_fires_one_event_per_transition_not_per_frame():
+    """Callbacks are **edge**-triggered: one event per speech *run*, not per frame.
+
+    The transition tests above assert ``>= 1`` start/end because the real
+    classifier flickers on noise — so they pass just as happily against a
+    *level*-triggered detector that re-fires ``on_speech_start`` for every single
+    speech frame. That would spam the timeline with one "speech started" per 30 ms.
+    Scripting the verdicts lets us pin the real contract: a 5-frame speech run
+    surrounded by silence yields exactly ONE start and exactly ONE end.
+    """
+    verdicts = [False, True, True, True, True, True, False, False]
+    vad, stub, starts, ends = _vad_with_scripted_verdicts(verdicts)
+
+    vad.process(AudioChunk(data=_frames(len(verdicts))))
+
+    assert stub.calls == len(verdicts), "every whole frame must be classified"
+    assert len(starts) == 1, f"speech run must fire exactly one start, got {len(starts)}"
+    assert len(ends) == 1, f"speech run must fire exactly one end, got {len(ends)}"
+    assert not vad.is_speaking
+
+
+def test_vad_buffers_partial_frames_across_chunks():
+    """A frame split across chunks is reassembled — the residual is not dropped.
+
+    ``process()`` keeps a partial frame in ``self._buf`` and completes it from the
+    next chunk. Every other test feeds whole-frame-sized chunks, so a regression
+    that discarded the residual each call (or classified a short frame) would go
+    unnoticed. Streaming transports hand us arbitrarily-sized chunks, so this is
+    the class's normal operating mode, not an edge case.
+    """
+    vad, stub, starts, _ends = _vad_with_scripted_verdicts([True])
+    payload = _frames(1)
+    third = len(payload) // 3
+
+    vad.process(AudioChunk(data=payload[:third]))
+    assert stub.calls == 0, "a sub-frame chunk must not be classified"
+    vad.process(AudioChunk(data=payload[third : 2 * third]))
+    assert stub.calls == 0, "still short of a whole frame — must keep buffering"
+
+    vad.process(AudioChunk(data=payload[2 * third :]))
+
+    assert stub.calls == 1, "the reassembled frame must be classified exactly once"
+    assert len(starts) == 1
+    assert vad.is_speaking
+
+
 def test_vad_fallback_warning_message_names_adapter_and_accuracy_caveat():
     """Content-shape assertion separate from the rate-limit shape below."""
     WebRTCVadFallback.reset_warnings()

--- a/python/tests/voice/test_vad.py
+++ b/python/tests/voice/test_vad.py
@@ -64,6 +64,32 @@ def test_vad_fallback_rate_limits_by_adapter_name(adapter_names, expected_warnin
     assert len(user_warnings) == expected_warning_count
 
 
+def test_vad_fallback_rate_limit_keys_on_name_string_not_python_class():
+    """The dedupe key is the caller-passed ``adapter_name`` string, not the
+    Python class.
+
+    The parametrized test above varies only the name, so on its own it cannot
+    distinguish "keyed on the string" from "keyed on the (single) class". This
+    pins the distinction explicitly with a *second* class: ``_warned_adapters``
+    is a ClassVar shared down the hierarchy, so a subclass instance built with a
+    string the base already warned for stays silent, while a fresh string warns.
+    Guards against a refactor that switches the key to ``type(self)`` / per-class
+    state — which would re-warn once per adapter class and defeat the rate-limit.
+    """
+
+    class _SubclassVad(WebRTCVadFallback):
+        pass
+
+    WebRTCVadFallback.reset_warnings()
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        WebRTCVadFallback("SharedName")  # base class warns for "SharedName"
+        _SubclassVad("SharedName")  # different class, same string → silent
+        _SubclassVad("OtherName")  # different class, new string → warns
+    user_warnings = [w for w in captured if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 2
+
+
 def test_vad_detects_silence_to_voice_to_silence_transitions():
     # Use dense random-noise "voice" between two silence chunks. Broadband
     # high-energy audio is reliably classified as speech by webrtcvad at

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -14,6 +14,26 @@ Feature: Voice agent testing in Scenario SDK
     And optional TTS provider deps (google-cloud-texttospeech, cartesia) are lazy-imported only when their provider prefix is used
 
   # ======================================================================
+  # README — @e2e voice demo isolation requirement (issue #491)
+  #
+  # The @e2e scenarios below are demonstrated by runnable examples in
+  # python/examples/voice/, wrapped by python/tests/voice/test_*_e2e.py, and
+  # exercised only by the on-demand voice-integration.yml workflow (they hit
+  # live providers and need API keys). python-ci deselects them via
+  # `-m "not integration"`.
+  #
+  # The MULTI-TURN demos (long_hold, accent_loop, emotional_escalation,
+  # multi_intent, silence_handling, random_interruptions) additionally carry
+  # the `voice_multiturn` pytest marker and MUST run one pytest process each —
+  # see TESTING.md "Voice @e2e suite — isolation requirement". Collecting them
+  # together in one process wedges teardown (the synchronous LangWatch
+  # event-bus drain blocks on telemetry; root cause documented in TESTING.md).
+  # Do NOT re-suppress a wedge with @pytest.mark.skip — that leaves the @e2e
+  # contract asserted-but-never-run. voice-integration.yml runs each marked
+  # demo in its own process instead.
+  # ======================================================================
+
+  # ======================================================================
   # Core API — §4.1 Voice Agent Adapters (Source L130-243)
   # ======================================================================
 


### PR DESCRIPTION
> **Scariest thing** — this PR un-skips 6 voice `@e2e` demos and **4 of them FAIL** when actually run. They fail for real, pre-existing reasons the skip had hidden since May; `voice-integration` has never been green (30/30 `failure`). The trap is the green checkmarks on *this* PR — they cover only the hermetic half (marker split, unit suites, pyright). Merging on that green while assuming #491 is done would tick an acceptance criterion that is **provably false**, which is why this says `Refs #491`, not `Closes`. Nothing in CI will stop you; only this line will. → **#796**
> **Start here** — `.github/workflows/voice-integration.yml`. Two things live there. (1) The **reachability gate** (`steps.stub_bot.outcome == 'success'`): without it the isolated step this PR adds **could never execute** — a step above it collects three Twilio-gated tests that `pytest.fail` on absent secrets, and a failed step skips everything below. The demos would have gone from "skipped" to "un-skipped but unreachable", which is the same asserted-but-never-run hole in a new costume. (2) `--timeout=540` on the isolated step: I reproduced the #491 drain and measured it adding **+153s to a 27.6s demo**; without the override the demos blow `pytest.ini`'s 60s cap and `timeout_method = thread` kills the **whole pytest process**.

## Why

The 6 multi-turn voice `@e2e` demos carried `@pytest.mark.skip` ("Hangs in full suite … multi-turn max_turns demos wedge pytest process"), so a large slice of the `@e2e` behavioral contract was asserted in the feature file but never actually run. This diagnoses the wedge and removes the skips without re-papering the contract.

Refs #491 — deliberately a non-closing link. This PR must NOT tick that issue's AC4 (*"CI runs whichever path was chosen and stays green"*), which is **provably unmet**. See "Anything surprising?".

## What changed

- **Root-caused the wedge (creds-free).** `scenario.run()` teardown calls `event_bus.drain()` synchronously, which blocks on an unbounded `queue.join()` until the `daemon=False` telemetry worker POSTs every scenario event (30s httpx timeout, drained serially). Teardown cost ≈ `events × up-to-30s` whenever the LangWatch endpoint is reachable-but-slow; multi-turn voice demos emit the most events (one/turn + base64 audio) so their teardown is the most exposed. Chose to **document + isolate** rather than re-architect the shared event bus — high blast radius, and the demos need live creds so a fix can't be verified in python-ci anyway. Bounding the drain is tracked SDK-wide as #791.
- **Resolution = per-process isolation (issue's path b), no skip papering.** Removed the 6 `@pytest.mark.skip`; tagged the demos `@pytest.mark.voice_multiturn` (registered in `pytest.ini`). `voice-integration.yml` deselects them from the two bulk single-process steps and runs each in its **own** pytest process (set discovered by marker, so it can't drift). Fresh process per demo neutralises the telemetry drain **and** the documented adapter task/subprocess leaks at once.
- **Lifted a 60s guillotine that would have hit on the very first run.** `pytest.ini` sets `timeout = 60` and **wins over** `pyproject.toml` — pytest says so on every run: `configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)`. So pyproject's *"@e2e voice tests can legitimately take 5+ min / per-test timeout deliberately NOT set"* note is **dead config**, and the un-skipped demos inherited the unit suite's 60s per-test cap (none carries a `@pytest.mark.timeout` override). That 60s is the **same budget `scenario/voice/adapter.py:91` allows for a *single* turn's STT+LLM+TTS** (`response_timeout = 60.0`) — on tests that burn a hard 15s in `scenario.sleep(15)` before running up to 8 live turns and an LLM judge. Un-skipping under that cap would have traded "asserted but never run" for "run, shot at 60s, red". The isolated step now overrides to `--timeout=540` inside the existing `timeout 600` wall (same idiom as python-ci's Examples step, which overrides to `--timeout=300` for exactly this reason). Job `timeout-minutes` 45 → 90, since the isolated step's own worst case is 6 × 600s = 60 min and a 45-min job cap would have fired mid-loop.
- **Collection failures now fail LOUDLY.** The isolated step declares no `shell:`, so it runs under GitHub's default `bash -e {0}` (errexit **on**) — a bare `collect_out=$(pytest --collect-only)` aborted the step the instant pytest exited non-zero, *before* `collect_rc=$?` was read, discarding the diagnostics captured into the variable. The step failed, but **blind**. Now guarded with `|| collect_rc=$?`.
- **Docs.** `TESTING.md` gets the confirmed root cause + the supported marker mechanism; `specs/voice-agents.feature` gets a README block (comment-only — the 127-scenario contract is unchanged).
- **VAD (P3.2).** Three cases: the warning rate-limit keyed on the `adapter_name` string (not `type(self)`), **edge-triggering**, and **partial-frame carry-over**. See Test plan.

## Test plan

- `pytest tests/voice/test_vad.py` → **9 passed**.
- `pytest tests/voice/test_feature_file_contract.py` → **5 passed** (127-scenario contract intact after the feature-file comment block).
- python-ci mirror `CI=true pytest tests/ -m "not integration"` → **1024 passed / 28 skipped / 0 failed**.
- `uv run pyright .` → **0 errors**.
- Marker split (creds-free): `pytest -m voice_multiturn --collect-only` → exactly the 6 demos; `pytest -m "integration and not voice_multiturn" --collect-only` → the other e2e, none of the 6; no `@pytest.mark.skip` left on the 6; marker registered (no `PytestUnknownMark`).
- Timeout override verified per-invocation, not global: the isolated invocation reports `timeout: 540.0s`; the unit suite still reports `timeout: 60.0s`.

**The three VAD cases are proven by mutation, not by being green.** Green is not evidence, so each was proven to *discriminate* — mutate production, confirm the OLD tests stay blind and the NEW one turns red:

| mutation to `scenario/voice/vad.py` | old tests | new test |
|---|---|---|
| `if is_speech and not self._speaking:` → `if is_speech:` (level- instead of edge-triggered — one "speech started" per 30 ms frame) | **7 passed (blind)** | `test_vad_fires_one_event_per_transition_not_per_frame` **fails** |
| `self._buf.extend(chunk.data)` → `self._buf = bytearray(chunk.data)` (drop the buffered partial frame) | **7 passed (blind)** | `test_vad_buffers_partial_frames_across_chunks` **fails** |

The pre-existing transition test asserts `len(starts) >= 1` — honest, because the real classifier flickers on noise — but that fuzziness is exactly what let a level-triggered regression hide. Both new cases script the classifier's per-frame verdicts (`_ScriptedVad`) so the contract is *exactly* assertable. Re-run after the harness was refactored to `monkeypatch.setattr` (a changed harness can silently stop discriminating) — still discriminates.

The loud-collection-failure fix was proven the same way, under `bash -e` with a drifted marker (pytest exit 5):

| | exit | output |
|---|---|---|
| old (bare assignment) | 5 | **0 bytes — silent red step** |
| new (`\|\| collect_rc=$?`) | 1 | `ERROR: collecting voice_multiturn demos failed (pytest exit 5)` + full pytest diagnostics |

## How I can prove I was successful

### 0. It ran in CI — twice. First time in this repo's history.

I made the isolated step **reachable** (it never was) and dispatched the workflow twice: **[29231496466](https://github.com/langwatch/scenario/actions/runs/29231496466)** and **[29232114006](https://github.com/langwatch/scenario/actions/runs/29232114006)**. The Twilio step failed (missing secrets, as predicted) and **the steps below it ran anyway** — the reachability gate working. The isolated step discovered all six demos and ran each in its own process.

| demo | local | CI run 1 | CI run 2 |
|---|---|---|---|
| `accent_loop` | FAIL | FAIL | FAIL |
| `emotional_escalation` | FAIL | FAIL | FAIL |
| `long_hold` | FAIL | FAIL | FAIL |
| `multi_intent` | **PASS** | **PASS** | **FAIL** |
| `random_interruptions` | **PASS** | FAIL | FAIL |
| `silence_handling` | FAIL | **PASS** | **PASS** |

**Read this per-demo, not per-tally.** Local and run 1 both totalled 2-pass/4-fail, but **different demos passed** — 3 of the 6 do not give a stable verdict. Only `accent_loop`, `emotional_escalation` and `long_hold` fail deterministically everywhere. Details + triage on **#796**.

**This settles #491's AC4** (*"CI runs whichever path was chosen and stays green"*): CI now **runs** the path ✅ and it is **not green** ❌. Measured across two runs. Hence `Refs #491`, not `Closes`.

### 0b. The cap defect — proven by a same-run A/B, then fixed and re-verified

| | run 1 | run 2 |
|---|---|---|
| `Run @e2e voice demos` (**no** `--timeout`) | **2 kills** | — |
| isolated multi-turn (`--timeout=540`) | **0 kills** | — |
| **whole workflow `+++ Timeout +++`** | **4** | **0** |

Run 1 was the A/B: in the same job, same live telemetry, the capped step survived and the uncapped one was killed. All four pytest steps are now capped (`1aa075f`) and run 2 confirms **zero timeout kills anywhere**. Consequence: some of this workflow's historic reds were **spurious** — tests shot at 60s rather than genuinely failing — and the verdicts above are honest results rather than timeout artefacts.

### 1. The #491 drain — reproduced creds-free, and measured

Pointed `LANGWATCH_ENDPOINT` at a socket that accepts-but-never-responds (dummy key — nothing ever answers, so it need not be valid). Same demo, same bot, telemetry the only variable:

| `multi_intent` | wall |
|---|---|
| telemetry off (control) | **27.6s** |
| telemetry on → black-hole endpoint | **181s** (still passes) |

**+153s of pure teardown.** Forcing a stack dump mid-teardown shows exactly where it parks:

```
scenario.event_bus.drain()
  File ".../scenario/_events/event_bus.py", line 229, in drain
    self._event_queue.join()
    self.all_tasks_done.wait()
```
```
event_reporter ERROR [SCENARIO_RUN_STARTED]      Event POST error: ReadTimeout(...)   06:46:56
event_reporter ERROR [SCENARIO_MESSAGE_SNAPSHOT] Event POST error: ReadTimeout(...)   06:47:26
```

The POST errors are **exactly 30s apart** — httpx's timeout, per event, drained **serially**. Teardown cost ≈ `events × 30s` (5 events ≈ 153s ✓). This is #491's root cause, confirmed rather than inherited.

### 2. Why that becomes a "wedge" — and why `--timeout=540` is the load-bearing fix

**181s is 3× `pytest.ini`'s 60s cap**, and `timeout_method = thread` kills the **whole pytest process**, not just the one test. Measured directly: 6 demos in one shared process without the override → **killed at 63s, 0 of 6 reported, no summary**. That is indistinguishable from "the suite wedges."

In CI `LANGWATCH_API_KEY` **is** set, so this is the CI condition — every demo would blow the cap and the suite would die at the first one. The `--timeout=540` override is what makes the demos survivable at all. Independently: **`random_interruptions` passes at 109.9s** and would have been killed and reported RED without it.

### 3. The demos, run one process each (what this PR ships)

| demo | wall | verdict | over the 60s cap? |
|---|---|---|---|
| `multi_intent` | 27.6s | **PASS** | no |
| `silence_handling` | 47.2s | FAIL (judge) | no |
| `accent_loop` | 56.6s | FAIL (judge) | no |
| `emotional_escalation` | **62.7s** | FAIL (judge: *"only one user turn is present"*) | **YES** |
| `long_hold` | **84.5s** | FAIL (`FirstChunkTimeoutError`) | **YES** |
| `random_interruptions` | **109.9s** | **PASS** | **YES** |

**2 passed, 4 failed, zero timeout kills** — every demo reached a real verdict and exited.

### 4. Honest bound on the isolation claim

With the cap lifted **and telemetry off**, all 6 run together in ONE process in 424s with **no wedge** — so isolation is *not* what rescues the happy path. Its value is bounding a pathological drain: cost scales with event count, so a higher-turn demo can still exceed 540s, and isolation + `timeout 600` then loses **one demo instead of the whole suite**. It is defence-in-depth, and the PR is now framed that way rather than as "isolation is the fix."

The 4 failures are real, pre-existing, and were hidden by the skip — see #796. Mutation tables above cover the VAD and collection-failure fixes.

## Human verification

This is a **backend-only** change — `scenario.run()` teardown analysis plus test-suite isolation in CI. There is **no UI surface**: no screen, page, or rendered artifact to inspect, so live-app visual proof does not apply here. `backend-only, no UI surface`. <!-- no-ui-surface -->

To confirm by hand (all creds-free):

1. **The 60s guillotine was real.** `uv run pytest -p no:cacheprovider tests/voice/test_long_hold_e2e.py --collect-only` → header reads `configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)` and `timeout: 60.0s`. Add `--timeout=540` (what the isolated step now passes) → header reads `timeout: 540.0s`. Meanwhile `scenario/voice/adapter.py:91` gives a *single* turn 60s, and `examples/voice/long_hold.py:90,94` does `scenario.sleep(15)` then `max_turns=8`.
2. **Marker split is exact.** `pytest -m voice_multiturn --collect-only` → exactly the 6 multi-turn demos; `pytest -m "integration and not voice_multiturn" --collect-only` → the rest, none of the 6. No `@pytest.mark.skip` remains on the 6.
3. **Unit suites green.** `pytest tests/voice/test_vad.py` → 9 passed; `pytest tests/voice/test_feature_file_contract.py` → 5 passed.
4. **VAD tests actually discriminate.** Apply either mutation from the table above and watch the new case go red while the old 7 stay green.

## Anything surprising?

- ⚠️ **I ran the 6 demos — 4 of them FAIL. #491 AC4 is provably unmet. Tracked as #796.** These had never once been executed (skipped since #350 in May 2026; `voice-integration` is dispatch-only, not a required check, and has **never been green** — 30 of its last 30 runs are `failure`). Details + full evidence in #796. The wedge is fixed; the demos' own correctness is a separate, pre-existing problem that the skip was hiding. That is exactly what "remove the skips without re-papering the contract" is supposed to expose, so I am shipping the truth rather than a new marker to hide behind — but it means **merging this must not tick that issue's final AC**, which is why the link above is a non-closing `Refs` reference.
- The wedge root cause is the same family as **#791** (unbounded telemetry drain, exit-124 class). This PR isolates around it; #791 is the SDK-wide bound.
- The issue estimated "10" skipped wrappers; the actual wedge set is **6** `@pytest.mark.skip` e2e wrappers. The other 4 skips are `skipif(CI=='true')` ("scenario.run hangs in python-ci; fine locally") — a separate, pre-existing family (very likely the same drain root cause) left out of scope here.
- **Rebase note for reviewers:** `origin/main` landed the #708 "CI honesty" fixes on the *same two* workflow steps this PR rewrites (dropping a `|| true` exit-swallow, adding `set -o pipefail` and `--reruns 1`). The conflict was resolved by **keeping main's honesty semantics** and layering the `not voice_multiturn` marker split on top — no `|| true` was reintroduced and nothing from #708 was weakened. Worth a look at `.github/workflows/voice-integration.yml` specifically.
- **Non-blocking, deliberately not fixed here:** the isolated step lacks the `--reruns 1` that both bulk steps carry (it interacts with `-x` and doubles the time budget), and its output goes only to the inline GHA log rather than the `/tmp/e2e-voice-results.log` artifact the bulk step uploads. Both are follow-ups on #796, not regressions.







