### PR TITLE
fix(ci): make live voice CI fail when voice tests fail (#708)

### DIFF
--- a/.github/workflows/javascript-voice-integration.yml
+++ b/.github/workflows/javascript-voice-integration.yml
@@ -118,7 +118,17 @@ jobs:
       # produces a green run for the demos that DID run.
       # ---------------------------------------------------------------
       - name: Run @e2e voice demos
-        run: pnpm -F vitest-examples test run tests/voice 2>&1 | tee /tmp/js-e2e-voice-results.log
+        # CI honesty (#708): `tee` is the last command in the pipe, so without
+        # `pipefail` the step exits 0 (tee's status) even when vitest fails —
+        # the bug that let run 28175076500 report `success` while the vitest
+        # summary read `Test Files 4 failed`. GitHub's default `run` shell is
+        # `bash -e {0}` (no pipefail); `shell: bash` + `set -o pipefail` make
+        # vitest's non-zero exit the pipeline's exit, so a real test failure
+        # fails this step and the workflow.
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm -F vitest-examples test run tests/voice 2>&1 | tee /tmp/js-e2e-voice-results.log
         working-directory: javascript
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/javascript-voice-integration.yml
+++ b/.github/workflows/javascript-voice-integration.yml
@@ -128,7 +128,13 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          pnpm -F vitest-examples test run tests/voice 2>&1 | tee /tmp/js-e2e-voice-results.log
+          # Flake tolerance (#708): the hosted-ElevenLabs live demos are
+          # ambiently flaky (intermittent `receiveAudio timed out` /
+          # `Event POST failed`). `--retry.count=1` reruns only a failing test
+          # once — a transient flake is absorbed, but a genuinely-failing test
+          # fails BOTH attempts and still goes red, so the gate stays both
+          # deterministic and honest (retry is not the same as swallowing).
+          pnpm -F vitest-examples test run tests/voice --retry.count=1 2>&1 | tee /tmp/js-e2e-voice-results.log
         working-directory: javascript
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -111,9 +111,19 @@ jobs:
         working-directory: python
 
       - name: Run marker-tagged integration tests
-        # `|| true` so the step doesn't fail when zero tests match the
-        # marker. Real failures are caught by the next two steps' assertions.
-        run: uv run pytest tests/voice -m integration -v --tb=short || true
+        # CI honesty (#708): `|| true` previously swallowed ALL non-zero exits
+        # to tolerate "no tests matched the marker" (pytest exit 5) — but it
+        # also hid real test failures. Tolerate exit 5 only; propagate every
+        # other non-zero so a genuine failure fails the step and the workflow.
+        shell: bash
+        run: |
+          rc=0
+          uv run pytest tests/voice -m integration -v --tb=short || rc=$?
+          if [ "$rc" -eq 5 ]; then
+            echo "No integration-marked tests collected — treating as pass."
+            exit 0
+          fi
+          exit "$rc"
         working-directory: python
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -137,7 +147,12 @@ jobs:
       # Run the @e2e voice demos (fail-fast on missing infrastructure).
       # ---------------------------------------------------------------
       - name: Run @e2e voice demos
+        # CI honesty (#708): `tee` masks pytest's exit without `pipefail` (same
+        # class of bug as the vitest step). Set it so a failing demo fails the
+        # step instead of being swallowed by tee's exit 0.
+        shell: bash
         run: |
+          set -o pipefail
           uv run pytest tests/voice/ -v --tb=short -q 2>&1 | tee /tmp/e2e-voice-results.log
         working-directory: python
         env:

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -118,7 +118,10 @@ jobs:
         shell: bash
         run: |
           rc=0
-          uv run pytest tests/voice -m integration -v --tb=short || rc=$?
+          # `--reruns 1` (pytest-rerunfailures, already a dep): absorb a single
+          # ambient hosted-EL flake (#708) while a genuine failure that fails
+          # both attempts still propagates.
+          uv run pytest tests/voice -m integration -v --tb=short --reruns 1 || rc=$?
           if [ "$rc" -eq 5 ]; then
             echo "No integration-marked tests collected — treating as pass."
             exit 0
@@ -153,7 +156,10 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          uv run pytest tests/voice/ -v --tb=short -q 2>&1 | tee /tmp/e2e-voice-results.log
+          # `--reruns 1` (pytest-rerunfailures): absorb a single ambient
+          # hosted-EL flake (#708); a genuine failure that fails both attempts
+          # still propagates through `pipefail` and fails the step.
+          uv run pytest tests/voice/ -v --tb=short -q --reruns 1 2>&1 | tee /tmp/e2e-voice-results.log
         working-directory: python
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Why

Closes #708.

The on-demand live voice CI reported **`success` even when tests failed**, so "live voice-integration green" meant nothing. Verified bad run: [`28175076500`](https://github.com/langwatch/scenario/actions/runs/28175076500) finished `conclusion: success` while its own vitest summary read `Test Files 4 failed | 14 passed | 1 skipped`. This PR makes the **test runner's exit authoritative** in both voice workflows, then makes the gate **deterministic** against the known-flaky hosted-ElevenLabs live tests — without re-hiding real failures.

## What changed

Two commits, deliberately separated so the reviewer can see honesty and flake-tolerance independently:

- **`58bfbce` — exit honesty (the fix for #708).** The piped steps ran under GitHub's *default* `run` shell, which is `bash -e {0}` — **no `pipefail`**. So `vitest … | tee` (and `pytest … | tee`) exited with `tee`'s `0`, masking the real failure. Made each piped step `shell: bash` + `set -o pipefail` so the runner's non-zero exit becomes the step (and workflow) exit. Replaced the Python `|| true` soft-fail with **explicit `exit 5`-only tolerance** (pytest's "no tests collected" — the sole legit reason the `|| true` existed), propagating every other non-zero.
- **`c4456ba` — deterministic gate, not a swallow.** Added `--retry.count=1` (Vitest 4) / `--reruns 1` (pytest-rerunfailures, already a dep) so a single ambient hosted-EL flake (`receiveAudio timed out`, `Event POST failed`) is absorbed, while a genuinely-failing test fails **both** attempts and still goes red. Retry ≠ swallow: the honesty from commit 1 is preserved.

| File : step | Before (swallowed) | After (honest) |
|---|---|---|
| `javascript-voice-integration.yml` : "Run @e2e voice demos" (L120) | `vitest … \| tee` on default `bash -e` → step exits tee's `0` | `shell: bash` + `set -o pipefail` (L130) + `--retry.count=1` (L137) |
| `voice-integration.yml` : "Run marker-tagged integration tests" (L113) | `pytest … \|\| true` → all non-zero swallowed | exit-5-only tolerance + `--reruns 1` (L124) |
| `voice-integration.yml` : "Run @e2e voice demos" (L152) | `pytest … \| tee` (no pipefail) → step exits tee's `0` | `set -o pipefail` (L158) + `--reruns 1` (L162) |

## How I can prove I was successful

**1. The bug is real** — run [`28175076500`](https://github.com/langwatch/scenario/actions/runs/28175076500) is `conclusion: success` (confirmed via `gh run view`) despite `Test Files 4 failed` in the same logs (#708).

**2. The exit-code plumbing now propagates failure** — a harness that reproduces the *exact* shell semantics each step relies on (GitHub's default `bash -e` vs. explicit `shell: bash` = `bash --noprofile --norc -eo pipefail`). CLI transcript (no app/UI in this change, so this is the artifact):

```text
### CASE 1: BEFORE (default GH shell: bash -e, NO pipefail) — vitest | tee
  step-exit=0  (0 => FAILURE SWALLOWED, workflow green)
### CASE 2: AFTER (shell: bash => bash --noprofile --norc -eo pipefail) — set -o pipefail; vitest | tee
  step-exit=1  (non-zero => FAILURE PROPAGATES, workflow red)
### CASE 3: control — pipefail with a PASSING command still succeeds
  step-exit=0  (0 => clean pass still green)
### CASE 4: BEFORE (python sibling) — pytest ... || true
  step-exit=0  (0 => REAL FAILURE SWALLOWED)
### CASE 5: AFTER (python sibling) — real failure (exit 1) propagates, exit 5 tolerated
  pytest-exit=1 => step-exit=1
  collected nothing (exit 5) -> tolerated
  pytest-exit=5 => step-exit=0
  pytest-exit=0 => step-exit=0
### YAML validity (both edited workflows)
  OK  .github/workflows/javascript-voice-integration.yml
  OK  .github/workflows/voice-integration.yml
```

CASE 1/4 reproduce the swallow; CASE 2/5 show propagation after the fix; CASE 3 and the `exit 5` / `exit 0` rows show no false-reds (clean passes and empty marker-matches still green).

**3. Retry ≠ swallow** — `--retry.count` / `--reruns` re-run only on failure; a deterministically-failing test fails both attempts → still red. Flake tolerance is bounded to single transients.

## Human verification

Shell semantics (no checkout needed):

1. Swallow (old): `bash -e -c 'false | tee /dev/null; echo "exit=$?"'` → `exit=0`.
2. Fixed: `bash -eo pipefail -c 'false | tee /dev/null; echo "exit=$?"'` → `exit=1` (and with `-e`, the step aborts here).
3. `|| true` (old): `bash -c 'false || true; echo "exit=$?"'` → `exit=0`.

End-to-end (real workflow, costs API money + needs secrets — reviewer's call):

4. Temporarily add a guaranteed-failing assertion to one voice demo on a scratch branch, `gh workflow run javascript-voice-integration.yml --ref <branch>`, and confirm the run now ends **red** (pre-fix it ended green).

## Anything surprising?

- Both voice workflows are `workflow_dispatch`-only and gated behind paid live keys, so **PR CI does not auto-exercise them** — they can't self-validate on this PR without spending real API money. Proof above is therefore shell-semantics simulation + the verified pre-fix run, not a fresh live run.
- `--reruns 1` is added to both Python `tests/voice` steps (marker + @e2e) because the hosted-EL e2e wrappers are auto-marked `integration` and run in both; tolerating one but not the other would leave a flaky-red path.


## Backend-only — no UI surface

This PR changes only `.github/workflows/*.yml` (CI exit-code authority + flake-tolerance) — there is **no application or UI surface**, so live-app visual proof is N/A. Verification = the shell-semantics proof above (`bash -eo pipefail: false|tee → exit 1`; `--retry.count=1`/`--reruns 1` reruns only failures so a genuine failure still goes red) + `yaml.safe_load` clean. <!-- no-ui-surface -->
