### PR TITLE
fix(#695): twilio terminal sentinel on silent/tool-only stop (dead-recv-loop hang)

### DIFF
--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -341,7 +341,11 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     const client = await startCall(adapter);
 
     const call = defaultVoiceCall(adapter, agentTurnInput());
-    await sleep(50); // let the drain block in its first receiveAudio
+    // `defaultVoiceCall` reaches its first `receiveAudio` synchronously, so the
+    // drain's queue waiter is already parked by the time the call above returns
+    // its promise. This sleep is belt-and-braces: it keeps the test honest if a
+    // future `await` is ever introduced ahead of the first receive.
+    await sleep(50);
     client.send(stopFrame());
 
     const message = await call;

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -29,7 +29,7 @@
  * post-fix it returns another empty chunk. Each test asserts BOTH calls behave.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AudioChunk } from "../../audio-chunk";
 import { TwilioAgentAdapter } from "../twilio";
@@ -68,6 +68,50 @@ function scriptedSocket(frames: string[]): MediaStreamWebSocket {
     },
     close() {
       // No-op for the double.
+    },
+  };
+}
+
+/**
+ * A `MediaStreamWebSocket` double the test can feed mid-flight: `receiveText()`
+ * blocks until `push()` supplies a frame — a string frame, `null` (socket
+ * close), or an `Error` (transport failure, rejecting the pending read). Used
+ * for scenarios that need the loop *live and idle* at the moment the test
+ * calls `receiveAudio` (the scripted double above always terminates first).
+ */
+function controllableSocket(): MediaStreamWebSocket & {
+  push(item: string | null | Error): void;
+} {
+  const queued: Array<string | null | Error> = [];
+  const waiters: Array<{
+    resolve: (v: string | null) => void;
+    reject: (e: Error) => void;
+  }> = [];
+  return {
+    send() {
+      // Outbound is irrelevant to these inbound-drain tests.
+    },
+    close() {
+      // No-op for the double.
+    },
+    push(item: string | null | Error): void {
+      const waiter = waiters.shift();
+      if (waiter) {
+        if (item instanceof Error) waiter.reject(item);
+        else waiter.resolve(item);
+        return;
+      }
+      queued.push(item);
+    },
+    receiveText(): Promise<string | null> {
+      if (queued.length > 0) {
+        const item = queued.shift()!;
+        if (item instanceof Error) return Promise.reject(item);
+        return Promise.resolve(item);
+      }
+      return new Promise((resolve, reject) => {
+        waiters.push({ resolve, reject });
+      });
     },
   };
 }
@@ -164,5 +208,62 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     // second call is also the post-teardown drain probe that threw pre-fix.
     const second = await adapter.receiveAudio(RECV_TIMEOUT_S);
     expect(second.data.length).toBe(0);
+  });
+
+  it("transport error mid-stream: session rejects but both drain calls return empty (throw path)", async () => {
+    const adapter = await connectedAdapter();
+    // The production `finally` claims all THREE termination paths — stop,
+    // close, throw — enqueue the sentinel. This pins the throw path: the
+    // socket's pending read rejects, the session surfaces the error, and the
+    // drain still terminates cleanly instead of hanging or asserting liveness.
+    const sock = controllableSocket();
+    const session = adapter._driveStreamSession(sock);
+    sock.push(startFrame());
+    sock.push(new Error("boom: transport failure"));
+    await expect(session).rejects.toThrow("boom: transport failure");
+
+    // The loop's finally ran on the throw path and production teardown nulled
+    // the transport.
+    expect(adapter._streamWsForTest).toBeNull();
+
+    const first = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(first.data.length).toBe(0);
+    const second = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(second.data.length).toBe(0);
+  });
+
+  it("second session on the same adapter: stale terminal flag must not truncate the new call's first turn", async () => {
+    const adapter = await connectedAdapter();
+    // Session 1 completes silently: its finally marks the call ended and
+    // enqueues the terminal sentinel. Drain it fully.
+    await adapter._driveStreamSession(scriptedSocket([startFrame(), stopFrame()]));
+    const s1 = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(s1.data.length).toBe(0);
+
+    // Session 2 begins on the SAME connected adapter (a Twilio Media Streams
+    // reconnect / back-to-back call) and is mid-call: started, nothing
+    // buffered yet.
+    const sock = controllableSocket();
+    const session2 = adapter._driveStreamSession(sock);
+    sock.push(startFrame("MZ695b", "CA695b"));
+    await vi.waitFor(() => expect(adapter._streamWsForTest).not.toBeNull());
+
+    // The regression this pins: if session 1's `_streamEnded` were still set
+    // (flag scoped to the connection instead of the call), this receiveAudio
+    // would synthesize an empty "end of call" sentinel INSTANTLY and the new
+    // call's first agent turn would read as silent. With the per-call reset it
+    // waits for the real audio that arrives next.
+    const audioP = adapter.receiveAudio(RECV_TIMEOUT_S);
+    // 800 bytes µ-law == the 100ms flush threshold, so the media branch
+    // flushes immediately — no stop frame needed for the audio to land.
+    sock.push(buildMediaFrame("MZ695b", new Uint8Array(800).fill(0x7f)));
+    const audio = await audioP;
+    expect(audio.data.length).toBeGreaterThan(0);
+
+    // Session 2 then terminates normally and drains clean.
+    sock.push(stopFrame());
+    await session2;
+    const tail = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(tail.data.length).toBe(0);
   });
 });

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Issue #695 — the Twilio adapter must terminate its inbound queue on a silent
+ * / tool-only completion (a #648-class dead-recv-loop hang).
+ *
+ * The Media Streams loop (`TwilioWebhookServer.mediaStreamLoop`) is the
+ * *producer* for the adapter's inbound queue; `receiveAudio` is a bare
+ * `queue.take()`. A turn that completed WITHOUT trailing audio — a `"stop"`
+ * frame with nothing buffered (a silent agent turn or a tool-only turn), or a
+ * socket close — left the queue empty, so `receiveAudio` rejected at
+ * `responseTimeout` instead of returning cleanly. This is the same latent hang
+ * fixed for ElevenLabs / generic WebSocket in #648 and for OpenAI Realtime in
+ * #646.
+ *
+ * The fix mirrors that reference pattern: on *any* terminal exit of the loop,
+ * enqueue an empty `AudioChunk` so the base `drainAgentResponse` (which breaks
+ * on an empty chunk) exits cleanly.
+ *
+ * These tests drive the loop via the `_driveMediaStream` seam with a scripted
+ * mock socket — the adapter binds an OS-assigned port via `connect()` (stubbed
+ * REST, no real Twilio account) but no real WS upgrade happens. `receiveAudio`
+ * is handed a short budget so an un-fixed adapter (empty queue) rejects fast
+ * instead of stalling the suite; the fix resolves immediately from the
+ * already-enqueued sentinel, so that budget never actually elapses on green.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AudioChunk } from "../../audio-chunk";
+import { TwilioAgentAdapter } from "../twilio";
+import type { MediaStreamWebSocket } from "../twilio-server";
+import { buildMediaFrame, TwilioRESTHelper } from "../twilio-shared";
+
+const STREAM_SID = "MZ695";
+// receiveAudio budget: an un-fixed adapter leaves the queue empty and `take`
+// rejects after this many seconds (the red signal). The fix resolves instantly
+// from the already-enqueued sentinel, so this never elapses on green.
+const RECV_TIMEOUT_S = 2;
+
+function startFrame(streamSid = STREAM_SID, callSid = "CA695"): string {
+  return JSON.stringify({ event: "start", start: { streamSid, callSid } });
+}
+
+function stopFrame(): string {
+  return JSON.stringify({ event: "stop" });
+}
+
+/**
+ * A `MediaStreamWebSocket` double whose `receiveText()` serves `frames` in
+ * order, then resolves `null` (a socket close — the real adapter's close
+ * signal). Every test scripts an explicit terminal: a `"stop"` frame the loop
+ * returns on, or the trailing close.
+ */
+function scriptedSocket(frames: string[]): MediaStreamWebSocket {
+  let idx = 0;
+  return {
+    send() {
+      // Outbound is irrelevant to these inbound-drain tests.
+    },
+    receiveText() {
+      if (idx < frames.length) return Promise.resolve(frames[idx++]!);
+      return Promise.resolve(null); // socket closed
+    },
+    close() {
+      // No-op for the double.
+    },
+  };
+}
+
+function stubRest(): TwilioRESTHelper {
+  const stub = new TwilioRESTHelper("ACtest", "secret");
+  stub.resolvePhoneNumberSid = async () => "PNxxxx";
+  stub.readVoiceUrl = async () => null;
+  stub.writeVoiceUrl = async () => undefined;
+  stub.placeCall = async () => "CAtest";
+  stub.sendDtmfOnCall = async () => undefined;
+  return stub;
+}
+
+const tracked: TwilioAgentAdapter[] = [];
+
+async function connectedAdapter(): Promise<TwilioAgentAdapter> {
+  const adapter = new TwilioAgentAdapter({
+    accountSid: "ACtest",
+    authToken: "secret",
+    phoneNumber: "+14155556959",
+    publicBaseUrl: "https://example695.test",
+    rest: stubRest(),
+  });
+  await adapter.connect();
+  tracked.push(adapter);
+  return adapter;
+}
+
+afterEach(async () => {
+  while (tracked.length > 0) {
+    try {
+      await tracked.pop()!.disconnect();
+    } catch {
+      // Best-effort teardown.
+    }
+  }
+});
+
+describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
+  it("stop frame with no trailing audio returns an empty chunk, not a hang", async () => {
+    const adapter = await connectedAdapter();
+    // start → stop, no media: the "stop" branch flushes nothing.
+    await adapter._driveMediaStream(scriptedSocket([startFrame(), stopFrame()]));
+
+    const chunk = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(chunk).toBeInstanceOf(AudioChunk);
+    expect(chunk.data.length).toBe(0); // empty terminal, not a hang
+  });
+
+  it("socket close mid-stream returns an empty chunk, not a hang", async () => {
+    const adapter = await connectedAdapter();
+    // Only a start frame, then the socket closes (receiveText → null).
+    await adapter._driveMediaStream(scriptedSocket([startFrame()]));
+
+    const chunk = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(chunk.data.length).toBe(0);
+  });
+
+  it("normal audio turn still drains its trailing PCM (no regression)", async () => {
+    const adapter = await connectedAdapter();
+    // 160 bytes of µ-law (~20ms) — under the 100ms batch threshold, so the
+    // "stop" flush is what enqueues it: exactly the trailing-audio path.
+    const mulaw = new Uint8Array(160).fill(0x7f);
+    await adapter._driveMediaStream(
+      scriptedSocket([startFrame(), buildMediaFrame(STREAM_SID, mulaw), stopFrame()]),
+    );
+
+    const first = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    // Real audio survived as the first chunk; the sentinel lands after it.
+    expect(first.data.length).toBeGreaterThan(0);
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -15,12 +15,18 @@
  * enqueue an empty `AudioChunk` so the base `drainAgentResponse` (which breaks
  * on an empty chunk) exits cleanly.
  *
- * These tests drive the loop via the `_driveMediaStream` seam with a scripted
- * mock socket — the adapter binds an OS-assigned port via `connect()` (stubbed
- * REST, no real Twilio account) but no real WS upgrade happens. `receiveAudio`
- * is handed a short budget so an un-fixed adapter (empty queue) rejects fast
- * instead of stalling the suite; the fix resolves immediately from the
- * already-enqueued sentinel, so that budget never actually elapses on green.
+ * **Why these tests drive the production wrapper.** In production the loop is
+ * reached via `_handleStreamSocket`, whose `finally` nulls `_streamWs` /
+ * `_streamSid` synchronously right after the loop returns or throws. A test that
+ * drives `mediaStreamLoop` (or the `_driveMediaStream` seam) alone leaves those
+ * set, so `receiveAudio`'s `_assertStreamLive` gate never fires — which is why
+ * an earlier version of this suite went green on a fix that still threw in
+ * production (reviewer P2 blocker on PR #697). These tests use the
+ * `_driveStreamSession` seam, which runs the SAME `runStreamSession` wrapper
+ * production uses — loop plus the transport-nulling `finally`. The regression
+ * the fix targets is the drain's *second* `receiveAudio` call (the tail-silence
+ * probe) landing after that reset: pre-fix it throws "no live media stream";
+ * post-fix it returns another empty chunk. Each test asserts BOTH calls behave.
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -102,33 +108,51 @@ afterEach(async () => {
 });
 
 describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
-  it("stop frame with no trailing audio returns an empty chunk, not a hang", async () => {
+  it("stop frame with no trailing audio: both drain calls return empty after production teardown", async () => {
     const adapter = await connectedAdapter();
-    // start → stop, no media: the "stop" branch flushes nothing.
-    await adapter._driveMediaStream(scriptedSocket([startFrame(), stopFrame()]));
+    // start → stop, no media: the "stop" branch flushes nothing. Driven through
+    // the REAL production wrapper, which nulls _streamWs/_streamSid on return.
+    await adapter._driveStreamSession(scriptedSocket([startFrame(), stopFrame()]));
 
-    const chunk = await adapter.receiveAudio(RECV_TIMEOUT_S);
-    expect(chunk).toBeInstanceOf(AudioChunk);
-    expect(chunk.data.length).toBe(0); // empty terminal, not a hang
+    // Production nulled the transport — the condition that threw pre-fix.
+    expect(adapter._streamWsForTest).toBeNull();
+    expect(adapter._streamSidForTest).toBeUndefined();
+
+    const first = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(first).toBeInstanceOf(AudioChunk);
+    expect(first.data.length).toBe(0); // empty terminal, not a hang
+
+    // The drain's tail-silence probe — a SECOND receiveAudio after teardown.
+    // This is the call that throws "no live media stream" pre-fix.
+    const second = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(second.data.length).toBe(0);
   });
 
-  it("socket close mid-stream returns an empty chunk, not a hang", async () => {
+  it("socket close mid-stream: both drain calls return empty after production teardown", async () => {
     const adapter = await connectedAdapter();
     // Only a start frame, then the socket closes (receiveText → null).
-    await adapter._driveMediaStream(scriptedSocket([startFrame()]));
+    await adapter._driveStreamSession(scriptedSocket([startFrame()]));
 
-    const chunk = await adapter.receiveAudio(RECV_TIMEOUT_S);
-    expect(chunk.data.length).toBe(0);
+    expect(adapter._streamWsForTest).toBeNull();
+    expect(adapter._streamSidForTest).toBeUndefined();
+
+    const first = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(first.data.length).toBe(0);
+
+    const second = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(second.data.length).toBe(0);
   });
 
-  it("normal audio turn still drains its trailing PCM (no regression)", async () => {
+  it("normal audio turn still drains its trailing PCM after production teardown (no regression)", async () => {
     const adapter = await connectedAdapter();
     // 160 bytes of µ-law (~20ms) — under the 100ms batch threshold, so the
     // "stop" flush is what enqueues it: exactly the trailing-audio path.
     const mulaw = new Uint8Array(160).fill(0x7f);
-    await adapter._driveMediaStream(
+    await adapter._driveStreamSession(
       scriptedSocket([startFrame(), buildMediaFrame(STREAM_SID, mulaw), stopFrame()]),
     );
+
+    expect(adapter._streamWsForTest).toBeNull(); // production teardown ran
 
     const first = await adapter.receiveAudio(RECV_TIMEOUT_S);
     // Real audio survived as the first chunk; the sentinel lands after it.
@@ -136,7 +160,8 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
 
     // And the terminal sentinel lands AFTER the real audio (FIFO), not instead
     // of it: the next chunk is the empty sentinel. Pins the ordering invariant —
-    // a fix that enqueued the sentinel before the flush would fail here.
+    // a fix that enqueued the sentinel before the flush would fail here. This
+    // second call is also the post-teardown drain probe that threw pre-fix.
     const second = await adapter.receiveAudio(RECV_TIMEOUT_S);
     expect(second.data.length).toBe(0);
   });

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -397,6 +397,37 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     client.close();
   }, 15_000);
 
+  it("an undrained terminal sentinel does not truncate the next call's first turn", async () => {
+    // A call that ends while NO drain is running leaves its terminal sentinel
+    // buffered. The next media-stream session on the same connected adapter must
+    // not serve that stale empty chunk as its first turn's audio: `receiveAudio`
+    // drains a non-empty queue without checking liveness, and `drainAgentResponse`
+    // breaks on an empty chunk — so the new call's first agent turn would be
+    // truncated to silence, its real audio stranded for the turn after.
+    const adapter = await routeAdapter();
+    // Agent 2 "thinks" for longer than tail silence before speaking, so a stale
+    // first chunk closes the turn before the real audio can land.
+    adapter.responseTailSilence = 0.2;
+
+    // Session 1: caller hangs up between turns; nothing consumes the sentinel.
+    const first = await startCall(adapter);
+    first.send(stopFrame());
+    await awaitTeardown(adapter);
+    first.close();
+
+    // Session 2: a Twilio reconnect / back-to-back call.
+    const second = await startCall(adapter);
+    const call = defaultVoiceCall(adapter, agentTurnInput());
+    setTimeout(() => {
+      // 800 bytes µ-law == the 100ms flush threshold: flushes immediately.
+      second.send(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
+    }, 600);
+
+    const message = await call;
+    expect(audioBytes(message)).toBeGreaterThan(0); // real audio, not a stale sentinel
+    second.close();
+  }, 15_000);
+
   it("audio buffered before hangup is not lost when the turn starts after teardown", async () => {
     // Pre-fix the liveness assert fired before the queue was read, so this
     // audio was dropped on the floor along with the crash.

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -30,11 +30,16 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
 
+import { defaultVoiceCall } from "../../adapter.runtime";
 import { AudioChunk } from "../../audio-chunk";
+import { extractAudio } from "../../messages";
 import { TwilioAgentAdapter } from "../twilio";
 import type { MediaStreamWebSocket } from "../twilio-server";
 import { buildMediaFrame, TwilioRESTHelper } from "../twilio-shared";
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 const STREAM_SID = "MZ695";
 // receiveAudio budget: an un-fixed adapter leaves the queue empty and `take`
@@ -266,4 +271,144 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     const tail = await adapter.receiveAudio(RECV_TIMEOUT_S);
     expect(tail.data.length).toBe(0);
   });
+});
+
+/**
+ * The anti-drift gate (PR #697 P2 blocker). Everything above drives
+ * `runStreamSession` by name; these tests drive nothing by name. They start the
+ * adapter's REAL http+ws server, connect a REAL `ws` client to the REAL
+ * `/twilio/stream` upgrade path — so `_handleStreamSocket` and `adaptWsSocket`
+ * run — and let the REAL production consumer (`defaultVoiceCall` →
+ * `drainAgentResponse`, what every agent turn runs) read the result.
+ *
+ * A fix that only works when a test calls the wrapper by name cannot pass here,
+ * and these fail if `_handleStreamSocket` ever stops delegating to
+ * `runStreamSession`.
+ *
+ * Where the JS pre-fix behaviour differs from the Python twin: `drainAgentResponse`
+ * wraps its tail-silence `receiveAudio` in `try { … } catch { break }` (added by
+ * #734), so a throw on the drain's *second* call is swallowed and silently
+ * truncates the turn rather than crashing. The uncaught crash lands on the
+ * drain's *first* `receiveAudio`, which has no such guard — i.e. whenever the
+ * agent turn begins after the transport was already nulled. The last two tests
+ * below pin exactly that, and are the ones that throw
+ * `Error: no live media stream` against the pre-fix adapter.
+ */
+describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
+  /** Poll until the route handler's `finally` has nulled the transport. */
+  async function awaitTeardown(adapter: TwilioAgentAdapter): Promise<void> {
+    await vi.waitFor(() => expect(adapter._streamWsForTest).toBeNull(), {
+      timeout: 5_000,
+    });
+  }
+
+  function openClient(adapter: TwilioAgentAdapter): Promise<WebSocket> {
+    const url = `${adapter.localBaseUrl.replace(/^http:/, "ws:")}/twilio/stream`;
+    return new Promise((resolve, reject) => {
+      const client = new WebSocket(url);
+      client.once("open", () => resolve(client));
+      client.once("error", reject);
+    });
+  }
+
+  /** No incoming audio → `defaultVoiceCall` goes straight to the drain. */
+  function agentTurnInput(): Parameters<typeof defaultVoiceCall>[1] {
+    return { newMessages: [] } as unknown as Parameters<typeof defaultVoiceCall>[1];
+  }
+
+  async function routeAdapter(): Promise<TwilioAgentAdapter> {
+    const adapter = await connectedAdapter(); // starts the REAL http+ws server
+    // Small drain budgets so a hang (the original #695 symptom) fails inside the
+    // per-test timeout rather than stalling the suite.
+    adapter.responseTimeout = 5;
+    adapter.responseTailSilence = 0.5;
+    return adapter;
+  }
+
+  async function startCall(adapter: TwilioAgentAdapter): Promise<WebSocket> {
+    const client = await openClient(adapter);
+    client.send(startFrame());
+    await vi.waitFor(() => expect(adapter._streamSidForTest).toBe(STREAM_SID), {
+      timeout: 5_000,
+    });
+    return client;
+  }
+
+  const audioBytes = (message: unknown): number => extractAudio(message)?.data.length ?? 0;
+
+  it("silent stop mid-drain: the real route drains cleanly", async () => {
+    const adapter = await routeAdapter();
+    const client = await startCall(adapter);
+
+    const call = defaultVoiceCall(adapter, agentTurnInput());
+    await sleep(50); // let the drain block in its first receiveAudio
+    client.send(stopFrame());
+
+    const message = await call;
+    expect(audioBytes(message)).toBe(0); // clean terminal — not a hang, not a crash
+    await awaitTeardown(adapter);
+    client.close();
+  }, 15_000);
+
+  it("socket close with no stop frame mid-drain: the real route drains cleanly", async () => {
+    const adapter = await routeAdapter();
+    const client = await startCall(adapter);
+
+    const call = defaultVoiceCall(adapter, agentTurnInput());
+    await sleep(50);
+    client.close(); // Twilio drops the media socket, no stop frame
+
+    const message = await call;
+    expect(audioBytes(message)).toBe(0);
+    await awaitTeardown(adapter);
+  }, 15_000);
+
+  it("normal audio turn: trailing PCM survives the real route's teardown", async () => {
+    const adapter = await routeAdapter();
+    const client = await startCall(adapter);
+
+    const call = defaultVoiceCall(adapter, agentTurnInput());
+    await sleep(50);
+    // 160 bytes µ-law (~20ms) is under the 100ms batch threshold, so the "stop"
+    // flush is what enqueues it: exactly the trailing-audio path.
+    client.send(buildMediaFrame(STREAM_SID, new Uint8Array(160).fill(0x7f)));
+    client.send(stopFrame());
+
+    const message = await call;
+    expect(audioBytes(message)).toBeGreaterThan(0); // audio reached the drain
+    await awaitTeardown(adapter);
+    client.close();
+  }, 15_000);
+
+  it("agent turn starting after hangup: drains cleanly instead of throwing", async () => {
+    // The tightest form of the P0: the route already nulled the transport when
+    // the drain makes its FIRST receiveAudio call — the next agent turn after
+    // the caller hung up. Pre-fix this throws "no live media stream" out of
+    // defaultVoiceCall, with the terminal sentinel unread in the queue.
+    const adapter = await routeAdapter();
+    const client = await startCall(adapter);
+
+    client.send(stopFrame());
+    await awaitTeardown(adapter);
+    expect(adapter._streamSidForTest).toBeUndefined();
+
+    const message = await defaultVoiceCall(adapter, agentTurnInput());
+    expect(audioBytes(message)).toBe(0);
+    client.close();
+  }, 15_000);
+
+  it("audio buffered before hangup is not lost when the turn starts after teardown", async () => {
+    // Pre-fix the liveness assert fired before the queue was read, so this
+    // audio was dropped on the floor along with the crash.
+    const adapter = await routeAdapter();
+    const client = await startCall(adapter);
+
+    client.send(buildMediaFrame(STREAM_SID, new Uint8Array(160).fill(0x7f)));
+    client.send(stopFrame());
+    await awaitTeardown(adapter);
+
+    const message = await defaultVoiceCall(adapter, agentTurnInput());
+    expect(audioBytes(message)).toBeGreaterThan(0); // recovered, not lost
+    client.close();
+  }, 15_000);
 });

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -290,9 +290,23 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
  * #734), so a throw on the drain's *second* call is swallowed and silently
  * truncates the turn rather than crashing. The uncaught crash lands on the
  * drain's *first* `receiveAudio`, which has no such guard — i.e. whenever the
- * agent turn begins after the transport was already nulled. The last two tests
- * below pin exactly that, and are the ones that throw
+ * agent turn begins after the transport was already nulled. The two after-hangup
+ * tests below pin exactly that, and are the ones that throw
  * `Error: no live media stream` against the pre-fix adapter.
+ *
+ * **The two layers are complements; neither subsumes the other.** Measured, not
+ * assumed:
+ * - Delete the drain-side guard in `receiveAudio` → only 2 of these 6 route tests
+ *   go red (the after-hangup pair). The other 3 stay green because their *first*
+ *   `receiveAudio` succeeds and `catch { break }` swallows the second-call throw.
+ *   For those scenarios the wrapper-level suite above is the ONLY net.
+ * - Delete the loop's sentinel `_enqueueInbound(...)` but keep `_markStreamEnded()`
+ *   → all 5 wrapper-level tests still pass, while the two mid-drain route tests
+ *   block to `responseTimeout` (~5.07s) — the original #695 hang, resurfaced. The
+ *   wrapper layer cannot see the sentinel: a consumer that is not *already blocked*
+ *   is served a synthesized empty chunk by the flag alone.
+ *
+ * So do not delete either suite believing the other covers it.
  */
 describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
   /** Poll until the route handler's `finally` has nulled the transport. */

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -133,5 +133,11 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     const first = await adapter.receiveAudio(RECV_TIMEOUT_S);
     // Real audio survived as the first chunk; the sentinel lands after it.
     expect(first.data.length).toBeGreaterThan(0);
+
+    // And the terminal sentinel lands AFTER the real audio (FIFO), not instead
+    // of it: the next chunk is the empty sentinel. Pins the ordering invariant —
+    // a fix that enqueued the sentinel before the flush would fail here.
+    const second = await adapter.receiveAudio(RECV_TIMEOUT_S);
+    expect(second.data.length).toBe(0);
   });
 });

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -271,13 +271,13 @@ export class TwilioWebhookServer {
   async mediaStreamLoop(ws: MediaStreamWebSocket): Promise<void> {
     const adapter = this._adapter;
     adapter._setStreamWs(ws);
-    // `_streamEnded` is per-CALL state: re-arm it alongside `_streamWs` so a
-    // second media-stream session on the same connected adapter (Twilio
-    // reconnect, back-to-back call) does not start with the previous session's
-    // terminal flag stuck true — which would make `receiveAudio` synthesize an
-    // empty "end of call" sentinel on any transient empty queue mid-turn and
-    // truncate the new call's first agent turn.
-    adapter._resetStreamEnded();
+    // The terminal flag AND the inbound queue are per-CALL state: re-arm both
+    // alongside `_streamWs` so a second media-stream session on the same
+    // connected adapter (Twilio reconnect, back-to-back call) starts clean —
+    // neither inheriting the previous call's terminal flag nor draining its
+    // leftover terminal sentinel as this call's first chunk. See
+    // `_resetCallState`.
+    adapter._resetCallState();
 
     const buffered: number[] = [];
     const flushThresholdBytes = (BATCH_MS / TWILIO_FRAME_MS) * 160; // 100ms = 800 bytes µ-law

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -235,9 +235,24 @@ export class TwilioWebhookServer {
   }
 
   private async _handleStreamSocket(ws: WsWebSocket): Promise<void> {
-    const adapted = adaptWsSocket(ws);
+    await this.runStreamSession(adaptWsSocket(ws));
+  }
+
+  /**
+   * Production per-connection wrapper around {@link mediaStreamLoop}: runs the
+   * loop, then — in a `finally` that fires on stop, socket close, OR a throw —
+   * nulls the adapter's `_streamWs`/`_streamSid` transport state, exactly as the
+   * real `/twilio/stream` handler does after a call ends.
+   *
+   * This is the seam tests must drive to reproduce the #695 teardown race: the
+   * terminal sentinel is enqueued inside the loop's own `finally`, then THIS
+   * `finally` nulls the transport — so a `receiveAudio` following the reset must
+   * still drain cleanly. Driving `mediaStreamLoop` alone skips this reset and
+   * hides the bug (that was the shipped tests' flaw, PR #697 P2 blocker).
+   */
+  async runStreamSession(ws: MediaStreamWebSocket): Promise<void> {
     try {
-      await this.mediaStreamLoop(adapted);
+      await this.mediaStreamLoop(ws);
     } finally {
       this._adapter._setStreamWs(null);
       this._adapter._setStreamSid(undefined);
@@ -300,10 +315,20 @@ export class TwilioWebhookServer {
     } finally {
       // Terminal sentinel (#695; mirrors the #648 / #646 fix). Whether the loop
       // exits on a "stop" frame, a socket close (`receiveText` resolves null),
-      // or a throw, enqueue an empty AudioChunk so a `receiveAudio` blocked on
-      // the inbound queue returns cleanly instead of timing out on a silent /
-      // tool-only turn. Unlike the Python twin, no null-guard is needed here:
-      // the inbound queue object is never nulled — `disconnect()` only `reset()`s it.
+      // or a throw, mark the call ended and enqueue an empty AudioChunk so a
+      // `receiveAudio` blocked on the inbound queue returns cleanly instead of
+      // timing out on a silent / tool-only turn. All three termination paths
+      // (stop / close / throw) funnel through this `finally`, so the sentinel is
+      // genuinely reachable on each.
+      //
+      // `_markStreamEnded()` is called FIRST and unconditionally:
+      // `_handleStreamSocket` nulls `_streamWs`/`_streamSid` synchronously right
+      // after this loop returns, so `receiveAudio`'s follow-up call would
+      // otherwise trip `_assertStreamLive`. The flag tells `receiveAudio` to
+      // keep draining post-teardown rather than assert liveness. Unlike the
+      // Python twin, no null-guard is needed on the queue: it's never nulled —
+      // `disconnect()` only `reset()`s it.
+      adapter._markStreamEnded();
       adapter._enqueueInbound(new AudioChunk({ data: new Uint8Array(0) }));
     }
   }

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -265,36 +265,45 @@ export class TwilioWebhookServer {
       adapter._enqueueInbound(new AudioChunk({ data: pcm }));
     };
 
-    while (true) {
-      const text = await ws.receiveText();
-      if (text == null) return; // socket closed
-      const frame = parseMediaStreamFrame(text);
-      if (!frame) continue;
+    try {
+      while (true) {
+        const text = await ws.receiveText();
+        if (text == null) return; // socket closed
+        const frame = parseMediaStreamFrame(text);
+        if (!frame) continue;
 
-      if (frame.event === "start") {
-        if (frame.streamSid) adapter._setStreamSid(frame.streamSid);
-        if (frame.callSid) adapter._setCallSid(frame.callSid);
-        adapter._signalStreamConnected();
-      } else if (frame.event === "media" && frame.payloadMulaw) {
-        for (const byte of frame.payloadMulaw) buffered.push(byte);
-        if (buffered.length >= flushThresholdBytes) flush();
-      } else if (frame.event === "dtmf" && frame.dtmfDigit) {
-        twilioLogger.debug("received DTMF", { digit: frame.dtmfDigit });
-        if (adapter.onDtmf) {
-          try {
-            adapter.onDtmf(frame.dtmfDigit);
-          } catch (err) {
-            // Callback errors are swallowed — adapter contract says they don't
-            // tear down the stream — but they ARE worth logging.
-            twilioLogger.warn("onDtmf callback raised; continuing", {
-              error: err instanceof Error ? err.message : String(err),
-            });
+        if (frame.event === "start") {
+          if (frame.streamSid) adapter._setStreamSid(frame.streamSid);
+          if (frame.callSid) adapter._setCallSid(frame.callSid);
+          adapter._signalStreamConnected();
+        } else if (frame.event === "media" && frame.payloadMulaw) {
+          for (const byte of frame.payloadMulaw) buffered.push(byte);
+          if (buffered.length >= flushThresholdBytes) flush();
+        } else if (frame.event === "dtmf" && frame.dtmfDigit) {
+          twilioLogger.debug("received DTMF", { digit: frame.dtmfDigit });
+          if (adapter.onDtmf) {
+            try {
+              adapter.onDtmf(frame.dtmfDigit);
+            } catch (err) {
+              // Callback errors are swallowed — adapter contract says they don't
+              // tear down the stream — but they ARE worth logging.
+              twilioLogger.warn("onDtmf callback raised; continuing", {
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
           }
+        } else if (frame.event === "stop") {
+          flush();
+          return;
         }
-      } else if (frame.event === "stop") {
-        flush();
-        return;
       }
+    } finally {
+      // Terminal sentinel (#695; mirrors the #648 / #646 fix). Whether the loop
+      // exits on a "stop" frame, a socket close (`receiveText` resolves null),
+      // or a throw, enqueue an empty AudioChunk so a `receiveAudio` blocked on
+      // the inbound queue returns cleanly instead of timing out on a silent /
+      // tool-only turn.
+      adapter._enqueueInbound(new AudioChunk({ data: new Uint8Array(0) }));
     }
   }
 }

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -249,6 +249,9 @@ export class TwilioWebhookServer {
    * `finally` nulls the transport — so a `receiveAudio` following the reset must
    * still drain cleanly. Driving `mediaStreamLoop` alone skips this reset and
    * hides the bug (that was the shipped tests' flaw, PR #697 P2 blocker).
+   *
+   * @internal Production entry is `_handleStreamSocket`; tests reach this via
+   * `TwilioAgentAdapter._driveStreamSession`. Not public API.
    */
   async runStreamSession(ws: MediaStreamWebSocket): Promise<void> {
     try {
@@ -268,6 +271,13 @@ export class TwilioWebhookServer {
   async mediaStreamLoop(ws: MediaStreamWebSocket): Promise<void> {
     const adapter = this._adapter;
     adapter._setStreamWs(ws);
+    // `_streamEnded` is per-CALL state: re-arm it alongside `_streamWs` so a
+    // second media-stream session on the same connected adapter (Twilio
+    // reconnect, back-to-back call) does not start with the previous session's
+    // terminal flag stuck true — which would make `receiveAudio` synthesize an
+    // empty "end of call" sentinel on any transient empty queue mid-turn and
+    // truncate the new call's first agent turn.
+    adapter._resetStreamEnded();
 
     const buffered: number[] = [];
     const flushThresholdBytes = (BATCH_MS / TWILIO_FRAME_MS) * 160; // 100ms = 800 bytes µ-law

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -302,7 +302,8 @@ export class TwilioWebhookServer {
       // exits on a "stop" frame, a socket close (`receiveText` resolves null),
       // or a throw, enqueue an empty AudioChunk so a `receiveAudio` blocked on
       // the inbound queue returns cleanly instead of timing out on a silent /
-      // tool-only turn.
+      // tool-only turn. Unlike the Python twin, no null-guard is needed here:
+      // the inbound queue object is never nulled — `disconnect()` only `reset()`s it.
       adapter._enqueueInbound(new AudioChunk({ data: new Uint8Array(0) }));
     }
   }

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -422,11 +422,26 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   /** @internal */ _markStreamEnded(): void {
     this._streamEnded = true;
   }
-  /** @internal Re-armed at media-stream-loop entry: the flag is per-call, not
-   * per-connection, so a second session on the same connected adapter must not
-   * inherit the previous session's terminal state. */
-  _resetStreamEnded(): void {
+  /**
+   * @internal Re-arm per-CALL state at media-stream-loop entry. Both halves are
+   * per-call, not per-connection, so a second session on the same connected
+   * adapter must not inherit either of them.
+   *
+   * The flag alone is not enough: the previous call's `finally` ENQUEUED a
+   * terminal sentinel, and if that call ended while no drain was running (the
+   * caller hung up between turns) the sentinel is still buffered. `receiveAudio`
+   * drains a non-empty queue without checking liveness, so the new call's first
+   * `receiveAudio` would hand that stale empty chunk to `drainAgentResponse` as
+   * its first chunk — and the drain breaks on an empty chunk, truncating the new
+   * call's first agent turn to silence.
+   *
+   * No frame of this call has been enqueued yet, so buffered chunks are the
+   * previous session's residue. `clearBuffered` (not `reset`) so a consumer
+   * already parked in `take()` stays parked for the new call's real audio.
+   */
+  _resetCallState(): void {
     this._streamEnded = false;
+    this._inboundQueue.clearBuffered();
   }
   /** @internal Test-only view of the transport state the server nulls on teardown. */
   get _streamWsForTest(): MediaStreamWebSocket | null {
@@ -517,6 +532,16 @@ class InboundQueue {
   /** True when no buffered chunk is immediately available to `take()`. */
   isEmpty(): boolean {
     return this._items.length === 0;
+  }
+
+  /**
+   * Drop buffered chunks but leave parked waiters alone — unlike {@link reset},
+   * which also rejects them. Used at media-stream-loop entry to clear the
+   * previous call's residue without failing a consumer already waiting on the
+   * new call's audio.
+   */
+  clearBuffered(): void {
+    this._items = [];
   }
 
   reset(): void {

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -18,7 +18,6 @@
  * codec live in `./twilio-shared.ts`.
  */
 
-
 import { AgentRole } from "../../domain/agents";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
@@ -118,7 +117,9 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   // sentinel) WITHOUT re-asserting transport liveness — `_handleStreamSocket`
   // nulls `_streamWs`/`_streamSid` synchronously right after the loop returns,
   // so the drain's second receiveAudio would otherwise hit `_assertStreamLive`
-  // and throw "no live media stream" (#695). Reset on connect().
+  // and throw "no live media stream" (#695). Reset on connect(), disconnect(),
+  // and at media-stream-loop entry (per-call scope — a second session on the
+  // same connected adapter must not inherit the previous session's flag).
   private _streamEnded = false;
 
   constructor(options: TwilioAgentAdapterOptions) {
@@ -311,22 +312,26 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     // `_handleStreamSocket` nulls `_streamWs`/`_streamSid` synchronously right
     // after the loop returns. The drain loop (`drainAgentResponse`) always makes
     // a *second* receiveAudio call after the first chunk — by then liveness has
-    // flipped. So we must NOT gate on transport liveness once the call has ended
-    // or there is already buffered audio to hand back; the terminal sentinel and
-    // any trailing audio still need to drain cleanly (#695). `_assertStreamLive`
-    // is only for genuine pre-connection misuse: never-started stream, empty
-    // queue, no end-of-call.
-    if (this._streamEnded || !this._inboundQueue.isEmpty()) {
-      // End-of-call drain path. When the call has ended and the queue empties
-      // out, hand back another empty sentinel so a caller that keeps polling
-      // (or the drain's tail-silence probe) terminates cleanly instead of
-      // rejecting on timeout.
-      if (this._streamEnded && this._inboundQueue.isEmpty()) {
-        return new AudioChunk({ data: new Uint8Array(0) });
-      }
+    // flipped. So the liveness assert only guards the genuinely-live-and-idle
+    // case; buffered audio and the end-of-call drain bypass it (#695).
+    //
+    // Two sentinel sources cooperate here, and BOTH are load-bearing: the
+    // loop's `finally` ENQUEUES one empty chunk — that is what wakes a consumer
+    // already blocked in `take()` at the moment the call ends (flipping
+    // `_streamEnded` alone wakes nobody) — and this method SYNTHESIZES further
+    // empty chunks for every call after the queue has drained (the tail-silence
+    // probe, or any caller that keeps polling). Delete either and a hang comes
+    // back.
+    if (!this._inboundQueue.isEmpty()) {
+      // Buffered audio or the loop-enqueued terminal sentinel — drain it,
+      // live or not.
       return this._inboundQueue.take(timeout * 1000);
     }
-
+    if (this._streamEnded) {
+      // Call ended and fully drained: synthesize another empty sentinel.
+      return new AudioChunk({ data: new Uint8Array(0) });
+    }
+    // Live call, nothing buffered yet: assert liveness, then wait.
     this._assertStreamLive();
     return this._inboundQueue.take(timeout * 1000);
   }
@@ -416,6 +421,12 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   }
   /** @internal */ _markStreamEnded(): void {
     this._streamEnded = true;
+  }
+  /** @internal Re-armed at media-stream-loop entry: the flag is per-call, not
+   * per-connection, so a second session on the same connected adapter must not
+   * inherit the previous session's terminal state. */
+  _resetStreamEnded(): void {
+    this._streamEnded = false;
   }
   /** @internal Test-only view of the transport state the server nulls on teardown. */
   get _streamWsForTest(): MediaStreamWebSocket | null {

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -112,6 +112,14 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   private _streamConnected = makeDeferred<void>();
   private _inboundQueue: InboundQueue = new InboundQueue();
   private _connected = false;
+  // Set true by the media-stream loop's terminal path (stop / socket close /
+  // throw) the moment it enqueues the end-of-call sentinel. Once the call has
+  // ended, receiveAudio must keep draining the queue (and hand back the
+  // sentinel) WITHOUT re-asserting transport liveness — `_handleStreamSocket`
+  // nulls `_streamWs`/`_streamSid` synchronously right after the loop returns,
+  // so the drain's second receiveAudio would otherwise hit `_assertStreamLive`
+  // and throw "no live media stream" (#695). Reset on connect().
+  private _streamEnded = false;
 
   constructor(options: TwilioAgentAdapterOptions) {
     super();
@@ -152,6 +160,7 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     this._mode = "idle";
     this._streamConnected = makeDeferred<void>();
     this._inboundQueue.reset();
+    this._streamEnded = false;
 
     this._webhookServer = new TwilioWebhookServer(this);
     await this._webhookServer.start();
@@ -201,6 +210,7 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     this._streamWs = null;
     this._streamConnected = makeDeferred<void>();
     this._inboundQueue.reset();
+    this._streamEnded = false;
   }
 
   // ------------------------------------------------------------------ direction
@@ -297,6 +307,26 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   }
 
   override async receiveAudio(timeout: number): Promise<AudioChunk> {
+    // Once the media-stream loop has ended (stop / socket close / throw),
+    // `_handleStreamSocket` nulls `_streamWs`/`_streamSid` synchronously right
+    // after the loop returns. The drain loop (`drainAgentResponse`) always makes
+    // a *second* receiveAudio call after the first chunk — by then liveness has
+    // flipped. So we must NOT gate on transport liveness once the call has ended
+    // or there is already buffered audio to hand back; the terminal sentinel and
+    // any trailing audio still need to drain cleanly (#695). `_assertStreamLive`
+    // is only for genuine pre-connection misuse: never-started stream, empty
+    // queue, no end-of-call.
+    if (this._streamEnded || !this._inboundQueue.isEmpty()) {
+      // End-of-call drain path. When the call has ended and the queue empties
+      // out, hand back another empty sentinel so a caller that keeps polling
+      // (or the drain's tail-silence probe) terminates cleanly instead of
+      // rejecting on timeout.
+      if (this._streamEnded && this._inboundQueue.isEmpty()) {
+        return new AudioChunk({ data: new Uint8Array(0) });
+      }
+      return this._inboundQueue.take(timeout * 1000);
+    }
+
     this._assertStreamLive();
     return this._inboundQueue.take(timeout * 1000);
   }
@@ -346,6 +376,21 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   }
 
   /**
+   * Test seam: drive the FULL production per-connection wrapper
+   * ({@link TwilioWebhookServer.runStreamSession}) over a provided socket — the
+   * loop PLUS the `finally` that nulls `_streamWs`/`_streamSid`, exactly as the
+   * real `/twilio/stream` handler does after a call ends. Unlike
+   * {@link _driveMediaStream} (loop only), this reproduces the #695 teardown
+   * race so a follow-up `receiveAudio` runs against nulled transport state.
+   */
+  async _driveStreamSession(ws: MediaStreamWebSocket): Promise<void> {
+    if (!this._webhookServer) {
+      throw new Error("TwilioAgentAdapter: not connected; cannot drive stream.");
+    }
+    await this._webhookServer.runStreamSession(ws);
+  }
+
+  /**
    * Called by the server when an inbound webhook is rejected (caller filter
    * or bad signature). Exposed for tests; production callers see the HTTP
    * response and never look at this counter.
@@ -368,6 +413,17 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   }
   /** @internal */ _enqueueInbound(chunk: AudioChunk): void {
     this._inboundQueue.put(chunk);
+  }
+  /** @internal */ _markStreamEnded(): void {
+    this._streamEnded = true;
+  }
+  /** @internal Test-only view of the transport state the server nulls on teardown. */
+  get _streamWsForTest(): MediaStreamWebSocket | null {
+    return this._streamWs;
+  }
+  /** @internal Test-only view of the transport state the server nulls on teardown. */
+  get _streamSidForTest(): string | undefined {
+    return this._streamSid;
   }
   /** @internal */ _onWebhookRejected(): void {
     this.rejectedCount += 1;
@@ -446,6 +502,11 @@ class InboundQueue {
     reject: (err: Error) => void;
     timer: NodeJS.Timeout;
   }> = [];
+
+  /** True when no buffered chunk is immediately available to `take()`. */
+  isEmpty(): boolean {
+    return this._items.length === 0;
+  }
 
   reset(): void {
     this._items = [];

--- a/python/scenario/voice/adapters/_twilio_server.py
+++ b/python/scenario/voice/adapters/_twilio_server.py
@@ -220,49 +220,60 @@ class TwilioWebhookServer:
         buffered_mulaw = bytearray()
         BATCH_MS = 100
 
-        while True:
-            msg = await ws.receive_text()
-            frame = parse_media_stream_frame(msg)
-            if frame is None:
-                continue
+        try:
+            while True:
+                msg = await ws.receive_text()
+                frame = parse_media_stream_frame(msg)
+                if frame is None:
+                    continue
 
-            if frame.event == "start":
-                adapter._stream_sid = frame.stream_sid
-                if frame.call_sid and adapter._call_sid is None:
-                    adapter._call_sid = frame.call_sid
-                adapter._stream_connected.set()
+                if frame.event == "start":
+                    adapter._stream_sid = frame.stream_sid
+                    if frame.call_sid and adapter._call_sid is None:
+                        adapter._call_sid = frame.call_sid
+                    adapter._stream_connected.set()
 
-            elif frame.event == "media" and frame.payload_mulaw:
-                buffered_mulaw.extend(frame.payload_mulaw)
-                # 20ms per frame → flush every ~5 frames. Queue may be
-                # None if disconnect() raced ahead of the final frames;
-                # drop the chunk silently in that window.
-                if (
-                    len(buffered_mulaw) >= (BATCH_MS * 8)
-                    and adapter._inbound_queue is not None
-                ):
-                    pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
-                    buffered_mulaw.clear()
-                    await adapter._inbound_queue.put(AudioChunk(data=pcm))
+                elif frame.event == "media" and frame.payload_mulaw:
+                    buffered_mulaw.extend(frame.payload_mulaw)
+                    # 20ms per frame → flush every ~5 frames. Queue may be
+                    # None if disconnect() raced ahead of the final frames;
+                    # drop the chunk silently in that window.
+                    if (
+                        len(buffered_mulaw) >= (BATCH_MS * 8)
+                        and adapter._inbound_queue is not None
+                    ):
+                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        buffered_mulaw.clear()
+                        await adapter._inbound_queue.put(AudioChunk(data=pcm))
 
-            elif frame.event == "dtmf" and frame.dtmf_digit:
-                logger.debug("TwilioAgentAdapter: received DTMF %s", frame.dtmf_digit)
-                if adapter.on_dtmf is not None:
-                    try:
-                        adapter.on_dtmf(frame.dtmf_digit)
-                    except Exception:
-                        logger.warning(
-                            "TwilioAgentAdapter.on_dtmf callback raised; continuing",
-                            exc_info=True,
-                        )
+                elif frame.event == "dtmf" and frame.dtmf_digit:
+                    logger.debug("TwilioAgentAdapter: received DTMF %s", frame.dtmf_digit)
+                    if adapter.on_dtmf is not None:
+                        try:
+                            adapter.on_dtmf(frame.dtmf_digit)
+                        except Exception:
+                            logger.warning(
+                                "TwilioAgentAdapter.on_dtmf callback raised; continuing",
+                                exc_info=True,
+                            )
 
-            elif frame.event == "stop":
-                # Flush trailing audio then exit. After disconnect() has
-                # already reset state, _inbound_queue may be None — guard
-                # against a race where Twilio's final stop frame arrives
-                # after teardown started.
-                if buffered_mulaw and adapter._inbound_queue is not None:
-                    pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
-                    buffered_mulaw.clear()
-                    await adapter._inbound_queue.put(AudioChunk(data=pcm))
-                return
+                elif frame.event == "stop":
+                    # Flush trailing audio then exit. After disconnect() has
+                    # already reset state, _inbound_queue may be None — guard
+                    # against a race where Twilio's final stop frame arrives
+                    # after teardown started.
+                    if buffered_mulaw and adapter._inbound_queue is not None:
+                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        buffered_mulaw.clear()
+                        await adapter._inbound_queue.put(AudioChunk(data=pcm))
+                    return
+        finally:
+            # Terminal sentinel (#695; mirrors the #648 / #646 fix). Whether the
+            # loop exits on a "stop" frame, a socket close (``receive_text``
+            # raises ``WebSocketDisconnect``), or any error, enqueue an empty
+            # ``AudioChunk`` so a ``recv_audio`` blocked on the inbound queue
+            # returns cleanly instead of hanging to ``response_timeout`` on a
+            # silent / tool-only turn. Guard the disconnect race where
+            # ``disconnect()`` already nulled the queue.
+            if adapter._inbound_queue is not None:
+                await adapter._inbound_queue.put(AudioChunk(data=b""))

--- a/python/scenario/voice/adapters/_twilio_server.py
+++ b/python/scenario/voice/adapters/_twilio_server.py
@@ -192,20 +192,43 @@ class TwilioWebhookServer:
         app.post("/twilio/voice")(_voice)
 
         async def _stream(ws):
-            await ws.accept()
-            logger.debug("TwilioAgentAdapter: WS connection accepted")
-            try:
-                await self.media_stream_loop(ws)
-            except WebSocketDisconnect:
-                logger.debug("TwilioAgentAdapter: WS disconnected")
-            finally:
-                adapter._stream_ws = None
-                adapter._stream_sid = None
+            await self.run_stream_session(ws)
 
         _stream.__annotations__ = {"ws": WebSocket, "return": None}
         app.websocket("/twilio/stream")(_stream)
 
         return app
+
+    async def run_stream_session(self, ws: Any) -> None:
+        """Production per-connection wrapper around :meth:`media_stream_loop`
+        (twin of the JS ``TwilioWebhookServer.runStreamSession``): accept the
+        socket, run the loop, swallow the disconnect, then — in a ``finally``
+        that fires on stop, socket close, OR a raise — null the adapter's
+        ``_stream_ws``/``_stream_sid`` transport state, exactly as the real
+        ``/twilio/stream`` route does after a call ends.
+
+        This is the seam tests must drive to reproduce the #695 teardown race:
+        the terminal sentinel is enqueued inside the loop's own ``finally``,
+        then THIS ``finally`` nulls the transport — so a ``recv_audio``
+        following the reset must still drain cleanly. Driving
+        ``media_stream_loop`` alone skips this reset and hides the bug (that
+        was the shipped tests' flaw, PR #697 P2 blocker). Internal: production
+        enters via the ``/twilio/stream`` route; not public API.
+        """
+        # Deferred import, matching this module's pattern of keeping fastapi
+        # out of import-time dependencies (see build_app).
+        from fastapi import WebSocketDisconnect
+
+        adapter = self._adapter
+        await ws.accept()
+        logger.debug("TwilioAgentAdapter: WS connection accepted")
+        try:
+            await self.media_stream_loop(ws)
+        except WebSocketDisconnect:
+            logger.debug("TwilioAgentAdapter: WS disconnected")
+        finally:
+            adapter._stream_ws = None
+            adapter._stream_sid = None
 
     async def media_stream_loop(self, ws: Any) -> None:
         """Per-call Media Streams loop: parse frames, enqueue audio, fire DTMF."""
@@ -214,6 +237,14 @@ class TwilioWebhookServer:
         assert adapter._stream_connected is not None
 
         adapter._stream_ws = ws
+        # ``_stream_ended`` is per-CALL state: re-arm it alongside
+        # ``_stream_ws`` so a second media-stream session on the same connected
+        # adapter (Twilio reconnect, back-to-back call) does not start with the
+        # previous session's terminal flag stuck True — which would make
+        # ``recv_audio`` synthesize an empty "end of call" sentinel on any
+        # transient empty queue mid-turn and truncate the new call's first
+        # agent turn.
+        adapter._stream_ended = False
         # Buffer µ-law for batched decoding — send_audio/recv_audio operate at
         # the AudioChunk level, so we coalesce ~100ms of incoming µ-law per
         # chunk to avoid thousands of tiny AudioChunk objects.

--- a/python/scenario/voice/adapters/_twilio_server.py
+++ b/python/scenario/voice/adapters/_twilio_server.py
@@ -270,10 +270,20 @@ class TwilioWebhookServer:
         finally:
             # Terminal sentinel (#695; mirrors the #648 / #646 fix). Whether the
             # loop exits on a "stop" frame, a socket close (``receive_text``
-            # raises ``WebSocketDisconnect``), or any error, enqueue an empty
-            # ``AudioChunk`` so a ``recv_audio`` blocked on the inbound queue
-            # returns cleanly instead of hanging to ``response_timeout`` on a
-            # silent / tool-only turn. Guard the disconnect race where
+            # raises ``WebSocketDisconnect``), or any error, mark the call ended
+            # and enqueue an empty ``AudioChunk`` so a ``recv_audio`` blocked on
+            # the inbound queue returns cleanly instead of hanging to
+            # ``response_timeout`` on a silent / tool-only turn. All three
+            # termination paths (stop / close / throw) funnel through this
+            # ``finally``, so the sentinel is genuinely reachable on each.
+            #
+            # ``_stream_ended`` is set FIRST and unconditionally: the production
+            # ``_stream()`` wrapper nulls ``_stream_ws``/``_stream_sid``
+            # synchronously right after this loop returns, so ``recv_audio``'s
+            # follow-up call would otherwise trip ``_assert_stream_live``. The
+            # flag tells ``recv_audio`` to keep draining post-teardown rather
+            # than assert liveness. Guard the disconnect race where
             # ``disconnect()`` already nulled the queue.
+            adapter._stream_ended = True
             if adapter._inbound_queue is not None:
                 await adapter._inbound_queue.put(AudioChunk(data=b""))

--- a/python/scenario/voice/adapters/_twilio_server.py
+++ b/python/scenario/voice/adapters/_twilio_server.py
@@ -237,14 +237,26 @@ class TwilioWebhookServer:
         assert adapter._stream_connected is not None
 
         adapter._stream_ws = ws
-        # ``_stream_ended`` is per-CALL state: re-arm it alongside
-        # ``_stream_ws`` so a second media-stream session on the same connected
-        # adapter (Twilio reconnect, back-to-back call) does not start with the
-        # previous session's terminal flag stuck True — which would make
-        # ``recv_audio`` synthesize an empty "end of call" sentinel on any
-        # transient empty queue mid-turn and truncate the new call's first
-        # agent turn.
+        # ``_stream_ended`` AND the inbound queue are per-CALL state: re-arm and
+        # purge both alongside ``_stream_ws`` so a second media-stream session on
+        # the same connected adapter (Twilio reconnect, back-to-back call) starts
+        # clean.
+        #
+        # The flag alone is not enough. The previous call's ``finally`` ENQUEUED a
+        # terminal sentinel; if that call ended while no drain was running (the
+        # caller hung up between turns), the sentinel is still sitting in the
+        # queue. ``recv_audio`` drains a non-empty queue without checking
+        # liveness, so the new call's first ``recv_audio`` would hand that stale
+        # empty chunk to ``_drain_agent_response`` as its first chunk — and the
+        # drain breaks on an empty chunk, truncating the new call's first agent
+        # turn to silence and stranding its real audio for the turn after.
+        #
+        # No frame of THIS call has been enqueued yet, so anything present is the
+        # previous session's residue and is safe to drop. Waiters are untouched:
+        # a consumer already parked in ``get()`` stays parked for real audio.
         adapter._stream_ended = False
+        while not adapter._inbound_queue.empty():
+            adapter._inbound_queue.get_nowait()
         # Buffer µ-law for batched decoding — send_audio/recv_audio operate at
         # the AudioChunk level, so we coalesce ~100ms of incoming µ-law per
         # chunk to avoid thousands of tiny AudioChunk objects.

--- a/python/scenario/voice/adapters/twilio.py
+++ b/python/scenario/voice/adapters/twilio.py
@@ -155,6 +155,14 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         self._stream_connected: Optional[asyncio.Event] = None
         self._stream_ws: Any = None  # starlette WebSocket
         self._inbound_queue: Optional[asyncio.Queue[AudioChunk]] = None
+        # Set True by the media-stream loop's terminal path (stop / socket close
+        # / throw) the moment it enqueues the end-of-call sentinel. Once the call
+        # has ended, recv_audio must keep draining the queue (and hand back the
+        # sentinel) WITHOUT re-asserting transport liveness — the real
+        # production wrapper nulls _stream_ws/_stream_sid synchronously right
+        # after the loop returns, so the drain's second recv_audio would
+        # otherwise hit _assert_stream_live and crash (#695). Reset on connect().
+        self._stream_ended: bool = False
 
 
     # ------------------------------------------------------------------ repr
@@ -200,6 +208,7 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         self._stream_connected = asyncio.Event()
         self._inbound_queue = asyncio.Queue()
         self._server_shutdown = asyncio.Event()
+        self._stream_ended = False
         self._mode = "idle"
 
         # Webhook server is its own unit — see _twilio_server.py. The
@@ -263,6 +272,7 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         self._stream_connected = None
         self._stream_ws = None
         self._inbound_queue = None
+        self._stream_ended = False
 
     # ------------------------------------------------------------------ direction
 
@@ -456,8 +466,34 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
             await asyncio.sleep(frame_secs)
 
     async def recv_audio(self, timeout: float) -> AudioChunk:
+        # Once the media-stream loop has ended (stop / socket close / throw), the
+        # real production wrapper (_stream() in _twilio_server.build_app) nulls
+        # _stream_ws/_stream_sid synchronously right after the loop returns. The
+        # drain loop (_drain_agent_response) always makes a *second* recv_audio
+        # call after the first chunk — by then liveness has flipped. So we must
+        # NOT gate on transport liveness once the call has ended or there is
+        # already buffered audio to hand back; the terminal sentinel and any
+        # trailing audio still need to drain cleanly (#695). _assert_stream_live
+        # is only for genuine pre-connection misuse: never-started stream, empty
+        # queue, no end-of-call.
+        if self._inbound_queue is None:
+            # disconnect() tore the adapter down mid-drain — nothing left to
+            # read. Surface the connection error rather than an AttributeError.
+            self._assert_connected()
+            raise RuntimeError(
+                "TwilioAgentAdapter: inbound queue is gone; adapter disconnected."
+            )
+
+        if self._stream_ended or not self._inbound_queue.empty():
+            # End-of-call drain path: read whatever is queued. When the call has
+            # ended and the queue empties out, hand back another empty sentinel
+            # so a caller that keeps polling (or the drain's tail-silence probe)
+            # terminates cleanly instead of blocking to timeout or raising.
+            if self._stream_ended and self._inbound_queue.empty():
+                return AudioChunk(data=b"")
+            return await asyncio.wait_for(self._inbound_queue.get(), timeout=timeout)
+
         self._assert_stream_live()
-        assert self._inbound_queue is not None
         return await asyncio.wait_for(self._inbound_queue.get(), timeout=timeout)
 
     async def send_dtmf(self, tones: str) -> None:

--- a/python/scenario/voice/adapters/twilio.py
+++ b/python/scenario/voice/adapters/twilio.py
@@ -161,7 +161,10 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         # sentinel) WITHOUT re-asserting transport liveness — the real
         # production wrapper nulls _stream_ws/_stream_sid synchronously right
         # after the loop returns, so the drain's second recv_audio would
-        # otherwise hit _assert_stream_live and crash (#695). Reset on connect().
+        # otherwise hit _assert_stream_live and crash (#695). Reset on
+        # connect(), disconnect(), and at media-stream-loop entry (per-call
+        # scope — a second session on the same connected adapter must not
+        # inherit the previous session's flag).
         self._stream_ended: bool = False
 
 
@@ -466,33 +469,41 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
             await asyncio.sleep(frame_secs)
 
     async def recv_audio(self, timeout: float) -> AudioChunk:
-        # Once the media-stream loop has ended (stop / socket close / throw), the
-        # real production wrapper (_stream() in _twilio_server.build_app) nulls
+        # Once the media-stream loop has ended (stop / socket close / throw),
+        # the production wrapper (run_stream_session in _twilio_server) nulls
         # _stream_ws/_stream_sid synchronously right after the loop returns. The
         # drain loop (_drain_agent_response) always makes a *second* recv_audio
-        # call after the first chunk — by then liveness has flipped. So we must
-        # NOT gate on transport liveness once the call has ended or there is
-        # already buffered audio to hand back; the terminal sentinel and any
-        # trailing audio still need to drain cleanly (#695). _assert_stream_live
-        # is only for genuine pre-connection misuse: never-started stream, empty
-        # queue, no end-of-call.
+        # call after the first chunk — by then liveness has flipped. So the
+        # liveness assert only guards the genuinely-live-and-idle case; buffered
+        # audio and the end-of-call drain bypass it (#695).
+        #
+        # Two sentinel sources cooperate here, and BOTH are load-bearing: the
+        # loop's ``finally`` ENQUEUES one empty chunk — that is what wakes a
+        # consumer already blocked in ``queue.get()`` at the moment the call
+        # ends (flipping ``_stream_ended`` alone wakes nobody) — and this method
+        # SYNTHESIZES further empty chunks for every call after the queue has
+        # drained (the tail-silence probe, or any caller that keeps polling).
+        # Delete either and a hang comes back.
         if self._inbound_queue is None:
             # disconnect() tore the adapter down mid-drain — nothing left to
-            # read. Surface the connection error rather than an AttributeError.
+            # read. In the current teardown order _assert_connected() raises
+            # first (_rest is nulled before _inbound_queue, synchronously), so
+            # the explicit raise below is a reordering guard, not a live path —
+            # it keeps this method's error honest if disconnect() is ever
+            # resequenced.
             self._assert_connected()
             raise RuntimeError(
                 "TwilioAgentAdapter: inbound queue is gone; adapter disconnected."
             )
 
-        if self._stream_ended or not self._inbound_queue.empty():
-            # End-of-call drain path: read whatever is queued. When the call has
-            # ended and the queue empties out, hand back another empty sentinel
-            # so a caller that keeps polling (or the drain's tail-silence probe)
-            # terminates cleanly instead of blocking to timeout or raising.
-            if self._stream_ended and self._inbound_queue.empty():
-                return AudioChunk(data=b"")
+        if not self._inbound_queue.empty():
+            # Buffered audio or the loop-enqueued terminal sentinel — drain it,
+            # live or not.
             return await asyncio.wait_for(self._inbound_queue.get(), timeout=timeout)
-
+        if self._stream_ended:
+            # Call ended and fully drained: synthesize another empty sentinel.
+            return AudioChunk(data=b"")
+        # Live call, nothing buffered yet: assert liveness, then wait.
         self._assert_stream_live()
         return await asyncio.wait_for(self._inbound_queue.get(), timeout=timeout)
 

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -1,0 +1,176 @@
+"""
+Issue #695 — the Twilio adapter must terminate its inbound queue on a silent /
+tool-only completion (a #648-class dead-recv-loop hang).
+
+The Twilio Media Streams loop (``_twilio_server.media_stream_loop``) is the
+*producer* for the adapter's ``_inbound_queue``; ``recv_audio`` is a bare
+``await _inbound_queue.get()``. Historically a turn that completed WITHOUT
+trailing audio — a ``"stop"`` frame with nothing buffered (a silent agent turn
+or a tool-only turn), or a socket close — left the queue empty, so ``recv_audio``
+blocked to ``response_timeout`` instead of returning cleanly. This is the same
+latent hang fixed for ElevenLabs / generic WebSocket in #648 and for OpenAI
+Realtime in #646/PR #647.
+
+The fix mirrors that reference pattern: on *any* terminal exit of the media
+stream loop, enqueue an empty ``AudioChunk`` sentinel so the base
+``_drain_agent_response`` loop (which breaks on an empty chunk) exits cleanly.
+
+These tests drive ``media_stream_loop`` directly with a scripted WebSocket
+double — no real port, no uvicorn. Each terminal-case test hands ``recv_audio``
+a generous nominal ``timeout`` (the budget it would otherwise hang for) and
+wraps the call in a short outer ceiling, so an un-fixed adapter that blocks on
+the empty queue fails fast instead of stalling the suite — the empty-chunk fix
+returns immediately, far under the ceiling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Optional
+
+import pytest
+
+from scenario.voice import AudioChunk, TwilioAgentAdapter
+from scenario.voice.adapters._twilio_server import TwilioWebhookServer
+from scenario.voice.adapters._twilio_shared import build_media_frame
+
+# recv_audio is handed a long nominal budget (what an un-fixed adapter would
+# hang for); the outer ceiling fails the test fast if the empty-chunk terminal
+# is missing. The fix returns instantly, far under the ceiling.
+RECV_TIMEOUT = 30.0
+OUTER_CEILING = 2.0
+STREAM_SID = "MZ695"
+
+
+def _start_frame(stream_sid: str = STREAM_SID, call_sid: str = "CA695") -> str:
+    """The handshake frame Twilio sends as the first WS message on a new call."""
+    return json.dumps(
+        {"event": "start", "start": {"streamSid": stream_sid, "callSid": call_sid}}
+    )
+
+
+def _stop_frame() -> str:
+    return json.dumps({"event": "stop"})
+
+
+class _ScriptedWS:
+    """A starlette-WebSocket double whose ``receive_text()`` serves ``frames``
+    in order, then raises ``close_with`` (modelling a socket close).
+
+    Every test scripts an explicit terminal (a ``"stop"`` frame the loop returns
+    on, or a ``close_with`` exception), so ``receive_text`` is never called past
+    the programmed frames without one — the trailing ``AssertionError`` guards
+    against a test that accidentally lets the loop spin.
+    """
+
+    def __init__(
+        self, frames: list[str], *, close_with: Optional[BaseException] = None
+    ) -> None:
+        self._frames = list(frames)
+        self._idx = 0
+        self._close_with = close_with
+        self.sent: list[str] = []
+
+    async def receive_text(self) -> str:
+        if self._idx < len(self._frames):
+            msg = self._frames[self._idx]
+            self._idx += 1
+            return msg
+        if self._close_with is not None:
+            raise self._close_with
+        raise AssertionError(  # pragma: no cover
+            "scripted WS exhausted without a terminal frame"
+        )
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+
+def _make_connected_adapter() -> TwilioAgentAdapter:
+    """Construct an adapter with just enough state for ``media_stream_loop`` +
+    ``recv_audio`` — without binding a real port (``connect()`` spins uvicorn).
+
+    ``_assert_connected`` only checks ``_rest is not None``; ``recv_audio`` needs
+    an inbound queue; ``media_stream_loop`` also touches ``_stream_connected``.
+    """
+    adapter = TwilioAgentAdapter(
+        account_sid="AC" + "0" * 32,
+        auth_token="secret",
+        phone_number="+14155556959",
+        public_base_url="https://example695.trycloudflare.com",
+    )
+    adapter._rest = object()  # type: ignore[assignment]
+    adapter._inbound_queue = asyncio.Queue()
+    adapter._stream_connected = asyncio.Event()
+    return adapter
+
+
+async def _drive(adapter: TwilioAgentAdapter, ws: _ScriptedWS) -> None:
+    """Run the media-stream loop to its terminal over the scripted socket."""
+    server = TwilioWebhookServer(adapter)
+    await server.media_stream_loop(ws)
+
+
+@pytest.mark.asyncio
+async def test_stop_without_trailing_audio_returns_empty_chunk():
+    """A ``"stop"`` frame with no buffered audio (silent / tool-only turn)
+    enqueues an empty terminal sentinel, so ``recv_audio`` returns cleanly
+    instead of hanging. Pre-fix the queue stays empty and ``recv_audio`` blocks
+    to the outer ceiling.
+    """
+    adapter = _make_connected_adapter()
+    ws = _ScriptedWS([_start_frame(), _stop_frame()])
+
+    await _drive(adapter, ws)
+
+    chunk = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert isinstance(chunk, AudioChunk)
+    assert chunk.data == b""  # empty terminal, not a hang
+
+
+@pytest.mark.asyncio
+async def test_socket_close_returns_empty_chunk():
+    """A socket close mid-stream (``receive_text`` raises ``WebSocketDisconnect``)
+    enqueues the terminal sentinel before the disconnect propagates, so a
+    ``recv_audio`` blocked on the queue returns cleanly. Pre-fix nothing is
+    enqueued and ``recv_audio`` hangs to the outer ceiling.
+    """
+    from starlette.websockets import WebSocketDisconnect
+
+    adapter = _make_connected_adapter()
+    ws = _ScriptedWS([_start_frame()], close_with=WebSocketDisconnect(code=1000))
+
+    with pytest.raises(WebSocketDisconnect):
+        await _drive(adapter, ws)
+
+    chunk = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert isinstance(chunk, AudioChunk)
+    assert chunk.data == b""
+
+
+@pytest.mark.asyncio
+async def test_normal_audio_turn_still_drains():
+    """No regression: a turn carrying trailing audio still yields the decoded
+    PCM as the first chunk — the terminal sentinel lands *after* it, not
+    instead of it.
+    """
+    adapter = _make_connected_adapter()
+    # 160 bytes of µ-law (~20ms). Under the 100ms batch threshold, so the
+    # "stop" flush is what enqueues it — exactly the trailing-audio path.
+    mulaw = bytes([0x7F]) * 160
+    ws = _ScriptedWS(
+        [_start_frame(), build_media_frame(STREAM_SID, mulaw), _stop_frame()]
+    )
+
+    await _drive(adapter, ws)
+
+    first = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert isinstance(first, AudioChunk)
+    assert len(first.data) > 0  # real audio survived; not clobbered by the sentinel

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -379,7 +379,9 @@ class TestRealRoute:
 
                 speaker = asyncio.create_task(_slow_agent())
                 merged = await asyncio.wait_for(drain, timeout=ROUTE_CEILING)
-                await speaker
+                # Join the speaker so a failure inside it surfaces here rather
+                # than as a stray "task exception never retrieved" warning.
+                await asyncio.wait_for(speaker, timeout=ROUTE_CEILING)
 
         assert len(merged.data) > 0  # the new call's real audio, not a stale sentinel
 

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -35,6 +35,17 @@ This suite therefore has two layers, and both are load-bearing:
    error; a second session on the same connected adapter). They drive
    ``run_stream_session`` directly, which layer 1 proves is what the route runs.
 
+The layers are complements, and **neither subsumes the other**. Measured, not
+assumed — delete the loop's sentinel ``put(...)`` but keep ``_stream_ended``:
+every wrapper-level test in this file still PASSES, while three ``TestRealRoute``
+tests go red (the JS twin blocks to ``responseTimeout`` — the original #695
+hang). The wrapper layer cannot see the sentinel, because a consumer that is not
+*already blocked* is served a synthesized empty chunk by the flag alone; only a
+test with a live drain waiting at the instant the call ends catches it. Delete
+the drain-side guard in ``recv_audio`` instead, and ``TestRealRoute`` goes red
+with ``RuntimeError: no live media stream`` while three of the JS route tests
+still pass. So do not trim either layer believing the other covers it.
+
 The regression the fix targets is the drain calling ``recv_audio`` *after* the
 transport reset. ``_drain_agent_response`` always probes for tail silence after
 its first chunk, so it lands there on every call termination. Pre-fix that call

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -12,19 +12,21 @@ cleanly. This is the same latent hang fixed for ElevenLabs / generic WebSocket
 in #648 and for OpenAI Realtime in #646/PR #647.
 
 **Why these tests drive the REAL production wrapper.** In production the loop is
-never reached via ``media_stream_loop`` directly — it goes through the
-``_stream()`` closure inside ``build_app()`` (the ``/twilio/stream`` WebSocket
-route). That wrapper nulls ``adapter._stream_ws`` / ``_stream_sid``
-*synchronously, in the same task, immediately after the loop returns or raises*
-(``_twilio_server.py`` ``_stream``'s ``finally``). Any test that calls
-``media_stream_loop`` directly leaves those attributes set to whatever the loop
-last wrote, so ``recv_audio``'s ``_assert_stream_live`` gate never fires — which
-is exactly why an earlier version of this suite went green on a fix that still
-crashed in production (reviewer P2 blocker on PR #697).
+never reached via ``media_stream_loop`` directly — it goes through
+``TwilioWebhookServer.run_stream_session`` (which the ``/twilio/stream``
+WebSocket route delegates to, one line). That wrapper nulls
+``adapter._stream_ws`` / ``_stream_sid`` *synchronously, in the same task,
+immediately after the loop returns or raises* (its ``finally``). Any test that
+calls ``media_stream_loop`` directly leaves those attributes set to whatever the
+loop last wrote, so ``recv_audio``'s ``_assert_stream_live`` gate never fires —
+which is exactly why an earlier version of this suite went green on a fix that
+still crashed in production (reviewer P2 blocker on PR #697).
 
-So each test here fetches the *actual* ``_stream`` endpoint off the built app's
-routes and runs it. That reproduces the production teardown sequencing exactly:
-the loop enqueues the terminal sentinel, then ``_stream``'s ``finally`` nulls the
+So each test here drives ``run_stream_session`` — the named production wrapper
+(twin of the JS ``runStreamSession`` seam; it replaced this suite's earlier
+``app.routes`` endpoint introspection, which was coupled to a Starlette
+internal). That reproduces the production teardown sequencing exactly: the loop
+enqueues the terminal sentinel, then the wrapper's ``finally`` nulls the
 transport state. The regression the fix targets is the drain loop's *second*
 ``recv_audio`` call (``_drain_agent_response`` always probes for tail silence
 after the first chunk) landing after that reset. Pre-fix that second call raises
@@ -68,9 +70,9 @@ class _ScriptedWS:
     """A starlette-WebSocket double whose ``receive_text()`` serves ``frames``
     in order, then raises ``close_with`` (modelling a socket close).
 
-    ``accept()`` is a no-op so the real ``_stream`` wrapper (which calls
-    ``await ws.accept()`` before the loop) drives cleanly. Every test scripts an
-    explicit terminal (a ``"stop"`` frame the loop returns on, or a
+    ``accept()`` is a no-op so the real ``run_stream_session`` wrapper (which
+    calls ``await ws.accept()`` before the loop) drives cleanly. Every test
+    scripts an explicit terminal (a ``"stop"`` frame the loop returns on, or a
     ``close_with`` exception), so ``receive_text`` is never called past the
     programmed frames without one.
     """
@@ -103,8 +105,8 @@ class _ScriptedWS:
 
 def _make_connected_adapter() -> TwilioAgentAdapter:
     """Construct an adapter with just enough state for the production
-    ``_stream`` wrapper + ``recv_audio`` — without binding a real port
-    (``connect()`` spins uvicorn).
+    ``run_stream_session`` wrapper + ``recv_audio`` — without binding a real
+    port (``connect()`` spins uvicorn).
 
     ``_assert_connected`` only checks ``_rest is not None``; ``recv_audio`` needs
     an inbound queue; the loop also touches ``_stream_connected``; ``_build_app``
@@ -123,31 +125,57 @@ def _make_connected_adapter() -> TwilioAgentAdapter:
     return adapter
 
 
-def _production_stream_endpoint(adapter: TwilioAgentAdapter) -> Any:
-    """Pull the REAL ``_stream`` closure off the built app's ``/twilio/stream``
-    route.
-
-    This is the exact function production runs per WebSocket connection: it
-    ``accept()``s, calls ``media_stream_loop``, and — critically — nulls
-    ``adapter._stream_ws`` / ``_stream_sid`` in its ``finally``. Driving it
-    directly reproduces the production teardown sequencing that a bare
-    ``media_stream_loop`` call skips.
+class _ControllableWS:
+    """A starlette-WebSocket double the test can feed mid-flight:
+    ``receive_text()`` blocks until ``push()`` supplies a frame — a string
+    frame, or an exception instance to raise (socket close / transport
+    failure). Used for scenarios that need the loop *live and idle* at the
+    moment the test calls ``recv_audio`` (the scripted double above always
+    terminates first).
     """
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[Any]" = asyncio.Queue()
+        self.sent: list[str] = []
+
+    def push(self, item: Any) -> None:
+        self._queue.put_nowait(item)
+
+    async def accept(self) -> None:
+        return None
+
+    async def receive_text(self) -> str:
+        item = await self._queue.get()
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+
+async def _drive_production(adapter: TwilioAgentAdapter, ws: Any) -> None:
+    """Run the real production per-connection wrapper
+    (``TwilioWebhookServer.run_stream_session`` — what the ``/twilio/stream``
+    route delegates to) to its terminal over the given socket double.
+
+    On return, ``adapter._stream_ws`` / ``_stream_sid`` have been nulled by the
+    wrapper's ``finally`` — exactly as in production after a call ends.
+    """
+    assert adapter._webhook_server is not None
+    await adapter._webhook_server.run_stream_session(ws)
+
+
+def test_stream_route_delegates_to_run_stream_session():
+    """Wiring smoke: the built app still exposes ``/twilio/stream``, whose
+    endpoint is the one-line delegate to ``run_stream_session`` (the seam the
+    rest of this suite drives). Guards against the route and the named wrapper
+    drifting apart.
+    """
+    adapter = _make_connected_adapter()
     app = adapter._build_app()
-    for route in app.routes:
-        if getattr(route, "path", None) == "/twilio/stream":
-            return route.endpoint  # type: ignore[attr-defined]
-    raise AssertionError("no /twilio/stream route on the built app")  # pragma: no cover
-
-
-async def _drive_production(adapter: TwilioAgentAdapter, ws: _ScriptedWS) -> None:
-    """Run the real ``_stream`` wrapper to its terminal over the scripted socket.
-
-    On return, ``adapter._stream_ws`` / ``_stream_sid`` have been nulled by
-    ``_stream``'s ``finally`` — exactly as in production after a call ends.
-    """
-    stream = _production_stream_endpoint(adapter)
-    await stream(ws)
+    paths = [getattr(route, "path", None) for route in app.routes]
+    assert "/twilio/stream" in paths
 
 
 @pytest.mark.asyncio
@@ -156,15 +184,15 @@ async def test_stop_without_trailing_audio_drains_through_production_teardown():
     driven through the REAL ``_stream`` wrapper. After the wrapper nulls the
     transport state, the drain loop's first AND second ``recv_audio`` calls both
     return cleanly. Pre-fix the second call raises ``RuntimeError: no live media
-    stream`` (the transport was nulled by ``_stream``'s ``finally``).
+    stream`` (the transport was nulled by the wrapper's ``finally``).
     """
     adapter = _make_connected_adapter()
     ws = _ScriptedWS([_start_frame(), _stop_frame()])
 
     await _drive_production(adapter, ws)
 
-    # Production nulled the transport in _stream's finally — the very condition
-    # that made recv_audio crash pre-fix.
+    # Production nulled the transport in run_stream_session's finally — the
+    # very condition that made recv_audio crash pre-fix.
     assert adapter._stream_ws is None
     assert adapter._stream_sid is None
 
@@ -186,9 +214,9 @@ async def test_stop_without_trailing_audio_drains_through_production_teardown():
 @pytest.mark.asyncio
 async def test_socket_close_drains_through_production_teardown():
     """A socket close mid-stream (``receive_text`` raises ``WebSocketDisconnect``),
-    driven through the REAL ``_stream`` wrapper. ``_stream`` swallows the
-    disconnect and nulls the transport in its ``finally``; the terminal sentinel
-    was enqueued before that. Both drain ``recv_audio`` calls return cleanly.
+    driven through the REAL production wrapper, which swallows the disconnect
+    and nulls the transport in its ``finally``; the terminal sentinel was
+    enqueued before that. Both drain ``recv_audio`` calls return cleanly.
     Pre-fix the second raises ``RuntimeError: no live media stream``.
     """
     from starlette.websockets import WebSocketDisconnect
@@ -196,7 +224,7 @@ async def test_socket_close_drains_through_production_teardown():
     adapter = _make_connected_adapter()
     ws = _ScriptedWS([_start_frame()], close_with=WebSocketDisconnect(code=1000))
 
-    # _stream catches WebSocketDisconnect internally — it does NOT propagate.
+    # run_stream_session catches WebSocketDisconnect — it does NOT propagate.
     await _drive_production(adapter, ws)
 
     assert adapter._stream_ws is None
@@ -219,7 +247,7 @@ async def test_socket_close_drains_through_production_teardown():
 async def test_normal_audio_turn_still_drains_through_production_teardown():
     """No regression: a turn carrying trailing audio still yields the decoded
     PCM as the first chunk — the terminal sentinel lands *after* it, not instead
-    of it — even though the real ``_stream`` wrapper has already nulled the
+    of it — even though the real production wrapper has already nulled the
     transport state by the time the drain reads.
     """
     adapter = _make_connected_adapter()
@@ -248,3 +276,97 @@ async def test_normal_audio_turn_still_drains_through_production_teardown():
         adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
     )
     assert second.data == b""
+
+
+@pytest.mark.asyncio
+async def test_transport_error_drains_through_production_teardown():
+    """The THROW termination path (the third of stop / close / throw the
+    production ``finally`` claims): ``receive_text`` raises a
+    non-``WebSocketDisconnect`` error. ``run_stream_session`` propagates it —
+    but the loop's ``finally`` enqueued the sentinel and the wrapper's
+    ``finally`` nulled the transport first, so both drain ``recv_audio`` calls
+    still return cleanly.
+    """
+    adapter = _make_connected_adapter()
+    ws = _ScriptedWS(
+        [_start_frame()], close_with=RuntimeError("boom: transport failure")
+    )
+
+    with pytest.raises(RuntimeError, match="boom: transport failure"):
+        await _drive_production(adapter, ws)
+
+    assert adapter._stream_ws is None  # teardown ran on the throw path
+    assert adapter._stream_sid is None
+
+    first = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert first.data == b""
+
+    second = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert second.data == b""
+
+
+@pytest.mark.asyncio
+async def test_second_session_stale_flag_does_not_truncate_first_turn():
+    """``_stream_ended`` is per-CALL state. After a completed first session, a
+    second media-stream session on the SAME connected adapter (Twilio
+    reconnect / back-to-back call) must not inherit the stale terminal flag —
+    pre-fix, ``recv_audio`` on the new live call with a transiently empty queue
+    would synthesize an empty "end of call" sentinel INSTANTLY and truncate the
+    new call's first agent turn. With the loop-entry reset it waits for the
+    real audio.
+    """
+    adapter = _make_connected_adapter()
+
+    # Session 1 completes silently and is fully drained.
+    await _drive_production(adapter, _ScriptedWS([_start_frame(), _stop_frame()]))
+    s1 = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert s1.data == b""
+
+    # Session 2 begins mid-call: started, nothing buffered yet.
+    ws2 = _ControllableWS()
+    session2 = asyncio.create_task(_drive_production(adapter, ws2))
+    ws2.push(_start_frame("MZ695b", "CA695b"))
+    for _ in range(200):  # wait until the loop re-armed the transport
+        if adapter._stream_ws is not None:
+            break
+        await asyncio.sleep(0.01)
+    assert adapter._stream_ws is not None
+
+    recv = asyncio.create_task(adapter.recv_audio(timeout=RECV_TIMEOUT))
+    # Give a stale-flag bug its chance to resolve instantly with b"" before the
+    # real audio is pushed — that instant-empty is exactly the regression.
+    await asyncio.sleep(0.05)
+    # 800 bytes µ-law == the 100ms flush threshold, so the media branch flushes
+    # immediately — no stop frame needed for the audio to land.
+    ws2.push(build_media_frame("MZ695b", bytes([0x7F]) * 800))
+    audio = await asyncio.wait_for(recv, timeout=OUTER_CEILING)
+    assert len(audio.data) > 0  # real audio, not a synthesized end-of-call sentinel
+
+    # Session 2 then terminates normally and drains clean.
+    ws2.push(_stop_frame())
+    await asyncio.wait_for(session2, timeout=OUTER_CEILING)
+    tail = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert tail.data == b""
+
+
+@pytest.mark.asyncio
+async def test_recv_audio_with_nulled_queue_raises_connection_error():
+    """The disconnect-mid-drain guard: with ``_inbound_queue`` nulled (as
+    ``disconnect()`` does) but the REST client still present, ``recv_audio``
+    surfaces the explicit "inbound queue is gone" RuntimeError rather than an
+    ``AttributeError`` — pinning the reordering guard the cascade keeps ahead
+    of the queue reads.
+    """
+    adapter = _make_connected_adapter()
+    adapter._inbound_queue = None
+
+    with pytest.raises(RuntimeError, match="inbound queue is gone"):
+        await adapter.recv_audio(timeout=0.1)

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -153,8 +153,21 @@ def _free_port() -> int:
     return port
 
 
-async def _wait_for_bind(port: int) -> None:
+async def _wait_for_bind(port: int, server_task: "asyncio.Task[None]") -> None:
+    """Wait until the port accepts, failing loudly if uvicorn died instead.
+
+    ``_free_port`` reserves then releases a port, so another listener can win the
+    race. uvicorn reacts to a failed bind with ``sys.exit(1)`` — a ``SystemExit``,
+    which is a ``BaseException`` and therefore slips past the ``suppress(Exception)``
+    in ``TwilioWebhookServer.run()``. Without this check the connect below would
+    succeed against the *other* listener and the test would fail much later with a
+    bare ``SystemExit`` instead of "address already in use".
+    """
     for _ in range(200):
+        if server_task.done():
+            # Re-raise whatever killed the server (SystemExit, OSError, …).
+            server_task.result()
+            raise AssertionError("uvicorn exited before binding")
         try:
             _reader, writer = await asyncio.open_connection("127.0.0.1", port)
             writer.close()
@@ -179,7 +192,7 @@ async def _serve_real_route(
     assert adapter._webhook_server is not None
     server_task = asyncio.create_task(adapter._webhook_server.run())
     try:
-        await _wait_for_bind(adapter.http_port)
+        await _wait_for_bind(adapter.http_port, server_task)
         yield f"ws://127.0.0.1:{adapter.http_port}/twilio/stream"
     finally:
         assert adapter._server_shutdown is not None
@@ -246,15 +259,15 @@ class TestRealRoute:
     ) -> None:
         """Twilio drops the media socket with no ``stop`` frame and no audio."""
         async with _serve_real_route(route_adapter) as url:
-            client = await websockets.connect(url)
-            await client.send(_start_frame())
-            assert route_adapter._stream_connected is not None
-            await asyncio.wait_for(
-                route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
-            )
-            drain = asyncio.create_task(route_adapter._drain_agent_response())
-            await asyncio.sleep(0.05)
-            await client.close()
+            async with websockets.connect(url) as client:
+                await client.send(_start_frame())
+                assert route_adapter._stream_connected is not None
+                await asyncio.wait_for(
+                    route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
+                )
+                drain = asyncio.create_task(route_adapter._drain_agent_response())
+                await asyncio.sleep(0.05)  # let the drain block in recv_audio
+            # Leaving the ``async with`` closes the socket — the termination path.
             merged = await asyncio.wait_for(drain, timeout=ROUTE_CEILING)
 
         assert merged.data == b""
@@ -315,6 +328,60 @@ class TestRealRoute:
             )
 
         assert merged.data == b""
+
+    @pytest.mark.asyncio
+    async def test_undrained_sentinel_does_not_truncate_the_next_call(
+        self, route_adapter: TwilioAgentAdapter
+    ) -> None:
+        """A call that ends while NO drain is running leaves its terminal
+        sentinel buffered. The next media-stream session on the same connected
+        adapter must not serve that stale empty chunk as its first turn's audio.
+
+        Without the queue purge at loop entry, session 2's drain reads the stale
+        sentinel as its first chunk, breaks on it once tail-silence elapses, and
+        the new call's first agent turn is truncated to silence — with its real
+        audio stranded for the turn after.
+        """
+        # Agent 2 "thinks" for longer than tail silence before it speaks, so a
+        # stale first chunk closes the turn before the real audio can land.
+        route_adapter.response_tail_silence = 0.2
+        speak_after = 0.6
+
+        async with _serve_real_route(route_adapter) as url:
+            # Session 1: caller hangs up between turns; nothing consumes it.
+            async with websockets.connect(url) as first:
+                await first.send(_start_frame())
+                assert route_adapter._stream_connected is not None
+                await asyncio.wait_for(
+                    route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
+                )
+                await first.send(_stop_frame())
+            await _await_teardown(route_adapter)
+            assert route_adapter._inbound_queue is not None
+            assert route_adapter._inbound_queue.qsize() == 1  # sentinel, unread
+
+            # Session 2: a Twilio reconnect / back-to-back call.
+            async with websockets.connect(url) as second:
+                await second.send(_start_frame("MZ695b", "CA695b"))
+                for _ in range(int(ROUTE_CEILING / 0.01)):
+                    if route_adapter._stream_sid == "MZ695b":
+                        break
+                    await asyncio.sleep(0.01)
+                assert route_adapter._stream_sid == "MZ695b"
+
+                drain = asyncio.create_task(route_adapter._drain_agent_response())
+
+                async def _slow_agent() -> None:
+                    await asyncio.sleep(speak_after)
+                    # 800 bytes µ-law == the 100ms flush threshold, so the media
+                    # branch flushes immediately — no stop frame needed.
+                    await second.send(build_media_frame("MZ695b", bytes([0x7F]) * 800))
+
+                speaker = asyncio.create_task(_slow_agent())
+                merged = await asyncio.wait_for(drain, timeout=ROUTE_CEILING)
+                await speaker
+
+        assert len(merged.data) > 0  # the new call's real audio, not a stale sentinel
 
     @pytest.mark.asyncio
     async def test_audio_buffered_before_hangup_is_not_lost(

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -134,7 +134,9 @@ def _make_connected_adapter(http_port: int = 0) -> TwilioAgentAdapter:
         public_base_url="https://example695.trycloudflare.com",
         http_port=http_port,
     )
-    adapter._rest = object()  # type: ignore[assignment]
+    # Stand-in for the REST client: only _assert_connected's `is not None`
+    # check reads it, and constructing a real one needs live Twilio credentials.
+    adapter._rest = object()  # type: ignore[assignment]  # sentinel; never called
     adapter._inbound_queue = asyncio.Queue()
     adapter._stream_connected = asyncio.Event()
     adapter._server_shutdown = asyncio.Event()

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -174,3 +174,11 @@ async def test_normal_audio_turn_still_drains():
     )
     assert isinstance(first, AudioChunk)
     assert len(first.data) > 0  # real audio survived; not clobbered by the sentinel
+
+    # And the terminal sentinel lands AFTER the real audio (FIFO), not instead
+    # of it: the next chunk is the empty sentinel. Pins the ordering invariant —
+    # a fix that enqueued the sentinel BEFORE the flush would fail here.
+    second = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert second.data == b""

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -1,33 +1,43 @@
 """
 Issue #695 — the Twilio adapter must terminate its inbound queue on a silent /
-tool-only completion (a #648-class dead-recv-loop hang).
+tool-only completion (a #648-class dead-recv-loop hang) *and* survive the drain
+loop's follow-up ``recv_audio`` after the call has ended.
 
 The Twilio Media Streams loop (``_twilio_server.media_stream_loop``) is the
-*producer* for the adapter's ``_inbound_queue``; ``recv_audio`` is a bare
-``await _inbound_queue.get()``. Historically a turn that completed WITHOUT
-trailing audio — a ``"stop"`` frame with nothing buffered (a silent agent turn
-or a tool-only turn), or a socket close — left the queue empty, so ``recv_audio``
-blocked to ``response_timeout`` instead of returning cleanly. This is the same
-latent hang fixed for ElevenLabs / generic WebSocket in #648 and for OpenAI
-Realtime in #646/PR #647.
+*producer* for the adapter's ``_inbound_queue``. Historically a turn that
+completed WITHOUT trailing audio — a ``"stop"`` frame with nothing buffered (a
+silent agent turn or a tool-only turn), or a socket close — left the queue
+empty, so ``recv_audio`` blocked to ``response_timeout`` instead of returning
+cleanly. This is the same latent hang fixed for ElevenLabs / generic WebSocket
+in #648 and for OpenAI Realtime in #646/PR #647.
 
-The fix mirrors that reference pattern: on *any* terminal exit of the media
-stream loop, enqueue an empty ``AudioChunk`` sentinel so the base
-``_drain_agent_response`` loop (which breaks on an empty chunk) exits cleanly.
+**Why these tests drive the REAL production wrapper.** In production the loop is
+never reached via ``media_stream_loop`` directly — it goes through the
+``_stream()`` closure inside ``build_app()`` (the ``/twilio/stream`` WebSocket
+route). That wrapper nulls ``adapter._stream_ws`` / ``_stream_sid``
+*synchronously, in the same task, immediately after the loop returns or raises*
+(``_twilio_server.py`` ``_stream``'s ``finally``). Any test that calls
+``media_stream_loop`` directly leaves those attributes set to whatever the loop
+last wrote, so ``recv_audio``'s ``_assert_stream_live`` gate never fires — which
+is exactly why an earlier version of this suite went green on a fix that still
+crashed in production (reviewer P2 blocker on PR #697).
 
-These tests drive ``media_stream_loop`` directly with a scripted WebSocket
-double — no real port, no uvicorn. Each terminal-case test hands ``recv_audio``
-a generous nominal ``timeout`` (the budget it would otherwise hang for) and
-wraps the call in a short outer ceiling, so an un-fixed adapter that blocks on
-the empty queue fails fast instead of stalling the suite — the empty-chunk fix
-returns immediately, far under the ceiling.
+So each test here fetches the *actual* ``_stream`` endpoint off the built app's
+routes and runs it. That reproduces the production teardown sequencing exactly:
+the loop enqueues the terminal sentinel, then ``_stream``'s ``finally`` nulls the
+transport state. The regression the fix targets is the drain loop's *second*
+``recv_audio`` call (``_drain_agent_response`` always probes for tail silence
+after the first chunk) landing after that reset. Pre-fix that second call raises
+``RuntimeError: no live media stream``; post-fix it returns another empty chunk.
+Each test therefore asserts BOTH the first ``recv_audio`` (the sentinel) and the
+second (the post-teardown drain probe) behave cleanly.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -58,10 +68,11 @@ class _ScriptedWS:
     """A starlette-WebSocket double whose ``receive_text()`` serves ``frames``
     in order, then raises ``close_with`` (modelling a socket close).
 
-    Every test scripts an explicit terminal (a ``"stop"`` frame the loop returns
-    on, or a ``close_with`` exception), so ``receive_text`` is never called past
-    the programmed frames without one — the trailing ``AssertionError`` guards
-    against a test that accidentally lets the loop spin.
+    ``accept()`` is a no-op so the real ``_stream`` wrapper (which calls
+    ``await ws.accept()`` before the loop) drives cleanly. Every test scripts an
+    explicit terminal (a ``"stop"`` frame the loop returns on, or a
+    ``close_with`` exception), so ``receive_text`` is never called past the
+    programmed frames without one.
     """
 
     def __init__(
@@ -71,6 +82,9 @@ class _ScriptedWS:
         self._idx = 0
         self._close_with = close_with
         self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        return None
 
     async def receive_text(self) -> str:
         if self._idx < len(self._frames):
@@ -88,11 +102,13 @@ class _ScriptedWS:
 
 
 def _make_connected_adapter() -> TwilioAgentAdapter:
-    """Construct an adapter with just enough state for ``media_stream_loop`` +
-    ``recv_audio`` — without binding a real port (``connect()`` spins uvicorn).
+    """Construct an adapter with just enough state for the production
+    ``_stream`` wrapper + ``recv_audio`` — without binding a real port
+    (``connect()`` spins uvicorn).
 
     ``_assert_connected`` only checks ``_rest is not None``; ``recv_audio`` needs
-    an inbound queue; ``media_stream_loop`` also touches ``_stream_connected``.
+    an inbound queue; the loop also touches ``_stream_connected``; ``_build_app``
+    needs a ``_webhook_server``.
     """
     adapter = TwilioAgentAdapter(
         account_sid="AC" + "0" * 32,
@@ -103,61 +119,108 @@ def _make_connected_adapter() -> TwilioAgentAdapter:
     adapter._rest = object()  # type: ignore[assignment]
     adapter._inbound_queue = asyncio.Queue()
     adapter._stream_connected = asyncio.Event()
+    adapter._webhook_server = TwilioWebhookServer(adapter)
     return adapter
 
 
-async def _drive(adapter: TwilioAgentAdapter, ws: _ScriptedWS) -> None:
-    """Run the media-stream loop to its terminal over the scripted socket."""
-    server = TwilioWebhookServer(adapter)
-    await server.media_stream_loop(ws)
+def _production_stream_endpoint(adapter: TwilioAgentAdapter) -> Any:
+    """Pull the REAL ``_stream`` closure off the built app's ``/twilio/stream``
+    route.
+
+    This is the exact function production runs per WebSocket connection: it
+    ``accept()``s, calls ``media_stream_loop``, and — critically — nulls
+    ``adapter._stream_ws`` / ``_stream_sid`` in its ``finally``. Driving it
+    directly reproduces the production teardown sequencing that a bare
+    ``media_stream_loop`` call skips.
+    """
+    app = adapter._build_app()
+    for route in app.routes:
+        if getattr(route, "path", None) == "/twilio/stream":
+            return route.endpoint  # type: ignore[attr-defined]
+    raise AssertionError("no /twilio/stream route on the built app")  # pragma: no cover
+
+
+async def _drive_production(adapter: TwilioAgentAdapter, ws: _ScriptedWS) -> None:
+    """Run the real ``_stream`` wrapper to its terminal over the scripted socket.
+
+    On return, ``adapter._stream_ws`` / ``_stream_sid`` have been nulled by
+    ``_stream``'s ``finally`` — exactly as in production after a call ends.
+    """
+    stream = _production_stream_endpoint(adapter)
+    await stream(ws)
 
 
 @pytest.mark.asyncio
-async def test_stop_without_trailing_audio_returns_empty_chunk():
-    """A ``"stop"`` frame with no buffered audio (silent / tool-only turn)
-    enqueues an empty terminal sentinel, so ``recv_audio`` returns cleanly
-    instead of hanging. Pre-fix the queue stays empty and ``recv_audio`` blocks
-    to the outer ceiling.
+async def test_stop_without_trailing_audio_drains_through_production_teardown():
+    """A ``"stop"`` frame with no buffered audio (silent / tool-only turn),
+    driven through the REAL ``_stream`` wrapper. After the wrapper nulls the
+    transport state, the drain loop's first AND second ``recv_audio`` calls both
+    return cleanly. Pre-fix the second call raises ``RuntimeError: no live media
+    stream`` (the transport was nulled by ``_stream``'s ``finally``).
     """
     adapter = _make_connected_adapter()
     ws = _ScriptedWS([_start_frame(), _stop_frame()])
 
-    await _drive(adapter, ws)
+    await _drive_production(adapter, ws)
 
-    chunk = await asyncio.wait_for(
+    # Production nulled the transport in _stream's finally — the very condition
+    # that made recv_audio crash pre-fix.
+    assert adapter._stream_ws is None
+    assert adapter._stream_sid is None
+
+    first = await asyncio.wait_for(
         adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
     )
-    assert isinstance(chunk, AudioChunk)
-    assert chunk.data == b""  # empty terminal, not a hang
+    assert isinstance(first, AudioChunk)
+    assert first.data == b""  # empty terminal sentinel, not a hang
+
+    # The drain's tail-silence probe — a SECOND recv_audio after teardown. This
+    # is the call that raises "no live media stream" pre-fix.
+    second = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert isinstance(second, AudioChunk)
+    assert second.data == b""
 
 
 @pytest.mark.asyncio
-async def test_socket_close_returns_empty_chunk():
-    """A socket close mid-stream (``receive_text`` raises ``WebSocketDisconnect``)
-    enqueues the terminal sentinel before the disconnect propagates, so a
-    ``recv_audio`` blocked on the queue returns cleanly. Pre-fix nothing is
-    enqueued and ``recv_audio`` hangs to the outer ceiling.
+async def test_socket_close_drains_through_production_teardown():
+    """A socket close mid-stream (``receive_text`` raises ``WebSocketDisconnect``),
+    driven through the REAL ``_stream`` wrapper. ``_stream`` swallows the
+    disconnect and nulls the transport in its ``finally``; the terminal sentinel
+    was enqueued before that. Both drain ``recv_audio`` calls return cleanly.
+    Pre-fix the second raises ``RuntimeError: no live media stream``.
     """
     from starlette.websockets import WebSocketDisconnect
 
     adapter = _make_connected_adapter()
     ws = _ScriptedWS([_start_frame()], close_with=WebSocketDisconnect(code=1000))
 
-    with pytest.raises(WebSocketDisconnect):
-        await _drive(adapter, ws)
+    # _stream catches WebSocketDisconnect internally — it does NOT propagate.
+    await _drive_production(adapter, ws)
 
-    chunk = await asyncio.wait_for(
+    assert adapter._stream_ws is None
+    assert adapter._stream_sid is None
+
+    first = await asyncio.wait_for(
         adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
     )
-    assert isinstance(chunk, AudioChunk)
-    assert chunk.data == b""
+    assert isinstance(first, AudioChunk)
+    assert first.data == b""
+
+    second = await asyncio.wait_for(
+        adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
+    )
+    assert isinstance(second, AudioChunk)
+    assert second.data == b""
 
 
 @pytest.mark.asyncio
-async def test_normal_audio_turn_still_drains():
+async def test_normal_audio_turn_still_drains_through_production_teardown():
     """No regression: a turn carrying trailing audio still yields the decoded
-    PCM as the first chunk — the terminal sentinel lands *after* it, not
-    instead of it.
+    PCM as the first chunk — the terminal sentinel lands *after* it, not instead
+    of it — even though the real ``_stream`` wrapper has already nulled the
+    transport state by the time the drain reads.
     """
     adapter = _make_connected_adapter()
     # 160 bytes of µ-law (~20ms). Under the 100ms batch threshold, so the
@@ -167,7 +230,9 @@ async def test_normal_audio_turn_still_drains():
         [_start_frame(), build_media_frame(STREAM_SID, mulaw), _stop_frame()]
     )
 
-    await _drive(adapter, ws)
+    await _drive_production(adapter, ws)
+
+    assert adapter._stream_ws is None  # production teardown ran
 
     first = await asyncio.wait_for(
         adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
@@ -175,9 +240,10 @@ async def test_normal_audio_turn_still_drains():
     assert isinstance(first, AudioChunk)
     assert len(first.data) > 0  # real audio survived; not clobbered by the sentinel
 
-    # And the terminal sentinel lands AFTER the real audio (FIFO), not instead
-    # of it: the next chunk is the empty sentinel. Pins the ordering invariant —
-    # a fix that enqueued the sentinel BEFORE the flush would fail here.
+    # The terminal sentinel lands AFTER the real audio (FIFO), not instead of it:
+    # the next chunk is the empty sentinel. Pins the ordering invariant — a fix
+    # that enqueued the sentinel BEFORE the flush would fail here. And this
+    # second call is also the post-teardown drain probe that crashed pre-fix.
     second = await asyncio.wait_for(
         adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
     )

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -11,27 +11,35 @@ empty, so ``recv_audio`` blocked to ``response_timeout`` instead of returning
 cleanly. This is the same latent hang fixed for ElevenLabs / generic WebSocket
 in #648 and for OpenAI Realtime in #646/PR #647.
 
-**Why these tests drive the REAL production wrapper.** In production the loop is
-never reached via ``media_stream_loop`` directly — it goes through
-``TwilioWebhookServer.run_stream_session`` (which the ``/twilio/stream``
-WebSocket route delegates to, one line). That wrapper nulls
-``adapter._stream_ws`` / ``_stream_sid`` *synchronously, in the same task,
-immediately after the loop returns or raises* (its ``finally``). Any test that
-calls ``media_stream_loop`` directly leaves those attributes set to whatever the
-loop last wrote, so ``recv_audio``'s ``_assert_stream_live`` gate never fires —
-which is exactly why an earlier version of this suite went green on a fix that
-still crashed in production (reviewer P2 blocker on PR #697).
+**Why these tests never call ``media_stream_loop``.** In production the loop is
+reached through ``TwilioWebhookServer.run_stream_session``, whose ``finally``
+nulls ``adapter._stream_ws`` / ``_stream_sid`` *synchronously, in the same task,
+immediately after the loop returns or raises*. A test that calls
+``media_stream_loop`` directly leaves those attributes set to whatever the loop
+last wrote, so ``recv_audio``'s ``_assert_stream_live`` gate never fires — which
+is exactly why an earlier version of this suite went green on a fix that still
+crashed in production (reviewer P2 blocker on PR #697).
 
-So each test here drives ``run_stream_session`` — the named production wrapper
-(twin of the JS ``runStreamSession`` seam; it replaced this suite's earlier
-``app.routes`` endpoint introspection, which was coupled to a Starlette
-internal). That reproduces the production teardown sequencing exactly: the loop
-enqueues the terminal sentinel, then the wrapper's ``finally`` nulls the
-transport state. The regression the fix targets is the drain loop's *second*
-``recv_audio`` call (``_drain_agent_response`` always probes for tail silence
-after the first chunk) landing after that reset. Pre-fix that second call raises
-``RuntimeError: no live media stream``; post-fix it returns another empty chunk.
-Each test therefore asserts BOTH the first ``recv_audio`` (the sentinel) and the
+This suite therefore has two layers, and both are load-bearing:
+
+1. ``TestRealRoute`` — the anti-drift gate. Boots the adapter's REAL uvicorn
+   server, connects a REAL WebSocket client to the REAL ``/twilio/stream`` route,
+   and drives the REAL production consumer (``_drain_agent_response``, which
+   every ``call()`` turn runs). Nothing is stubbed between the socket and the
+   drain, so it cannot go green on a fix that only works through a seam — and it
+   fails if ``_stream()`` ever stops delegating to ``run_stream_session``. This
+   is the layer that answers the P2 blocker.
+
+2. The wrapper-level tests below it — fast, and able to script terminations a
+   real socket cannot produce (a ``receive_text`` that raises a non-disconnect
+   error; a second session on the same connected adapter). They drive
+   ``run_stream_session`` directly, which layer 1 proves is what the route runs.
+
+The regression the fix targets is the drain calling ``recv_audio`` *after* the
+transport reset. ``_drain_agent_response`` always probes for tail silence after
+its first chunk, so it lands there on every call termination. Pre-fix that call
+raises ``RuntimeError: no live media stream``; post-fix it returns an empty
+chunk. The tests assert BOTH the first ``recv_audio`` (the sentinel) and the
 second (the post-teardown drain probe) behave cleanly.
 """
 
@@ -39,9 +47,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Optional
+import socket
+from contextlib import asynccontextmanager, suppress
+from typing import Any, AsyncIterator, Optional
 
 import pytest
+import websockets
 
 from scenario.voice import AudioChunk, TwilioAgentAdapter
 from scenario.voice.adapters._twilio_server import TwilioWebhookServer
@@ -52,6 +63,9 @@ from scenario.voice.adapters._twilio_shared import build_media_frame
 # is missing. The fix returns instantly, far under the ceiling.
 RECV_TIMEOUT = 30.0
 OUTER_CEILING = 2.0
+# The real-route tests bind a port and run uvicorn, so they get a wider ceiling
+# than the in-process wrapper tests — still far below any hang.
+ROUTE_CEILING = 10.0
 STREAM_SID = "MZ695"
 
 
@@ -103,26 +117,230 @@ class _ScriptedWS:
         self.sent.append(text)
 
 
-def _make_connected_adapter() -> TwilioAgentAdapter:
+def _make_connected_adapter(http_port: int = 0) -> TwilioAgentAdapter:
     """Construct an adapter with just enough state for the production
-    ``run_stream_session`` wrapper + ``recv_audio`` — without binding a real
-    port (``connect()`` spins uvicorn).
+    ``run_stream_session`` wrapper + ``recv_audio`` — without going through
+    ``connect()`` (which would need live Twilio REST credentials to resolve the
+    phone-number SID).
 
-    ``_assert_connected`` only checks ``_rest is not None``; ``recv_audio`` needs
-    an inbound queue; the loop also touches ``_stream_connected``; ``_build_app``
-    needs a ``_webhook_server``.
+    Everything the media-stream path touches is the real object: the webhook
+    server, its FastAPI app, and its ``/twilio/stream`` route. Only ``_rest`` is
+    a stand-in, and only ``_assert_connected``'s ``is not None`` check reads it.
     """
     adapter = TwilioAgentAdapter(
         account_sid="AC" + "0" * 32,
         auth_token="secret",
         phone_number="+14155556959",
         public_base_url="https://example695.trycloudflare.com",
+        http_port=http_port,
     )
     adapter._rest = object()  # type: ignore[assignment]
     adapter._inbound_queue = asyncio.Queue()
     adapter._stream_connected = asyncio.Event()
+    adapter._server_shutdown = asyncio.Event()
     adapter._webhook_server = TwilioWebhookServer(adapter)
     return adapter
+
+
+# ---------------------------------------------------------------- real route
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+async def _wait_for_bind(port: int) -> None:
+    for _ in range(200):
+        try:
+            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            return
+        except OSError:
+            await asyncio.sleep(0.05)
+    raise AssertionError(f"uvicorn never bound 127.0.0.1:{port}")
+
+
+@asynccontextmanager
+async def _serve_real_route(
+    adapter: TwilioAgentAdapter,
+) -> AsyncIterator[str]:
+    """Boot the adapter's REAL uvicorn server and yield the ``ws://`` URL of the
+    REAL ``/twilio/stream`` route.
+
+    This is the production entry point end to end: uvicorn → FastAPI →
+    ``_stream()`` → ``run_stream_session`` → ``media_stream_loop``. No seam, no
+    socket double. A fix that only works when a test calls the wrapper by name
+    cannot pass through here.
+    """
+    assert adapter._webhook_server is not None
+    server_task = asyncio.create_task(adapter._webhook_server.run())
+    try:
+        await _wait_for_bind(adapter.http_port)
+        yield f"ws://127.0.0.1:{adapter.http_port}/twilio/stream"
+    finally:
+        assert adapter._server_shutdown is not None
+        adapter._server_shutdown.set()
+        with suppress(Exception):
+            await asyncio.wait_for(server_task, timeout=5.0)
+
+
+async def _await_teardown(adapter: TwilioAgentAdapter) -> None:
+    """Wait until the route handler's ``finally`` has nulled the transport."""
+    for _ in range(200):
+        if adapter._stream_ws is None:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("production route never tore the transport down")
+
+
+@pytest.fixture
+def route_adapter() -> TwilioAgentAdapter:
+    adapter = _make_connected_adapter(http_port=_free_port())
+    # Small drain budgets: a hang (the original #695 symptom) then fails inside
+    # ROUTE_CEILING rather than stalling the suite.
+    adapter.response_timeout = 5.0
+    adapter.response_tail_silence = 0.5
+    return adapter
+
+
+class TestRealRoute:
+    """Drive the REAL ``/twilio/stream`` route over a REAL WebSocket, and let the
+    REAL production consumer (``_drain_agent_response``, which every ``call()``
+    turn runs) read the result.
+
+    These are the tests the P2 blocker on PR #697 asked for: they exercise the
+    exact code path a live Twilio call takes, so they catch the class of bug
+    where the sentinel is enqueued but ``recv_audio`` refuses to read it once the
+    route's ``finally`` has nulled the transport. Every one of them raises
+    ``RuntimeError: no live media stream`` out of ``_drain_agent_response``
+    against the pre-fix adapter.
+    """
+
+    @pytest.mark.asyncio
+    async def test_silent_stop_drains_cleanly(
+        self, route_adapter: TwilioAgentAdapter
+    ) -> None:
+        """A silent / tool-only turn: ``stop`` frame, no audio ever buffered."""
+        async with _serve_real_route(route_adapter) as url:
+            async with websockets.connect(url) as client:
+                await client.send(_start_frame())
+                assert route_adapter._stream_connected is not None
+                await asyncio.wait_for(
+                    route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
+                )
+                drain = asyncio.create_task(route_adapter._drain_agent_response())
+                await asyncio.sleep(0.05)  # let the drain block in recv_audio
+                await client.send(_stop_frame())
+                merged = await asyncio.wait_for(drain, timeout=ROUTE_CEILING)
+
+        assert merged.data == b""  # clean terminal, not a hang and not a crash
+        assert route_adapter._stream_ws is None  # the route's finally ran
+
+    @pytest.mark.asyncio
+    async def test_socket_close_without_stop_frame_drains_cleanly(
+        self, route_adapter: TwilioAgentAdapter
+    ) -> None:
+        """Twilio drops the media socket with no ``stop`` frame and no audio."""
+        async with _serve_real_route(route_adapter) as url:
+            client = await websockets.connect(url)
+            await client.send(_start_frame())
+            assert route_adapter._stream_connected is not None
+            await asyncio.wait_for(
+                route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
+            )
+            drain = asyncio.create_task(route_adapter._drain_agent_response())
+            await asyncio.sleep(0.05)
+            await client.close()
+            merged = await asyncio.wait_for(drain, timeout=ROUTE_CEILING)
+
+        assert merged.data == b""
+        assert route_adapter._stream_ws is None
+
+    @pytest.mark.asyncio
+    async def test_normal_audio_turn_survives_teardown(
+        self, route_adapter: TwilioAgentAdapter
+    ) -> None:
+        """No regression: a turn carrying trailing audio still yields that audio
+        through the real route — the sentinel terminates the drain after it, and
+        does not replace it.
+        """
+        async with _serve_real_route(route_adapter) as url:
+            async with websockets.connect(url) as client:
+                await client.send(_start_frame())
+                assert route_adapter._stream_connected is not None
+                await asyncio.wait_for(
+                    route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
+                )
+                drain = asyncio.create_task(route_adapter._drain_agent_response())
+                await asyncio.sleep(0.05)
+                # 160 bytes µ-law (~20ms) is under the 100ms batch threshold, so
+                # the "stop" flush is what enqueues it: the trailing-audio path.
+                await client.send(build_media_frame(STREAM_SID, bytes([0x7F]) * 160))
+                await client.send(_stop_frame())
+                merged = await asyncio.wait_for(drain, timeout=ROUTE_CEILING)
+
+        assert len(merged.data) > 0  # the caller's audio reached the drain
+        assert route_adapter._stream_ws is None
+
+    @pytest.mark.asyncio
+    async def test_turn_starting_after_hangup_drains_cleanly(
+        self, route_adapter: TwilioAgentAdapter
+    ) -> None:
+        """The tightest form of the P0: the call has already ended and the route
+        has already nulled the transport when the drain makes its FIRST
+        ``recv_audio`` call — the next agent turn after the caller hung up.
+
+        Pre-fix this raises ``RuntimeError: no live media stream`` immediately,
+        with the terminal sentinel sitting unread in the queue.
+        """
+        async with _serve_real_route(route_adapter) as url:
+            async with websockets.connect(url) as client:
+                await client.send(_start_frame())
+                assert route_adapter._stream_connected is not None
+                await asyncio.wait_for(
+                    route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
+                )
+                await client.send(_stop_frame())
+            await _await_teardown(route_adapter)
+            assert route_adapter._stream_ws is None
+            assert route_adapter._stream_sid is None
+
+            # The agent turn begins only now, against a fully torn-down stream.
+            merged = await asyncio.wait_for(
+                route_adapter._drain_agent_response(), timeout=ROUTE_CEILING
+            )
+
+        assert merged.data == b""
+
+    @pytest.mark.asyncio
+    async def test_audio_buffered_before_hangup_is_not_lost(
+        self, route_adapter: TwilioAgentAdapter
+    ) -> None:
+        """Audio that landed in the queue before the hangup must still reach the
+        drain even though the route already nulled the transport. Pre-fix the
+        liveness assert fired first and that audio was dropped on the floor along
+        with the crash.
+        """
+        async with _serve_real_route(route_adapter) as url:
+            async with websockets.connect(url) as client:
+                await client.send(_start_frame())
+                assert route_adapter._stream_connected is not None
+                await asyncio.wait_for(
+                    route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
+                )
+                await client.send(build_media_frame(STREAM_SID, bytes([0x7F]) * 160))
+                await client.send(_stop_frame())
+            await _await_teardown(route_adapter)
+
+            merged = await asyncio.wait_for(
+                route_adapter._drain_agent_response(), timeout=ROUTE_CEILING
+            )
+
+        assert len(merged.data) > 0  # buffered audio recovered, not lost
 
 
 class _ControllableWS:
@@ -155,27 +373,18 @@ class _ControllableWS:
 
 
 async def _drive_production(adapter: TwilioAgentAdapter, ws: Any) -> None:
-    """Run the real production per-connection wrapper
+    """Run the production per-connection wrapper
     (``TwilioWebhookServer.run_stream_session`` — what the ``/twilio/stream``
-    route delegates to) to its terminal over the given socket double.
+    route delegates to, as ``TestRealRoute`` proves) to its terminal over the
+    given socket double.
 
     On return, ``adapter._stream_ws`` / ``_stream_sid`` have been nulled by the
-    wrapper's ``finally`` — exactly as in production after a call ends.
+    wrapper's ``finally`` — exactly as in production after a call ends. Used for
+    the terminations a real socket cannot produce (a ``receive_text`` that raises
+    a non-disconnect error; a second session on the same connected adapter).
     """
     assert adapter._webhook_server is not None
     await adapter._webhook_server.run_stream_session(ws)
-
-
-def test_stream_route_delegates_to_run_stream_session():
-    """Wiring smoke: the built app still exposes ``/twilio/stream``, whose
-    endpoint is the one-line delegate to ``run_stream_session`` (the seam the
-    rest of this suite drives). Guards against the route and the named wrapper
-    drifting apart.
-    """
-    adapter = _make_connected_adapter()
-    app = adapter._build_app()
-    paths = [getattr(route, "path", None) for route in app.routes]
-    assert "/twilio/stream" in paths
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Reviewer cockpit**
- **Scariest thing:** `receiveAudio` / `recv_audio` semantics changed at end-of-call — once the media-stream loop terminates, the adapter returns **empty chunks instantly and indefinitely** (previously: block → `response_timeout`), and the liveness assert is bypassed whenever the queue is non-empty. A caller that used timeout-as-end-of-audio now sees instant empties. This matches the #648/#646 sibling contract, but it is the PR's real behavior change.
- **Start here:** the new `TestRealRoute` / `describe("Twilio real /twilio/stream route")` blocks. They drive the **real route over a real socket**, so they are the only tests here that could have caught the P0 the first review found. If you read one thing, read what they assert after the transport is nulled.

## Why

The Twilio voice adapter shares the same latent **dead-recv-loop hang** fixed for ElevenLabs + the generic WebSocket adapter (#648) and OpenAI Realtime (#646). A turn that completes **without trailing audio** — a silent agent turn or a tool-only turn, i.e. a `"stop"` frame with nothing buffered, or a socket close — never gave the inbound queue a terminal sentinel, so `recv_audio` / `receiveAudio` blocked to `response_timeout` instead of returning cleanly.

Fixing the producer alone then introduced a **worse** bug, which @Aryansharma28 caught by hand: the per-connection wrapper nulls `_stream_ws`/`_stream_sid` synchronously after the loop, so the drain's next `recv_audio` hit `_assert_stream_live()` and raised `RuntimeError: no live media stream`. The hang became a **crash**. Both are fixed here, and both are now pinned by tests that run through the production route.

Closes #695.

## What changed

- **Sentinel in a loop-wide `try/finally`** (both langs) → alternative was enqueuing at each `return` site → one guard covers **all three** terminal paths (`"stop"` frame, socket close, mid-loop throw); the trailing-audio flush still runs first, so a real turn yields its PCM and the sentinel lands after it (FIFO ordering is test-pinned).
- **Drain-side rework — the P0 fix** (`_streamEnded` / `_stream_ended` per-call flag; `receiveAudio`/`recv_audio` reordered to drain-buffered → synthesize-empty-if-ended → assert-live-and-wait) → the alternative was leaving the liveness assert first, which is what crashed → consequence: the assert now guards only the genuinely-live-and-idle case, and after end-of-call the adapter synthesizes empty chunks for every further call.
- **Real-route test layer** (`TestRealRoute` + its JS twin) → the alternative was the named-wrapper seam the previous round used → consequence: a fix that works through a seam but crashes through the route now **fails CI**. This is what the P2 blocker asked for, and it is the only layer that would have caught the P0.
- **Per-call state is re-armed AND purged at loop entry** (`_resetCallState` / the PY twin) → the alternative was re-arming the flag alone, which is what the first version did and which **truncates the next call's first turn** when the previous call ended undrained (§4 of the proof — a bug this PR introduced and self-review caught) → consequence: a second Media Streams session on the same connected adapter inherits neither the stale flag nor the stale sentinel. JS uses `clearBuffered`, not `reset`, so a consumer already parked in `take()` is not rejected.
- PY keeps the disconnect-race guard (`_inbound_queue is not None`) and adds an explicit `RuntimeError` when the queue was nulled mid-drain; JS needs neither (its queue is `reset()`, never nulled).

## How it works

```
javascript/src/voice/adapters/
├── twilio-server.ts   _handleStreamSocket → runStreamSession (loop + transport-nulling finally)
│                      mediaStreamLoop (finally: _markStreamEnded + empty-chunk sentinel)
└── twilio.ts          receiveAudio (drain queue → synthesize-if-ended → assert-live), _streamEnded flag,
                       _resetCallState (flag re-arm + InboundQueue.clearBuffered)
python/scenario/voice/adapters/
├── _twilio_server.py  _stream() route → run_stream_session (accept + loop + disconnect-swallow + nulling finally)
│                      media_stream_loop (entry: re-arm flag + purge queue; finally: _stream_ended=True + sentinel)
└── twilio.py          recv_audio (same 3-step order), _stream_ended flag, nulled-queue RuntimeError guard
```

Producer and consumer cooperate, and **both halves are load-bearing — now measured, not asserted**: the loop's `finally` **enqueues one** empty chunk (that is what wakes a consumer already blocked in `take()`/`get()` at the instant the call ends — flipping the flag alone wakes nobody); `receiveAudio`/`recv_audio` **synthesizes further** empties once the call has ended and the queue is drained (the drain's tail-silence probe, or any later poll).

Delete the enqueue (**[S]**) and the hang comes straight back: the JS route tests block to `responseTimeout` (5072 ms / 5055 ms) and PY's go red — while **every wrapper-level test still passes**, because a consumer that is not already blocked gets a synthesized empty chunk from the flag. That is the sharpest demonstration in this PR of why the route layer had to exist.

Test layering:

```
TestRealRoute / describe("real /twilio/stream route")   ← real uvicorn|http+ws, real WS client,
   real socket → real route → real wrapper → real loop     real consumer. Anti-drift gate.
wrapper-level tests                                      ← script terminations a real socket cannot
   run_stream_session / _driveStreamSession                produce: mid-loop throw, session reconnect.
```

## Acceptance criteria

Each row names the test that gates it **and whether that test actually discriminates** — i.e. goes red when the fix is reverted. This PR exists because a named test that passed while the behaviour was broken shipped once already, so a test name alone is not evidence.

Three reverts are referenced, each isolating one half of the fix; everything else stays intact.
**[S]** = remove only the sentinel `put(...)` from the loop's `finally`, keeping the `_stream_ended` flag.
**[G]** = revert only the ~6-line drain-side guard in `recv_audio`/`receiveAudio`.
**[P]** = revert only the loop-entry queue purge.

| # | Criterion | Gating evidence | Discriminates? | Status |
|---|-----------|-----------------|----------------|--------|
| AC1 | PY: a consumer already blocked in `recv_audio` when the call ends is **woken** — the loop's `finally` enqueues the sentinel; the flag alone wakes nobody | `TestRealRoute::test_silent_stop_drains_cleanly`, `::test_socket_close_without_stop_frame_drains_cleanly` | under **[S]**: 3 route tests red. ⚠️ The wrapper twins do **not** discriminate — all 6 pass under [S], because with the flag set `recv_audio` synthesizes an empty chunk for a consumer that is not already blocked | ✅ |
| AC2 | JS twin of AC1 | `silent stop mid-drain…`, `socket close with no stop frame mid-drain…` (route suite) | under **[S]**: both route tests red, blocking to `responseTimeout` (5072 ms / 5055 ms) — **the original #695 hang, resurfaced**. All 5 wrapper tests pass under [S] | ✅ |
| AC3 | Silent-stop returns an empty chunk instead of blocking to `response_timeout`; a normal-audio turn still yields its PCM | `TestRealRoute::test_silent_stop_drains_cleanly`, `::test_normal_audio_turn_survives_teardown` (+ JS twins) | PY yes; JS route **no** (see AC7) — JS gated by the wrapper twins | ✅ |
| AC4 *(review P0)* | No `no live media stream` out of the drain on any termination path, after the route nulls the transport | PY: 5 `TestRealRoute` tests. JS: the 2 first-`receiveAudio` route tests **plus** the wrapper suite | under **[G]**: PY route 5 failed; JS route 2 failed, 3 passed | ✅ |
| AC5 *(review P0)* | Throw path: a mid-loop transport error still enqueues the sentinel and the drain returns empty | PY: `test_transport_error_drains_through_production_teardown` — a production-reachable path. **JS: wrapper-level contract only** — `adaptWsSocket` maps `error`/`close` to `resolve(null)` and never rejects, so JS has no live throw source; the JS twin is necessarily a seam test | PY yes; JS pins the `finally` contract for future callers | ✅ |
| AC6 | A second session on the same connected adapter does not inherit the previous call's terminal **flag** | `test_second_session_stale_flag_does_not_truncate_first_turn` (+ JS twin) | yes | ✅ |
| AC7 *(review P2)* | The route layer is the anti-drift gate: it fails if `_stream()` / `_handleStreamSocket` ever stops delegating. **It is not a complete net on its own in JS** — because `drainAgentResponse` swallows a second-call throw (`catch { break }`, `adapter.runtime.ts:651`), only the 2 first-`receiveAudio` JS route tests discriminate the P0. The 3 JS wrapper-level tests are the sole net for the other scenarios and **must be retained** | `TestRealRoute` (PY, 6) + `describe("Twilio real /twilio/stream route")` (JS, 6) + the JS wrapper suite (5) | under **[G]**: PY 5/6 route red; JS 2/6 route red | ✅ |
| AC8 *(self-review)* | A call that ends **undrained** must not leave its sentinel to truncate the next call's first turn | `test_undrained_sentinel_does_not_truncate_the_next_call` (+ JS twin) | under **[P]**: PY `assert 0 > 0`; JS `expected 0 to be greater than 0` | ✅ |
| AC9 *(self-review)* | Audio buffered before a hangup is **delivered** on the drain that runs after teardown — not dropped. (A fix that returned an empty chunk here would satisfy AC4 while losing the caller's audio.) | `test_audio_buffered_before_hangup_is_not_lost` (+ JS twin), both assert `> 0` bytes | under **[G]**: red in both langs | ✅ |
| AC10 *(self-review)* | A turn whose **first** `recv_audio`/`receiveAudio` runs after teardown returns an empty chunk, not a throw — the next agent turn after the caller hung up. This, not the follow-up call, is where JS actually crashes | `test_turn_starting_after_hangup_drains_cleanly` (+ JS twin) | under **[G]**: red in both langs | ✅ |
| AC11 | `disconnect()` racing an in-flight drain has a **specified** per-language outcome: PY raises `RuntimeError("inbound queue is gone…")`; JS leaves the blocked `receiveAudio` parked until its own timeout | PY: `test_recv_audio_with_nulled_queue_raises_connection_error`. JS: unasserted — the divergence is real and tracked in #757 | PY yes; JS explicitly untested here | ✅ |
| AC12 | The loop-entry purge does not degrade the pre-existing one-call-per-`connect()` behaviour | Probed against the real route: a second concurrent `start` frame already flips the adapter's single `_streamSid` slot (`MZ_A` → `MZ_B`), orphaning the first socket independently of the queue | reasoning + probe, no test (concurrent sessions were already unsupported) | ✅ |

## Test plan

- `python/tests/voice/test_twilio_silent_stop_drain.py` — **12 tests** (6 real-route + 6 wrapper-level)
- `javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts` — **11 tests** (6 real-route + 5 wrapper-level)

The JS wrapper-level suite is **not** redundant with the route suite. It is the only coverage for the mid-loop throw path (unreachable through a real socket) and, per AC7, the only discriminating coverage for 3 of the 6 JS route scenarios. Deleting it on the belief that the route layer supersedes it would silently reopen the P2.

## Human verification

Backend-only library fix — no UI surface. Reproduce the crash, then watch the fix resolve it:

1. **Check out the branch**, `uv sync` in `python/`, `pnpm install` in `javascript/`.
2. **Green:**
   - `cd python && uv run pytest tests/voice/test_twilio_silent_stop_drain.py` → **12 passed**
   - `cd javascript && npx vitest run src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts` → **11 passed**
3. **Red — revert only the drain-side guard** (the P0 fix, ~6 lines per language). In `python/scenario/voice/adapters/twilio.py` `recv_audio` and `javascript/src/voice/adapters/twilio.ts` `receiveAudio`, replace the three-step body with the original two lines:
   ```
   self._assert_stream_live()                                  # PY
   return await asyncio.wait_for(self._inbound_queue.get(), timeout=timeout)
   ```
   ```
   this._assertStreamLive();                                   // JS
   return this._inboundQueue.take(timeout * 1000);
   ```
   Re-run the real-route tests only:
   - `uv run pytest tests/voice/test_twilio_silent_stop_drain.py -k TestRealRoute` → **5 failed**, every one `RuntimeError: TwilioAgentAdapter: no live media stream`
   - `npx vitest run src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts -t "real /twilio/stream route"` → **2 failed**, both `Error: TwilioAgentAdapter: no live media stream`

   (The 6th real-route test in each language guards a different regression — see §4 — and is unaffected by this revert.)

   The sentinel, the wrapper and the per-call flag all stay in place under that revert — so the delta isolates the drain-side guard as the load-bearing fix.

## How I can prove I was successful

<!-- no-ui-surface -->

**Backend-only, no UI surface.** A latent-hang library fix in the Twilio voice adapter; there is no rendered component and no playable artifact short of a live Twilio PSTN call. Per repo convention the **red→green falsifiability delta is the demonstration** — and this round it is taken **through the real production route**, because a passing seam test is exactly what let the P0 ship last time.

### 1. The P0, reproduced through the real route — `proven`

A standalone harness boots the adapter's real uvicorn server, connects a **real WebSocket client** to the **real `/twilio/stream` route**, and drives the **real production consumer** (`_drain_agent_response`, which every `call()` turn runs). Run against this branch's pre-fix tree (`7a2731d` — since rebased away, so it is no longer an ancestor of HEAD; the same pre-fix `recv_audio` shape is on `origin/main`), **all three** call-termination paths crash — including the normal-audio no-regression case:

> The permanently reproducible form of this delta is §2 below, which runs the **committed** tests against a minimal revert of the fix. Treat §1 as the discovery run.

```
CASE: silent-stop
  real uvicorn on 127.0.0.1:50621, connecting real WS to /twilio/stream
  start frame ACKed by the production route (stream_connected set)
  call terminated (audio=False, stop_frame=True), socket closed
  ❌ UNCAUGHT CRASH out of _drain_agent_response:
Traceback (most recent call last):
  File ".../scenario/voice/adapter.py", line 283, in _drain_agent_response
    nxt = await self.recv_audio(timeout=self.response_tail_silence)
  File ".../scenario/voice/adapters/twilio.py", line 459, in recv_audio
    self._assert_stream_live()
  File ".../scenario/voice/adapters/twilio.py", line 517, in _assert_stream_live
    raise RuntimeError(
RuntimeError: TwilioAgentAdapter: no live media stream. Call place_call() or wait_for_call() first.

SUMMARY
  FAIL  silent-stop (stop frame, no audio)
  FAIL  tool-only-stop (socket close, no stop, no audio)
  FAIL  normal-audio (media + stop, no-regression)
```

At this PR's HEAD, the same harness, unchanged:

```
SUMMARY
  PASS  silent-stop (stop frame, no audio)          → drain returned 0 bytes
  PASS  tool-only-stop (socket close, no stop)      → drain returned 0 bytes
  PASS  normal-audio (media + stop, no-regression)  → drain returned 956 bytes
```

The JS twin (real `http`+`ws` server, real `ws` client through `_handleStreamSocket` → `adaptWsSocket`, real `defaultVoiceCall`) shows the **same defect at a different call site** — see "Anything surprising?" below:

```
pre-fix                                             HEAD
  PASS  silent-stop (drain running)                   PASS   [0, 0] bytes
  PASS  tool-only-stop (drain running)                PASS   [0, 0] bytes
  PASS  normal-audio (drain running)                  PASS   [960, 0] bytes
  FAIL  next-turn-after-hangup                        PASS   [0, 0] bytes
  FAIL  buffered-audio-after-hangup                   PASS   [960, 0] bytes  ← audio recovered, not lost

Error: TwilioAgentAdapter: no live media stream. Call placeCall() or waitForCall() first.
    at TwilioAgentAdapter._assertStreamLive (src/voice/adapters/twilio.ts:369:13)
    at TwilioAgentAdapter.receiveAudio (src/voice/adapters/twilio.ts:284:10)
    at drainAgentResponse (src/voice/adapter.runtime.ts:450:31)
    at defaultVoiceCall (src/voice/adapter.runtime.ts:284:24)
```

### 2. The regression tests fail for the right reason — `proven`

Isolating the fix: at HEAD, revert **only** the six-line drain-side guard (sentinel, wrapper and per-call flag all left intact). The new real-route tests go red with the genuine production error, not a missing-symbol error:

```
# PY — pytest tests/voice/test_twilio_silent_stop_drain.py -k TestRealRoute
scenario/voice/adapters/twilio.py:556: RuntimeError: TwilioAgentAdapter: no live media stream. …
FAILED …::TestRealRoute::test_silent_stop_drains_cleanly
FAILED …::TestRealRoute::test_socket_close_without_stop_frame_drains_cleanly
FAILED …::TestRealRoute::test_normal_audio_turn_survives_teardown
FAILED …::TestRealRoute::test_turn_starting_after_hangup_drains_cleanly
FAILED …::TestRealRoute::test_audio_buffered_before_hangup_is_not_lost
5 failed, 6 deselected in 1.38s

# JS — vitest -t "real /twilio/stream route"
Error: TwilioAgentAdapter: no live media stream. Call placeCall() or waitForCall() first.
Tests  2 failed | 3 passed | 5 skipped (10)
```

Restore the guard → **PY 12 passed · JS 11 passed**:

```
tests/voice/test_twilio_silent_stop_drain.py:  12 passed, 11 warnings in 2.48s
Test Files  1 passed (1)   Tests  11 passed (11)   Duration 2.18s
```

### 4. A bug this PR introduced, found by self-review and fixed — `proven`

The loop's `finally` enqueues the sentinel; loop entry re-armed `_stream_ended` but **never purged the queue**. If a call ends while no drain is running (the caller hangs up between turns), that sentinel stays buffered — and the *next* media-stream session on the same connected adapter reads it as its first chunk. `_drain_agent_response` breaks on an empty chunk, so the new call's first agent turn is **truncated to silence** and its real audio is stranded for the turn after.

Reproduced through the real route (session 1 stops undrained; session 2's agent speaks after tail-silence elapses):

```
after session 1 (no drain ran): inbound queue holds 1 chunk(s)
session 2 live; queue still holds 1 chunk(s)
session 2 first agent turn: merged audio = 0 bytes
❌ BUG CONFIRMED: session 2's first agent turn was TRUNCATED to silence
```

With the purge (`clearBuffered`, not `reset` — parked waiters must survive):

```
after session 1 (no drain ran): inbound queue holds 1 chunk(s)
session 2 live; queue still holds 0 chunk(s)
session 2 first agent turn: merged audio = 4796 bytes
✅ session 2's first turn carried its real audio
```

The pre-existing "second session" tests missed this because they drain session 1's sentinel first — they exercise the stale-*flag* path, never the stale-*chunk* path. Both languages now have a real-route regression test that goes red when **only** the purge is removed (`assert 0 > 0` / `expected 0 to be greater than 0`).

### 2b. The wrapper tests cannot see the sentinel — only the route can — `proven`

Removing **only** the sentinel `put(...)` from the loop's `finally` (keeping the `_stream_ended` flag):

```
# PY — pytest tests/voice/test_twilio_silent_stop_drain.py
FAILED TestRealRoute::test_silent_stop_drains_cleanly
FAILED TestRealRoute::test_socket_close_without_stop_frame_drains_cleanly
FAILED TestRealRoute::test_undrained_sentinel_does_not_truncate_the_next_call
3 failed, 9 passed            ← all 6 wrapper-level tests PASSED

# JS — vitest, verbose
× real route > silent stop mid-drain: the real route drains cleanly            5072ms
× real route > socket close with no stop frame mid-drain: … drains cleanly     5055ms
✓ (all 5 wrapper-level tests)
Tests  2 failed | 9 passed (11)
```

The two JS failures took **5.07 s** — they blocked to `responseTimeout`. That is the original #695 dead-recv-loop hang, resurfaced. Every wrapper-level test stayed green through it, because a consumer that is not *already blocked* is served a synthesized empty chunk by the flag alone.

This is the clearest statement of why the route layer had to exist, and it corrects an earlier version of this PR body: the wrapper tests do **not** gate the sentinel. Their value is the mid-loop throw path and (per AC7) three JS scenarios the route layer cannot discriminate. The two layers are complements, not a hierarchy.

### 3. Gates — `proven`

| Gate | Command | Result |
|---|---|---|
| PY types | `uv run pyright .` | `0 errors, 0 warnings, 0 informations` |
| PY twilio suite | `pytest tests/voice/ -k twilio` | `72 passed` (2 e2e demos fail on missing `cloudflared` — identical on `origin/main`) |
| JS build | `pnpm build:all` | exit 0 |
| JS types | `pnpm typecheck:all` | exit 0 |
| JS tests | `pnpm run test:ci` | exit 0 — `917 passed, 1 skipped` |
| JS lint | `eslint` on the changed file | clean (repo-wide `lint:all` is red on `main`; this PR adds zero new errors) |

Local full `pytest tests/` wedges at `tests/voice/test_agent_wait_false.py::test_agent_wait_false_returns_before_turn_finishes` — a `scenario.run` telemetry-drain hang that reproduces **identically on `origin/main`** with none of this PR's files in its path. Pre-existing, environment-caused; CI (which runs `pytest tests/` without `LANGWATCH_API_KEY`) does not hit it.

GitHub CI is green at HEAD `5fcb317` — `test (3.12)`, `python-complete`, `javascript-complete`, `ci-checks (24.x)`, both CodeQL analyses, CodeRabbit; cross-checked with `gh run list` (`python-ci`, `javascript-ci`, `docs-ci` all `success`). The only `skipping` jobs are docs-ci's `build` (no docs changed) and the firefighting auto-approve pair — neither gates this PR. Rebased onto `c8eeb5e` (#755, which forbids non-null assertions in library `src/`); one trivial blank-line conflict, resolved to main's side, and every gate above re-run on the rebased tree.

## Anything surprising?

- **The JS crash lands on a different call than the review comment says.** `drainAgentResponse` wraps its tail-silence `receiveAudio` in `try { … } catch { break }` (added by #734), so a throw on the drain's *second* call is **swallowed** — it silently truncates the turn rather than crashing. The uncaught crash is on the drain's **first** `receiveAudio`, which has no such guard: an agent turn that begins after the transport was already nulled. Python has no such catch, so there the crash is on the second call exactly as described. Same defect, same fix; the two languages just surface it at different call sites. The pre-fix JS run above shows this directly: the three mid-drain cases pass, the two after-hangup cases crash.
- **Pre-fix, buffered audio was lost, not just crashed.** `buffered-audio-after-hangup` shows audio sitting in the queue when the liveness assert fired. At HEAD the drain recovers it (960 bytes).
- **End-of-call poll semantics changed (intended):** after the call ends and the queue drains, `receiveAudio`/`recv_audio` returns an empty chunk **instantly, on every call** — it no longer blocks to timeout. Callers using timeout-as-end-signal now get instant empties (this is the #648-sibling contract).
- **PY-only guard with no JS twin:** `recv_audio` raises an explicit `RuntimeError("inbound queue is gone…")` if `disconnect()` nulled the queue mid-drain — a reordering guard; JS has no equivalent because its queue is never nulled, only `reset()`.
- **Only 2 of the 6 JS real-route tests are load-bearing for the P0.** Because of the `catch { break }` above, reverting the drain-side guard leaves `silent-stop`, `tool-only-stop` and `normal-audio` green in JS — their *first* `receiveAudio` succeeds and the broken second-call throw is swallowed. The two after-hangup tests are the discriminating ones. The wrapper-level JS tests are therefore the only reliable net for the other three scenarios; do not delete them believing the route layer supersedes them. Python has no such gap — all 5 go red. This is stated in the test file's own header comment.
- **Two latent issues found by self-review, filed rather than smuggled in here.** Both are pre-existing and touch shared runtime, so they are out of this PR's scope: the tail-loop error-swallowing above is #756, and a PY/TS divergence where `disconnect()` leaves a blocked `recv_audio` parked until timeout is #757.
- **The loop-entry purge assumes one call at a time — which the adapter already did.** If two Media Streams sockets were ever live at once, session B's purge would drop session A's buffered audio. That is not a new failure introduced here: probed it against the real route, and B's `start` frame already clobbers the adapter's single `_streamWs`/`_streamSid` slot (`streamSid` flips `MZ_A` → `MZ_B`), orphaning A's socket regardless of the queue. The adapter models one call per `connect()`; concurrent sessions were broken before this change and are broken after, in the same way.
- **Swept the sibling adapters for the same stale-sentinel shape.** Most are structurally immune (no long-lived queue, or a per-turn reset); ElevenLabs (TS) already defends against it explicitly. One recurrence found by code-reading — `gemini-live.ts`'s `interrupt()` never clears its long-lived queue, where the Python twin drains it — filed as #760 (not reproduced; a repro test is the first task there). Twilio is fixed here; the sweep did not turn up anything else that needs changing in this PR.
- **The JS mid-loop-throw path is not reachable through a real socket today.** `adaptWsSocket` maps `ws`'s `error` and `close` events to `resolve(null)` and never rejects, and `parseMediaStreamFrame` returns `null` on bad JSON — so `mediaStreamLoop` has no live throw source. The wrapper-level throw test covers the `finally` contract for future callers; it is not a production path. This also bounds @Aryansharma28's P5 note on `void this._handleStreamSocket(ws)`: the unhandled rejection it worries about has no reachable trigger today (and the `void` predates this PR — it is on `main`).
