### PR TITLE
test(voice): harden audio-derived STT assertion against a transient outage (#725)

### DIFF
--- a/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
@@ -237,6 +237,11 @@ if (hasHostedKey || hasComposableKey) {
             }
             // Audio-DERIVED transcript proof: force STT over the recorded user
             // bytes (onlyMissing:false) and require non-empty speech per turn.
+            // Clear any transcript carried over from the live run: a forced
+            // re-run leaves a stale transcript in place if STT throws (a
+            // transient outage), so without this the check below could green
+            // on old text instead of the freshly audio-derived transcript.
+            for (const s of userSegs) s.transcript = undefined;
             await voice.transcribeSegments(
               { segments: userSegs, timeline: [] },
               { onlyMissing: false },

--- a/javascript/examples/vitest/tests/voice/gemini-live.test.ts
+++ b/javascript/examples/vitest/tests/voice/gemini-live.test.ts
@@ -138,6 +138,11 @@ describeFeature(
           }
           // Audio-DERIVED transcript proof: force STT over the recorded user
           // bytes (onlyMissing:false) and require non-empty speech per user turn.
+          // Clear any transcript carried over from the live run: a forced
+          // re-run leaves a stale transcript in place if STT throws (a
+          // transient outage), so without this the check below could green
+          // on old text instead of the freshly audio-derived transcript.
+          for (const s of userSegList) s.transcript = undefined;
           await voice.transcribeSegments(
             { segments: userSegList, timeline: [] },
             { onlyMissing: false },

--- a/javascript/examples/vitest/tests/voice/openai-realtime-agent.test.ts
+++ b/javascript/examples/vitest/tests/voice/openai-realtime-agent.test.ts
@@ -144,6 +144,11 @@ describeFeature(
             // bytes (onlyMissing:false overwrites any transport-supplied text),
             // then require every user turn to transcribe to non-empty speech —
             // silence or a text-only commit cannot satisfy this.
+            // Clear any transcript carried over from the live run: a forced
+            // re-run leaves a stale transcript in place if STT throws (a
+            // transient outage), so without this the check below could green
+            // on old text instead of the freshly audio-derived transcript.
+            for (const s of userSegs) s.transcript = undefined;
             await voice.transcribeSegments(
               { segments: userSegs, timeline: [] },
               { onlyMissing: false },

--- a/javascript/examples/vitest/tests/voice/pipecat-ws.test.ts
+++ b/javascript/examples/vitest/tests/voice/pipecat-ws.test.ts
@@ -129,6 +129,11 @@ describeFeature(
           // Audio-DERIVED transcript proof: Pipecat (Twilio Media Streams)
           // carries audio only, so STT over the recorded user bytes is the only
           // source of a transcript — force it and require non-empty per turn.
+          // Clear any transcript carried over from the live run: a forced
+          // re-run leaves a stale transcript in place if STT throws (a
+          // transient outage), so without this the check below could green
+          // on old text instead of the freshly audio-derived transcript.
+          for (const s of userSegs) s.transcript = undefined;
           await voice.transcribeSegments(
             { segments: userSegs, timeline: [] },
             { onlyMissing: false },

--- a/javascript/src/voice/__tests__/transcribe-stale-transcript.test.ts
+++ b/javascript/src/voice/__tests__/transcribe-stale-transcript.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression guard for the audio-derived STT assertion (#725).
+ *
+ * The voice example tests prove a turn is "audio-derived" by force-running STT
+ * over the recorded user bytes (`transcribeSegments(..., { onlyMissing: false })`)
+ * and then asserting every user segment has a non-empty `transcript`. But
+ * `transcribeSegments` catches a provider throw and leaves `transcript`
+ * untouched (documented graceful-degrade). So if a segment already carries a
+ * transcript from the live run and STT then suffers a transient outage (the
+ * provider throws), the stale transcript survives and the assertion greens
+ * dishonestly. The fix is to clear the transcripts before the forced re-run.
+ *
+ * These tests exercise the real `transcribeSegments` path with a throwing
+ * provider to lock both facts: the stale transcript survives an outage, and
+ * clearing it first makes the outage observable.
+ */
+import { describe, expect, it } from "vitest";
+
+import { type STTProvider } from "../stt";
+import { transcribeSegments } from "../transcribe";
+import type { AudioSegment, VoiceRecording } from "../recording.types";
+
+const PCM_BYTES = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+function userSegment(transcript?: string): AudioSegment {
+  return {
+    speaker: "user",
+    startTime: 0,
+    endTime: 1,
+    audio: PCM_BYTES,
+    transcript,
+  };
+}
+
+/** STT provider that always throws, standing in for a transient outage. */
+const outageProvider: STTProvider = {
+  transcribe: async () => {
+    throw new Error("stt upstream timed out");
+  },
+};
+
+describe("transcribeSegments under a transient STT outage (#725)", () => {
+  describe("given a user segment that already carries a live-run transcript", () => {
+    describe("when a forced re-run hits an STT outage", () => {
+      it("leaves the stale transcript in place, so a non-empty check greens dishonestly", async () => {
+        const recording: VoiceRecording = {
+          segments: [userSegment("stale live-run text")],
+          timeline: [],
+        };
+
+        await transcribeSegments(recording, {
+          provider: outageProvider,
+          onlyMissing: false,
+          logWarn: () => {},
+        });
+
+        // The outage was swallowed and the old transcript survived: the
+        // "(transcript ?? '').trim().length > 0" bar the example tests use
+        // would still pass. This is exactly the hole #725 closes.
+        expect(recording.segments[0]!.transcript).toBe("stale live-run text");
+        expect((recording.segments[0]!.transcript ?? "").trim().length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe("given the transcript is cleared before the forced re-run", () => {
+    describe("when the re-run hits an STT outage", () => {
+      it("leaves the transcript empty, so the non-empty check fails honestly", async () => {
+        const recording: VoiceRecording = {
+          segments: [userSegment("stale live-run text")],
+          timeline: [],
+        };
+
+        // The fix applied by the example tests before the forced re-run.
+        for (const s of recording.segments) s.transcript = undefined;
+
+        await transcribeSegments(recording, {
+          provider: outageProvider,
+          onlyMissing: false,
+          logWarn: () => {},
+        });
+
+        expect(recording.segments[0]!.transcript).toBeUndefined();
+        expect((recording.segments[0]!.transcript ?? "").trim().length).toBe(0);
+      });
+    });
+
+    describe("when the re-run reaches a healthy provider", () => {
+      it("fills the audio-derived transcript, so the happy path still passes", async () => {
+        const recording: VoiceRecording = {
+          segments: [userSegment("stale live-run text")],
+          timeline: [],
+        };
+        const healthy: STTProvider = { transcribe: async () => "audio derived text" };
+
+        for (const s of recording.segments) s.transcript = undefined;
+
+        await transcribeSegments(recording, {
+          provider: healthy,
+          onlyMissing: false,
+          logWarn: () => {},
+        });
+
+        expect(recording.segments[0]!.transcript).toBe("audio derived text");
+        expect((recording.segments[0]!.transcript ?? "").trim().length).toBeGreaterThan(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Ticket

Closes #725. The voice example tests prove a turn is audio-derived by force-running STT over the recorded user bytes and asserting each user segment has a non-empty transcript. A transient STT outage could green that assertion on a stale transcript instead of failing honestly.

## Priority pick

Top-priority deliverable in langwatch/scenario after excluding the migration (#720) and the process-meta retrofit (#516); the other P2 refactor (#721) is blocked on the still-open PR #701 that introduces the code it targets.

## Root cause (audited)

`transcribeSegments` (javascript/src/voice/transcribe.ts) catches a per-segment provider throw, logs a warning, and leaves `transcript` untouched (documented graceful-degrade). With `{ onlyMissing: false }` it re-targets every segment, but on a throw it never overwrites. So a user segment that already carries a transcript from the live run keeps that text when STT suffers a transient outage, and the example assertion `(s.transcript ?? "").trim().length > 0` passes on stale data.

## Change

Clear the user-segment transcripts immediately before the forced re-run, in all four permutation tests that use this pattern:

- `elevenlabs-hosted.test.ts`, `openai-realtime-agent.test.ts`, `pipecat-ws.test.ts`, `gemini-live.test.ts`

After clearing, a healthy re-run fills a fresh audio-derived transcript, while an outage leaves it empty and fails the assertion honestly. Scoped to the tests; no product code changed.

## Evidence

New unit test `javascript/src/voice/__tests__/transcribe-stale-transcript.test.ts` exercises the real `transcribeSegments` path with a throwing provider and locks the mechanism:

```
Test Files  1 passed (1)
Tests  3 passed (3)   EXIT=0
```

- **stale transcript survives an outage** (documents the hole): with a live-run transcript and a throwing provider, `transcript` is unchanged and the non-empty check would still pass.
- **cleared transcript fails honestly**: after the clear, a throwing provider leaves `transcript` undefined and the non-empty check is 0.
- **happy path preserved**: after the clear, a healthy provider fills the audio-derived transcript and the check passes.

Typecheck clean in both workspaces (`javascript` and `examples/vitest`), EXIT=0. No em/en dashes; no lockfile churn.

The four edited files are env-gated real-audio E2E demos (require the STT/agent provider keys), so their full run is a reviewer/CI step; the unit test above proves the hardening mechanism deterministically without those keys.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.
