### PR TITLE
feat(agents): add OpenCode agent adapter (#5001)

### DIFF
--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -1,0 +1,293 @@
+# ADR-005: OpenCodeAgentAdapter — drive opencode via @opencode-ai/sdk as a scenario agent (#5001)
+
+**Date:** 2026-06-23
+
+**Status:** Accepted
+
+**Companion docs:** [ADR-001 Concurrency](./001-scenario-concurrency-model.md) · [ADR-002 Voice Provider State](./002-voice-provider-state.md) · [ADR-003 Voice Internal Design](./003-voice-internal-design.md) · [ADR-004 ffmpeg Bundling](./004-ffmpeg-bundling.md)
+
+_This is an Engineering Design Record. Committed at repo-root `docs/adr/005-opencode-agent-adapter.md` alongside ADR-001..004 (not under `javascript/docs/`)._
+
+## Why this doc exists
+
+Issue #5001 requests a scenario adapter for [opencode](https://opencode.ai/), an
+open-source AI coding agent. The adapter lets authors run scenario tests that drive
+opencode as the agent under test — the same way PR #687 introduced
+`ClaudeCodeAgentAdapter` for the Claude Code CLI. Several non-obvious design calls
+were made during a `/decide` + devils-advocate pass:
+
+- The class shape diverges from the original issue spec's skeleton (which assumed a
+  non-existent API).
+- The testability seam is dependency injection, NOT `vi.mock` of the SDK (rejected
+  after analysis).
+- The payload strategy is new-messages-only, NOT full-history (deliberate divergence
+  from #687's first-turn behavior, for reasons specific to opencode's server-side
+  state model).
+- Error handling requires two independent checks per call (transport and semantic).
+- Several concurrency, teardown, and empty-response edge cases were identified and
+  hardened against before implementation began.
+
+This record makes those calls auditable so future contributors understand what was
+decided and why.
+
+## Context
+
+### The original spec skeleton was wrong
+
+The issue spec included a bare-factory skeleton modeled on a `langwatch/langwatch`
+helper. That helper accessed a `ScenarioExecutionStateLike.lastNewUserMessageStr()`
+method that **does not exist** on scenario's TypeScript `AgentInput`
+(`javascript/src/domain/agents/index.ts:54-83`). The existing `AgentInput` exposes
+`messages: ModelMessage[]` and `newMessages: ModelMessage[]` — the adapter must
+derive the prompt text from those arrays itself.
+
+### The authoritative in-repo precedent is PR #687
+
+`ClaudeCodeAgentAdapter` (PR #687, open at time of writing) is the correct
+structural template:
+- `class ClaudeCodeAgentAdapter extends AgentAdapter` with `role = AgentRole.AGENT`
+  and a named `sessions = new Map<string, string>()`.
+- A lowercase `claudeCodeAgent(config)` factory as the public entry point.
+- Session-id tracking for stateful multi-turn continuation.
+
+The OpenCode adapter mirrors this shape directly.
+
+### The SDK transport: `@opencode-ai/sdk@1.17.9`
+
+`createOpencode(options?)` spawns the `opencode` binary's HTTP server
+(`cross-spawn('opencode', ['serve', ...])`) and returns
+`Promise<{ client: OpencodeClient; server: { url: string; close(): void } }>`.
+The completion primitive is `client.session.prompt({ path: { id }, body: { model, parts } })`,
+which resolves only AFTER the assistant finishes — no SSE event stream needed.
+Response shape: `{ data: { info: AssistantMessage; parts: Part[] }, error }`.
+Assistant text lives in `result.data.parts` (filter `type === "text"`, skip
+`ignored === true`). `result.data.info` is metadata, not the reply text.
+
+## Decision
+
+### 1. Shape: class + lowercase factory
+
+```
+javascript/src/agents/opencode/
+  opencode-agent.adapter.ts    — class OpenCodeAgentAdapter + helpers
+  index.ts                     — barrel + openCodeAgent(config) factory
+javascript/src/agents/__tests__/opencode-adapter.test.ts
+```
+
+`class OpenCodeAgentAdapter extends AgentAdapter` with `role = AgentRole.AGENT` and
+`name = "OpenCodeAgent"`. A `openCodeAgent(config)` factory is exported as the
+recommended user-facing constructor. This mirrors PR #687's `ClaudeCodeAgentAdapter`
+shape and is wired into `javascript/src/agents/index.ts` via `export * from "./opencode"`.
+
+### 2. Config: `model` is REQUIRED (product choice, not SDK constraint)
+
+```typescript
+interface OpenCodeAgentAdapterConfig {
+  model: { providerID: string; modelID: string };  // REQUIRED
+  workingDirectory?: string;
+  timeout?: number;
+  logger?: Logger;
+  client?: OpencodeClient;  // injection seam — see §4
+}
+```
+
+`model` is **required** as a product decision for reproducible, explicit model
+selection in evaluations. The `@opencode-ai/sdk` `model` field is itself optional
+(the server has a default), but scenario evaluations must be deterministic and
+auditable — an implicit default breaks that guarantee. Recommended starting value:
+`{ providerID: "openai", modelID: "gpt-4o-mini" }`.
+
+### 3. Session-per-threadId: create once, reuse after
+
+```typescript
+private sessions = new Map<string, string>(); // threadId → sessionId
+```
+
+On a thread's first call: `client.session.create({ body: { title: \`scenario:${threadId}\` } })`.
+On all subsequent calls for that thread: reuse the stored `sessionId`. This is the
+genuinely new pattern relative to #687 — opencode exposes a first-class server-side
+session object (analogous to `claude --resume`) rather than a CLI flag. One
+`session.create` per thread over the adapter's lifetime satisfies AC-2.
+
+### 4. Testability seam: inject `OpencodeClient`, do NOT `vi.mock` the SDK
+
+Config accepts an optional `client?: OpencodeClient`. When provided, the adapter
+uses it directly and does not own the server. When absent, the adapter lazily calls
+`createOpencode()` (memoized as a `Promise`, see §9) and owns the resulting server.
+
+**Why injection over `vi.mock`:** the realtime adapter precedent
+(`javascript/src/agents/realtime/realtime-agent.adapter.ts:49`) injects its live
+`RealtimeSession` object — it does not mock the SDK module. Injecting a typed fake
+`OpencodeClient` means the fake must satisfy the REAL `OpencodeClient` interface, so
+a breaking SDK envelope change fails the fake's TypeScript compilation and surfaces
+immediately. A `vi.mock` of `@opencode-ai/sdk` constructs a fiction — tests pass as
+long as the mock matches our beliefs about the SDK, NOT as long as the SDK stays
+compatible with our code.
+
+PR #687 was forced into `vi.mock` because it shells out via `child_process` with no
+injection seam. opencode provides a first-class typed client; we take the better seam.
+
+### 5. Payload: new messages only, NOT full-history flatten
+
+Each `call` sends only `input.newMessages` (USER-role messages from the delta), NOT
+`input.messages` (the full history). This is a deliberate divergence from PR #687's
+first-turn behavior.
+
+**Why:** #687 sends `input.messages` (full history) on the first turn because the
+`claude -p` CLI is stateless — the server holds nothing, so the full transcript must
+be serialized into the prompt. opencode holds server-side session state. Re-feeding
+the agent's own prior replies as user text into a stateful session double-seeds
+context and produces degenerate or truncated replies. The branch on session existence
+is ONLY for `session.create` vs. reuse — never for payload composition.
+
+Session-injected non-user messages (e.g. a canned `scenario.agent(...)` turn placed
+before the first real user message) are not replayed into the opencode session. This
+is the same boundary the realtime adapter relies on: server-side state is the source
+of truth for the agent's context, not the scenario transcript.
+
+If `extractNewUserText(input.newMessages)` resolves to an empty string (no user
+messages in the delta), the adapter throws a clear error:
+
+> "opencode is prompt-driven and cannot open a conversation on its own; ensure a
+> `user()` step precedes `agent()` in the script."
+
+### 6. Error handling: two independent layers per call
+
+A single `client.session.prompt(...)` call requires TWO error checks:
+
+1. **Transport error** (`result.error` is set): HTTP-level or SDK-level failure.
+   Throw a friendly named error. If this was a continuation turn (a stored
+   `sessionId` existed), evict it from `sessions` so the next call recreates — this
+   mirrors #687's stale `--resume` eviction.
+
+2. **Semantic error** (`result.data.info?.error` is set): opencode returns HTTP 200
+   for model-level failures (`ProviderAuthError`, `MessageOutputLengthError`,
+   `MessageAbortedError`, `ApiError`, `UnknownError`). A 200 with a semantic error
+   carries zero text parts. Both fields must be checked; checking only `result.error`
+   silently returns an empty response on semantic failures.
+
+### 7. Never emit a silent empty assistant turn
+
+`partsToText(parts)` filters `type === "text"` parts (skipping `ignored === true`)
+and concatenates. It does NOT throw on non-text parts (tool calls, step-start,
+step-finish, reasoning, etc.) — a real opencode reply interleaves these with text
+and they must be skipped cleanly (AC-6).
+
+Three outcomes after filtering:
+
+| Condition | Action |
+|-----------|--------|
+| Non-empty text after filtering | Return it — normal path |
+| Empty text but non-text parts present | Return a readable fallback render (e.g. `[tool: <name>]`) — AC-4 forbids silent empty turns |
+| No parts at all | Throw — the response is structurally invalid |
+
+AC-4 explicitly forbids empty or truncated responses, so the adapter must not
+manufacture one under any condition.
+
+### 8. Concurrency: memoize the server-start PROMISE
+
+```typescript
+private serverPromise: Promise<{ client: OpencodeClient; server: { url: string; close(): void } }> | null = null;
+```
+
+The memoized value is the **Promise**, not the resolved value. Two threads' concurrent
+first calls both await the same Promise and therefore cannot spawn two `opencode serve`
+processes. Resolving the memoized value and then memoizing it would create a race
+window between `createOpencode()` returning and the resolved value being stored.
+
+### 9. Timeout: AbortSignal, not Promise.race
+
+`timeout?: number` is forwarded to `client.session.prompt(...)` as an `AbortSignal`
+(via `AbortSignal.timeout(ms)`), NOT implemented as `Promise.race`. `Promise.race`
+abandons the in-flight request without actually cancelling it — the opencode server
+continues processing. An `AbortSignal` propagates the cancel to the HTTP layer so the
+request is actually aborted.
+
+### 10. Teardown
+
+```typescript
+async close(): Promise<void>
+```
+
+If the adapter spawned its own server (i.e., `config.client` was absent and
+`serverPromise` was set): awaits the Promise and calls `server.close()`. If a client
+was injected, `close()` is a no-op — the injector owns its server. Document calling
+`adapter.close()` in `afterAll` (mirrors `session.close()` in the realtime adapter).
+
+## Alternatives considered
+
+### `vi.mock("@opencode-ai/sdk")` for tests
+
+The jest/vitest module-mock approach was the natural first impulse, and how PR #687
+is tested (unavoidably — it shells `child_process`). Rejected here because opencode
+provides a typed `OpencodeClient` that can be satisfied by a fake implementation
+that TypeScript checks. A module mock is a fiction; a typed fake is a contract. The
+compile-time check on the fake provides exactly the regression protection we want
+when the SDK's response envelope changes.
+
+### Full-history flatten on every turn (matching #687)
+
+Rejected for stateful sessions. #687's full-history flatten is a workaround for a
+stateless CLI transport. opencode's `session.prompt` continues an existing session —
+re-sending prior agent replies as user text produces degenerate context. The divergence
+is intentional and documented; it is not a defect to be reconciled with #687.
+
+### Bare factory function (original spec skeleton)
+
+Rejected. The spec skeleton was modeled on a `langwatch/langwatch` helper that assumed
+`ScenarioExecutionStateLike.lastNewUserMessageStr()` — a method that does not exist on
+scenario's `AgentInput`. Beyond the missing API, the class shape is correct here:
+session state (`sessions` map, `serverPromise`) requires instance scope. A bare factory
+returning a closure could hold the same state, but the class shape is the established
+in-repo pattern (PR #687, realtime adapter) and produces better tooling and error traces.
+
+### Single error check on `result.error`
+
+Rejected. The SDK's `throwOnError` defaults to `false` and the response style is
+`"fields"`, which means HTTP-200 semantic errors populate `result.data.info.error`
+with a non-null union (`ProviderAuthError | MessageOutputLengthError | ...`) while
+`result.error` is `undefined`. Checking only `result.error` silently returns an
+empty-text response for the semantic-error case, violating AC-4.
+
+## Consequences / open tensions
+
+### AC-4 (live multi-turn run) is unprovable in CI
+
+`createOpencode()` shells out to the `opencode` binary, which is absent from CI
+runners. The integration test for AC-4 is env-gated (`RUN_OPENCODE_E2E=1`) and is
+skipped in CI. AC-4 evidence must be a manual 3-run proof (logs or screenshot)
+attached to the PR — the same shape as #687's `e2e-proof.png`. This is a structural
+limitation of adapters that wrap external binaries, not a deficiency of the adapter
+design.
+
+### Unit tests prove parsing/branching, not lifecycle
+
+The injected-fake unit tests (AC-1, AC-2, AC-3, AC-6) verify session mapping,
+payload extraction, error branching, and text-part filtering against the real
+`OpencodeClient` interface. They prove nothing about the real `createOpencode()`
+spawn, the binary lifecycle, or true multi-turn continuation — only the live AC-4
+integration test does that.
+
+### Agent-first scenarios unsupported
+
+opencode requires a user message to begin a turn (`session.prompt` needs a non-empty
+`parts` array). Like #687, the adapter throws a clear error if no user message is
+present in the delta rather than silently calling `session.prompt` with an empty
+body. Unlike the realtime adapter (which can issue `response.create` to make the
+agent speak first), this is a hard transport constraint of the prompt-driven model.
+
+### `model` required-ness is a product call, not enforced by the SDK
+
+The `@opencode-ai/sdk` `model` field is optional — the opencode server applies its
+own default. Making `model` required in `OpenCodeAgentAdapterConfig` is a scenario
+product decision: evaluations need an explicit, pinned model for reproducibility. If
+future opencode versions expose a stable, documented server default, this constraint
+could be relaxed — but that is its own decision.
+
+### Server ownership responsibility falls to the caller for injected clients
+
+When `client` is injected, `close()` is a no-op and the adapter makes no attempt to
+shut down the server. The caller is responsible for calling `server.close()` in their
+own `afterAll`. This mirrors the realtime adapter's ownership model for injected
+sessions, but it is easy to miss. Examples in the docs (AC-5) must show the correct
+`afterAll` teardown for both cases.

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -260,6 +260,31 @@ attached to the PR — the same shape as #687's `e2e-proof.png`. This is a struc
 limitation of adapters that wrap external binaries, not a deficiency of the adapter
 design.
 
+### The live e2e is flaky: `session.prompt` intermittently stalls
+
+Measured over 17 consecutive live runs on one machine: **13 passed, 4 stalled.** A
+passing run completes the whole two-turn scenario in 11–33s; a stalled run makes no
+progress and is only ended by a timeout. The stall is inside `session.prompt` — the
+adapter has issued the request and the opencode server never answers.
+
+Ruled out, each checked directly at the time of a stall cluster: provider rate
+limiting (`GET /v1/models` and a `gpt-5.4-mini` completion both returned 200 in
+under 1.5s, with a full quota), a slow provider (a bare `opencode run -m
+openai/gpt-5.4-mini` answered in 4–6s, three times), a zombie server holding port
+4096 (no matching process, port free), and accumulated local session state. It also
+predates the adapter's `timeout`: the first observed stall ran with no timeout
+configured. It did not reproduce while instrumented, so the stalling turn is not
+identified — both turns are equally suspect.
+
+Two consequences. First, `timeout` is not optional for the e2e: without it, vitest's
+own test timeout kills the test body, the `finally` never runs, and the temp working
+dir and the spawned server both leak — the leaked server then holds port 4096 and
+fails the *next* run fast. With `timeout` set below the vitest timeout, the stall
+surfaces as `[OpenCodeAgent] TimeoutError` and teardown still runs. Second, AC-4's
+proof is a **majority of live runs**, not a clean sweep; anyone re-running it should
+expect roughly one stall in four and should not read a single red run as a
+regression in this adapter.
+
 ### Unit tests prove parsing/branching, not lifecycle
 
 The injected-fake unit tests (AC-1, AC-2, AC-3, AC-6) verify session mapping,

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -43,8 +43,8 @@ derive the prompt text from those arrays itself.
 
 ### The authoritative in-repo precedent is PR #687
 
-`ClaudeCodeAgentAdapter` (PR #687, open at time of writing) is the correct
-structural template:
+`ClaudeCodeAgentAdapter` (the sibling adapter in `agents/claude-code/`) is the
+correct structural template:
 - `class ClaudeCodeAgentAdapter extends AgentAdapter` with `role = AgentRole.AGENT`
   and a named `sessions = new Map<string, string>()`.
 - A lowercase `claudeCodeAgent(config)` factory as the public entry point.

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -95,7 +95,7 @@ interface OpenCodeAgentAdapterConfig {
 selection in evaluations. The `@opencode-ai/sdk` `model` field is itself optional
 (the server has a default), but scenario evaluations must be deterministic and
 auditable — an implicit default breaks that guarantee. Recommended starting value:
-`{ providerID: "openai", modelID: "gpt-4.1-mini" }`.
+`{ providerID: "openai", modelID: "gpt-5.4-mini" }`.
 
 ### 3. Session-per-threadId: create once, reuse after
 

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -211,8 +211,16 @@ async close(): Promise<void>
 
 If the adapter spawned its own server (i.e., `config.client` was absent and
 `serverPromise` was set): awaits the Promise and calls `server.close()`. If a client
-was injected, `close()` is a no-op — the injector owns its server. Document calling
-`adapter.close()` in `afterAll` (mirrors `session.close()` in the realtime adapter).
+was injected, `close()` shuts nothing down — the injector owns its server. Document
+calling `adapter.close()` in `afterAll` (mirrors `session.close()` in the realtime
+adapter).
+
+`close()` is **terminal** either way: it marks the adapter closed synchronously on
+entry, and any `call(...)` issued afterwards rejects with a clear closed-adapter
+error instead of racing the torn-down (or relinquished) server into an opaque
+transport failure. Calls already in flight when `close()` runs remain the caller's
+teardown contract to sequence (await the scenario, then close); an overlapping call
+fails loudly at the transport layer rather than corrupting session state.
 
 ## Alternatives considered
 
@@ -311,11 +319,11 @@ could be relaxed — but that is its own decision.
 
 ### Server ownership responsibility falls to the caller for injected clients
 
-When `client` is injected, `close()` is a no-op and the adapter makes no attempt to
-shut down the server. The caller is responsible for calling `server.close()` in their
-own `afterAll`. This mirrors the realtime adapter's ownership model for injected
-sessions, but it is easy to miss. Examples in the docs (AC-5) must show the correct
-`afterAll` teardown for both cases.
+When `client` is injected, `close()` makes no attempt to shut down the server (it
+still marks the adapter closed — post-close calls reject). The caller is responsible
+for calling `server.close()` in their own `afterAll`. This mirrors the realtime
+adapter's ownership model for injected sessions, but it is easy to miss. Examples in
+the docs (AC-5) must show the correct `afterAll` teardown for both cases.
 
 ### The owned server is unauthenticated, on a fixed loopback port
 

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -291,3 +291,46 @@ shut down the server. The caller is responsible for calling `server.close()` in 
 own `afterAll`. This mirrors the realtime adapter's ownership model for injected
 sessions, but it is easy to miss. Examples in the docs (AC-5) must show the correct
 `afterAll` teardown for both cases.
+
+### The owned server is unauthenticated, on a fixed loopback port
+
+`createOpencode()` with no options binds `127.0.0.1:4096`. Loopback-only, so it is not
+network-exposed — but `ServerOptions` offers no auth token, and this adapter exposes no
+`port`/`hostname` override. While the server is alive, any other local process or user
+on the same host can reach it and drive the same coding-agent session against
+`workingDirectory`. On a shared CI runner or devbox, treat `workingDirectory` as
+readable and writable by any co-tenant process. This is inherent to `opencode serve`,
+not a defect of this adapter, but callers must know it.
+
+Corollary for tests: opencode is **tool-bearing** (shell + file read/write) and is not
+constrained to the prompts it is given. The live e2e therefore runs in an `fs.mkdtemp`
+directory, never `process.cwd()` — the repo working tree holds a gitignored `.env` with
+real provider keys, and a self-directed read of that file would flow back as assistant
+text into the judge prompt and CI logs.
+
+### Spawn failure is terminal, and forwards the child's raw output
+
+`ensureClient()` memoizes with `serverPromise ??= createOpencode()`, so a **rejected**
+spawn is never evicted — unlike `resolveSessionId`, which evicts a failed `create` so
+the next turn retries. A transient spawn failure (port contention, slow binary startup)
+therefore poisons the adapter for its lifetime. This asymmetry is deliberate — a missing
+binary will not fix itself, and retry-spam is worse — but it means a caller who shares
+one adapter across a whole test file loses every subsequent scenario.
+
+Relatedly, when the child exits non-zero the SDK rejects with `Server exited with code
+N\nServer output: <raw stdout+stderr>`, which `ensureClient()` propagates verbatim. The
+adapter's own `describeError()` never touches this path, so its careful field-scoping
+(`.name`, `.data.message` only) does not apply. Whether `opencode serve`'s crash output
+can contain secrets is a property of that binary, not of this repo — an open gap, not a
+confirmed leak.
+
+### A server restart mid-run silently invalidates every session id
+
+Session ids live server-side. If the owned server dies between turns and a later call
+reconnects to a fresh one, every id in the `sessions` map is stale. The adapter cannot
+today distinguish "this session is gone because the server restarted" from "this session
+id was bad": the prompt-error path evicts the one session and recreates it, without
+flushing the map or resetting `serverPromise`. Classifying connection-level failures
+(`ECONNREFUSED`, connection reset) separately would let the adapter flush both. Not
+reachable in current usage — the server is spawned once per adapter and torn down in
+`close()` — so it is recorded here rather than solved speculatively.

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -95,7 +95,7 @@ interface OpenCodeAgentAdapterConfig {
 selection in evaluations. The `@opencode-ai/sdk` `model` field is itself optional
 (the server has a default), but scenario evaluations must be deterministic and
 auditable — an implicit default breaks that guarantee. Recommended starting value:
-`{ providerID: "openai", modelID: "gpt-4o-mini" }`.
+`{ providerID: "openai", modelID: "gpt-4.1-mini" }`.
 
 ### 3. Session-per-threadId: create once, reuse after
 

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -215,12 +215,16 @@ was injected, `close()` shuts nothing down — the injector owns its server. Doc
 calling `adapter.close()` in `afterAll` (mirrors `session.close()` in the realtime
 adapter).
 
-`close()` is **terminal** either way: it marks the adapter closed synchronously on
-entry, and any `call(...)` issued afterwards rejects with a clear closed-adapter
-error instead of racing the torn-down (or relinquished) server into an opaque
-transport failure. Calls already in flight when `close()` runs remain the caller's
-teardown contract to sequence (await the scenario, then close); an overlapping call
-fails loudly at the transport layer rather than corrupting session state.
+`close()` is **terminal** either way, and **idempotent** (repeat calls return
+immediately; the owned server is closed at most once). Any `call(...)` issued after
+`close()` rejects with a clear closed-adapter error. The rationale differs by
+ownership path: with an **owned** server the memoized handle now points at a
+torn-down server, so the guard replaces an opaque transport failure with the real
+cause; with an **injected** client nothing was shut down — the rejection is the
+adapter's end-of-life contract (create a new adapter to keep calling), not a broken
+transport. Calls already in flight when `close()` runs remain the caller's teardown
+contract to sequence (await the scenario, then close); an overlapping call fails
+loudly at the transport layer rather than corrupting session state.
 
 ## Alternatives considered
 

--- a/docs/adr/005-opencode-agent-adapter.md
+++ b/docs/adr/005-opencode-agent-adapter.md
@@ -67,7 +67,7 @@ Assistant text lives in `result.data.parts` (filter `type === "text"`, skip
 
 ### 1. Shape: class + lowercase factory
 
-```
+```text
 javascript/src/agents/opencode/
   opencode-agent.adapter.ts    — class OpenCodeAgentAdapter + helpers
   index.ts                     — barrel + openCodeAgent(config) factory
@@ -86,7 +86,7 @@ interface OpenCodeAgentAdapterConfig {
   model: { providerID: string; modelID: string };  // REQUIRED
   workingDirectory?: string;
   timeout?: number;
-  logger?: Logger;
+  logger?: OpenCodeLogger;
   client?: OpencodeClient;  // injection seam — see §4
 }
 ```

--- a/docs/docs/pages/agent-integration/opencode.mdx
+++ b/docs/docs/pages/agent-integration/opencode.mdx
@@ -1,0 +1,158 @@
+---
+title: OpenCode Adapter
+description: Drive the OpenCode coding agent (sst/opencode) as an agent-under-test in a Scenario run — tests real tool use and multi-turn coding behavior against a live server.
+---
+
+# `OpenCodeAgentAdapter`
+
+Drives the [OpenCode](https://opencode.ai/) coding agent (`sst/opencode`) via
+`@opencode-ai/sdk` as an agent-under-test inside a Scenario run. The adapter
+keeps conversation state server-side — one OpenCode session per scenario thread
+— so each turn sends only the new user message, not a full-history replay.
+
+:::info TypeScript only
+
+The OpenCode adapter is TypeScript-only today. Python parity is tracked as a
+follow-up.
+
+:::
+
+## Install
+
+```bash
+npm install @langwatch/scenario @opencode-ai/sdk
+```
+
+The adapter does NOT install the `opencode` binary automatically. For **live
+runs** (no injected `client`), install the CLI separately:
+
+```bash
+npm install -g opencode-ai
+```
+
+Or follow the installation docs at [opencode.ai](https://opencode.ai/).
+
+## Usage
+
+:::code-group
+
+```typescript [typescript]
+import scenario, { openCodeAgent } from "@langwatch/scenario";
+import path from "path";
+
+let adapter: ReturnType<typeof openCodeAgent>;
+
+beforeAll(() => {
+  adapter = openCodeAgent({
+    model: { providerID: "openai", modelID: "gpt-4o-mini" },
+    workingDirectory: path.resolve(__dirname, "../fixtures/my-project"),
+    timeout: 60_000,
+  });
+});
+
+afterAll(async () => {
+  await adapter.close();
+});
+
+it("refactors the target file correctly", async () => {
+  const result = await scenario.run({
+    name: "OpenCode refactor scenario",
+    agents: [
+      adapter,
+      scenario.userSimulatorAgent(),
+      scenario.judgeAgent({
+        criteria: [
+          "Agent made the requested code change",
+          "Agent did not introduce new errors or regressions",
+        ],
+      }),
+    ],
+    script: [
+      scenario.user("Rename the `calculate` function to `computeTotal` in utils.ts"),
+      scenario.agent(),
+      scenario.user("Now add a JSDoc comment to the renamed function"),
+      scenario.agent(),
+      scenario.judge(),
+    ],
+  });
+
+  expect(result.success).toBe(true);
+});
+```
+
+:::
+
+`openCodeAgent(config)` is the recommended factory. It constructs a new
+`OpenCodeAgentAdapter` and is the idiomatic entry point — matching the lowercase
+factory pattern used by `userSimulatorAgent` and `claudeCodeAgent`.
+
+## Auto-start and teardown
+
+When you **omit** `client` from the config, the adapter automatically spawns and
+owns an `opencode serve` process on first use. There is no manual server startup
+step.
+
+- The adapter calls `createOpencode()` from `@opencode-ai/sdk`, which shells out
+  to the `opencode` binary on PATH. If the binary is absent, the first `call`
+  rejects with a clear spawn error.
+- Call `await adapter.close()` in `afterAll` to shut the auto-spawned server
+  down cleanly. Skipping this leaves an orphan process.
+
+```typescript
+afterAll(async () => {
+  await adapter.close(); // shuts down the auto-spawned opencode server
+});
+```
+
+When you provide your own `client`, `close()` is a no-op — you own the server
+lifecycle.
+
+## Provider API keys
+
+OpenCode reads provider credentials from its **own environment** — the adapter
+does not inject them. Which variable you need depends on the `providerID` you
+configure:
+
+| `providerID` | Required env var |
+|---|---|
+| `openai` | `OPENAI_API_KEY` |
+| `anthropic` | `ANTHROPIC_API_KEY` |
+| `google` | `GOOGLE_API_KEY` |
+| others | See `opencode auth login` or the OpenCode provider docs |
+
+Set the variable in your shell or CI environment before running tests. Scenario's
+own user-simulator and judge agents also need an LLM key — typically
+`OPENAI_API_KEY`.
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-4o-mini" }`. |
+| `workingDirectory` | `string` | — | Directory the OpenCode agent operates on. Forwarded as `query.directory` on each SDK call. File reads and writes inside the agent resolve relative to this path. |
+| `timeout` | `number` | none (unbounded) | Per-call timeout in ms. Cancels the in-flight prompt via `AbortSignal` and rejects the call. Best-effort: depends on whether the underlying server honours the abort. |
+| `logger` | `Logger` | no-op | Receives all adapter diagnostics (`log` and `warn`). Omit for silent operation. |
+| `client` | `OpencodeClient` | — | Advanced injection seam. Provide a pre-built `OpencodeClient` to drive a custom or pre-started server, or to inject a fake for unit tests. When provided, `close()` is a no-op. |
+
+## How it differs from Claude Code
+
+The Claude Code adapter spawns `claude -p` fresh for every turn and replays the
+full conversation history as a flat prompt, because the CLI is stateless.
+OpenCode keeps the conversation server-side in a named session: the adapter
+creates one session per `threadId` on the first turn and sends only the new user
+message on every subsequent turn. As a result, there is no full-history rebuild
+per turn — the OpenCode server holds the transcript and the adapter delivers
+deltas only.
+
+## Caveats
+
+- **`opencode` must be on PATH** (or installed globally via `npm i -g opencode-ai`)
+  when no `client` is injected. The adapter does not install the binary.
+- **Provider keys are not injected** — configure them in the environment as
+  described above. A missing key produces a `ProviderAuthError` on the first
+  prompt call.
+- **Agent-first scenarios are unsupported** — OpenCode requires a user message to
+  begin a turn. If the scenario's script starts with `scenario.agent()` before
+  any `scenario.user()`, the adapter throws a descriptive error.
+- **`model` is required** — the OpenCode server has its own default, but scenario
+  evaluations must pin a deterministic model for reproducibility.

--- a/docs/docs/pages/agent-integration/opencode.mdx
+++ b/docs/docs/pages/agent-integration/opencode.mdx
@@ -130,7 +130,7 @@ own user-simulator and judge agents also need an LLM key — typically
 |---|---|---|---|
 | `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-5.4-mini" }`. |
 | `workingDirectory` | `string` | — | Directory the OpenCode agent operates on. Forwarded as `query.directory` on each SDK call. File reads and writes inside the agent resolve relative to this path. |
-| `timeout` | `number` | none (unbounded) | Per-call timeout in ms. Cancels the in-flight prompt via `AbortSignal` and rejects the call. Best-effort: depends on whether the underlying server honours the abort. |
+| `timeout` | `number` | none (unbounded) | Timeout in ms for the `session.prompt` call. Cancels the in-flight prompt via `AbortSignal` and rejects the call. Bounds the **prompt only** — not the one-time server spawn or `session.create` — so total `call()` time is `spawn + create + timeout`. Best-effort: depends on whether the underlying server honours the abort. |
 | `logger` | `OpenCodeLogger` | no-op | Receives all adapter diagnostics (`log`). Omit for silent operation. |
 | `client` | `OpencodeClient` | — | Advanced injection seam. Provide a pre-built `OpencodeClient` to drive a custom or pre-started server, or to inject a fake for unit tests. When provided, `close()` is a no-op. |
 

--- a/docs/docs/pages/agent-integration/opencode.mdx
+++ b/docs/docs/pages/agent-integration/opencode.mdx
@@ -156,3 +156,13 @@ deltas only.
   any `scenario.user()`, the adapter throws a descriptive error.
 - **`model` is required** — the OpenCode server has its own default, but scenario
   evaluations must pin a deterministic model for reproducibility.
+
+## See also
+
+- [Writing Scenarios](/basics/writing-scenarios) — `scenario.run`, the `script`
+  steps (`scenario.user`, `scenario.agent`, `scenario.judge`), and how agents are
+  wired together.
+- [User Simulator Agent](/basics/user-simulator) — the `userSimulatorAgent()` that
+  drives the user turns in the examples above.
+- [Judge Agent](/basics/judge-agent) — the `judgeAgent()` that evaluates the
+  conversation against your criteria.

--- a/docs/docs/pages/agent-integration/opencode.mdx
+++ b/docs/docs/pages/agent-integration/opencode.mdx
@@ -131,7 +131,7 @@ own user-simulator and judge agents also need an LLM key — typically
 | `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-5.4-mini" }`. |
 | `workingDirectory` | `string` | — | Directory the OpenCode agent operates on. Forwarded as `query.directory` on each SDK call. File reads and writes inside the agent resolve relative to this path. |
 | `timeout` | `number` | none (unbounded) | Per-call timeout in ms. Cancels the in-flight prompt via `AbortSignal` and rejects the call. Best-effort: depends on whether the underlying server honours the abort. |
-| `logger` | `Logger` | no-op | Receives all adapter diagnostics (`log` and `warn`). Omit for silent operation. |
+| `logger` | `OpenCodeLogger` | no-op | Receives all adapter diagnostics (`log`). Omit for silent operation. |
 | `client` | `OpencodeClient` | — | Advanced injection seam. Provide a pre-built `OpencodeClient` to drive a custom or pre-started server, or to inject a fake for unit tests. When provided, `close()` is a no-op. |
 
 ## How it differs from Claude Code

--- a/docs/docs/pages/agent-integration/opencode.mdx
+++ b/docs/docs/pages/agent-integration/opencode.mdx
@@ -129,7 +129,7 @@ own user-simulator and judge agents also need an LLM key — typically
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-5.4-mini" }`. |
-| `workingDirectory` | `string` | — | Directory the OpenCode agent operates on. Forwarded as `query.directory` on each SDK call. File reads and writes inside the agent resolve relative to this path. |
+| `workingDirectory` | `string` | **required** | Directory the OpenCode agent operates on. Forwarded as `query.directory` on each SDK call. File reads and writes inside the agent resolve relative to this path. **Required for safety** — OpenCode is tool-bearing, so you must scope it to a directory it is meant to touch (see the security caveat below). |
 | `timeout` | `number` | none (unbounded) | Timeout in ms for the `session.prompt` call. Cancels the in-flight prompt via `AbortSignal` and rejects the call. Bounds the **prompt only** — not the one-time server spawn or `session.create` — so total `call()` time is `spawn + create + timeout`. Best-effort: depends on whether the underlying server honours the abort. |
 | `logger` | `OpenCodeLogger` | no-op | Receives all adapter diagnostics (`log`). Omit for silent operation. |
 | `client` | `OpencodeClient` | — | Advanced injection seam. Provide a pre-built `OpencodeClient` to drive a custom or pre-started server, or to inject a fake for unit tests. When provided, `close()` is a no-op. |
@@ -146,6 +146,14 @@ deltas only.
 
 ## Caveats
 
+- **`workingDirectory` scopes the agent — never point it at a directory holding
+  secrets.** OpenCode is tool-bearing: it reads and writes files and runs shell
+  inside `workingDirectory`. Point it at a scratch or fixture directory the agent
+  is meant to operate on — never your repo root or any directory containing a
+  `.env`, credentials, or private source. The field is **required** precisely so
+  this choice is always explicit; the sibling Claude Code adapter takes the same
+  stance. (Left unscoped, the agent would inherit the server process's cwd, which
+  in a test run is often the very directory holding your keys.)
 - **`opencode` must be on PATH** (or installed globally via `npm i -g opencode-ai`)
   when no `client` is injected. The adapter does not install the binary.
 - **Provider keys are not injected** — configure them in the environment as

--- a/docs/docs/pages/agent-integration/opencode.mdx
+++ b/docs/docs/pages/agent-integration/opencode.mdx
@@ -44,7 +44,7 @@ let adapter: ReturnType<typeof openCodeAgent>;
 
 beforeAll(() => {
   adapter = openCodeAgent({
-    model: { providerID: "openai", modelID: "gpt-4.1-mini" },
+    model: { providerID: "openai", modelID: "gpt-5.4-mini" },
     workingDirectory: path.resolve(__dirname, "../fixtures/my-project"),
     timeout: 60_000,
   });
@@ -128,7 +128,7 @@ own user-simulator and judge agents also need an LLM key — typically
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-4.1-mini" }`. |
+| `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-5.4-mini" }`. |
 | `workingDirectory` | `string` | — | Directory the OpenCode agent operates on. Forwarded as `query.directory` on each SDK call. File reads and writes inside the agent resolve relative to this path. |
 | `timeout` | `number` | none (unbounded) | Per-call timeout in ms. Cancels the in-flight prompt via `AbortSignal` and rejects the call. Best-effort: depends on whether the underlying server honours the abort. |
 | `logger` | `Logger` | no-op | Receives all adapter diagnostics (`log` and `warn`). Omit for silent operation. |

--- a/docs/docs/pages/agent-integration/opencode.mdx
+++ b/docs/docs/pages/agent-integration/opencode.mdx
@@ -44,7 +44,7 @@ let adapter: ReturnType<typeof openCodeAgent>;
 
 beforeAll(() => {
   adapter = openCodeAgent({
-    model: { providerID: "openai", modelID: "gpt-4o-mini" },
+    model: { providerID: "openai", modelID: "gpt-4.1-mini" },
     workingDirectory: path.resolve(__dirname, "../fixtures/my-project"),
     timeout: 60_000,
   });
@@ -128,7 +128,7 @@ own user-simulator and judge agents also need an LLM key — typically
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-4o-mini" }`. |
+| `model` | `{ providerID: string; modelID: string }` | **required** | Provider and model the OpenCode agent runs. Required as a product decision for reproducible, auditable evaluations — pin a deterministic model. Example: `{ providerID: "openai", modelID: "gpt-4.1-mini" }`. |
 | `workingDirectory` | `string` | — | Directory the OpenCode agent operates on. Forwarded as `query.directory` on each SDK call. File reads and writes inside the agent resolve relative to this path. |
 | `timeout` | `number` | none (unbounded) | Per-call timeout in ms. Cancels the in-flight prompt via `AbortSignal` and rejects the call. Best-effort: depends on whether the underlying server honours the abort. |
 | `logger` | `Logger` | no-op | Receives all adapter diagnostics (`log` and `warn`). Omit for silent operation. |

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -296,6 +296,10 @@ export default defineConfig({
           link: "/agent-integration/openai",
         },
         {
+          text: "OpenCode",
+          link: "/agent-integration/opencode",
+        },
+        {
           text: "Pydantic AI",
           link: "/agent-integration/pydantic-ai",
         },

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -386,6 +386,10 @@ export default defineConfig({
           link: "/agent-integration/openai",
         },
         {
+          text: "OpenCode",
+          link: "/agent-integration/opencode",
+        },
+        {
           text: "Pydantic AI",
           link: "/agent-integration/pydantic-ai",
         },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -57,6 +57,7 @@
     "@ag-ui/core": "^0.0.28",
     "@ai-sdk/openai": "^3.0.26",
     "@openai/agents": "^0.3.3",
+    "@opencode-ai/sdk": "1.17.9",
     "@opentelemetry/sdk-node": "0.212.0",
     "ai": "^6.0.0",
     "chalk": "^5.6.2",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -58,6 +58,7 @@
     "@ag-ui/core": "^0.0.58",
     "@ai-sdk/openai": "^3.0.26",
     "@openai/agents": "^0.16.0",
+    "@opencode-ai/sdk": "1.17.9",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "2.10.0",
     "@opentelemetry/sdk-node": "0.221.0",

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@openai/agents':
         specifier: ^0.3.3
         version: 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)
+      '@opencode-ai/sdk':
+        specifier: 1.17.9
+        version: 1.17.9
       '@opentelemetry/sdk-node':
         specifier: 0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.1)
@@ -1221,6 +1224,9 @@ packages:
     resolution: {integrity: sha512-YaKnqv0M6bCVvn47pThkFfyHz8xWJ+0Ll9ZnhvwJZ5gyPX0UxHIUeUs9SMG9BSvNuJNJHlc5uvfUDGYAmKJClw==}
     peerDependencies:
       zod: ^3.25.40 || ^4.0
+
+  '@opencode-ai/sdk@1.17.9':
+    resolution: {integrity: sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==}
 
   '@opentelemetry/api-logs@0.205.0':
     resolution: {integrity: sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==}
@@ -6494,6 +6500,10 @@ snapshots:
       - supports-color
       - utf-8-validate
       - ws
+
+  '@opencode-ai/sdk@1.17.9':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@opentelemetry/api-logs@0.205.0':
     dependencies:

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@openai/agents':
         specifier: ^0.16.0
         version: 0.16.0(ws@8.21.3)(zod@3.25.76)
+      '@opencode-ai/sdk':
+        specifier: 1.17.9
+        version: 1.17.9
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -1244,6 +1247,9 @@ packages:
     resolution: {integrity: sha512-IINrp7Iajg6sHIoh56jD0WqIszk0+lEkyj/sWsNZgT/m6oFEuZC5UHsOhQX7Rc6uUhRyEQE7knzk8iyxpWd+Dg==}
     peerDependencies:
       zod: ^4.0.0
+
+  '@opencode-ai/sdk@1.17.9':
+    resolution: {integrity: sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==}
 
   '@opentelemetry/api-logs@0.205.0':
     resolution: {integrity: sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==}
@@ -3047,6 +3053,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -6565,6 +6572,10 @@ snapshots:
       - supports-color
       - utf-8-validate
       - ws
+
+  '@opencode-ai/sdk@1.17.9':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@opentelemetry/api-logs@0.205.0':
     dependencies:

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -123,7 +123,7 @@ function makeConfig(
   overrides: Partial<Omit<OpenCodeAgentAdapterConfig, "client" | "model">> = {},
 ): OpenCodeAgentAdapterConfig {
   return {
-    model: { providerID: "openai", modelID: "gpt-4o-mini" },
+    model: { providerID: "openai", modelID: "gpt-4.1-mini" },
     client,
     ...overrides,
   };
@@ -547,14 +547,14 @@ describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
         const scenario = (await import("../../index.js")).default;
         const { openai } = await import("@ai-sdk/openai");
 
-        const judgeModelId = process.env.SCENARIO_JUDGE_MODEL ?? "gpt-4o-mini";
+        const judgeModelId = process.env.SCENARIO_JUDGE_MODEL ?? "gpt-4.1-mini";
 
         // Use the real openCodeAgent — NO injected client, lets the adapter
         // spawn the opencode binary (requires opencode on PATH + provider keys).
         const agent = openCodeAgent({
           model: {
             providerID: process.env.OPENCODE_PROVIDER_ID ?? "openai",
-            modelID: process.env.OPENCODE_MODEL_ID ?? "gpt-4o-mini",
+            modelID: process.env.OPENCODE_MODEL_ID ?? "gpt-4.1-mini",
           },
           workingDirectory: process.cwd(),
         });

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -30,10 +30,10 @@ import { describe, it, expect, vi, type Mock } from "vitest";
 // OpencodeClient is type-only — the adapter owns the real SDK import at
 // runtime. We import the type purely so we can cast our fake to it.
 
-import { AgentRole, type AgentInput } from "../../domain/index.js";
+import { AgentRole, type AgentInput } from "../../domain";
 // The source under test does NOT exist yet; these imports will fail at
 // collection time (expected RED) until the implementer ships the adapter.
-import { AgentAdapter } from "../../domain/index.js";
+import { AgentAdapter } from "../../domain";
 import {
   OpenCodeAgentAdapter,
   openCodeAgent,
@@ -366,7 +366,7 @@ describe("OpenCodeAgentAdapter AC-6/R2/R3 — parts filtering and error handling
       });
       const adapter = new OpenCodeAgentAdapter(makeConfig(client));
 
-      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow();
+      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/prompt failed/);
     });
   });
 
@@ -460,6 +460,25 @@ describe("OpenCodeAgentAdapter R4 — stale session eviction after prompt error"
     expect(createSpy).toHaveBeenCalledTimes(2);
     expect(promptSpy).toHaveBeenCalledTimes(3);
   });
+
+  it("rejects when session.create fails and recreates the session on the next call", async () => {
+    let createCalls = 0;
+    const { client, createSpy } = makeFakeClient({
+      createResult: () => {
+        createCalls++;
+        return createCalls === 1
+          ? { data: undefined, error: { status: 503, message: "unavailable" } }
+          : sessionOk("sess-ok");
+      },
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    await expect(
+      adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "create-fail" })),
+    ).rejects.toThrow(/session\.create failed/);
+    // next call on the same thread must retry create (stale rejected promise evicted)
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "create-fail" }));
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -468,16 +487,20 @@ describe("OpenCodeAgentAdapter R4 — stale session eviction after prompt error"
 
 describe("OpenCodeAgentAdapter concurrency + config validation", () => {
   it("dedupes concurrent first-calls on the same threadId to ONE session.create", async () => {
-    // Two calls fired together on the same thread must share one session.create
-    // (the stored in-flight promise closes the check-then-create race).
-    const { client, createSpy } = makeFakeClient();
+    // Gate the create on a manual deferred so BOTH calls are genuinely in-flight
+    // before either resolves — otherwise the first call could finish creating
+    // before the second even starts, and the test would pass without the fix.
+    let releaseCreate!: () => void;
+    const gate = new Promise<void>((r) => { releaseCreate = r; });
+    const { client, createSpy } = makeFakeClient({
+      createResult: () => gate.then(() => sessionOk("sess-1")),
+    });
     const adapter = new OpenCodeAgentAdapter(makeConfig(client));
-
-    await Promise.all([
-      adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race" })),
-      adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race" })),
-    ]);
-
+    const p1 = adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race" }));
+    const p2 = adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race" }));
+    await Promise.resolve(); // let both reach resolveSessionId and share the in-flight create
+    releaseCreate();
+    await Promise.all([p1, p2]);
     expect(createSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -520,7 +543,7 @@ describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
     it(
       "runs a multi-turn coding scenario with a real judge and returns a passing verdict",
       async () => {
-        // Re-import the real scenario barrel (no mocks in scope for this test).
+        // Dynamic import keeps the heavy scenario barrel out of the unit-test path; loaded only when the env-gated e2e runs.
         const scenario = (await import("../../index.js")).default;
         const { openai } = await import("@ai-sdk/openai");
 

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -590,7 +590,12 @@ describe("OpenCodeAgentAdapter concurrency + config validation", () => {
     // rejection is ever unobserved.
     const e1 = expect(p1).rejects.toThrow(/session\.create failed/);
     const e2 = expect(p2).rejects.toThrow(/session\.create failed/);
-    await Promise.resolve(); // let both calls reach resolveSessionId and share the in-flight create
+    // Wait for a macrotask boundary (vi.waitFor polls on timers), which drains
+    // BOTH calls' microtask chains regardless of call()'s internal await depth:
+    // p1 is parked inside the gated create, p2 is attached to the same stored
+    // promise. Decoupled from await topology — inserting an await inside
+    // call()/resolveSessionId cannot break this synchronization.
+    await vi.waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
     releaseCreate();
     await Promise.all([e1, e2]);
     // Both concurrent callers shared ONE create attempt.
@@ -668,6 +673,43 @@ describe("OpenCodeAgentAdapter close()", () => {
     await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/closed/i);
     expect(createSpy).not.toHaveBeenCalled();
     expect(promptSpy).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — a second close() resolves and the adapter stays closed", async () => {
+    // Double-close is ordinary teardown code (a finally plus an afterAll both
+    // closing). The guard makes repeat close() a no-op instead of re-driving
+    // teardown against an already-closed server.
+    const { client, createSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    await adapter.close();
+
+    await expect(adapter.close()).resolves.toBeUndefined();
+    await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/closed/i);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("lets a call() already past the closed-guard complete normally when close() runs mid-flight", async () => {
+    // The guard is entry-only BY DESIGN (ADR-005 §10): teardown sequencing is
+    // the caller's contract. This pins the injected-client sub-case: an
+    // in-flight call is not corrupted or cancelled by a concurrent close() —
+    // it completes; only the NEXT call is rejected.
+    let releasePrompt!: () => void;
+    const gate = new Promise<void>((r) => { releasePrompt = r; });
+    const { client, promptSpy } = makeFakeClient({
+      promptResult: () =>
+        gate.then(() => promptOk([{ type: "text", text: "mid-flight ok" }])),
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    const inFlight = adapter.call(SIMPLE_INPUT);
+    // Macrotask-boundary wait: the call is past the guard and parked inside
+    // the gated prompt before close() runs.
+    await vi.waitFor(() => expect(promptSpy).toHaveBeenCalledTimes(1));
+    await adapter.close();
+    releasePrompt();
+
+    await expect(inFlight).resolves.toContain("mid-flight ok");
+    await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/closed/i);
   });
 });
 

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -1,0 +1,559 @@
+/**
+ * Unit tests for the OpenCode agent adapter (`OpenCodeAgentAdapter`).
+ *
+ * Creds-free injection strategy (no real server, no spawn): the tests inject a
+ * fake `OpencodeClient` — a plain object whose `session.create` and
+ * `session.prompt` are `vi.fn()` spies. The adapter accepts the client via the
+ * `client` config field (injection seam; avoids `vi.mock` of the SDK).
+ *
+ * Coverage:
+ *   AC-1  — constructs, implements interface, factory works, call returns string.
+ *   AC-2  — one session per threadId; distinct threadIds → distinct sessions.
+ *   AC-3  — prompt body = latest user message; return = concatenated text parts.
+ *   AC-6  — partsToText: only text parts concatenated; unknown parts skipped (no
+ *            throw); info.error → reject (R2 HTTP-200 semantic error); transport
+ *            error → reject; empty parts → reject; non-text-only → non-empty
+ *            fallback (R3).
+ *   empty-input guard — agent-first (newMessages=[]) → reject before any RPC.
+ *   R4 continuation eviction — stale sessionId evicted after prompt error; next
+ *            call recreates session.
+ *   AC-4 (env-gated) — live multi-turn coding scenario.
+ *
+ * Plus an env-gated integration test (skipped unless `RUN_OPENCODE_E2E=1`)
+ * that runs a real `scenario.run(...)` with `openCodeAgent` and a real judge.
+ */
+
+import type { OpencodeClient } from "@opencode-ai/sdk";
+import type { ModelMessage } from "ai";
+import { describe, it, expect, vi, type Mock } from "vitest";
+
+// OpencodeClient is type-only — the adapter owns the real SDK import at
+// runtime. We import the type purely so we can cast our fake to it.
+
+import { AgentRole, type AgentInput } from "../../domain/index.js";
+// The source under test does NOT exist yet; these imports will fail at
+// collection time (expected RED) until the implementer ships the adapter.
+import { AgentAdapter } from "../../domain/index.js";
+import {
+  OpenCodeAgentAdapter,
+  openCodeAgent,
+  type OpenCodeAgentAdapterConfig,
+} from "../opencode/index.js";
+
+// ---------------------------------------------------------------------------
+// Fake client helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal part shapes the tests push through. */
+interface FakePart {
+  type: string;
+  text?: string;
+  ignored?: boolean;
+  [k: string]: unknown;
+}
+
+/** Default prompt success response. */
+function promptOk(parts: FakePart[] = [{ type: "text", text: "hello" }]) {
+  return { data: { info: {}, parts }, error: undefined };
+}
+
+/** Default session create success response. */
+function sessionOk(id = "sess-1") {
+  return { data: { id }, error: undefined };
+}
+
+/**
+ * Build a typed fake `OpencodeClient`. The real SDK's `session.create` and
+ * `session.prompt` both follow the "fields" responseStyle — they resolve to
+ * `{ data, error }` — never throw. Our fakes mirror that contract exactly.
+ */
+function makeFakeClient(opts: {
+  createResult?: () => unknown;
+  promptResult?: () => unknown;
+} = {}): {
+  client: OpencodeClient;
+  createSpy: Mock;
+  promptSpy: Mock;
+} {
+  const createSpy = vi.fn(opts.createResult ?? (() => sessionOk()));
+  const promptSpy = vi.fn(opts.promptResult ?? (() => promptOk()));
+
+  const client = {
+    session: {
+      create: createSpy,
+      prompt: promptSpy,
+    },
+  } as unknown as OpencodeClient;
+
+  return { client, createSpy, promptSpy };
+}
+
+// ---------------------------------------------------------------------------
+// Input fixtures
+// ---------------------------------------------------------------------------
+
+function makeInput(
+  messages: ModelMessage[],
+  opts: {
+    threadId?: string;
+    newMessages?: ModelMessage[];
+  } = {},
+): AgentInput {
+  return {
+    threadId: opts.threadId ?? "opencode-thread",
+    messages,
+    // Mirror #687: default newMessages to full history (first-turn shape).
+    newMessages: opts.newMessages ?? messages,
+    requestedRole: AgentRole.AGENT,
+    scenarioState: {} as unknown as AgentInput["scenarioState"],
+    scenarioConfig: {
+      name: "opencode-test",
+      description: "A test scenario.",
+    } as unknown as AgentInput["scenarioConfig"],
+  } as AgentInput;
+}
+
+const SIMPLE_USER_MSG: ModelMessage = { role: "user", content: "hello" };
+
+const SIMPLE_INPUT = makeInput([SIMPLE_USER_MSG]);
+
+/** Build a minimal config with an injected client. */
+function makeConfig(
+  client: OpencodeClient,
+  overrides: Partial<Omit<OpenCodeAgentAdapterConfig, "client" | "model">> = {},
+): OpenCodeAgentAdapterConfig {
+  return {
+    model: { providerID: "openai", modelID: "gpt-4o-mini" },
+    client,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC-1 — interface conformance
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter AC-1 — interface conformance", () => {
+  it("is an instance of AgentAdapter", () => {
+    const { client } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    expect(adapter).toBeInstanceOf(AgentAdapter);
+  });
+
+  it("exposes role === AgentRole.AGENT", () => {
+    const { client } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    expect(adapter.role).toBe(AgentRole.AGENT);
+  });
+
+  it('has name === "OpenCodeAgent"', () => {
+    const { client } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    expect(adapter.name).toBe("OpenCodeAgent");
+  });
+
+  it("openCodeAgent factory returns an OpenCodeAgentAdapter", () => {
+    const { client } = makeFakeClient();
+    const adapter = openCodeAgent(makeConfig(client));
+    expect(adapter).toBeInstanceOf(OpenCodeAgentAdapter);
+  });
+
+  it("call(input) resolves to a string through the fake client", async () => {
+    const { client } = makeFakeClient({
+      promptResult: () => promptOk([{ type: "text", text: "world" }]),
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    const result = await adapter.call(SIMPLE_INPUT);
+    expect(typeof result).toBe("string");
+    expect((result as string).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2 — session-per-threadId
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter AC-2 — session-per-threadId", () => {
+  it("calls session.create exactly once for three calls on the same threadId", async () => {
+    const { client, createSpy, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await adapter.call(makeInput([SIMPLE_USER_MSG]));
+    await adapter.call(makeInput([SIMPLE_USER_MSG]));
+    await adapter.call(makeInput([SIMPLE_USER_MSG]));
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(promptSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("passes the created session id as path.id on every prompt call", async () => {
+    const sessionId = "sess-sticky";
+    const { client, createSpy, promptSpy } = makeFakeClient({
+      createResult: () => sessionOk(sessionId),
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await adapter.call(makeInput([SIMPLE_USER_MSG]));
+    await adapter.call(makeInput([SIMPLE_USER_MSG]));
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    for (const call of promptSpy.mock.calls) {
+      const opts = call[0] as { path?: { id?: string } };
+      expect(opts?.path?.id).toBe(sessionId);
+    }
+  });
+
+  it("calls session.create a second time for a different threadId", async () => {
+    const { client, createSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "thread-A" }));
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "thread-B" }));
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses distinct session ids for distinct threadIds", async () => {
+    let callCount = 0;
+    const { client, promptSpy } = makeFakeClient({
+      createResult: () => sessionOk(`sess-${++callCount}`),
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "thread-A" }));
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "thread-B" }));
+
+    const promptCallA = promptSpy.mock.calls[0]?.[0] as { path?: { id?: string } };
+    const promptCallB = promptSpy.mock.calls[1]?.[0] as { path?: { id?: string } };
+    expect(promptCallA?.path?.id).not.toBe(promptCallB?.path?.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3 — latest user message forwarded; reply returned
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter AC-3 — sends latest user message, returns reply", () => {
+  it("sends the new user message text as the prompt body text part", async () => {
+    const { client, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await adapter.call(makeInput([{ role: "user", content: "UNIQUE_USER_TEXT" }]));
+
+    const opts = promptSpy.mock.calls[0]?.[0] as {
+      body?: { parts?: Array<{ type: string; text?: string }> };
+    };
+    const textPart = opts?.body?.parts?.find((p) => p.type === "text");
+    expect(textPart?.text).toContain("UNIQUE_USER_TEXT");
+  });
+
+  it("returns the concatenated text parts from the assistant reply", async () => {
+    const { client } = makeFakeClient({
+      promptResult: () => promptOk([{ type: "text", text: "REPLY_CONTENT" }]),
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    const result = await adapter.call(SIMPLE_INPUT);
+    expect(result).toContain("REPLY_CONTENT");
+  });
+
+  it("renders array-shaped user content (content blocks) to text", async () => {
+    const { client, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    // User message whose content is an array of blocks (not a plain string).
+    await adapter.call(
+      makeInput([
+        {
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+        } as unknown as ModelMessage,
+      ]),
+    );
+
+    const opts = promptSpy.mock.calls[0]?.[0] as {
+      body?: { parts?: Array<{ type: string; text?: string }> };
+    };
+    const textPart = opts?.body?.parts?.find((p) => p.type === "text");
+    expect(textPart?.text).toContain("hi");
+  });
+
+  it("returns a non-empty string (the returned reply is not empty)", async () => {
+    const { client } = makeFakeClient({
+      promptResult: () => promptOk([{ type: "text", text: "not empty" }]),
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    const result = await adapter.call(SIMPLE_INPUT);
+    expect((result as string).trim().length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6 + R2/R3 — partsToText filtering and error surfaces
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter AC-6/R2/R3 — parts filtering and error handling", () => {
+  describe("given mixed parts (text + non-text)", () => {
+    it("concatenates only text parts and does not throw", async () => {
+      const mixedParts: FakePart[] = [
+        { type: "text", text: "A" },
+        { type: "tool", name: "bash", input: { cmd: "ls" } },
+        { type: "step-start" },
+        { type: "reasoning", text: "think" },
+        { type: "made-up-future", foo: 1 },
+        { type: "text", text: "B" },
+      ];
+      const { client } = makeFakeClient({
+        promptResult: () => promptOk(mixedParts),
+      });
+      const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+      const result = await adapter.call(SIMPLE_INPUT);
+      expect(result).toContain("A");
+      expect(result).toContain("B");
+      // Non-text type discriminators must NOT appear verbatim in the final text.
+      expect(result).not.toContain("step-start");
+      expect(result).not.toContain("reasoning");
+    });
+  });
+
+  describe("given a text part with ignored: true", () => {
+    it("skips the ignored part and does not include its text", async () => {
+      const parts: FakePart[] = [
+        { type: "text", text: "IGNORED_PART", ignored: true },
+        { type: "text", text: "VISIBLE_PART" },
+      ];
+      const { client } = makeFakeClient({
+        promptResult: () => promptOk(parts),
+      });
+      const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+      const result = await adapter.call(SIMPLE_INPUT);
+      expect(result).not.toContain("IGNORED_PART");
+      expect(result).toContain("VISIBLE_PART");
+    });
+  });
+
+  describe("given a semantic error in info.error (R2 — HTTP 200 with error)", () => {
+    it("rejects with a non-empty error message when info.error is truthy", async () => {
+      const { client } = makeFakeClient({
+        promptResult: () => ({
+          data: {
+            info: { error: { name: "MessageOutputLengthError", message: "too long" } },
+            parts: [],
+          },
+          error: undefined,
+        }),
+      });
+      const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow();
+      try {
+        await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "err-thread" }));
+      } catch (e) {
+        expect((e as Error).message.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("given a transport error (result.error is set) (R2 — transport layer)", () => {
+    it("rejects when result.error is truthy", async () => {
+      const { client } = makeFakeClient({
+        promptResult: () => ({
+          data: undefined,
+          error: { status: 500, message: "internal server error" },
+        }),
+      });
+      const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow();
+    });
+  });
+
+  describe("given an empty parts array with no info.error (R3 — truly empty response)", () => {
+    it("rejects when parts is empty and info has no error", async () => {
+      const { client } = makeFakeClient({
+        promptResult: () => ({ data: { info: {}, parts: [] }, error: undefined }),
+      });
+      const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow();
+    });
+  });
+
+  describe("given only non-text parts (R3 — non-empty fallback)", () => {
+    it("resolves to a non-empty string when all parts are non-text (tool-use fallback)", async () => {
+      const parts: FakePart[] = [
+        { type: "tool", name: "bash", input: { cmd: "echo hi" } },
+      ];
+      const { client } = makeFakeClient({
+        promptResult: () => promptOk(parts),
+      });
+      const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+      const result = await adapter.call(SIMPLE_INPUT);
+      // Must resolve (not reject) and the result must be a non-empty string.
+      expect(typeof result).toBe("string");
+      expect((result as string).trim().length).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-input guard — agent-first (no user turn)
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter empty-input guard", () => {
+  it("rejects before calling session.create or session.prompt when newMessages is empty", async () => {
+    const { client, createSpy, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    // Agent-first shape: the newMessages delta is empty (no user content).
+    await expect(
+      adapter.call(makeInput([SIMPLE_USER_MSG], { newMessages: [] })),
+    ).rejects.toThrow();
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(promptSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects with a message indicating a user turn is required", async () => {
+    const { client } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await expect(
+      adapter.call(makeInput([SIMPLE_USER_MSG], { newMessages: [] })),
+    ).rejects.toThrow(/user/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R4 — continuation eviction after prompt error
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter R4 — stale session eviction after prompt error", () => {
+  it("calls session.create again on the third call after the second call's prompt fails", async () => {
+    let promptCallIndex = 0;
+    const { client, createSpy, promptSpy } = makeFakeClient({
+      promptResult: () => {
+        promptCallIndex++;
+        if (promptCallIndex === 2) {
+          // Second prompt call fails with a transport error.
+          return { data: undefined, error: { status: 503, message: "unavailable" } };
+        }
+        return promptOk();
+      },
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    // Call 1: succeeds — session created.
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "evict-thread" }));
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    // Call 2: prompt fails — session should be evicted.
+    await expect(
+      adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "evict-thread" })),
+    ).rejects.toThrow();
+
+    // Call 3: same threadId — create must be called AGAIN (stale id evicted).
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "evict-thread" }));
+    expect(createSpy).toHaveBeenCalledTimes(2);
+    expect(promptSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// close() — teardown is callable
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter close()", () => {
+  it("resolves without error when close() is called on an injected-client adapter", async () => {
+    const { client } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    await expect(adapter.close()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4 env-gated integration (RUN_OPENCODE_E2E=1) — live multi-turn scenario
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
+  "OpenCodeAgentAdapter integration (RUN_OPENCODE_E2E=1)",
+  () => {
+    it(
+      "runs a multi-turn coding scenario with a real judge and returns a passing verdict",
+      async () => {
+        // Re-import the real scenario barrel (no mocks in scope for this test).
+        const scenario = (await import("../../index.js")).default;
+        const { openai } = await import("@ai-sdk/openai");
+
+        const judgeModelId = process.env.SCENARIO_JUDGE_MODEL ?? "gpt-4o-mini";
+
+        // Use the real openCodeAgent — NO injected client, lets the adapter
+        // spawn the opencode binary (requires opencode on PATH + provider keys).
+        const agent = openCodeAgent({
+          model: {
+            providerID: process.env.OPENCODE_PROVIDER_ID ?? "openai",
+            modelID: process.env.OPENCODE_MODEL_ID ?? "gpt-4o-mini",
+          },
+          workingDirectory: process.cwd(),
+        });
+
+        try {
+          const result = await scenario.run({
+            name: "opencode-e2e-multiturn",
+            description:
+              "Verifies the OpenCode adapter in a multi-turn coding scenario: " +
+              "user asks the agent to write a simple function, then add a test for it.",
+            agents: [
+              agent,
+              scenario.userSimulatorAgent({ model: openai(judgeModelId) }),
+              scenario.judgeAgent({
+                model: openai(judgeModelId),
+                criteria: [
+                  "The agent writes a working JavaScript/TypeScript function that adds two numbers.",
+                  "The agent acknowledges or writes a test for the function when asked.",
+                ],
+              }),
+            ],
+            script: [
+              scenario.user(
+                "Write a JavaScript function called `add` that takes two numbers and returns their sum. " +
+                "Just the function definition, no file operations needed.",
+              ),
+              scenario.agent(),
+              scenario.user(
+                "Now write a simple unit test for the `add` function you just wrote. " +
+                "Just the test code, using any test style you like.",
+              ),
+              scenario.agent(),
+              scenario.judge(),
+            ],
+          });
+
+          expect(result.success).toBe(true);
+
+          // Verify there are at least two non-empty assistant turns.
+          const assistantTurns = result.messages.filter(
+            (m: ModelMessage) => m.role === "assistant",
+          );
+          expect(assistantTurns.length).toBeGreaterThanOrEqual(2);
+
+          // The last assistant turn must mention the function or test in some form.
+          const lastAssistant = assistantTurns.at(-1);
+          const lastText =
+            typeof lastAssistant?.content === "string"
+              ? lastAssistant.content
+              : JSON.stringify(lastAssistant?.content ?? "");
+          expect(lastText.trim().length).toBeGreaterThan(0);
+        } finally {
+          // Tear down the auto-spawned opencode server so it does not leak its
+          // port bind to the next run (serial e2e runs would otherwise collide).
+          await agent.close();
+        }
+      },
+      180000,
+    );
+  },
+);

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -125,7 +125,12 @@ function makeConfig(
   overrides: Partial<Omit<OpenCodeAgentAdapterConfig, "client" | "model">> = {},
 ): OpenCodeAgentAdapterConfig {
   return {
+    // workingDirectory is required (the adapter refuses to run the tool-bearing
+    // agent in an unspecified cwd); a placeholder is fine for the injected-client
+    // unit tests, which never spawn a real server. Tests that assert directory
+    // forwarding override it via `overrides`.
     model: { providerID: "openai", modelID: "gpt-5.4-mini" },
+    workingDirectory: "/tmp/opencode-unit-wd",
     client,
     ...overrides,
   };
@@ -424,7 +429,12 @@ describe("OpenCodeAgentAdapter AC-6/R2/R3 — parts filtering and error handling
       });
       const adapter = new OpenCodeAgentAdapter(makeConfig(client));
 
-      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/prompt failed/);
+      // Assert on describeError's INTERPOLATED output (message + status), not
+      // just the static "prompt failed" prefix — otherwise a regression that
+      // guts describeError to a constant string would still pass this test.
+      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(
+        /prompt failed: internal server error \(status 500\)/,
+      );
     });
   });
 
@@ -532,9 +542,12 @@ describe("OpenCodeAgentAdapter R4 — stale session eviction after prompt error"
       },
     });
     const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    // Pin describeError's INTERPOLATED output (message + status), not just the
+    // static "session.create failed" prefix — otherwise gutting describeError to
+    // a constant string would leave this test green.
     await expect(
       adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "create-fail" })),
-    ).rejects.toThrow(/session\.create failed/);
+    ).rejects.toThrow(/session\.create failed for thread "create-fail": unavailable \(status 503\)/);
     // next call on the same thread must retry create (stale rejected promise evicted)
     await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "create-fail" }));
     expect(createSpy).toHaveBeenCalledTimes(2);
@@ -586,10 +599,12 @@ describe("OpenCodeAgentAdapter concurrency + config validation", () => {
 
     const p1 = adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race-reject" }));
     const p2 = adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race-reject" }));
-    // Attach both rejection expectations BEFORE releasing the gate so neither
-    // rejection is ever unobserved.
-    const e1 = expect(p1).rejects.toThrow(/session\.create failed/);
-    const e2 = expect(p2).rejects.toThrow(/session\.create failed/);
+    // Observe BOTH rejections immediately via allSettled — it attaches handlers
+    // synchronously, so neither rejection is ever unobserved — rather than storing
+    // deferred `expect(...).rejects` assertions and awaiting them later. That
+    // deferred pattern is deprecated in vitest and, on a real regression, splits
+    // one failure into a waitFor timeout plus a disconnected unhandled rejection.
+    const settled = Promise.allSettled([p1, p2]);
     // Wait for a macrotask boundary (vi.waitFor polls on timers), which drains
     // BOTH calls' microtask chains regardless of call()'s internal await depth:
     // p1 is parked inside the gated create, p2 is attached to the same stored
@@ -597,7 +612,17 @@ describe("OpenCodeAgentAdapter concurrency + config validation", () => {
     // call()/resolveSessionId cannot break this synchronization.
     await vi.waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
     releaseCreate();
-    await Promise.all([e1, e2]);
+    const results = await settled;
+    // Both concurrent callers reject with the SAME create-failed error — content
+    // pinned (message + status), not just the static prefix.
+    expect(results.map((r) => r.status)).toEqual(["rejected", "rejected"]);
+    for (const r of results) {
+      const reason = (r as PromiseRejectedResult).reason as Error;
+      expect(reason).toBeInstanceOf(Error);
+      expect(reason.message).toMatch(
+        /session\.create failed for thread "race-reject": unavailable \(status 503\)/,
+      );
+    }
     // Both concurrent callers shared ONE create attempt.
     expect(createSpy).toHaveBeenCalledTimes(1);
 

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -123,7 +123,7 @@ function makeConfig(
   overrides: Partial<Omit<OpenCodeAgentAdapterConfig, "client" | "model">> = {},
 ): OpenCodeAgentAdapterConfig {
   return {
-    model: { providerID: "openai", modelID: "gpt-4.1-mini" },
+    model: { providerID: "openai", modelID: "gpt-5.4-mini" },
     client,
     ...overrides,
   };
@@ -547,14 +547,14 @@ describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
         const scenario = (await import("../../index.js")).default;
         const { openai } = await import("@ai-sdk/openai");
 
-        const judgeModelId = process.env.SCENARIO_JUDGE_MODEL ?? "gpt-4.1-mini";
+        const judgeModelId = process.env.SCENARIO_JUDGE_MODEL ?? "gpt-5.4-mini";
 
         // Use the real openCodeAgent — NO injected client, lets the adapter
         // spawn the opencode binary (requires opencode on PATH + provider keys).
         const agent = openCodeAgent({
           model: {
             providerID: process.env.OPENCODE_PROVIDER_ID ?? "openai",
-            modelID: process.env.OPENCODE_MODEL_ID ?? "gpt-4.1-mini",
+            modelID: process.env.OPENCODE_MODEL_ID ?? "gpt-5.4-mini",
           },
           workingDirectory: process.cwd(),
         });

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -580,6 +580,24 @@ describe("OpenCodeAgentAdapter concurrency + config validation", () => {
     await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/timeout/i);
   });
 
+  // validateTimeout() is the SOLE guard in front of AbortSignal.timeout(), which
+  // throws a raw TypeError on a non-finite input. Pin both non-finite values, or
+  // dropping the Number.isFinite check would surface that TypeError to callers
+  // instead of the friendly validation message.
+  it.each([
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+  ])("throws on a non-finite timeout (%s) before any RPC", async (_label, timeout) => {
+    const { client, createSpy, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client, { timeout }));
+
+    await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(
+      /timeout must be a positive, finite number/i,
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(promptSpy).not.toHaveBeenCalled();
+  });
+
   it("forwards an AbortSignal to session.prompt when a positive timeout is set", async () => {
     const { client, promptSpy } = makeFakeClient();
     const adapter = new OpenCodeAgentAdapter(makeConfig(client, { timeout: 5000 }));

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -564,6 +564,43 @@ describe("OpenCodeAgentAdapter concurrency + config validation", () => {
     expect(createSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("propagates ONE rejecting session.create to ALL concurrent first-calls, then retries cleanly", async () => {
+    // The dedup map stores the create PROMISE un-awaited (that is the dedup
+    // mechanism — awaiting before storing would reopen the check-then-create
+    // race). This test pins the rejection half of that contract: every path
+    // that reads the stored promise awaits it, so a failing create rejects
+    // BOTH concurrent callers (no unhandled rejection, no hang), is evicted,
+    // and the next turn retries with a fresh create.
+    let releaseCreate!: () => void;
+    const gate = new Promise<void>((r) => { releaseCreate = r; });
+    let createCalls = 0;
+    const { client, createSpy } = makeFakeClient({
+      createResult: () => {
+        createCalls++;
+        return createCalls === 1
+          ? gate.then(() => ({ data: undefined, error: { status: 503, message: "unavailable" } }))
+          : sessionOk("sess-retry");
+      },
+    });
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    const p1 = adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race-reject" }));
+    const p2 = adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race-reject" }));
+    // Attach both rejection expectations BEFORE releasing the gate so neither
+    // rejection is ever unobserved.
+    const e1 = expect(p1).rejects.toThrow(/session\.create failed/);
+    const e2 = expect(p2).rejects.toThrow(/session\.create failed/);
+    await Promise.resolve(); // let both calls reach resolveSessionId and share the in-flight create
+    releaseCreate();
+    await Promise.all([e1, e2]);
+    // Both concurrent callers shared ONE create attempt.
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    // The rejected promise was evicted — the next turn retries and succeeds.
+    await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race-reject" }));
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("throws on timeout=0 (explicitly set, not silently ignored) before any RPC", async () => {
     const { client, createSpy, promptSpy } = makeFakeClient();
     const adapter = new OpenCodeAgentAdapter(makeConfig(client, { timeout: 0 }));
@@ -618,6 +655,19 @@ describe("OpenCodeAgentAdapter close()", () => {
     const { client } = makeFakeClient();
     const adapter = new OpenCodeAgentAdapter(makeConfig(client));
     await expect(adapter.close()).resolves.toBeUndefined();
+  });
+
+  it("rejects call() after close() with a clear closed-adapter error (no RPC attempted)", async () => {
+    // close() is terminal: a post-close call must fail with the real cause
+    // ("adapter is closed"), not race a torn-down server into an opaque
+    // transport error — the close()/call() sequencing gap from review.
+    const { client, createSpy, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+    await adapter.close();
+
+    await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/closed/i);
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(promptSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -23,6 +23,10 @@
  * that runs a real `scenario.run(...)` with `openCodeAgent` and a real judge.
  */
 
+import fs from "fs";
+import os from "os";
+import path from "path";
+
 import type { OpencodeClient } from "@opencode-ai/sdk";
 import type { ModelMessage } from "ai";
 import { describe, it, expect, vi, type Mock } from "vitest";
@@ -31,8 +35,6 @@ import { describe, it, expect, vi, type Mock } from "vitest";
 // runtime. We import the type purely so we can cast our fake to it.
 
 import { AgentRole, type AgentInput } from "../../domain";
-// The source under test does NOT exist yet; these imports will fail at
-// collection time (expected RED) until the implementer ships the adapter.
 import { AgentAdapter } from "../../domain";
 import {
   OpenCodeAgentAdapter,
@@ -286,6 +288,60 @@ describe("OpenCodeAgentAdapter AC-3 — sends latest user message, returns reply
     const result = await adapter.call(SIMPLE_INPUT);
     expect((result as string).trim().length).toBeGreaterThan(0);
   });
+
+  it("excludes assistant-role messages from the prompt (only user turns are sent)", async () => {
+    const { client, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    // Delta carrying BOTH an assistant echo and a user turn: only the user text
+    // is forwarded — OpenCode already holds the assistant turn server-side.
+    await adapter.call(
+      makeInput([SIMPLE_USER_MSG], {
+        newMessages: [
+          { role: "assistant", content: "ASSISTANT_ECHO" },
+          { role: "user", content: "USER_TEXT" },
+        ],
+      }),
+    );
+
+    const opts = promptSpy.mock.calls[0]?.[0] as {
+      body?: { parts?: Array<{ type: string; text?: string }> };
+    };
+    const textPart = opts?.body?.parts?.find((p) => p.type === "text");
+    expect(textPart?.text).toContain("USER_TEXT");
+    expect(textPart?.text).not.toContain("ASSISTANT_ECHO");
+  });
+
+  it("forwards the configured model to the session.prompt body", async () => {
+    const { client, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await adapter.call(SIMPLE_INPUT);
+
+    const opts = promptSpy.mock.calls[0]?.[0] as { body?: { model?: unknown } };
+    expect(opts?.body?.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4-mini",
+    });
+  });
+
+  it("forwards workingDirectory as query.directory on session.create AND session.prompt", async () => {
+    const { client, createSpy, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(
+      makeConfig(client, { workingDirectory: "/tmp/wd-x" }),
+    );
+
+    await adapter.call(SIMPLE_INPUT);
+
+    const createOpts = createSpy.mock.calls[0]?.[0] as {
+      query?: { directory?: string };
+    };
+    const promptOpts = promptSpy.mock.calls[0]?.[0] as {
+      query?: { directory?: string };
+    };
+    expect(createOpts?.query?.directory).toBe("/tmp/wd-x");
+    expect(promptOpts?.query?.directory).toBe("/tmp/wd-x");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -314,6 +370,8 @@ describe("OpenCodeAgentAdapter AC-6/R2/R3 — parts filtering and error handling
       // Non-text type discriminators must NOT appear verbatim in the final text.
       expect(result).not.toContain("step-start");
       expect(result).not.toContain("reasoning");
+      // A reasoning part's own TEXT must not leak — only visible text parts pass.
+      expect(result).not.toContain("think");
     });
   });
 
@@ -395,6 +453,8 @@ describe("OpenCodeAgentAdapter AC-6/R2/R3 — parts filtering and error handling
       // Must resolve (not reject) and the result must be a non-empty string.
       expect(typeof result).toBe("string");
       expect((result as string).trim().length).toBeGreaterThan(0);
+      // ...and READ readably — naming the tool, not "[object Object]" (renderNonTextPart → `[tool: bash]`).
+      expect(result).toContain("bash");
     });
   });
 });
@@ -519,6 +579,16 @@ describe("OpenCodeAgentAdapter concurrency + config validation", () => {
 
     await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/timeout/i);
   });
+
+  it("forwards an AbortSignal to session.prompt when a positive timeout is set", async () => {
+    const { client, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client, { timeout: 5000 }));
+
+    await adapter.call(SIMPLE_INPUT);
+
+    const opts = promptSpy.mock.calls[0]?.[0] as { signal?: unknown };
+    expect(opts?.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -549,6 +619,12 @@ describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
 
         const judgeModelId = process.env.SCENARIO_JUDGE_MODEL ?? "gpt-5.4-mini";
 
+        // Isolate this tool-bearing agent (shell + file read/write) from the
+        // repo: process.cwd() is javascript/, which holds a gitignored .env with
+        // a real OPENAI_API_KEY. Run it in an empty temp dir instead — the two
+        // scripted prompts reference no pre-existing files.
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-e2e-"));
+
         // Use the real openCodeAgent — NO injected client, lets the adapter
         // spawn the opencode binary (requires opencode on PATH + provider keys).
         const agent = openCodeAgent({
@@ -556,7 +632,7 @@ describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
             providerID: process.env.OPENCODE_PROVIDER_ID ?? "openai",
             modelID: process.env.OPENCODE_MODEL_ID ?? "gpt-5.4-mini",
           },
-          workingDirectory: process.cwd(),
+          workingDirectory: tmpDir,
         });
 
         try {
@@ -608,8 +684,13 @@ describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
           expect(lastText.trim().length).toBeGreaterThan(0);
         } finally {
           // Tear down the auto-spawned opencode server so it does not leak its
-          // port bind to the next run (serial e2e runs would otherwise collide).
-          await agent.close();
+          // port bind to the next run (serial e2e runs would otherwise collide),
+          // then remove the temp working dir — even if close() throws.
+          try {
+            await agent.close();
+          } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+          }
         }
       },
       180000,

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -645,11 +645,18 @@ describe.skipIf(!process.env.RUN_OPENCODE_E2E)(
 
         // Use the real openCodeAgent — NO injected client, lets the adapter
         // spawn the opencode binary (requires opencode on PATH + provider keys).
+        //
+        // `timeout` must stay BELOW this test's 180s vitest timeout. A live
+        // prompt can stall (observed ~1 run in 6); without a bound, vitest kills
+        // the test body and the `finally` below never runs, leaking the temp dir
+        // and the spawned server. Bounded, the stall rejects inside the test, so
+        // teardown still happens and the failure names its own cause.
         const agent = openCodeAgent({
           model: {
             providerID: process.env.OPENCODE_PROVIDER_ID ?? "openai",
             modelID: process.env.OPENCODE_MODEL_ID ?? "gpt-5.4-mini",
           },
+          timeout: 120_000,
           workingDirectory: tmpDir,
         });
 

--- a/javascript/src/agents/__tests__/opencode-adapter.test.ts
+++ b/javascript/src/agents/__tests__/opencode-adapter.test.ts
@@ -347,12 +347,12 @@ describe("OpenCodeAgentAdapter AC-6/R2/R3 — parts filtering and error handling
       });
       const adapter = new OpenCodeAgentAdapter(makeConfig(client));
 
-      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow();
-      try {
-        await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "err-thread" }));
-      } catch (e) {
-        expect((e as Error).message.length).toBeGreaterThan(0);
-      }
+      // Strict: a single rejects assertion that also proves the thrown message
+      // NAMES the semantic error variant (describeError surfaced info.error),
+      // rather than a try/catch that would silently pass if call() resolved.
+      await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(
+        /MessageOutputLengthError/,
+      );
     });
   });
 
@@ -459,6 +459,42 @@ describe("OpenCodeAgentAdapter R4 — stale session eviction after prompt error"
     await adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "evict-thread" }));
     expect(createSpy).toHaveBeenCalledTimes(2);
     expect(promptSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency + config validation
+// ---------------------------------------------------------------------------
+
+describe("OpenCodeAgentAdapter concurrency + config validation", () => {
+  it("dedupes concurrent first-calls on the same threadId to ONE session.create", async () => {
+    // Two calls fired together on the same thread must share one session.create
+    // (the stored in-flight promise closes the check-then-create race).
+    const { client, createSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client));
+
+    await Promise.all([
+      adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race" })),
+      adapter.call(makeInput([SIMPLE_USER_MSG], { threadId: "race" })),
+    ]);
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on timeout=0 (explicitly set, not silently ignored) before any RPC", async () => {
+    const { client, createSpy, promptSpy } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client, { timeout: 0 }));
+
+    await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/timeout/i);
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(promptSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws on a negative timeout", async () => {
+    const { client } = makeFakeClient();
+    const adapter = new OpenCodeAgentAdapter(makeConfig(client, { timeout: -5 }));
+
+    await expect(adapter.call(SIMPLE_INPUT)).rejects.toThrow(/timeout/i);
   });
 });
 

--- a/javascript/src/agents/index.ts
+++ b/javascript/src/agents/index.ts
@@ -4,3 +4,4 @@ export * from "./user-simulator-agent";
 export * from "./realtime";
 export * from "./claude-code";
 export * from "./red-team";
+export * from "./opencode";

--- a/javascript/src/agents/index.ts
+++ b/javascript/src/agents/index.ts
@@ -5,3 +5,4 @@ export * from "./realtime";
 export * from "./claude-code";
 export * from "./connected-agent";
 export * from "./red-team";
+export * from "./opencode";

--- a/javascript/src/agents/opencode/index.ts
+++ b/javascript/src/agents/opencode/index.ts
@@ -9,8 +9,8 @@ export type {
 
 /**
  * Factory for {@link OpenCodeAgentAdapter}, following the lowercase-factory idiom
- * used by `userSimulatorAgent` (and planned for the in-flight Claude Code adapter,
- * PR #687).
+ * used by `userSimulatorAgent` (and the sibling Claude Code adapter in
+ * `claude-code/`).
  *
  * Pass an injected `config.client` to drive a fake/real OpencodeClient directly
  * (no server spawn); omit it to let the adapter lazily spawn and own an OpenCode

--- a/javascript/src/agents/opencode/index.ts
+++ b/javascript/src/agents/opencode/index.ts
@@ -1,0 +1,20 @@
+import { OpenCodeAgentAdapter } from "./opencode-agent.adapter.js";
+import type { OpenCodeAgentAdapterConfig } from "./opencode-agent.adapter.js";
+
+export { OpenCodeAgentAdapter } from "./opencode-agent.adapter.js";
+export type {
+  OpenCodeAgentAdapterConfig,
+  Logger,
+} from "./opencode-agent.adapter.js";
+
+/**
+ * Factory for {@link OpenCodeAgentAdapter}, mirroring the lowercase-factory idiom
+ * used by `userSimulatorAgent` and the Claude Code sibling's `claudeCodeAgent`.
+ *
+ * Pass an injected `config.client` to drive a fake/real OpencodeClient directly
+ * (no server spawn); omit it to let the adapter lazily spawn and own an OpenCode
+ * server (requires the `opencode` binary on PATH). Remember to `await
+ * adapter.close()` in teardown when the adapter owns its server.
+ */
+export const openCodeAgent = (config: OpenCodeAgentAdapterConfig) =>
+  new OpenCodeAgentAdapter(config);

--- a/javascript/src/agents/opencode/index.ts
+++ b/javascript/src/agents/opencode/index.ts
@@ -4,12 +4,13 @@ import type { OpenCodeAgentAdapterConfig } from "./opencode-agent.adapter.js";
 export { OpenCodeAgentAdapter } from "./opencode-agent.adapter.js";
 export type {
   OpenCodeAgentAdapterConfig,
-  Logger,
+  OpenCodeLogger,
 } from "./opencode-agent.adapter.js";
 
 /**
- * Factory for {@link OpenCodeAgentAdapter}, mirroring the lowercase-factory idiom
- * used by `userSimulatorAgent` and the Claude Code sibling's `claudeCodeAgent`.
+ * Factory for {@link OpenCodeAgentAdapter}, following the lowercase-factory idiom
+ * used by `userSimulatorAgent` (and planned for the in-flight Claude Code adapter,
+ * PR #687).
  *
  * Pass an injected `config.client` to drive a fake/real OpencodeClient directly
  * (no server spawn); omit it to let the adapter lazily spawn and own an OpenCode

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -51,6 +51,10 @@
  *  d. The OpencodeClient is an injection seam (`config.client`): provide your own
  *     for tests (no real server, no spawn), or omit it to let the adapter lazily
  *     spawn and own an OpenCode server (closed by {@link OpenCodeAgentAdapter.close}).
+ *  e. `close()` is terminal: a `call(...)` issued after `close()` rejects with a
+ *     clear closed-adapter error instead of racing a torn-down server (with an
+ *     owned server the memoized handle would otherwise surface as a confusing
+ *     transport failure).
  */
 
 import { createOpencode } from "@opencode-ai/sdk";
@@ -139,7 +143,8 @@ export interface OpenCodeAgentAdapterConfig {
   /**
    * Injection seam for the OpenCode SDK client. When provided, the adapter uses
    * it directly and does NOT own/spawn a server ({@link OpenCodeAgentAdapter.close}
-   * is then a no-op). When omitted, the adapter lazily `createOpencode()`s a
+   * then shuts nothing down, but still marks the adapter closed — post-close
+   * calls reject). When omitted, the adapter lazily `createOpencode()`s a
    * server on first use and owns its lifecycle.
    */
   client?: OpencodeClient;
@@ -183,6 +188,14 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
    * spawn instead of racing.
    */
   private serverPromise: Promise<OwnedServer> | null = null;
+
+  /**
+   * Set the moment {@link close} is invoked — `close()` is terminal. A closed
+   * adapter must reject further `call`s loudly: with an owned server the
+   * memoized `serverPromise` now points at a torn-down server, so a post-close
+   * call would otherwise fail as a confusing transport error (or hang).
+   */
+  private closed = false;
 
   constructor(private config: OpenCodeAgentAdapterConfig) {
     super();
@@ -313,6 +326,16 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
    * @returns The concatenated assistant-visible text as a string.
    */
   async call(input: AgentInput): Promise<AgentReturnTypes> {
+    // close() is terminal — reject immediately with the real cause rather than
+    // letting the call race a torn-down (or injector-owned but relinquished)
+    // server and surface as an opaque transport error.
+    if (this.closed) {
+      throw new Error(
+        "OpenCodeAgentAdapter is closed — close() tears down the adapter (and " +
+          "any owned server). Create a new adapter instance for further calls.",
+      );
+    }
+
     // OpenCode is prompt-driven and holds prior turns server-side, so we send
     // ONLY the new user delta — never a full-history flatten. Compute it FIRST
     // so the empty-input guard rejects before any RPC (no wasted session
@@ -419,10 +442,19 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
 
   /**
    * Tear down any server this adapter spawned. When a `client` was injected the
-   * adapter owns no server and this is a no-op. Call this in a scenario's
-   * teardown (e.g. `afterAll`) to release the auto-spawned OpenCode server.
+   * adapter owns no server and nothing is shut down (the injector owns its
+   * server). Call this in a scenario's teardown (e.g. `afterAll`) to release
+   * the auto-spawned OpenCode server.
+   *
+   * Terminal: the adapter is marked closed synchronously on entry, so any
+   * `call(...)` issued after `close()` starts rejects with a clear
+   * closed-adapter error. Calls already in flight when `close()` runs are the
+   * caller's teardown contract to sequence (await the scenario before closing —
+   * the same ownership stance ADR-005 §10 records); if one does overlap, it
+   * fails loudly at the transport layer rather than corrupting state.
    */
   async close(): Promise<void> {
+    this.closed = true;
     if (!this.serverPromise) {
       return;
     }

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -147,13 +147,15 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
   name = "OpenCodeAgent";
 
   /**
-   * Per-thread OpenCode session ids (`threadId` → `session.id`). Populated after
-   * a thread's first turn and consulted on every subsequent turn to reuse the
-   * server-side session. The adapter instance is reused across a scenario's
-   * turns, so this persists for the conversation's lifetime. Evicted on a
-   * continuation prompt failure so the next turn rebuilds the session.
+   * Per-thread OpenCode session creation, keyed `threadId` → in-flight-or-resolved
+   * `Promise<session.id>`. Storing the PROMISE (not the resolved id) dedupes a
+   * check-then-create race: two concurrent first-calls on the same thread share
+   * ONE `session.create` instead of both creating (one-session-per-thread). The
+   * adapter instance is reused across a scenario's turns, so this persists for the
+   * conversation's lifetime; evicted on a failed create or a continuation prompt
+   * failure so the next turn rebuilds the session.
    */
-  private sessions = new Map<string, string>();
+  private sessions = new Map<string, Promise<string>>();
 
   /**
    * Memoized auto-spawned server promise — set only when no `client` is
@@ -197,6 +199,24 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
   }
 
   /**
+   * Resolve the per-call abort signal from `config.timeout`. Returns undefined
+   * when no timeout is configured. Throws on a non-positive or non-finite value
+   * (e.g. an explicitly-set `0`) so a bad timeout fails loudly rather than being
+   * silently ignored by a truthiness check — mirroring the Claude Code sibling's
+   * timeout validation.
+   */
+  private timeoutSignal(): AbortSignal | undefined {
+    const timeout = this.config.timeout;
+    if (timeout == null) return undefined;
+    if (!Number.isFinite(timeout) || timeout <= 0) {
+      throw new Error(
+        `OpenCodeAgentAdapter timeout must be a positive, finite number of milliseconds; received ${timeout}`,
+      );
+    }
+    return AbortSignal.timeout(timeout);
+  }
+
+  /**
    * Resolve (creating if needed) the server-side session id for a thread. The
    * `create` happens AT MOST once per `threadId` (subsequent turns reuse the
    * stored id), satisfying the one-session-per-thread contract.
@@ -207,26 +227,42 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     threadId: string,
     client: OpencodeClient,
   ): Promise<{ sessionId: string; isContinuation: boolean }> {
+    // A stored promise (in-flight OR resolved) means the session already exists
+    // or is being created for this thread → a continuation turn that awaits the
+    // same `session.create`. This closes the check-then-create race.
     const existing = this.sessions.get(threadId);
     if (existing) {
-      return { sessionId: existing, isContinuation: true };
+      return { sessionId: await existing, isContinuation: true };
     }
 
-    const created = await client.session.create({
-      body: { title: `scenario:${threadId}` },
-      ...(this.directoryQuery() ? { query: this.directoryQuery() } : {}),
-    });
-    if (created.error || !created.data?.id) {
-      throw new Error(
-        `OpenCode session.create failed for thread "${threadId}": ${describeError(
-          created.error,
-        )}`,
-      );
-    }
+    const creating = (async () => {
+      const created = await client.session.create({
+        body: { title: `scenario:${threadId}` },
+        ...(this.directoryQuery() ? { query: this.directoryQuery() } : {}),
+      });
+      if (created.error || !created.data?.id) {
+        throw new Error(
+          `OpenCode session.create failed for thread "${threadId}": ${describeError(
+            created.error,
+          )}`,
+        );
+      }
+      return created.data.id;
+    })();
+    this.sessions.set(threadId, creating);
 
-    const sessionId = created.data.id;
-    this.sessions.set(threadId, sessionId);
-    return { sessionId, isContinuation: false };
+    try {
+      const sessionId = await creating;
+      return { sessionId, isContinuation: false };
+    } catch (err) {
+      // Create failed — evict the rejected promise so a later turn retries
+      // instead of awaiting a permanently-rejected create. Guard on identity so
+      // a newer create promise (if any) is not clobbered.
+      if (this.sessions.get(threadId) === creating) {
+        this.sessions.delete(threadId);
+      }
+      throw err;
+    }
   }
 
   /**
@@ -250,6 +286,10 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
       );
     }
 
+    // Resolve (and validate) the timeout signal before any RPC, so a bad
+    // `timeout` (e.g. 0) fails fast instead of after a session.create.
+    const signal = this.timeoutSignal();
+
     const client = await this.ensureClient();
     const { sessionId, isContinuation } = await this.resolveSessionId(
       input.threadId,
@@ -270,9 +310,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
       // Best-effort cancellation: AbortSignal.timeout is a valid prompt option
       // (it survives on RequestOptions). If the server ignores it, the call
       // still settles when the prompt resolves.
-      ...(this.config.timeout
-        ? { signal: AbortSignal.timeout(this.config.timeout) }
-        : {}),
+      ...(signal ? { signal } : {}),
     });
 
     // Layer 1 — transport error. Evict a stale continuation session so the next

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -7,9 +7,10 @@
  * thread, drives a single `session.prompt(...)` completion, and returns the
  * assistant-visible text as a `string`.
  *
- * Unlike the Claude Code sibling adapter — which spawns `claude -p` per turn and
- * REPLAYS the conversation as a flat prompt — OpenCode keeps the full transcript
- * SERVER-SIDE keyed by a session id. The SDK's `session.prompt(...)` resolves
+ * Unlike a replay-style coding adapter — e.g. the in-flight Claude Code adapter
+ * (PR #687), which spawns `claude -p` per turn and REPLAYS the conversation as a
+ * flat prompt — OpenCode keeps the full transcript SERVER-SIDE keyed by a session
+ * id. The SDK's `session.prompt(...)` resolves
  * only after the assistant finishes (a completion primitive; no SSE needed), and
  * the session already holds the prior turns. Therefore:
  *  - We send ONLY the NEW user text ({@link extractNewUserText} over
@@ -24,8 +25,8 @@
  *  - Subsequent turns: reuse the stored id as `path.id` on `session.prompt(...)`.
  *  - If a continuation `prompt(...)` fails at the transport layer, the stored id
  *    is EVICTED so the next turn for that thread recreates the session (the
- *    stored session may no longer resolve) — mirroring the Claude Code sibling's
- *    `--resume` eviction.
+ *    stored session may no longer resolve) — the same eviction-on-failure stance
+ *    the in-flight Claude Code adapter (PR #687) takes for its `--resume` id.
  *
  * Two-layer error handling (the SDK uses responseStyle "fields" with
  * `throwOnError` defaulting to `false`, so the calls resolve to `{ data, error }`
@@ -42,11 +43,11 @@
  * completion with NO parts at all is treated as a genuine empty response and
  * rejected.
  *
- * Hardening (mirrors the Claude Code sibling):
+ * Hardening (the same defenses the in-flight Claude Code adapter (PR #687) adopts):
  *  a. Structured non-text parts are rendered readably, never `[object Object]`.
  *  b. An optional `timeout` cancels the in-flight prompt via `AbortSignal`.
- *  c. All diagnostics route through an injectable {@link Logger}; absent one, a
- *     no-op logger is used. No `console.*` and no `chalk` anywhere.
+ *  c. All diagnostics route through an injectable {@link OpenCodeLogger}; absent
+ *     one, a no-op logger is used. No `console.*` and no `chalk` anywhere.
  *  d. The OpencodeClient is an injection seam (`config.client`): provide your own
  *     for tests (no real server, no spawn), or omit it to let the adapter lazily
  *     spawn and own an OpenCode server (closed by {@link OpenCodeAgentAdapter.close}).
@@ -56,22 +57,22 @@ import { createOpencode } from "@opencode-ai/sdk";
 import type { OpencodeClient, Part } from "@opencode-ai/sdk";
 import type { ModelMessage } from "ai";
 
-import { AgentAdapter, AgentRole } from "../../domain/agents/index.js";
-import type { AgentInput, AgentReturnTypes } from "../../domain/agents/index.js";
+import { AgentAdapter, AgentRole } from "../../domain/agents";
+import type { AgentInput, AgentReturnTypes } from "../../domain/agents";
 
 /**
  * Minimal structural logger the adapter routes ALL diagnostics through. Provide
- * your own (e.g. wrapping a real logger) or omit it for silent operation.
+ * your own (e.g. wrapping a real logger) or omit it for silent operation. Named
+ * `OpenCodeLogger` to avoid colliding with the `Logger` class in
+ * `src/utils/logger.ts` when re-exported from the package barrel.
  */
-export interface Logger {
+export interface OpenCodeLogger {
   log: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
 }
 
 /** No-op logger used when none is injected — keeps the adapter silent and console-free. */
-const noopLogger: Logger = {
+const noopLogger: OpenCodeLogger = {
   log: () => undefined,
-  warn: () => undefined,
 };
 
 /**
@@ -83,6 +84,19 @@ interface OwnedServer {
   client: OpencodeClient;
   server: { close(): void };
 }
+
+/**
+ * The fields of an awaited `client.session.prompt(...)` the triage reads — under
+ * the SDK's "fields" responseStyle the call resolves to `{ data, error }` and
+ * never throws. Typed structurally (not via `Awaited<ReturnType<…>>`, whose
+ * generic `ThrowOnError` default collapses to the throw-branch and drops `error`)
+ * so {@link OpenCodeAgentAdapter.interpretPromptResult} reads exactly the surface
+ * it uses: the transport `error`, the semantic `data.info.error`, and `data.parts`.
+ */
+type PromptResult = {
+  error?: unknown;
+  data?: { info?: { error?: unknown }; parts?: Part[] };
+};
 
 /**
  * Configuration for {@link OpenCodeAgentAdapter}.
@@ -115,7 +129,7 @@ export interface OpenCodeAgentAdapterConfig {
   /**
    * Optional logger for all diagnostics. Defaults to a no-op logger (silent).
    */
-  logger?: Logger;
+  logger?: OpenCodeLogger;
 
   /**
    * Injection seam for the OpenCode SDK client. When provided, the adapter uses
@@ -170,7 +184,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
   }
 
   /** The effective logger (injected or no-op). */
-  private get logger(): Logger {
+  private get logger(): OpenCodeLogger {
     return this.config.logger ?? noopLogger;
   }
 
@@ -202,8 +216,8 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
    * Resolve the per-call abort signal from `config.timeout`. Returns undefined
    * when no timeout is configured. Throws on a non-positive or non-finite value
    * (e.g. an explicitly-set `0`) so a bad timeout fails loudly rather than being
-   * silently ignored by a truthiness check — mirroring the Claude Code sibling's
-   * timeout validation.
+   * silently ignored by a truthiness check — the same timeout validation the
+   * in-flight Claude Code adapter (PR #687) performs.
    */
   private timeoutSignal(): AbortSignal | undefined {
     const timeout = this.config.timeout;
@@ -214,6 +228,24 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
       );
     }
     return AbortSignal.timeout(timeout);
+  }
+
+  /**
+   * Evict a thread's stored session promise so the next turn rebuilds it.
+   *
+   * When `promise` is supplied, deletes ONLY if it is still the stored entry
+   * (identity guard) — so a newer create promise that replaced it is never
+   * clobbered. With no `promise`, deletes unconditionally (used when triaging a
+   * failed continuation prompt, where the stored entry is the one to drop).
+   */
+  private evictSession(threadId: string, promise?: Promise<string>): void {
+    if (promise === undefined) {
+      this.sessions.delete(threadId);
+      return;
+    }
+    if (this.sessions.get(threadId) === promise) {
+      this.sessions.delete(threadId);
+    }
   }
 
   /**
@@ -235,10 +267,11 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
       return { sessionId: await existing, isContinuation: true };
     }
 
+    const query = this.directoryQuery();
     const creating = (async () => {
       const created = await client.session.create({
         body: { title: `scenario:${threadId}` },
-        ...(this.directoryQuery() ? { query: this.directoryQuery() } : {}),
+        ...(query ? { query } : {}),
       });
       if (created.error || !created.data?.id) {
         throw new Error(
@@ -256,11 +289,9 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
       return { sessionId, isContinuation: false };
     } catch (err) {
       // Create failed — evict the rejected promise so a later turn retries
-      // instead of awaiting a permanently-rejected create. Guard on identity so
-      // a newer create promise (if any) is not clobbered.
-      if (this.sessions.get(threadId) === creating) {
-        this.sessions.delete(threadId);
-      }
+      // instead of awaiting a permanently-rejected create. Identity-guarded so a
+      // newer create promise (if any) is not clobbered.
+      this.evictSession(threadId, creating);
       throw err;
     }
   }
@@ -300,24 +331,45 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
       `OpenCode prompting session ${sessionId} (thread ${input.threadId})`,
     );
 
+    const query = this.directoryQuery();
     const result = await client.session.prompt({
       path: { id: sessionId },
       body: {
         model: this.config.model,
         parts: [{ type: "text", text: promptText }],
       },
-      ...(this.directoryQuery() ? { query: this.directoryQuery() } : {}),
+      ...(query ? { query } : {}),
       // Best-effort cancellation: AbortSignal.timeout is a valid prompt option
       // (it survives on RequestOptions). If the server ignores it, the call
       // still settles when the prompt resolves.
       ...(signal ? { signal } : {}),
     });
 
+    return this.interpretPromptResult(result, input.threadId, isContinuation);
+  }
+
+  /**
+   * Triage a resolved `session.prompt` result into assistant text (or a throw).
+   *
+   * Two error layers then the success path:
+   *  1. Transport (`result.error`) — on a continuation, evict the stale session
+   *     so the next turn recreates it, then throw the prompt-failed error.
+   *  2. Semantic (`result.data.info.error`) — HTTP 200 but a provider/runtime
+   *     error; throw it by name.
+   *  3. Success — return the concatenated text parts; if there are parts but no
+   *     visible text (e.g. a tool-only turn) return a non-empty readable
+   *     fallback (R3); only a parts-less completion is a genuine empty response.
+   */
+  private interpretPromptResult(
+    result: PromptResult,
+    threadId: string,
+    isContinuation: boolean,
+  ): string {
     // Layer 1 — transport error. Evict a stale continuation session so the next
     // turn recreates it, then surface a friendly error.
     if (result.error) {
       if (isContinuation) {
-        this.sessions.delete(input.threadId);
+        this.evictSession(threadId);
       }
       throw new Error(
         `OpenCode prompt failed: ${describeError(result.error)}`,
@@ -356,8 +408,12 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     if (!this.serverPromise) {
       return;
     }
-    const { server } = await this.serverPromise;
-    server.close();
+    try {
+      const { server } = await this.serverPromise;
+      server.close();
+    } catch {
+      // The server never started (spawn failed) — nothing to close.
+    }
   }
 }
 
@@ -383,48 +439,31 @@ export function extractNewUserText(newMessages: ModelMessage[]): string {
 }
 
 /**
- * Render a single message's content to a string.
+ * Render a USER message's content to text for the OpenCode prompt.
  *
- * A string is returned as-is; an array of content blocks is rendered block by
- * block ({@link renderContentBlock}) and joined. A message whose content is only
- * structured (e.g. tool) blocks therefore renders to those blocks — never an
- * empty string from a non-empty input.
+ * A string is returned as-is; an array of content blocks keeps only the text
+ * blocks (joined by newlines). Non-text blocks (image/file) are dropped — user
+ * turns are prose and only the text is forwarded to opencode. `extractNewUserText`
+ * only ever feeds USER-role content here, which never carries tool-call /
+ * tool-result / reasoning blocks, so those need no handling.
  */
 export function renderContent(content: ModelMessage["content"]): string {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
-  return content.map(renderContentBlock).filter(Boolean).join("\n");
-}
-
-/**
- * Render a single `ai`-SDK content block to a readable string. Structured blocks
- * are made readable rather than dropped, so a tool-call/tool-result is preserved
- * in the prompt instead of collapsing to a bare label. NOTE the `ai`-SDK block
- * discriminators are HYPHENATED (`tool-call`, `tool-result`).
- */
-function renderContentBlock(block: unknown): string {
-  if (typeof block === "string") return block;
-  if (!block || typeof block !== "object") return "";
-
-  const b = block as Record<string, unknown>;
-  switch (b["type"]) {
-    case "text":
-    case "reasoning":
-      return typeof b["text"] === "string" ? b["text"] : "";
-    case "tool-call":
-      return `[tool-call: ${String(b["toolName"] ?? "unknown")}(${safeStringify(
-        b["input"],
-      )})]`;
-    case "tool-result":
-      return `[tool-result: ${String(b["toolName"] ?? "unknown")} -> ${safeStringify(
-        b["output"] ?? b["result"],
-      )}]`;
-    case "file":
-      return `[file: ${String(b["mediaType"] ?? "application/octet-stream")}]`;
-    default:
-      // Unknown block: still surface it readably rather than dropping it.
-      return safeStringify(block);
-  }
+  return content
+    .map((block) => {
+      if (typeof block === "string") return block;
+      if (
+        block && typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        return (block as { text: string }).text;
+      }
+      return ""; // user turns are text; non-text blocks (image/file) are not forwarded to the prompt
+    })
+    .filter(Boolean)
+    .join("\n");
 }
 
 /**
@@ -433,20 +472,15 @@ function renderContentBlock(block: unknown): string {
  * Keeps ONLY `type === "text"` parts that are not `ignored`, joins their `.text`
  * with newlines, and SKIPS every other part type (tool, reasoning, step-start,
  * step-finish, file, …) WITHOUT throwing — a real reply interleaves those and
- * only the text parts are the visible assistant message. Defensive indexing (via
- * a `Record<string, unknown>` cast) avoids fighting the large `Part` union for
- * the three fields we read.
+ * only the text parts are the visible assistant message. Narrows on the `Part`
+ * union discriminant (`type === "text"`) rather than casting to
+ * `Record<string, unknown>`, restoring compile-time safety: if the SDK renames
+ * or adds a text variant, the build fails here instead of silently dropping text.
  */
 export function partsToText(parts: Part[] | undefined): string {
   return (parts ?? [])
-    .filter((part) => {
-      const p = part as unknown as Record<string, unknown>;
-      return p?.["type"] === "text" && p?.["ignored"] !== true;
-    })
-    .map((part) => {
-      const p = part as unknown as Record<string, unknown>;
-      return typeof p["text"] === "string" ? p["text"] : "";
-    })
+    .filter((p): p is Extract<Part, { type: "text" }> => p.type === "text" && p.ignored !== true)
+    .map((p) => p.text)
     .filter(Boolean)
     .join("\n");
 }
@@ -498,21 +532,18 @@ function describeError(error: unknown): string {
 }
 
 /**
- * Circular-safe `JSON.stringify`. A `WeakSet` seen-guard replaces any value
- * already on the current path with `"[Circular]"` so structured parts/blocks
- * never throw on a self-referential object. Non-serializable inputs fall back to
- * `String(value)`.
+ * Best-effort `JSON.stringify` for an unknown value. Mirrors the repo's
+ * `stringifyValue` helper in `agents/utils.ts`: strings pass through; a true
+ * circular reference makes `JSON.stringify` throw and we fall back to
+ * `String(value)`; an `undefined` result (e.g. a bare function/symbol) also
+ * falls back. No path-tracking — sibling references to the same object are
+ * serialized independently, not mislabelled `"[Circular]"`.
  */
 export function safeStringify(value: unknown): string {
-  const seen = new WeakSet<object>();
+  if (typeof value === "string") return value;
   try {
-    return JSON.stringify(value, (_key, val) => {
-      if (val && typeof val === "object") {
-        if (seen.has(val as object)) return "[Circular]";
-        seen.add(val as object);
-      }
-      return val as unknown;
-    });
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
   } catch {
     return String(value);
   }

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -59,6 +59,7 @@ import type { ModelMessage } from "ai";
 
 import { AgentAdapter, AgentRole } from "../../domain/agents";
 import type { AgentInput, AgentReturnTypes } from "../../domain/agents";
+import { stringifyValue } from "../utils";
 
 /**
  * Minimal structural logger the adapter routes ALL diagnostics through. Provide
@@ -213,21 +214,22 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
   }
 
   /**
-   * Resolve the per-call abort signal from `config.timeout`. Returns undefined
-   * when no timeout is configured. Throws on a non-positive or non-finite value
-   * (e.g. an explicitly-set `0`) so a bad timeout fails loudly rather than being
+   * Validate `config.timeout` eagerly, BEFORE any RPC. A null timeout is
+   * unbounded (no-op); a non-positive or non-finite value (e.g. an
+   * explicitly-set `0`) throws so a bad timeout fails loudly rather than being
    * silently ignored by a truthiness check — the same timeout validation the
-   * in-flight Claude Code adapter (PR #687) performs.
+   * in-flight Claude Code adapter (PR #687) performs. The abort signal itself is
+   * created separately, immediately before the prompt, so the spawn and
+   * `session.create` do not consume the timeout budget.
    */
-  private timeoutSignal(): AbortSignal | undefined {
+  private validateTimeout(): void {
     const timeout = this.config.timeout;
-    if (timeout == null) return undefined;
+    if (timeout == null) return;
     if (!Number.isFinite(timeout) || timeout <= 0) {
       throw new Error(
         `OpenCodeAgentAdapter timeout must be a positive, finite number of milliseconds; received ${timeout}`,
       );
     }
-    return AbortSignal.timeout(timeout);
   }
 
   /**
@@ -317,9 +319,11 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
       );
     }
 
-    // Resolve (and validate) the timeout signal before any RPC, so a bad
-    // `timeout` (e.g. 0) fails fast instead of after a session.create.
-    const signal = this.timeoutSignal();
+    // Validate the timeout eagerly, before any RPC, so a bad `timeout` (e.g. 0)
+    // fails fast instead of after a session.create. The abort budget itself is
+    // started later (just before the prompt) so it covers ONLY the prompt — the
+    // spawn and session.create must not consume it.
+    this.validateTimeout();
 
     const client = await this.ensureClient();
     const { sessionId, isContinuation } = await this.resolveSessionId(
@@ -332,6 +336,13 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     );
 
     const query = this.directoryQuery();
+    // Start the timeout budget HERE, immediately before the prompt, so the
+    // preceding spawn + session.create do not eat into it. Undefined when no
+    // timeout is configured (validateTimeout already rejected bad values).
+    const signal =
+      this.config.timeout != null
+        ? AbortSignal.timeout(this.config.timeout)
+        : undefined;
     const result = await client.session.prompt({
       path: { id: sessionId },
       body: {
@@ -491,7 +502,7 @@ export function partsToText(parts: Part[] | undefined): string {
  * and, when present, a name/tool/path hint — never returns "" for a real part.
  */
 export function renderNonTextPart(part: unknown): string {
-  if (!part || typeof part !== "object") return safeStringify(part);
+  if (!part || typeof part !== "object") return stringifyValue(part);
   const p = part as Record<string, unknown>;
   const type = typeof p["type"] === "string" ? (p["type"] as string) : "part";
   const hint = p["tool"] ?? p["name"] ?? p["path"] ?? p["filename"];
@@ -508,7 +519,7 @@ export function renderNonTextPart(part: unknown): string {
  * AND semantic `info.error` variants (`ProviderAuthError | UnknownError |
  * MessageOutputLengthError | MessageAbortedError | APIError`, each `{ name, data }`).
  * Reads `.name`, `.message`, `.data.message`, and a status/code defensively since
- * shapes vary across endpoints; falls back to `safeStringify`. The `error == null`
+ * shapes vary across endpoints; falls back to `stringifyValue`. The `error == null`
  * guard is reachable via the `session.create` call site (see {@link OpenCodeAgentAdapter}).
  */
 function describeError(error: unknown): string {
@@ -528,23 +539,5 @@ function describeError(error: unknown): string {
     if (base && status !== undefined) return `${base} (status ${String(status)})`;
     if (base) return base;
   }
-  return safeStringify(error);
-}
-
-/**
- * Best-effort `JSON.stringify` for an unknown value. Mirrors the repo's
- * `stringifyValue` helper in `agents/utils.ts`: strings pass through; a true
- * circular reference makes `JSON.stringify` throw and we fall back to
- * `String(value)`; an `undefined` result (e.g. a bare function/symbol) also
- * falls back. No path-tracking — sibling references to the same object are
- * serialized independently, not mislabelled `"[Circular]"`.
- */
-export function safeStringify(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    const serialized = JSON.stringify(value);
-    return serialized === undefined ? String(value) : serialized;
-  } catch {
-    return String(value);
-  }
+  return stringifyValue(error);
 }

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -218,7 +218,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     });
     if (created.error || !created.data?.id) {
       throw new Error(
-        `OpenCode session.create failed for thread "${threadId}": ${describeTransportError(
+        `OpenCode session.create failed for thread "${threadId}": ${describeError(
           created.error,
         )}`,
       );
@@ -282,7 +282,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
         this.sessions.delete(input.threadId);
       }
       throw new Error(
-        `OpenCode prompt failed: ${describeTransportError(result.error)}`,
+        `OpenCode prompt failed: ${describeError(result.error)}`,
       );
     }
 
@@ -290,7 +290,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     // provider/runtime error (and usually empty text). Name the variant.
     const infoError = result.data?.info?.error;
     if (infoError) {
-      throw new Error(`OpenCode returned an error: ${describeInfoError(infoError)}`);
+      throw new Error(`OpenCode returned an error: ${describeError(infoError)}`);
     }
 
     const parts = result.data?.parts;
@@ -428,42 +428,33 @@ export function renderNonTextPart(part: unknown): string {
     : `[${type}]`;
 }
 
-/** Describe a transport-layer error object defensively (shape varies across endpoints). */
-function describeTransportError(error: unknown): string {
-  if (error == null) return "unknown error";
-  if (typeof error === "string") return error;
-  if (typeof error === "object") {
-    const e = error as Record<string, unknown>;
-    const message =
-      typeof e["message"] === "string" ? (e["message"] as string) : undefined;
-    const status = e["status"] ?? e["statusCode"] ?? e["code"];
-    if (message && status !== undefined) return `${message} (status ${String(status)})`;
-    if (message) return message;
-  }
-  return safeStringify(error);
-}
-
 /**
- * Describe a semantic `info.error` variant by NAME. The union is
- * `ProviderAuthError | UnknownError | MessageOutputLengthError |
- * MessageAbortedError | APIError`, each `{ name, data }` — but we read `.name`,
- * `.message`, and `.data.message` defensively since shapes vary.
+ * Describe an error object of unknown/varying shape for a friendly message.
+ *
+ * Used for BOTH layers: transport errors (`result.error` — and `created.error`
+ * at the `session.create` site, which may be null when only `!data.id` tripped)
+ * AND semantic `info.error` variants (`ProviderAuthError | UnknownError |
+ * MessageOutputLengthError | MessageAbortedError | APIError`, each `{ name, data }`).
+ * Reads `.name`, `.message`, `.data.message`, and a status/code defensively since
+ * shapes vary across endpoints; falls back to `safeStringify`. The `error == null`
+ * guard is reachable via the `session.create` call site (see {@link OpenCodeAgentAdapter}).
  */
-function describeInfoError(error: unknown): string {
+function describeError(error: unknown): string {
   if (error == null) return "unknown error";
   if (typeof error === "string") return error;
   if (typeof error === "object") {
     const e = error as Record<string, unknown>;
     const name = typeof e["name"] === "string" ? (e["name"] as string) : undefined;
-    const data = (e["data"] as Record<string, unknown> | undefined) ?? undefined;
+    const data = e["data"] as Record<string, unknown> | undefined;
     const message =
       (typeof e["message"] === "string" ? (e["message"] as string) : undefined) ??
       (data && typeof data["message"] === "string"
         ? (data["message"] as string)
         : undefined);
-    if (name && message) return `${name}: ${message}`;
-    if (name) return name;
-    if (message) return message;
+    const status = e["status"] ?? e["statusCode"] ?? e["code"];
+    const base = name && message ? `${name}: ${message}` : (name ?? message);
+    if (base && status !== undefined) return `${base} (status ${String(status)})`;
+    if (base) return base;
   }
   return safeStringify(error);
 }

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -43,7 +43,8 @@
  * completion with NO parts at all is treated as a genuine empty response and
  * rejected.
  *
- * Hardening (the same defenses the in-flight Claude Code adapter (PR #687) adopts):
+ * Hardening (a–c mirror the in-flight Claude Code adapter, PR #687; d–e are
+ * specific to this adapter's SDK/server model):
  *  a. Structured non-text parts are rendered readably, never `[object Object]`.
  *  b. An optional `timeout` cancels the in-flight prompt via `AbortSignal`.
  *  c. All diagnostics route through an injectable {@link OpenCodeLogger}; absent
@@ -51,10 +52,9 @@
  *  d. The OpencodeClient is an injection seam (`config.client`): provide your own
  *     for tests (no real server, no spawn), or omit it to let the adapter lazily
  *     spawn and own an OpenCode server (closed by {@link OpenCodeAgentAdapter.close}).
- *  e. `close()` is terminal: a `call(...)` issued after `close()` rejects with a
- *     clear closed-adapter error instead of racing a torn-down server (with an
- *     owned server the memoized handle would otherwise surface as a confusing
- *     transport failure).
+ *  e. `close()` is terminal and idempotent: a `call(...)` issued after `close()`
+ *     rejects with a clear closed-adapter error — full contract on
+ *     {@link OpenCodeAgentAdapter.close}.
  */
 
 import { createOpencode } from "@opencode-ai/sdk";
@@ -190,10 +190,9 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
   private serverPromise: Promise<OwnedServer> | null = null;
 
   /**
-   * Set the moment {@link close} is invoked — `close()` is terminal. A closed
-   * adapter must reject further `call`s loudly: with an owned server the
-   * memoized `serverPromise` now points at a torn-down server, so a post-close
-   * call would otherwise fail as a confusing transport error (or hang).
+   * Set once {@link close} runs — the adapter is terminal after close(). The
+   * full close contract (why post-close calls reject on BOTH ownership paths)
+   * lives on {@link close}; other sites point there.
    */
   private closed = false;
 
@@ -326,13 +325,12 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
    * @returns The concatenated assistant-visible text as a string.
    */
   async call(input: AgentInput): Promise<AgentReturnTypes> {
-    // close() is terminal — reject immediately with the real cause rather than
-    // letting the call race a torn-down (or injector-owned but relinquished)
-    // server and surface as an opaque transport error.
+    // close() is terminal (full contract on close()) — reject post-close calls
+    // immediately with the real cause instead of an opaque downstream failure.
     if (this.closed) {
       throw new Error(
-        "OpenCodeAgentAdapter is closed — close() tears down the adapter (and " +
-          "any owned server). Create a new adapter instance for further calls.",
+        "OpenCodeAgentAdapter is closed — no calls are accepted after close(). " +
+          "Create a new adapter instance for further calls.",
       );
     }
 
@@ -441,19 +439,28 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
   }
 
   /**
-   * Tear down any server this adapter spawned. When a `client` was injected the
-   * adapter owns no server and nothing is shut down (the injector owns its
-   * server). Call this in a scenario's teardown (e.g. `afterAll`) to release
-   * the auto-spawned OpenCode server.
+   * Tear down any server this adapter spawned, and mark the adapter closed.
+   * Call it in a scenario's teardown (e.g. `afterAll`).
    *
-   * Terminal: the adapter is marked closed synchronously on entry, so any
-   * `call(...)` issued after `close()` starts rejects with a clear
-   * closed-adapter error. Calls already in flight when `close()` runs are the
-   * caller's teardown contract to sequence (await the scenario before closing —
-   * the same ownership stance ADR-005 §10 records); if one does overlap, it
-   * fails loudly at the transport layer rather than corrupting state.
+   * The full close contract — stated once, here; other sites point at this:
+   *  - Owned server (no `client` injected): awaits the memoized spawn and
+   *    closes the server. A post-close call would hit the torn-down server and
+   *    surface as an opaque transport error, so it rejects with a clear
+   *    closed-adapter error instead.
+   *  - Injected `client`: nothing is shut down (the injector owns its server),
+   *    but the adapter is still terminal — post-close calls reject by
+   *    contract, not because anything broke. Create a new adapter instance to
+   *    keep calling.
+   *  - Idempotent: repeat `close()` calls return immediately; the owned server
+   *    is closed at most once.
+   *  - In-flight calls are not cancelled: sequencing teardown (await the run,
+   *    then close) is the caller's contract — ADR-005 §10. An overlapping call
+   *    fails loudly at the transport layer rather than corrupting state.
    */
   async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
     this.closed = true;
     if (!this.serverPromise) {
       return;

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -106,7 +106,7 @@ export interface OpenCodeAgentAdapterConfig {
    * Provider/model the OpenCode agent runs. REQUIRED — this is a product choice
    * for reproducible evals (the SDK itself treats `model` as optional, but a
    * scenario should pin a deterministic model), e.g.
-   * `{ providerID: "openai", modelID: "gpt-4o-mini" }`.
+   * `{ providerID: "openai", modelID: "gpt-4.1-mini" }`.
    */
   model: { providerID: string; modelID: string };
 
@@ -146,7 +146,7 @@ export interface OpenCodeAgentAdapterConfig {
  * @example
  * ```typescript
  * const adapter = new OpenCodeAgentAdapter({
- *   model: { providerID: "openai", modelID: "gpt-4o-mini" },
+ *   model: { providerID: "openai", modelID: "gpt-4.1-mini" },
  *   workingDirectory: "/tmp/project",
  * });
  * await scenario.run({

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -7,9 +7,9 @@
  * thread, drives a single `session.prompt(...)` completion, and returns the
  * assistant-visible text as a `string`.
  *
- * Unlike a replay-style coding adapter — e.g. the in-flight Claude Code adapter
- * (PR #687), which spawns `claude -p` per turn and REPLAYS the conversation as a
- * flat prompt — OpenCode keeps the full transcript SERVER-SIDE keyed by a session
+ * Unlike a replay-style coding adapter — e.g. the sibling Claude Code adapter
+ * (`claude-code/`), which spawns `claude -p` per turn and REPLAYS the conversation
+ * as a flat prompt — OpenCode keeps the full transcript SERVER-SIDE keyed by a session
  * id. The SDK's `session.prompt(...)` resolves
  * only after the assistant finishes (a completion primitive; no SSE needed), and
  * the session already holds the prior turns. Therefore:
@@ -26,7 +26,7 @@
  *  - If a continuation `prompt(...)` fails at the transport layer, the stored id
  *    is EVICTED so the next turn for that thread recreates the session (the
  *    stored session may no longer resolve) — the same eviction-on-failure stance
- *    the in-flight Claude Code adapter (PR #687) takes for its `--resume` id.
+ *    the sibling Claude Code adapter (`claude-code/`) takes for its `--resume` id.
  *
  * Two-layer error handling (the SDK uses responseStyle "fields" with
  * `throwOnError` defaulting to `false`, so the calls resolve to `{ data, error }`
@@ -43,7 +43,7 @@
  * completion with NO parts at all is treated as a genuine empty response and
  * rejected.
  *
- * Hardening (a–c mirror the in-flight Claude Code adapter, PR #687; d–e are
+ * Hardening (a–c mirror the sibling Claude Code adapter (`claude-code/`); d–e are
  * specific to this adapter's SDK/server model):
  *  a. Structured non-text parts are rendered readably, never `[object Object]`.
  *  b. An optional `timeout` cancels the in-flight prompt via `AbortSignal`.
@@ -120,8 +120,16 @@ export interface OpenCodeAgentAdapterConfig {
    * both `session.create` and `session.prompt` (the SDK has no top-level `cwd`;
    * working directory is a per-request query parameter). Files the agent reads
    * or writes resolve relative to this.
+   *
+   * REQUIRED — mirrors the sibling Claude Code adapter's `workingDirectory`.
+   * OpenCode is tool-bearing (it reads/writes files and runs shell), so the
+   * caller MUST name the directory it operates in. Were this optional and left
+   * unset, no `query.directory` would be sent and the agent would fall back to
+   * the OpenCode server's inherited process cwd — whatever launched it — which
+   * may hold secrets (e.g. a gitignored `.env`). Point it at a scratch or
+   * project directory the agent is meant to touch, never one holding credentials.
    */
-  workingDirectory?: string;
+  workingDirectory: string;
 
   /**
    * Timeout in milliseconds for the `session.prompt` call. When set, the
@@ -222,11 +230,9 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     return client;
   }
 
-  /** `query.directory` payload when a working directory is configured, else nothing. */
-  private directoryQuery(): { directory: string } | undefined {
-    return this.config.workingDirectory
-      ? { directory: this.config.workingDirectory }
-      : undefined;
+  /** `query.directory` payload scoping the agent to the configured working directory (always set — the field is required). */
+  private directoryQuery(): { directory: string } {
+    return { directory: this.config.workingDirectory };
   }
 
   /**
@@ -234,7 +240,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
    * value. A null timeout is unbounded (returns undefined); a non-positive or
    * non-finite value (e.g. an explicitly-set `0`) throws so a bad timeout fails
    * loudly rather than being silently ignored by a truthiness check — the same
-   * timeout validation the in-flight Claude Code adapter (PR #687) performs.
+   * timeout validation the sibling Claude Code adapter (`claude-code/`) performs.
    *
    * Returning the value (rather than re-reading `config.timeout` at the signal
    * site) keeps "the value validated" and "the value used" the same number:
@@ -293,7 +299,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     const creating = (async () => {
       const created = await client.session.create({
         body: { title: `scenario:${threadId}` },
-        ...(query ? { query } : {}),
+        query,
       });
       if (created.error || !created.data?.id) {
         throw new Error(
@@ -377,7 +383,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
         model: this.config.model,
         parts: [{ type: "text", text: promptText }],
       },
-      ...(query ? { query } : {}),
+      query,
       // Best-effort cancellation: AbortSignal.timeout is a valid prompt option
       // (it survives on RequestOptions). If the server ignores it, the call
       // still settles when the prompt resolves.
@@ -487,7 +493,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
  * dropped and the rest joined by a blank line. Returns "" when there is no user
  * content (the agent-first / empty-delta case the caller guards on).
  */
-export function extractNewUserText(newMessages: ModelMessage[]): string {
+function extractNewUserText(newMessages: ModelMessage[]): string {
   return newMessages
     .filter((m) => m.role === "user")
     .map((m) => renderContent(m.content))
@@ -504,7 +510,7 @@ export function extractNewUserText(newMessages: ModelMessage[]): string {
  * only ever feeds USER-role content here, which never carries tool-call /
  * tool-result / reasoning blocks, so those need no handling.
  */
-export function renderContent(content: ModelMessage["content"]): string {
+function renderContent(content: ModelMessage["content"]): string {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
   return content
@@ -534,7 +540,7 @@ export function renderContent(content: ModelMessage["content"]): string {
  * `Record<string, unknown>`, restoring compile-time safety: if the SDK renames
  * or adds a text variant, the build fails here instead of silently dropping text.
  */
-export function partsToText(parts: Part[] | undefined): string {
+function partsToText(parts: Part[] | undefined): string {
   return (parts ?? [])
     .filter((p): p is Extract<Part, { type: "text" }> => p.type === "text" && p.ignored !== true)
     .map((p) => p.text)
@@ -547,7 +553,7 @@ export function partsToText(parts: Part[] | undefined): string {
  * fallback (a completion with parts but no visible text). Surfaces the part type
  * and, when present, a name/tool/path hint — never returns "" for a real part.
  */
-export function renderNonTextPart(part: unknown): string {
+function renderNonTextPart(part: unknown): string {
   if (!part || typeof part !== "object") return stringifyValue(part);
   const p = part as Record<string, unknown>;
   const type = typeof p["type"] === "string" ? (p["type"] as string) : "part";

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -120,10 +120,14 @@ export interface OpenCodeAgentAdapterConfig {
   workingDirectory?: string;
 
   /**
-   * Per-call timeout in milliseconds. When set, the in-flight `session.prompt`
-   * is cancelled via `AbortSignal.timeout(timeout)` and the call rejects.
-   * Best-effort: if the underlying server ignores the abort, the call still
-   * settles when the prompt resolves. Default: none (unbounded).
+   * Timeout in milliseconds for the `session.prompt` call. When set, the
+   * in-flight prompt is cancelled via `AbortSignal.timeout(timeout)` and the
+   * call rejects. Best-effort: if the underlying server ignores the abort, the
+   * call still settles when the prompt resolves. Default: none (unbounded).
+   *
+   * Bounds the **prompt only** — not the one-time server spawn or
+   * `session.create` that may precede it. Total `call()` wall-clock is
+   * therefore `spawn + create + timeout`, not `timeout`.
    */
   timeout?: number;
 
@@ -214,22 +218,26 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
   }
 
   /**
-   * Validate `config.timeout` eagerly, BEFORE any RPC. A null timeout is
-   * unbounded (no-op); a non-positive or non-finite value (e.g. an
-   * explicitly-set `0`) throws so a bad timeout fails loudly rather than being
-   * silently ignored by a truthiness check — the same timeout validation the
-   * in-flight Claude Code adapter (PR #687) performs. The abort signal itself is
-   * created separately, immediately before the prompt, so the spawn and
-   * `session.create` do not consume the timeout budget.
+   * Validate `config.timeout` eagerly, BEFORE any RPC, and return the validated
+   * value. A null timeout is unbounded (returns undefined); a non-positive or
+   * non-finite value (e.g. an explicitly-set `0`) throws so a bad timeout fails
+   * loudly rather than being silently ignored by a truthiness check — the same
+   * timeout validation the in-flight Claude Code adapter (PR #687) performs.
+   *
+   * Returning the value (rather than re-reading `config.timeout` at the signal
+   * site) keeps "the value validated" and "the value used" the same number:
+   * `config` is a caller-held mutable reference, and the two are now separated
+   * by the `ensureClient` / `resolveSessionId` awaits.
    */
-  private validateTimeout(): void {
+  private validateTimeout(): number | undefined {
     const timeout = this.config.timeout;
-    if (timeout == null) return;
+    if (timeout == null) return undefined;
     if (!Number.isFinite(timeout) || timeout <= 0) {
       throw new Error(
         `OpenCodeAgentAdapter timeout must be a positive, finite number of milliseconds; received ${timeout}`,
       );
     }
+    return timeout;
   }
 
   /**
@@ -323,7 +331,7 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     // fails fast instead of after a session.create. The abort budget itself is
     // started later (just before the prompt) so it covers ONLY the prompt — the
     // spawn and session.create must not consume it.
-    this.validateTimeout();
+    const timeoutMs = this.validateTimeout();
 
     const client = await this.ensureClient();
     const { sessionId, isContinuation } = await this.resolveSessionId(
@@ -337,12 +345,11 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
 
     const query = this.directoryQuery();
     // Start the timeout budget HERE, immediately before the prompt, so the
-    // preceding spawn + session.create do not eat into it. Undefined when no
-    // timeout is configured (validateTimeout already rejected bad values).
+    // preceding spawn + session.create do not eat into it. Built from the value
+    // `validateTimeout()` already checked, not a fresh read of the mutable
+    // `config`, so validated-value == used-value across the awaits above.
     const signal =
-      this.config.timeout != null
-        ? AbortSignal.timeout(this.config.timeout)
-        : undefined;
+      timeoutMs != null ? AbortSignal.timeout(timeoutMs) : undefined;
     const result = await client.session.prompt({
       path: { id: sessionId },
       body: {

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -106,7 +106,7 @@ export interface OpenCodeAgentAdapterConfig {
    * Provider/model the OpenCode agent runs. REQUIRED — this is a product choice
    * for reproducible evals (the SDK itself treats `model` as optional, but a
    * scenario should pin a deterministic model), e.g.
-   * `{ providerID: "openai", modelID: "gpt-4.1-mini" }`.
+   * `{ providerID: "openai", modelID: "gpt-5.4-mini" }`.
    */
   model: { providerID: string; modelID: string };
 
@@ -146,7 +146,7 @@ export interface OpenCodeAgentAdapterConfig {
  * @example
  * ```typescript
  * const adapter = new OpenCodeAgentAdapter({
- *   model: { providerID: "openai", modelID: "gpt-4.1-mini" },
+ *   model: { providerID: "openai", modelID: "gpt-5.4-mini" },
  *   workingDirectory: "/tmp/project",
  * });
  * await scenario.run({

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -1,0 +1,490 @@
+/**
+ * OpenCode Agent Adapter for Scenario Testing
+ *
+ * Adapts the OpenCode coding agent (via `@opencode-ai/sdk`) to the Scenario
+ * {@link AgentAdapter} interface. Each `call` extracts the new user turn,
+ * resolves (or reuses) a server-side OpenCode session for the conversation
+ * thread, drives a single `session.prompt(...)` completion, and returns the
+ * assistant-visible text as a `string`.
+ *
+ * Unlike the Claude Code sibling adapter — which spawns `claude -p` per turn and
+ * REPLAYS the conversation as a flat prompt — OpenCode keeps the full transcript
+ * SERVER-SIDE keyed by a session id. The SDK's `session.prompt(...)` resolves
+ * only after the assistant finishes (a completion primitive; no SSE needed), and
+ * the session already holds the prior turns. Therefore:
+ *  - We send ONLY the NEW user text ({@link extractNewUserText} over
+ *    `input.newMessages`), never a full-history flatten. Re-sending the whole
+ *    transcript every turn would duplicate context the server already has.
+ *  - We branch on session-exists ONLY to decide create-vs-reuse — NEVER to shape
+ *    the payload. The payload is always just the latest user delta.
+ *
+ * Session continuation (multiturn): the adapter instance is reused across a
+ * scenario's turns, so it keeps a per-thread map (`threadId` → `session.id`):
+ *  - First turn for a `threadId`: `session.create(...)`, store the returned id.
+ *  - Subsequent turns: reuse the stored id as `path.id` on `session.prompt(...)`.
+ *  - If a continuation `prompt(...)` fails at the transport layer, the stored id
+ *    is EVICTED so the next turn for that thread recreates the session (the
+ *    stored session may no longer resolve) — mirroring the Claude Code sibling's
+ *    `--resume` eviction.
+ *
+ * Two-layer error handling (the SDK uses responseStyle "fields" with
+ * `throwOnError` defaulting to `false`, so the calls resolve to `{ data, error }`
+ * and do NOT throw on HTTP errors):
+ *  1. Transport layer — `result.error` truthy ⇒ the request itself failed.
+ *  2. Semantic layer — `result.data.info.error` truthy ⇒ HTTP 200 but the
+ *     assistant message carries a provider/runtime error (and typically empty
+ *     text). We surface it by NAME (`ProviderAuthError | UnknownError |
+ *     MessageOutputLengthError | MessageAbortedError | APIError`).
+ *
+ * Empty-text fallback (R3): a successful completion with parts but no visible
+ * text (e.g. a tool-only turn) returns a NON-EMPTY readable fallback rather than
+ * "" — an empty string would silently look like a no-op assistant turn. Only a
+ * completion with NO parts at all is treated as a genuine empty response and
+ * rejected.
+ *
+ * Hardening (mirrors the Claude Code sibling):
+ *  a. Structured non-text parts are rendered readably, never `[object Object]`.
+ *  b. An optional `timeout` cancels the in-flight prompt via `AbortSignal`.
+ *  c. All diagnostics route through an injectable {@link Logger}; absent one, a
+ *     no-op logger is used. No `console.*` and no `chalk` anywhere.
+ *  d. The OpencodeClient is an injection seam (`config.client`): provide your own
+ *     for tests (no real server, no spawn), or omit it to let the adapter lazily
+ *     spawn and own an OpenCode server (closed by {@link OpenCodeAgentAdapter.close}).
+ */
+
+import { createOpencode } from "@opencode-ai/sdk";
+import type { OpencodeClient, Part } from "@opencode-ai/sdk";
+import type { ModelMessage } from "ai";
+
+import { AgentAdapter, AgentRole } from "../../domain/agents/index.js";
+import type { AgentInput, AgentReturnTypes } from "../../domain/agents/index.js";
+
+/**
+ * Minimal structural logger the adapter routes ALL diagnostics through. Provide
+ * your own (e.g. wrapping a real logger) or omit it for silent operation.
+ */
+export interface Logger {
+  log: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+}
+
+/** No-op logger used when none is injected — keeps the adapter silent and console-free. */
+const noopLogger: Logger = {
+  log: () => undefined,
+  warn: () => undefined,
+};
+
+/**
+ * The auto-spawned OpenCode server handle the adapter owns when no `client` is
+ * injected. We memoize the resolving PROMISE (not the resolved value) so two
+ * concurrent `call`s share a single server spawn instead of racing two.
+ */
+interface OwnedServer {
+  client: OpencodeClient;
+  server: { close(): void };
+}
+
+/**
+ * Configuration for {@link OpenCodeAgentAdapter}.
+ */
+export interface OpenCodeAgentAdapterConfig {
+  /**
+   * Provider/model the OpenCode agent runs. REQUIRED — this is a product choice
+   * for reproducible evals (the SDK itself treats `model` as optional, but a
+   * scenario should pin a deterministic model), e.g.
+   * `{ providerID: "openai", modelID: "gpt-4o-mini" }`.
+   */
+  model: { providerID: string; modelID: string };
+
+  /**
+   * Directory the OpenCode agent operates on. Forwarded as `query.directory` on
+   * both `session.create` and `session.prompt` (the SDK has no top-level `cwd`;
+   * working directory is a per-request query parameter). Files the agent reads
+   * or writes resolve relative to this.
+   */
+  workingDirectory?: string;
+
+  /**
+   * Per-call timeout in milliseconds. When set, the in-flight `session.prompt`
+   * is cancelled via `AbortSignal.timeout(timeout)` and the call rejects.
+   * Best-effort: if the underlying server ignores the abort, the call still
+   * settles when the prompt resolves. Default: none (unbounded).
+   */
+  timeout?: number;
+
+  /**
+   * Optional logger for all diagnostics. Defaults to a no-op logger (silent).
+   */
+  logger?: Logger;
+
+  /**
+   * Injection seam for the OpenCode SDK client. When provided, the adapter uses
+   * it directly and does NOT own/spawn a server ({@link OpenCodeAgentAdapter.close}
+   * is then a no-op). When omitted, the adapter lazily `createOpencode()`s a
+   * server on first use and owns its lifecycle.
+   */
+  client?: OpencodeClient;
+}
+
+/**
+ * Adapter that runs OpenCode as a Scenario agent.
+ *
+ * @example
+ * ```typescript
+ * const adapter = new OpenCodeAgentAdapter({
+ *   model: { providerID: "openai", modelID: "gpt-4o-mini" },
+ *   workingDirectory: "/tmp/project",
+ * });
+ * await scenario.run({
+ *   agents: [adapter, scenario.userSimulatorAgent(), scenario.judgeAgent({ criteria: [...] })],
+ *   script: [scenario.user("..."), scenario.agent(), scenario.judge()],
+ * });
+ * await adapter.close();
+ * ```
+ */
+export class OpenCodeAgentAdapter extends AgentAdapter {
+  role: AgentRole = AgentRole.AGENT;
+  name = "OpenCodeAgent";
+
+  /**
+   * Per-thread OpenCode session ids (`threadId` → `session.id`). Populated after
+   * a thread's first turn and consulted on every subsequent turn to reuse the
+   * server-side session. The adapter instance is reused across a scenario's
+   * turns, so this persists for the conversation's lifetime. Evicted on a
+   * continuation prompt failure so the next turn rebuilds the session.
+   */
+  private sessions = new Map<string, string>();
+
+  /**
+   * Memoized auto-spawned server promise — set only when no `client` is
+   * injected and the adapter spawns its own OpenCode server. Memoizing the
+   * PROMISE (not the resolved handle) makes concurrent first `call`s share one
+   * spawn instead of racing.
+   */
+  private serverPromise: Promise<OwnedServer> | null = null;
+
+  constructor(private config: OpenCodeAgentAdapterConfig) {
+    super();
+  }
+
+  /** The effective logger (injected or no-op). */
+  private get logger(): Logger {
+    return this.config.logger ?? noopLogger;
+  }
+
+  /**
+   * Resolve the OpencodeClient to drive. Returns the injected client if present;
+   * otherwise lazily spawns (and memoizes) an OpenCode server and returns its
+   * client. The server spawn shells out to the `opencode` binary, so live use
+   * (no injected client) requires `opencode` on PATH.
+   */
+  private async ensureClient(): Promise<OpencodeClient> {
+    if (this.config.client) {
+      return this.config.client;
+    }
+    // Memoize the PROMISE, not the resolved value: two concurrent calls must
+    // share one createOpencode() spawn rather than each spawning a server.
+    this.serverPromise ??= createOpencode();
+    const { client } = await this.serverPromise;
+    return client;
+  }
+
+  /** `query.directory` payload when a working directory is configured, else nothing. */
+  private directoryQuery(): { directory: string } | undefined {
+    return this.config.workingDirectory
+      ? { directory: this.config.workingDirectory }
+      : undefined;
+  }
+
+  /**
+   * Resolve (creating if needed) the server-side session id for a thread. The
+   * `create` happens AT MOST once per `threadId` (subsequent turns reuse the
+   * stored id), satisfying the one-session-per-thread contract.
+   *
+   * @returns the session id and whether it was reused (a continuation turn).
+   */
+  private async resolveSessionId(
+    threadId: string,
+    client: OpencodeClient,
+  ): Promise<{ sessionId: string; isContinuation: boolean }> {
+    const existing = this.sessions.get(threadId);
+    if (existing) {
+      return { sessionId: existing, isContinuation: true };
+    }
+
+    const created = await client.session.create({
+      body: { title: `scenario:${threadId}` },
+      ...(this.directoryQuery() ? { query: this.directoryQuery() } : {}),
+    });
+    if (created.error || !created.data?.id) {
+      throw new Error(
+        `OpenCode session.create failed for thread "${threadId}": ${describeTransportError(
+          created.error,
+        )}`,
+      );
+    }
+
+    const sessionId = created.data.id;
+    this.sessions.set(threadId, sessionId);
+    return { sessionId, isContinuation: false };
+  }
+
+  /**
+   * Process the conversation and return OpenCode's assistant text.
+   *
+   * @param input - Scenario agent input (conversation history etc.).
+   * @returns The concatenated assistant-visible text as a string.
+   */
+  async call(input: AgentInput): Promise<AgentReturnTypes> {
+    // OpenCode is prompt-driven and holds prior turns server-side, so we send
+    // ONLY the new user delta — never a full-history flatten. Compute it FIRST
+    // so the empty-input guard rejects before any RPC (no wasted session
+    // create/prompt for an agent-first wiring bug).
+    const promptText = extractNewUserText(input.newMessages);
+    if (!promptText) {
+      throw new Error(
+        "OpenCodeAgentAdapter received no user message to send. OpenCode is " +
+          "prompt-driven and cannot open a conversation on its own; ensure a " +
+          "user turn precedes the agent (e.g. a scenario.user(...) step before " +
+          "scenario.agent()).",
+      );
+    }
+
+    const client = await this.ensureClient();
+    const { sessionId, isContinuation } = await this.resolveSessionId(
+      input.threadId,
+      client,
+    );
+
+    this.logger.log(
+      `OpenCode prompting session ${sessionId} (thread ${input.threadId})`,
+    );
+
+    const result = await client.session.prompt({
+      path: { id: sessionId },
+      body: {
+        model: this.config.model,
+        parts: [{ type: "text", text: promptText }],
+      },
+      ...(this.directoryQuery() ? { query: this.directoryQuery() } : {}),
+      // Best-effort cancellation: AbortSignal.timeout is a valid prompt option
+      // (it survives on RequestOptions). If the server ignores it, the call
+      // still settles when the prompt resolves.
+      ...(this.config.timeout
+        ? { signal: AbortSignal.timeout(this.config.timeout) }
+        : {}),
+    });
+
+    // Layer 1 — transport error. Evict a stale continuation session so the next
+    // turn recreates it, then surface a friendly error.
+    if (result.error) {
+      if (isContinuation) {
+        this.sessions.delete(input.threadId);
+      }
+      throw new Error(
+        `OpenCode prompt failed: ${describeTransportError(result.error)}`,
+      );
+    }
+
+    // Layer 2 — semantic error: HTTP 200 but the assistant message carries a
+    // provider/runtime error (and usually empty text). Name the variant.
+    const infoError = result.data?.info?.error;
+    if (infoError) {
+      throw new Error(`OpenCode returned an error: ${describeInfoError(infoError)}`);
+    }
+
+    const parts = result.data?.parts;
+    const text = partsToText(parts);
+    if (text) {
+      return text;
+    }
+
+    // R3 — a completion with parts but no visible text (e.g. a tool-only turn):
+    // return a non-empty readable fallback rather than a silent "".
+    if (parts && parts.length > 0) {
+      return parts.map(renderNonTextPart).filter(Boolean).join("\n");
+    }
+
+    // No parts at all — a genuinely empty response.
+    throw new Error("OpenCode returned an empty response (no parts).");
+  }
+
+  /**
+   * Tear down any server this adapter spawned. When a `client` was injected the
+   * adapter owns no server and this is a no-op. Call this in a scenario's
+   * teardown (e.g. `afterAll`) to release the auto-spawned OpenCode server.
+   */
+  async close(): Promise<void> {
+    if (!this.serverPromise) {
+      return;
+    }
+    const { server } = await this.serverPromise;
+    server.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-scope helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the text of the NEW user turn(s) to send to OpenCode.
+ *
+ * Renders USER-role messages ONLY (via {@link renderContent}) — assistant and
+ * tool turns are deliberately NOT flattened, because OpenCode already holds them
+ * server-side; re-sending them would duplicate context. Empty renders are
+ * dropped and the rest joined by a blank line. Returns "" when there is no user
+ * content (the agent-first / empty-delta case the caller guards on).
+ */
+export function extractNewUserText(newMessages: ModelMessage[]): string {
+  return newMessages
+    .filter((m) => m.role === "user")
+    .map((m) => renderContent(m.content))
+    .filter((text) => text.trim().length > 0)
+    .join("\n\n");
+}
+
+/**
+ * Render a single message's content to a string.
+ *
+ * A string is returned as-is; an array of content blocks is rendered block by
+ * block ({@link renderContentBlock}) and joined. A message whose content is only
+ * structured (e.g. tool) blocks therefore renders to those blocks — never an
+ * empty string from a non-empty input.
+ */
+export function renderContent(content: ModelMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.map(renderContentBlock).filter(Boolean).join("\n");
+}
+
+/**
+ * Render a single `ai`-SDK content block to a readable string. Structured blocks
+ * are made readable rather than dropped, so a tool-call/tool-result is preserved
+ * in the prompt instead of collapsing to a bare label. NOTE the `ai`-SDK block
+ * discriminators are HYPHENATED (`tool-call`, `tool-result`).
+ */
+function renderContentBlock(block: unknown): string {
+  if (typeof block === "string") return block;
+  if (!block || typeof block !== "object") return "";
+
+  const b = block as Record<string, unknown>;
+  switch (b["type"]) {
+    case "text":
+    case "reasoning":
+      return typeof b["text"] === "string" ? b["text"] : "";
+    case "tool-call":
+      return `[tool-call: ${String(b["toolName"] ?? "unknown")}(${safeStringify(
+        b["input"],
+      )})]`;
+    case "tool-result":
+      return `[tool-result: ${String(b["toolName"] ?? "unknown")} -> ${safeStringify(
+        b["output"] ?? b["result"],
+      )}]`;
+    case "file":
+      return `[file: ${String(b["mediaType"] ?? "application/octet-stream")}]`;
+    default:
+      // Unknown block: still surface it readably rather than dropping it.
+      return safeStringify(block);
+  }
+}
+
+/**
+ * Concatenate the visible assistant text from an OpenCode response's parts.
+ *
+ * Keeps ONLY `type === "text"` parts that are not `ignored`, joins their `.text`
+ * with newlines, and SKIPS every other part type (tool, reasoning, step-start,
+ * step-finish, file, …) WITHOUT throwing — a real reply interleaves those and
+ * only the text parts are the visible assistant message. Defensive indexing (via
+ * a `Record<string, unknown>` cast) avoids fighting the large `Part` union for
+ * the three fields we read.
+ */
+export function partsToText(parts: Part[] | undefined): string {
+  return (parts ?? [])
+    .filter((part) => {
+      const p = part as unknown as Record<string, unknown>;
+      return p?.["type"] === "text" && p?.["ignored"] !== true;
+    })
+    .map((part) => {
+      const p = part as unknown as Record<string, unknown>;
+      return typeof p["text"] === "string" ? p["text"] : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Readable label for a non-text OpenCode part, used ONLY for the R3 empty-text
+ * fallback (a completion with parts but no visible text). Surfaces the part type
+ * and, when present, a name/tool/path hint — never returns "" for a real part.
+ */
+export function renderNonTextPart(part: unknown): string {
+  if (!part || typeof part !== "object") return safeStringify(part);
+  const p = part as Record<string, unknown>;
+  const type = typeof p["type"] === "string" ? (p["type"] as string) : "part";
+  const hint = p["tool"] ?? p["name"] ?? p["path"] ?? p["filename"];
+  return typeof hint === "string" && hint.length > 0
+    ? `[${type}: ${hint}]`
+    : `[${type}]`;
+}
+
+/** Describe a transport-layer error object defensively (shape varies across endpoints). */
+function describeTransportError(error: unknown): string {
+  if (error == null) return "unknown error";
+  if (typeof error === "string") return error;
+  if (typeof error === "object") {
+    const e = error as Record<string, unknown>;
+    const message =
+      typeof e["message"] === "string" ? (e["message"] as string) : undefined;
+    const status = e["status"] ?? e["statusCode"] ?? e["code"];
+    if (message && status !== undefined) return `${message} (status ${String(status)})`;
+    if (message) return message;
+  }
+  return safeStringify(error);
+}
+
+/**
+ * Describe a semantic `info.error` variant by NAME. The union is
+ * `ProviderAuthError | UnknownError | MessageOutputLengthError |
+ * MessageAbortedError | APIError`, each `{ name, data }` — but we read `.name`,
+ * `.message`, and `.data.message` defensively since shapes vary.
+ */
+function describeInfoError(error: unknown): string {
+  if (error == null) return "unknown error";
+  if (typeof error === "string") return error;
+  if (typeof error === "object") {
+    const e = error as Record<string, unknown>;
+    const name = typeof e["name"] === "string" ? (e["name"] as string) : undefined;
+    const data = (e["data"] as Record<string, unknown> | undefined) ?? undefined;
+    const message =
+      (typeof e["message"] === "string" ? (e["message"] as string) : undefined) ??
+      (data && typeof data["message"] === "string"
+        ? (data["message"] as string)
+        : undefined);
+    if (name && message) return `${name}: ${message}`;
+    if (name) return name;
+    if (message) return message;
+  }
+  return safeStringify(error);
+}
+
+/**
+ * Circular-safe `JSON.stringify`. A `WeakSet` seen-guard replaces any value
+ * already on the current path with `"[Circular]"` so structured parts/blocks
+ * never throw on a self-referential object. Non-serializable inputs fall back to
+ * `String(value)`.
+ */
+export function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(value, (_key, val) => {
+      if (val && typeof val === "object") {
+        if (seen.has(val as object)) return "[Circular]";
+        seen.add(val as object);
+      }
+      return val as unknown;
+    });
+  } catch {
+    return String(value);
+  }
+}

--- a/javascript/src/agents/opencode/opencode-agent.adapter.ts
+++ b/javascript/src/agents/opencode/opencode-agent.adapter.ts
@@ -57,7 +57,10 @@
  *     {@link OpenCodeAgentAdapter.close}.
  */
 
-import { createOpencode } from "@opencode-ai/sdk";
+// `@opencode-ai/sdk` is ESM-only (its `exports` map has no `require` condition), so a
+// static value import here would break the CJS build's `require('./dist/index.js')`
+// smoke test (smoke:dist). `createOpencode` is loaded lazily via dynamic `import()`
+// in `ensureClient()` instead; type-only imports are erased and stay static.
 import type { OpencodeClient, Part } from "@opencode-ai/sdk";
 import type { ModelMessage } from "ai";
 
@@ -225,7 +228,9 @@ export class OpenCodeAgentAdapter extends AgentAdapter {
     }
     // Memoize the PROMISE, not the resolved value: two concurrent calls must
     // share one createOpencode() spawn rather than each spawning a server.
-    this.serverPromise ??= createOpencode();
+    this.serverPromise ??= import("@opencode-ai/sdk").then(({ createOpencode }) =>
+      createOpencode(),
+    );
     const { client } = await this.serverPromise;
     return client;
   }

--- a/javascript/src/agents/utils.ts
+++ b/javascript/src/agents/utils.ts
@@ -29,7 +29,7 @@ const hasToolContent = (message: ModelMessage): boolean => {
   });
 };
 
-const stringifyValue = (value: unknown): string => {
+export const stringifyValue = (value: unknown): string => {
   if (typeof value === "string") return value;
   if (value === undefined) return "undefined";
   try {


### PR DESCRIPTION
- **Scariest thing** — `workingDirectory` is handed to a **tool-bearing** agent (shell + file read/write) that is not constrained to the prompts it's given. Point it at a directory holding credentials and a self-directed read — or a prompt injection from repo content — surfaces them as assistant text, straight into the judge prompt and CI logs. This PR's own e2e made exactly that mistake (`process.cwd()`, which holds a gitignored `.env`); it now runs in an `fs.mkdtemp` dir. Secondary risk: OpenCode keeps the transcript **server-side**, so if the `threadId → sessionId` map ever leaks across threads, turns land on the wrong conversation and the eval scores a context the test never set up — a **silently green** wrong answer, not a crash.
- **Start here** — `javascript/src/agents/opencode/opencode-agent.adapter.ts:280` (the promise-memoized create-vs-reuse that closes the check-then-create race) and `:407` (stale-session eviction after a prompt error).

## Summary

Adds an **`OpenCodeAgentAdapter`** (TypeScript) so `scenario` can simulate and evaluate the **OpenCode** coding agent ([sst/opencode](https://github.com/sst/opencode)) via the official [`@opencode-ai/sdk`](https://www.npmjs.com/package/@opencode-ai/sdk). This brings scenario's evaluation loop to the coding-agent use case for the first time.

Modeled on the in-house Claude Code adapter (a `class extends AgentAdapter` + a lowercase `openCodeAgent(config)` factory) and the realtime adapter's dependency-injection idiom. The genuinely new bit is **stateful session-per-thread**: OpenCode keeps the transcript server-side, so the adapter creates one session per `threadId` and sends only the new user turn each call — no full-history replay.

> **Relocation note:** this supersedes langwatch/langwatch#5004, where the adapter was built in the wrong repo. Per langwatch/langwatch#5001 it belongs in `langwatch/scenario` (next to the other adapters). langwatch/langwatch#5004 should close in favor of this PR.

## What changed

| File | What |
|---|---|
| `javascript/src/agents/opencode/opencode-agent.adapter.ts` | `OpenCodeAgentAdapter` class + helpers (`extractNewUserText`, `partsToText`, `renderContent`, …) |
| `javascript/src/agents/opencode/index.ts` | barrel + `openCodeAgent(config)` factory |
| `javascript/src/agents/index.ts` | `export * from "./opencode"` (re-exported through `@langwatch/scenario`) |
| `javascript/src/agents/utils.ts` | `export` the existing `stringifyValue` so the adapter reuses it instead of copying it |
| `javascript/src/agents/__tests__/opencode-adapter.test.ts` | 33 unit tests (injected fake client) + 1 env-gated live e2e |
| `javascript/package.json` | pin `@opencode-ai/sdk@1.17.9` |
| `docs/docs/pages/agent-integration/opencode.mdx` + `docs/vocs.config.tsx` | docs page + sidebar (AC-5) |
| `docs/adr/005-opencode-agent-adapter.md` | architecture decision record + trust-model tensions |

Key design calls (full rationale in the ADR):

- **Dependency-injected `OpencodeClient`** → alternative was `vi.mock` of the SDK → tests run against the *real* `OpencodeClient` interface, so an SDK envelope change fails the fake's compile instead of passing a mock that drifted.
- **New-user-delta payload** → alternative was full-history replay → OpenCode holds state server-side; re-feeding the agent's own prior replies as user text would double-seed context. Cost if wrong: the adapter is coupled to OpenCode's server-side statefulness and cannot be pointed at a stateless backend without a replay path.
- **Two-layer error handling** → alternative was trusting HTTP status → an HTTP-200 reply can still carry `ProviderAuthError | MessageOutputLengthError | …` in `result.data.info.error` with empty text. Continuation failures evict the stale session id rather than reusing a poisoned one.
- **`model` is required** → alternative was the SDK's optional `model` + server default → a floating server default makes evals irreproducible; the cost is one extra required field for every caller.

## Model: `gpt-5.4-mini`

Addressing @rogeriochaves' review (*"such an old model, we really should write docs with only the latest models always"*). Every opencode model reference — docs, ADR, adapter JSDoc, and the e2e default — is now `gpt-5.4-mini`, verified rather than assumed:

| Check | Result |
|---|---|
| OpenAI `GET /v1/models` | `gpt-5.4-mini` present; **no `gpt-5.5-mini` exists** → this is the newest *mini* tier |
| `opencode models` (its own catalog) | `openai/gpt-5.4-mini` present — an OpenAI-side model opencode doesn't know would still fail at runtime |
| Live AC-4 e2e on the new model | passes (below) |
| `grep` over every file this PR touches | zero `gpt-4o*` / `gpt-4.1*` hits |

## How it works

```
javascript/src/agents/opencode/
├── opencode-agent.adapter.ts   # OpenCodeAgentAdapter: threadId→sessionId map, delta payload,
│                               #   two-layer error handling, never-empty-turn fallback, close()
└── index.ts                    # barrel + openCodeAgent(config) factory
        ↓ re-exported through
javascript/src/agents/index.ts  → `import { openCodeAgent } from "@langwatch/scenario"`
```

`scenario.run()` calls `adapter.call(input)` per turn. The adapter resolves `input.threadId` to a server-side session (creating it once, memoized on the in-flight promise so concurrent first-turns can't double-create), sends **only the newest user message**, then flattens `result.data.parts` to text — keeping `type === "text"` parts and dropping tool/step/reasoning parts.

## Acceptance criteria

| # | AC | Status | Evidence |
|---|---|---|---|
| **AC-1** | Implements the scenario `AgentAdapter` interface | **proven** | `instanceof AgentAdapter`, `role === AGENT` unit tests; CI `Type check` green |
| **AC-2** | New session on first `call()` per `threadId`; reuse after | **proven** | unit tests assert one `session.create` per thread across N calls; same `path.id` reused |
| **AC-3** | Sends latest user msg, returns scenario-compatible reply | **proven** | unit tests assert the prompt body carries the user text — and that assistant-role turns are excluded |
| **AC-4** | Awaits **true completion** — real multi-turn coding task, coherent reply | **proven, flaky harness** | 13 of 17 live runs on `gpt-5.4-mini` pass; 4 stall in opencode's `session.prompt` (below) |
| **AC-5** | Docs: auto-start via `createOpencode()` + provider key env vars | **proven** | `agent-integration/opencode.mdx`; `docs-ci` green |
| **AC-6** | `Part[]`→message handles text + skips unknown parts gracefully | **proven** | unit test over `[text, tool, step-start, reasoning, unknown, text]` → only text, no throw |

## Human verification

A skeptical reviewer can re-derive every claim above:

1. **Unit tests, no creds needed:**
   `cd javascript && npx vitest run src/agents/__tests__/opencode-adapter.test.ts`
   → expect `33 passed | 1 skipped` (the skip is the env-gated AC-4 e2e).
2. **Confirm the model is really the latest mini:**
   `curl -s https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY" | jq -r '.data[].id' | grep '^gpt-5'`
   → `gpt-5.4-mini` present, no `gpt-5.5-mini`.
3. **Confirm opencode itself accepts it:**
   `OPENAI_API_KEY=sk-... opencode models | grep openai/gpt-5.4-mini`
4. **Live AC-4 run:**
   ```bash
   npm i -g opencode-ai@1.17.9     # the adapter shells out to the `opencode` binary
   export OPENAI_API_KEY=sk-...    # OpenCode's provider key + scenario's judge/user-sim key
   cd javascript
   RUN_OPENCODE_E2E=1 npx vitest run src/agents/__tests__/opencode-adapter.test.ts -t "multi-turn coding scenario"
   ```
   → `1 passed`. (If a prior run died hard, `pkill -f '[o]pencode serve'` first — `createOpencode()` binds port 4096.)
5. **Confirm the tests actually discriminate** — break a guard and watch the matching test fail, e.g. change `partsToText`'s `p.type === "text"` to `typeof p.text === "string"` and re-run: the "concatenates only text parts" test must go red.

## How I can prove I was successful

> **Update — `e1057ae` (2026-07-13): security fix + fresh multi-lens re-review.** A genuine re-review round (principles / hygiene / security / test / proof reviewers + uncle-bob / metz-beck / fowler / design-soundness personas + drift) found **two real issues the prior rounds missed**, both now fixed in `e1057ae`:
> - **[security] `workingDirectory` is now REQUIRED.** It was optional; omitting it sent no `query.directory`, so the tool-bearing OpenCode agent fell back to the server's inherited process cwd — in a test run, the directory holding a real `.env`. The sibling Claude Code adapter makes the field required for exactly this reason. Now required; `directoryQuery()` always scopes the agent; the hazard is documented in the adapter JSDoc and the docs Caveats.
> - **[proof] AC-4 re-proved with a HEAD-stamped capture.** The prior "2/2 clean" was an un-re-verified self-report backed by a stale, SHA-less terminal block. Freshly run at `e1057ae` below.
>
> Also applied from the same round: reworded stale "in-flight (PR #687)" comments (that adapter is merged — it is this branch's parent commit); made four module-private helpers non-`export`; strengthened the transport-error and create-failure tests to pin `describeError`'s interpolated output (a gutted `describeError` now fails them); replaced a deprecated deferred-`rejects` test pattern with `Promise.allSettled`. Non-blocking follow-ups filed: #793 (redact subprocess output on spawn-failure), #794 (extract shared adapter utils), #795 (`session.prompt` stall). Re-proved at `e1057ae`: `tsc --noEmit` 0 · `eslint` (touched files) 0 · `tsup` build success · unit **37 passed \| 1 skipped**. Design-soundness verified the adapter reads the real SDK contracts (error variants, `TextPart` discriminant, session shape) and does not reinvent an SDK built-in.

**AC-4 — live multi-turn scenario on `gpt-5.4-mini`.** `proven, with a flaky harness — read this before trusting a single run.` A real `scenario.run(...)` drives `openCodeAgent` (auto-spawned `opencode serve`) through a two-turn coding task with a real user-simulator and a real LLM judge. The test asserts `result.success === true` **and** `assistantTurns.length >= 2`, so a degenerate single-turn reply fails it.

I ran it **17 times** on the isolated-temp-dir configuration. **13 passed** (11–33s each). **4 stalled**: no progress, ended only by a timeout, with the request sitting inside opencode's `session.prompt`.

I could not pin the stall on this adapter, and I checked rather than assumed. At the time of a stall cluster: a direct `gpt-5.4-mini` completion returned **HTTP 200 in 0.6s** on a full quota (not rate limiting); a bare `opencode run -m openai/gpt-5.4-mini` answered in **4–6s**, three times (not a slow provider); **no** zombie `opencode serve` process existed and port 4096 was free; local session state was empty. The first stall also happened **before** any timeout was configured, so the timeout did not cause it. It refused to reproduce under instrumentation (5/5 green), so I cannot name the stalling turn — and I am not going to guess.

A clean run, the shipped configuration:

```
=== AC-4 e2e @ e1057ae ===
 Test Files  1 passed (1)
      Tests  1 passed | 37 skipped (38)
   Duration  18.61s (tests 18.23s)
=== VITEST_EXIT=0 (HEAD=e1057ae) ===
```
The seconds of test time are a real LLM round-trip, not a skip — the 37 "skipped" are the unit tests deselected by the `-t` name filter. Afterwards: **0** leftover temp dirs and **0** leaked `opencode serve` processes, which also demonstrates `close()` teardown.

A stalled run, after the fix (this is what a reviewer should expect to see roughly 1 run in 4):

```
Error: [OpenCodeAgent] TimeoutError: The operation was aborted due to timeout
  ❯ OpenCodeAgentAdapter.call src/agents/opencode/opencode-agent.adapter.ts:353
```
It fails *legibly*, and teardown still runs. That is not free: the e2e now sets `timeout: 120_000`, **below** vitest's 180s. Unbounded, vitest kills the test body, the `finally` never executes, and the temp dir **and** the spawned server both leak — the leaked server then holds port 4096 and fails the next run fast. I watched exactly that happen before fixing it. The tension is written into ADR-005.

**Bottom line for a reviewer:** the adapter awaits true completion and returns coherent multi-turn replies — that is well-evidenced. The *harness* is flaky because the external binary intermittently stalls. Do not read one red e2e as a regression in this adapter; re-run it.

**The tests discriminate — verified by mutation, not by passing.** A green test proves nothing until it can fail. Each guard was broken in turn and the matching test confirmed red, then restored:

| Guard broken | Test that caught it |
|---|---|
| `extractNewUserText`'s `role === "user"` filter | assistant-role messages are excluded ✅ red |
| `partsToText`'s `p.type === "text"` → `typeof p.text === "string"` | reasoning-part *text* must not leak ✅ red |
| `renderNonTextPart` → `String(part)` (`[object Object]`) | tool-only fallback renders readably ✅ red |
| drop `...(signal ? { signal } : {})` | positive timeout forwards an AbortSignal ✅ red |
| drop `model: this.config.model` | model reaches `body.model` ✅ red |
| drop `query` spread on `session.prompt` | `workingDirectory` reaches `query.directory` ✅ red |
| drop `Number.isFinite` from `validateTimeout` | non-finite timeout (NaN, Infinity) rejected ✅ red |

Five of those seven tests did not exist before this review round — the behavior they name could have regressed silently.

**Unit suite + gates at `e1057ae`.** `proven`:

```
 Test Files  1 passed (1)
      Tests  37 passed | 1 skipped (38)
```

CI green: `javascript-ci → ci-checks (24.x)` ran and passed every step — `Build`, `Lint`, `Lint (library)`, `Type check`, `Tests`, `Test (Examples)` — feeding the required `javascript-complete`; `docs-ci`, `python-ci`, and `Conventional Commits` also green. 15 checks pass, 0 fail. The 3 `skipped` checks are non-gating for this PR: `test` is **python-ci's** job, gated on `changes.outputs.relevant == 'true'` and this PR touches **0 `.py` files**; `firefighting` / `dismiss-firefighting-approval` are conditional.

**Review round at `318e4a2` + `47de1fa` — Aryan's await-question answered in code; the close()/call() race closed; ten-lens re-review findings applied.** `proven`:

- **The "Missing await" bot thread is a false positive on the dedup mechanism itself** — `sessions` is typed `Map<string, Promise<string>>`; `resolveSessionId` stores the create **promise** un-awaited *by design* (awaiting before storing would reopen the exact check-then-create race the memoization closes). Every read path awaits it: concurrent callers at `opencode-agent.adapter.ts:289`, the creator at `:310`, identity-guarded eviction on rejection at `:316` (anchors at `47de1fa`). The rejection half of that contract is now pinned by a new test — `propagates ONE rejecting session.create to ALL concurrent first-calls, then retries cleanly` — proving both concurrent callers reject with the create error (no unhandled rejection, no hang), the rejected promise is evicted, and the next turn retries fresh. The success half was already pinned (`dedupes concurrent first-calls on the same threadId to ONE session.create`).
- **`close()` is now terminal** — a `closed` flag is set synchronously on `close()` entry; a post-close `call()` rejects with a clear closed-adapter error instead of racing the torn-down server into an opaque transport failure. New test: `rejects call() after close() with a clear closed-adapter error (no RPC attempted)`. ADR-005 §10 records the contract (in-flight calls remain the caller's teardown contract to sequence).
- **`47de1fa` — ten-lens scoped re-review, every Fix applied**: close() made **idempotent** (double-close no longer re-drives `server.close()`; test), the close contract consolidated to ONE canonical home (the `close()` JSDoc — retires the "(or hang)" hedge and an error message that overclaimed teardown on the injected path), per-path rationale recorded in ADR-005 §10, an in-flight-close test (entry-only guard pinned: mid-flight call completes, next call rejects), and the concurrent-rejection test decoupled from await topology (`vi.waitFor` macrotask sync). Sibling gap + lifecycle-home decision → #763.

```
 Test Files  1 passed (1)
      Tests  37 passed | 1 skipped (38)
```

`tsc --noEmit` clean; `tsup` build clean; `eslint` on both touched `.ts` files: **0 problems** (repo-wide lint baseline untouched). Counts at `47de1fa`.

**SDK envelope confirmed live** (isolates the binary/key/envelope from the framework; model-independent):

```
[smoke] server up at http://127.0.0.1:4096 (1167ms)
[smoke] session.create -> id: ses_10a5cad42ffe195IuYMTWW8ika | error: undefined
[smoke] prompt resolved (5487ms)  | result.error: undefined  | info.error: undefined
[smoke] part types: ["step-start","text","step-finish"]   ← partsToText extracts only "text"
[smoke] ASSISTANT TEXT: "SMOKE_OK"
```

> **Scope note on AC-4's e2e:** it is **env-gated** (`RUN_OPENCODE_E2E=1`) and **skips in CI** — `createOpencode` spawns the real `opencode` binary, which CI does not have. AC-4's proof is therefore the captured local runs above, not a CI artifact — the same env-gated pattern the Claude Code adapter uses. AC-1/2/3/6 are fully covered by the 33 unit tests that *do* run in CI.

Closes langwatch/langwatch#5001

## Anything surprising?

**A credential-exposure bug in this PR's own test, found during review.** The live e2e passed `workingDirectory: process.cwd()` — i.e. `javascript/`, which holds a gitignored `.env` with a real `OPENAI_API_KEY` — to an agent that can run shell commands and read files, with nothing constraining it to the two scripted prompts. Fixed: it now runs in an `fs.mkdtempSync` temp dir, removed in the same `finally` as `close()`. The docs page had it right all along; the test didn't follow its own doc.

Separately, running the e2e 17 times (rather than the 3 the ADR asks for) exposed that **opencode's `session.prompt` intermittently stalls** — 4 of 17 runs. Worth knowing before anyone wires this into a gating job. Ruled out rate limiting, a slow provider, a zombie server, and local state; it predates the timeout and would not reproduce under instrumentation.

Review also surfaced three previously-unstated tensions, now written into ADR-005 → *Consequences / open tensions* rather than left in a comment thread: the owned server binds an **unauthenticated fixed loopback port** (so on a shared host any co-tenant process can drive the same agent against `workingDirectory`); a **rejected spawn is memoized forever**, asymmetric with session eviction, and the child's raw crash output is forwarded verbatim past `describeError`'s field-scoping; and a **server restart mid-run** silently invalidates every server-side session id. None is reachable in current usage, so none is fixed here.

## Surface declaration

<!-- no-ui-surface -->
**backend-only, no UI surface** — scenario SDK adapter (library internals, alongside the other scenario adapters: Claude Code, realtime, judge, red-team); user proof = the **AC-4 live multi-turn run** above, NOT a langwatch-app UI change. (This is the rare-valid backend-only case — an SDK adapter consumed by developers writing scenario tests, not app UI.)



