### PR TITLE
test(voice): hoist shared makeChunk fixture across voice agent tests (#532)

### DIFF
--- a/javascript/src/agents/__tests__/fixtures/make-chunk.ts
+++ b/javascript/src/agents/__tests__/fixtures/make-chunk.ts
@@ -1,0 +1,9 @@
+import { AudioChunk } from "../../../voice/audio-chunk";
+
+/**
+ * Minimal 4-byte {@link AudioChunk} fixture, optionally carrying a transcript.
+ * Shared across the voice agent tests (user simulator, assistant role, judge).
+ */
+export function makeChunk(transcript?: string): AudioChunk {
+  return new AudioChunk({ data: new Uint8Array(4), transcript });
+}

--- a/javascript/src/agents/__tests__/user-simulator-voice.test.ts
+++ b/javascript/src/agents/__tests__/user-simulator-voice.test.ts
@@ -24,6 +24,7 @@ import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect, vi } from "vitest";
 
 import { AudioChunk } from "../../voice/audio-chunk";
+import { makeChunk } from "./fixtures/make-chunk";
 import { extractAudio, messageHasAudio } from "../../voice/messages";
 import { userSimulatorAgent, type UserSimulatorAgentConfig } from "../user-simulator-agent";
 import type { AgentInput } from "../../domain";
@@ -50,10 +51,6 @@ const FEATURE_PATH = resolve(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Create a minimal 2-sample AudioChunk (valid PCM16 — even byte count). */
-function makeChunk(transcript?: string): AudioChunk {
-  return new AudioChunk({ data: new Uint8Array(4), transcript });
-}
 
 /**
  * Build a minimal {@link AgentInput} stub sufficient for user simulator tests.

--- a/javascript/src/agents/__tests__/voice-assistant-role.test.ts
+++ b/javascript/src/agents/__tests__/voice-assistant-role.test.ts
@@ -24,6 +24,7 @@ import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect } from "vitest";
 
 import { AudioChunk } from "../../voice/audio-chunk";
+import { makeChunk } from "./fixtures/make-chunk";
 import { createAudioMessage, extractAudio, messageHasAudio } from "../../voice/messages";
 import { JudgeAgent } from "../judge/judge-agent";
 
@@ -38,10 +39,6 @@ const FEATURE_PATH = resolve(
   "voice-agents.feature"
 );
 
-/** 4-byte (2-sample) AudioChunk — minimal valid PCM16. */
-function makeChunk(transcript?: string): AudioChunk {
-  return new AudioChunk({ data: new Uint8Array(4), transcript });
-}
 
 const feature = await loadFeature(FEATURE_PATH);
 

--- a/javascript/src/agents/judge/__tests__/judge-voice.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-voice.test.ts
@@ -21,7 +21,7 @@ import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { describe, expect, it } from "vitest";
 
 import { createAudioMessage } from "../../../voice/messages";
-import { AudioChunk } from "../../../voice/audio-chunk";
+import { makeChunk } from "../../__tests__/fixtures/make-chunk";
 import { judgeAgent, JudgeAgent, type JudgeAgentConfig } from "../judge-agent";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -40,10 +40,6 @@ const FEATURE_PATH = resolve(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** 4-byte (2-sample) AudioChunk — minimal valid PCM16. */
-function makeChunk(transcript?: string): AudioChunk {
-  return new AudioChunk({ data: new Uint8Array(4), transcript });
-}
 
 /** Build a message-bus message containing audio content. */
 function audioMessage(


### PR DESCRIPTION
## Ticket

Closes #532. The `makeChunk(transcript?)` AudioChunk fixture was copy-pasted across the voice agent tests.

## Priority pick

The scenario P2 tier was not deliverable this run: #725 shipped yesterday (PR #728, merged), #721 and #723 are blocked on unmerged PRs (#701 and #692 respectively, both commented on their issues), #720 is a migration, and #516 is process-meta. #576's sleep-helper smell is already resolved on main (`voice/utils.ts` now owns the shared `sleep`). #532 is the top clean, on-main, self-contained P3.

## Change

The exact same fixture

```ts
function makeChunk(transcript?: string): AudioChunk {
  return new AudioChunk({ data: new Uint8Array(4), transcript });
}
```

was defined three times: `agents/__tests__/user-simulator-voice.test.ts`, `agents/__tests__/voice-assistant-role.test.ts`, and `agents/judge/__tests__/judge-voice.test.ts`. Extract it to `agents/__tests__/fixtures/make-chunk.ts` and import it in all three. The judge test's now-unused `AudioChunk` import is dropped. (The `makeChunk` in `voice/__tests__/messages.test.ts` and `playback.test.ts` are different fixtures with different signatures and are left alone.)

## Evidence

- **Behavior preserved:** the three affected suites pass against the shared fixture:
  ```
  npx vitest run user-simulator-voice.test.ts voice-assistant-role.test.ts judge-voice.test.ts
  Test Files  3 passed (3)
  Tests  52 passed (52)   EXIT=0
  ```
- **Typecheck:** `pnpm typecheck` -> EXIT=0 (confirms the dropped `AudioChunk` import in the judge test left nothing dangling).
- **Hygiene:** no em/en dashes (the three removed doc-comments each carried one); no lockfile churn; 4 files (1 new fixture, 3 edited).

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.
