### PR TITLE
fix(voice): grace-wait + STT fallback so user-simulator reacts to real transcript (#734)

### DIFF
--- a/javascript/src/agents/__tests__/user-simulator-stt-fallback.test.ts
+++ b/javascript/src/agents/__tests__/user-simulator-stt-fallback.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #734 (AC2) — user-simulator STT fallback for a suppressed agent transcript.
+ *
+ * The grace-wait (AC1) is the primary fix, but if hosted ElevenLabs NEVER sends
+ * `agent_response` for a turn, the agent message still reaches the simulator as
+ * AUDIO with no text sibling. Without a fallback, `stripAudioContent` collapses
+ * it to a bare `[audio message]` and the text-only LLM fabricates a reply.
+ *
+ * This test forces that suppression: an assistant-role audio message carrying NO
+ * transcript, plus a stub STT provider resolved off `scenarioConfig.voice.stt`
+ * (the SAME per-run carrier the judge reads). It asserts the simulator's LLM
+ * input carries the STT-derived text — proving the simulator now transcribes the
+ * turn before stripping audio, mirroring the judge's pre-pass via the shared
+ * `transcribeAudioMessages` helper (no duplicated STT plumbing).
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import type { AgentInput } from "../../domain";
+import { AudioChunk } from "../../voice/audio-chunk";
+import { createAudioMessage } from "../../voice/messages";
+import type { STTProvider } from "../../voice/stt";
+import { userSimulatorAgent, type UserSimulatorAgentConfig } from "../user-simulator-agent";
+
+vi.mock("../../config", () => ({
+  getProjectConfig: vi.fn().mockResolvedValue({
+    defaultModel: { model: "openai/gpt-4.1-mini", temperature: 0 },
+  }),
+}));
+
+/** A 4-byte PCM16 audio chunk with NO transcript — models a suppressed agent_response. */
+function audioNoTranscript(): AudioChunk {
+  return new AudioChunk({ data: new Uint8Array([1, 2, 3, 4]) });
+}
+
+/** Build an AgentInput whose voice config carries a stub STT provider. */
+function makeInput(messages: unknown[], stt: STTProvider): AgentInput {
+  return {
+    threadId: "t-734-stt",
+    messages: messages as AgentInput["messages"],
+    newMessages: [],
+    requestedRole: "User" as AgentInput["requestedRole"],
+    scenarioConfig: {
+      name: "test",
+      description: "A test scenario description",
+      voice: { stt },
+    } as unknown as AgentInput["scenarioConfig"],
+    scenarioState: {} as AgentInput["scenarioState"],
+  };
+}
+
+/** Wire a spy LLM that records the messages it was called with and returns text. */
+function captureLlm(sim: ReturnType<typeof userSimulatorAgent>) {
+  const seen: { messages: Array<{ role: string; content: unknown }> } = { messages: [] };
+  (sim as unknown as {
+    invokeLLM: (p: { messages: Array<{ role: string; content: unknown }> }) => Promise<{
+      text: string;
+      toolCalls: [];
+      steps: [];
+    }>;
+  }).invokeLLM = async ({ messages }) => {
+    seen.messages = messages;
+    return { text: "ok", toolCalls: [], steps: [] };
+  };
+  return seen;
+}
+
+/** Flatten a captured message's content to a searchable string. */
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((p) =>
+        p && typeof p === "object" && typeof (p as { text?: unknown }).text === "string"
+          ? ((p as { text: string }).text)
+          : "",
+      )
+      .join(" ");
+  }
+  return "";
+}
+
+describe("#734 AC2 — user-simulator STT fallback for a suppressed agent transcript", () => {
+  it("transcribes an audio-only agent turn so the LLM sees real words, not [audio message]", async () => {
+    const stt: STTProvider = {
+      transcribe: vi.fn(async () => "we have the blue and the red option"),
+    };
+    const sim = userSimulatorAgent({ model: "openai/gpt-4.1-mini" } as UserSimulatorAgentConfig);
+    const seen = captureLlm(sim);
+
+    // An audio-only agent turn (assistant role, no transcript) — the suppressed
+    // agent_response case. This is what reaches the simulator after the grace-wait
+    // window elapses with no transcript.
+    const agentTurn = createAudioMessage(audioNoTranscript(), "assistant");
+
+    await sim.call(makeInput([agentTurn], stt));
+
+    expect((stt.transcribe as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+
+    // The transcribed words must appear in what the LLM saw — reframed as the
+    // agent's utterance ("[the agent said: …]") by stripAudioContent's echo-safety.
+    const allContent = seen.messages.map((m) => contentText(m.content)).join(" || ");
+    expect(allContent).toContain("we have the blue and the red option");
+    // And the bare placeholder must NOT be what the LLM received for that turn.
+    expect(allContent).not.toContain("[audio message]");
+  });
+
+  it("does NOT run STT when the agent turn already carries its transcript (no added cost)", async () => {
+    const stt: STTProvider = { transcribe: vi.fn(async () => "should not be called") };
+    const sim = userSimulatorAgent({ model: "openai/gpt-4.1-mini" } as UserSimulatorAgentConfig);
+    captureLlm(sim);
+
+    // Agent turn WITH a transcript (the grace-wait won the race) — the happy path.
+    const withTranscript = createAudioMessage(
+      new AudioChunk({ data: new Uint8Array([1, 2, 3, 4]), transcript: "here is your balance" }),
+      "assistant",
+    );
+
+    await sim.call(makeInput([withTranscript], stt));
+
+    // Fast path: no audio-without-transcript turn exists, so no provider is used.
+    expect((stt.transcribe as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+});

--- a/javascript/src/agents/__tests__/user-simulator-stt-fallback.test.ts
+++ b/javascript/src/agents/__tests__/user-simulator-stt-fallback.test.ts
@@ -104,6 +104,30 @@ describe("#734 AC2 — user-simulator STT fallback for a suppressed agent transc
     expect(allContent).not.toContain("[audio message]");
   });
 
+  it("caches the fallback transcript: two calls over the SAME audio-only turn run STT exactly once (#735 P2)", async () => {
+    // #735 P2: `call()` re-runs the STT pre-pass over the WHOLE history on every
+    // proceed() turn. A dropped agent_response leaves an audio-only turn sitting
+    // in history; without a per-instance cache it would be re-transcribed on
+    // every subsequent turn (O(turns^2) STT calls). One simulator instance must
+    // transcribe a given audio chunk at most once.
+    const stt: STTProvider = {
+      transcribe: vi.fn(async () => "we have the blue and the red option"),
+    };
+    const sim = userSimulatorAgent({ model: "openai/gpt-4.1-mini" } as UserSimulatorAgentConfig);
+    captureLlm(sim);
+
+    // The SAME suppressed audio-only agent turn, still in history across turns.
+    const agentTurn = createAudioMessage(audioNoTranscript(), "assistant");
+
+    // Two simulator calls over that same audio-only turn (models proceed() turns
+    // N and N+1 where the dropped-transcript audio remains in the history).
+    await sim.call(makeInput([agentTurn], stt));
+    await sim.call(makeInput([agentTurn], stt));
+
+    // STT ran ONCE, not once per call — the second call reused the cached transcript.
+    expect((stt.transcribe as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+
   it("does NOT run STT when the agent turn already carries its transcript (no added cost)", async () => {
     const stt: STTProvider = { transcribe: vi.fn(async () => "should not be called") };
     const sim = userSimulatorAgent({ model: "openai/gpt-4.1-mini" } as UserSimulatorAgentConfig);

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -8,6 +8,8 @@ import { AgentInput, UserSimulatorAgentAdapter } from "../domain";
 import { modelSchema } from "../domain/core/schemas/model.schema";
 import { Logger } from "../utils/logger";
 import { AudioChunk } from "../voice/audio-chunk";
+import { resolveVoiceConfig } from "../voice/config";
+import { transcribeAudioMessages } from "../voice/judge-stt";
 import { createAudioMessage } from "../voice/messages";
 import { synthesize } from "../voice/tts";
 
@@ -104,6 +106,38 @@ ${personaBlock}`.trim();
  *
  * Port of `python/scenario/user_simulator_agent.py:_strip_audio_content`.
  */
+/**
+ * True when any message carries an audio part but NO non-empty text sibling —
+ * i.e. a turn that would reach the text-only simulator as a bare
+ * `[audio message]` (#734). Gates the STT fallback so the common case (every
+ * audio turn already has its transcript — the grace-wait won the race) pays no
+ * STT cost and constructs no provider, mirroring the judge's `hasAudio` fast
+ * path.
+ */
+function hasAudioWithoutTranscript(messages: readonly ModelMessage[]): boolean {
+  return messages.some((msg) => {
+    const content = msg.content;
+    if (!Array.isArray(content)) return false;
+    const parts = content as Array<Record<string, unknown>>;
+    const hasAudio = parts.some(
+      (p) =>
+        p?.type === "input_audio" ||
+        p?.type === "audio" ||
+        (p?.type === "file" &&
+          typeof p["mediaType"] === "string" &&
+          (p["mediaType"] as string).startsWith("audio/")),
+    );
+    if (!hasAudio) return false;
+    const hasText = parts.some(
+      (p) =>
+        p?.type === "text" &&
+        typeof p["text"] === "string" &&
+        (p["text"] as string).length > 0,
+    );
+    return !hasText;
+  });
+}
+
 function stripAudioContent(messages: ModelMessage[]): ModelMessage[] {
   return messages.map((msg) => {
     const content = msg.content;
@@ -364,9 +398,29 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
     const systemPrompt =
       config?.systemPrompt ?? buildSystemPrompt(input.scenarioConfig.description, persona);
 
+    // #734 (AC2) — STT fallback safety net. Primary fix is the grace-wait in the
+    // adapter runtime (waits for EL's `agent_response` transcript before closing
+    // the turn); but if EL NEVER sends the transcript for a turn, the message
+    // still reaches here as audio-only and stripAudioContent would collapse it to
+    // a bare `[audio message]`, making the text-only LLM fabricate. Mirror the
+    // judge's STT pre-pass (the SAME shared helper, same per-run provider) to
+    // transcribe those turns to real words FIRST. `includeAudio: true` keeps the
+    // audio part so stripAudioContent's echo-safety reframing (`[the agent said:
+    // …]`, which keys on a turn having BOTH audio and text) still fires. Gated on
+    // an audio-without-transcript turn actually existing, so the common path
+    // (transcript already present) constructs no provider and pays no STT cost.
+    const preparedMessages = hasAudioWithoutTranscript(input.messages)
+      ? await transcribeAudioMessages({
+          messages: input.messages,
+          stt: resolveVoiceConfig(undefined, input.scenarioConfig.voice).stt,
+          includeAudio: true,
+          logWarn: (m) => this.logger.warn(m),
+        })
+      : input.messages;
+
     // Strip audio content from messages before sending to text LLM (§4.2 — the
     // LLM that generates text is always text-only; audio is synthesized separately).
-    const strippedMessages = stripAudioContent(input.messages);
+    const strippedMessages = stripAudioContent(preparedMessages);
 
     const messages: ModelMessage[] = [
       { role: "system", content: systemPrompt },

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -177,6 +177,18 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
   private logger = new Logger(this.constructor.name);
 
   /**
+   * Per-instance STT fallback transcript cache (#735 P2), keyed by a STABLE
+   * audio payload key. `call()` re-runs the STT pre-pass over the WHOLE history
+   * on every `proceed()` turn; without this cache an audio-only agent turn whose
+   * `agent_response` was dropped would be re-transcribed on turn N, N+1, N+2, …
+   * — O(turns^2) STT calls from a single transport hiccup, risking provider
+   * throttling later in the run. Scoped to the simulator instance so a chunk is
+   * transcribed at most once for the life of one simulator (survives across
+   * `proceed()` turns); a fresh simulator starts with an empty cache.
+   */
+  private readonly sttTranscriptCache = new Map<string, string>();
+
+  /**
    * LLM invocation function. Can be overridden to customize LLM behavior.
    */
   invokeLLM: (params: InvokeLLMParams) => Promise<InvokeLLMResult> =
@@ -422,6 +434,10 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
           messages: input.messages,
           stt: resolveVoiceConfig(undefined, input.scenarioConfig.voice).stt,
           includeAudio: true,
+          // Reuse a transcript for the same audio across proceed() turns so a
+          // dropped agent_response costs at most ONE STT call, not one per turn
+          // (#735 P2 — avoids O(turns^2) re-transcription).
+          transcriptCache: this.sttTranscriptCache,
           logWarn: (m) => this.logger.warn(m),
         });
       } catch (e) {

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -409,14 +409,29 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
     // …]`, which keys on a turn having BOTH audio and text) still fires. Gated on
     // an audio-without-transcript turn actually existing, so the common path
     // (transcript already present) constructs no provider and pays no STT cost.
-    const preparedMessages = hasAudioWithoutTranscript(input.messages)
-      ? await transcribeAudioMessages({
+    // The STT fallback is a safety net — it must never make things WORSE than no
+    // fix. `resolveVoiceConfig` falls back to a default OpenAI provider when
+    // `voice.stt` is unset, but a bad `voice.stt` descriptor (or a provider
+    // constructor) can still throw here. Catch it and continue with the original
+    // messages so `call()` still reaches the existing `[audio message]` path
+    // rather than aborting the whole turn on a config error.
+    let preparedMessages = input.messages;
+    if (hasAudioWithoutTranscript(input.messages)) {
+      try {
+        preparedMessages = await transcribeAudioMessages({
           messages: input.messages,
           stt: resolveVoiceConfig(undefined, input.scenarioConfig.voice).stt,
           includeAudio: true,
           logWarn: (m) => this.logger.warn(m),
-        })
-      : input.messages;
+        });
+      } catch (e) {
+        this.logger.warn(
+          `#734 STT fallback pre-pass failed; continuing with original messages: ${
+            (e as Error)?.message ?? e
+          }`,
+        );
+      }
+    }
 
     // Strip audio content from messages before sending to text LLM (§4.2 — the
     // LLM that generates text is always text-only; audio is synthesized separately).

--- a/javascript/src/voice/__tests__/composable-transcript-attach.test.ts
+++ b/javascript/src/voice/__tests__/composable-transcript-attach.test.ts
@@ -1,0 +1,89 @@
+/**
+ * #734 / #735 P1 — ComposableVoiceAgent attaches its own LLM reply as the chunk
+ * transcript, so the default call path never grace-waits or STT-transcribes text
+ * it already generated.
+ *
+ * ComposableVoiceAgent inherits `defaultVoiceCall`. Before this fix its
+ * `receiveAudio` returned a TTS chunk with NO transcript, and it exposes its
+ * text on `lastLlmResponse` (not `lastAgentTranscript`). So a Composable turn
+ * fell through to the grace-wait AND then to the simulator's STT fallback —
+ * re-transcribing audio it had just synthesized from known text. The turn ALREADY
+ * knows its exact words; this test locks that they ride on the returned chunk.
+ */
+import type { LanguageModel } from "ai";
+import { describe, it, expect, vi } from "vitest";
+
+import { AudioChunk } from "../audio-chunk";
+import type { STTProvider } from "../stt";
+
+// Stub the TTS router so `synthesize` yields known bytes with no network/provider.
+vi.mock("../tts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts")>();
+  return {
+    ...actual,
+    synthesize: vi.fn(async () => new AudioChunk({ data: new Uint8Array([9, 9, 9, 9]) })),
+  };
+});
+
+// Import AFTER the mock is registered.
+const { ComposableVoiceAgent } = await import("../adapters/composable");
+
+const stubStt: STTProvider = {
+  async transcribe(): Promise<string> {
+    return "user said hello";
+  },
+};
+
+/** Minimal ai-sdk LanguageModel stub returning a fixed reply. */
+function stubLlm(text: string): LanguageModel {
+  return {
+    specificationVersion: "v3" as const,
+    provider: "fake",
+    modelId: "fake-model",
+    supportedUrls: {},
+    doGenerate: async () => ({
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      content: [{ type: "text", text }],
+      warnings: [],
+    }),
+    doStream: async () => {
+      throw new Error("doStream not implemented in stub");
+    },
+  } as unknown as LanguageModel;
+}
+
+describe("#735 P1 — ComposableVoiceAgent carries its LLM reply as the chunk transcript", () => {
+  it("attaches lastLlmResponse text to the returned receiveAudio chunk", async () => {
+    const agent = new ComposableVoiceAgent({
+      stt: stubStt,
+      llm: stubLlm("here are your two options: blue and red"),
+      tts: "openai/nova",
+    });
+
+    // Drive one turn: user audio in (STT), then drain one agent chunk (LLM + TTS).
+    await agent.sendAudio(new AudioChunk({ data: new Uint8Array([1, 2, 3, 4]) }));
+    const chunk = await agent.receiveAudio(30);
+
+    // The turn's exact generated words ride on the chunk — so
+    // attachAgentTurnTranscript labels it directly, and defaultVoiceCall skips the
+    // grace-wait (merged.transcript set) and the simulator skips STT.
+    expect(chunk.transcript).toBe("here are your two options: blue and red");
+    expect(chunk.data.length).toBeGreaterThan(0);
+    expect(agent.lastLlmResponse).toBe("here are your two options: blue and red");
+  });
+
+  it("does not fabricate a transcript when the LLM returns empty text", async () => {
+    const agent = new ComposableVoiceAgent({
+      stt: stubStt,
+      llm: stubLlm(""),
+      tts: "openai/nova",
+    });
+
+    await agent.sendAudio(new AudioChunk({ data: new Uint8Array([1, 2, 3, 4]) }));
+    const chunk = await agent.receiveAudio(30);
+
+    // Empty reply → no transcript attached (nothing to label the turn with).
+    expect(chunk.transcript).toBeUndefined();
+  });
+});

--- a/javascript/src/voice/__tests__/judge-stt.test.ts
+++ b/javascript/src/voice/__tests__/judge-stt.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import { AudioChunk } from "../audio-chunk";
 import { createAudioMessage } from "../messages";
-import { prepareJudgeInput } from "../judge-stt";
+import { prepareJudgeInput, transcribeAudioMessages } from "../judge-stt";
 import type { STTProvider } from "../stt";
 import { judgeAgent } from "../../agents/judge/judge-agent";
 import type { JudgeAgentConfig } from "../../agents/judge/judge-agent";
@@ -41,6 +41,20 @@ function sttReturning(text: string): STTProvider & { calls: number } {
     async transcribe(_audio: AudioChunk): Promise<string> {
       calls += 1;
       return text;
+    },
+    get calls() {
+      return calls;
+    },
+  } as STTProvider & { calls: number };
+}
+
+/** STT stub that always REJECTS, counting how many times it was invoked. */
+function sttThrowing(): STTProvider & { calls: number } {
+  let calls = 0;
+  return {
+    async transcribe(_audio: AudioChunk): Promise<string> {
+      calls += 1;
+      throw new Error("stt boom");
     },
     get calls() {
       return calls;
@@ -147,6 +161,83 @@ describe("prepareJudgeInput (judge STT pre-pass)", () => {
 
     expect(stt.calls).toBe(0);
     expect(messages[0]).toBe(textMsg); // same reference — untouched
+  });
+});
+
+describe("transcribeAudioMessages caches NEGATIVE STT results (#735 P2)", () => {
+  // The STT fallback re-runs over the whole history on every proceed() turn. On
+  // the degraded path this feature exists for — STT throws or returns "" for a
+  // dropped/bad/silent audio turn — the chunk must be remembered so the same
+  // dead audio is NOT re-transcribed on every later turn (O(turns) provider
+  // hits during exactly the outage the fallback is meant to tolerate). A shared
+  // per-instance Map across two calls models turns N and N+1 with that audio
+  // still sitting in history.
+  describe("when STT throws for an audio-only turn", () => {
+    it("caches a failed STT attempt so the same audio is not re-transcribed on the next call", async () => {
+      const stt = sttThrowing();
+      const cache = new Map<string, string>();
+      const audioMsg = createAudioMessage(tone(), "assistant") as ModelMessage;
+
+      const first = await transcribeAudioMessages({
+        messages: [audioMsg],
+        stt,
+        includeAudio: false,
+        transcriptCache: cache,
+        logWarn: vi.fn(),
+      });
+      const second = await transcribeAudioMessages({
+        messages: [audioMsg],
+        stt,
+        includeAudio: false,
+        transcriptCache: cache,
+        logWarn: vi.fn(),
+      });
+
+      // STT was hit ONCE across both calls — the second short-circuited on the
+      // cached negative sentinel instead of re-hitting the provider.
+      expect(stt.calls).toBe(1);
+      // Neither call fabricated text nor crashed: audio dropped (text-only),
+      // no transcript part added — the graceful-degrade path is preserved.
+      for (const messages of [first, second]) {
+        const content = (messages[0] as { content: unknown[] }).content;
+        expect(
+          content.find((p) => (p as { type?: string }).type === "file"),
+        ).toBeUndefined();
+        expect(
+          content.find((p) => (p as { type?: string }).type === "text"),
+        ).toBeUndefined();
+      }
+    });
+  });
+
+  describe("when STT returns an empty transcript for an audio-only turn", () => {
+    it("caches the empty result so the same audio is not re-transcribed on the next call", async () => {
+      const stt = sttReturning("");
+      const cache = new Map<string, string>();
+      const audioMsg = createAudioMessage(tone(), "assistant") as ModelMessage;
+
+      await transcribeAudioMessages({
+        messages: [audioMsg],
+        stt,
+        includeAudio: false,
+        transcriptCache: cache,
+      });
+      const second = await transcribeAudioMessages({
+        messages: [audioMsg],
+        stt,
+        includeAudio: false,
+        transcriptCache: cache,
+      });
+
+      // Empty is a valid STT result: cached like any other, so the provider is
+      // hit ONCE across both calls, not once per call.
+      expect(stt.calls).toBe(1);
+      // An empty transcript adds no text part (same as undefined).
+      const content = (second[0] as { content: unknown[] }).content;
+      expect(
+        content.find((p) => (p as { type?: string }).type === "text"),
+      ).toBeUndefined();
+    });
   });
 });
 

--- a/javascript/src/voice/__tests__/transcript-grace-wait.test.ts
+++ b/javascript/src/voice/__tests__/transcript-grace-wait.test.ts
@@ -119,6 +119,37 @@ class RaceAdapter extends VoiceAgentAdapter {
   }
 }
 
+/**
+ * An adapter that returns raw audio and does NOT expose the `lastAgentTranscript`
+ * convention at all — models Twilio/Pipecat (raw-audio) and Composable (text on a
+ * different field). The grace-wait must skip these entirely: waiting could never
+ * succeed, so it would burn the full ceiling per turn for nothing (the P1).
+ */
+class TranscriptlessAdapter extends VoiceAgentAdapter {
+  override role = AgentRole.AGENT;
+  readonly capabilities = new AdapterCapabilities({
+    streamingTranscripts: false,
+    nativeVad: true,
+    dtmf: false,
+    interruption: false,
+    inputFormats: ["pcm16/24000"],
+    outputFormats: ["pcm16/24000"],
+  });
+  // NOTE: deliberately NO `lastAgentTranscript` field declared.
+
+  private index = 0;
+  private readonly responses: AudioChunk[] = [rawTone(0.5)];
+
+  async connect(): Promise<void> {}
+  async disconnect(): Promise<void> {}
+  async sendAudio(): Promise<void> {}
+
+  async receiveAudio(_timeout: number): Promise<AudioChunk> {
+    if (this.index < this.responses.length) return this.responses[this.index++]!;
+    return silentChunk(0);
+  }
+}
+
 /** Minimal AgentInput: one user turn, no executor state (recorder no-ops). */
 function inputWithUserTurn(): AgentInput {
   return {
@@ -200,5 +231,22 @@ describe("#734 transcript grace-wait (defaultVoiceCall)", () => {
     expect(transcriptOf(message)).toBeNull(); // audio-only turn, no fabricated text
     expect(elapsedMs).toBeGreaterThanOrEqual(90); // waited ~the ceiling
     expect(elapsedMs).toBeLessThan(2000); // but bounded, did not hang
+  });
+
+  it("adds ZERO latency for an adapter that does not expose lastAgentTranscript (P1 — Twilio/Pipecat/Composable)", async () => {
+    // The adapter never declares `lastAgentTranscript`, so the grace-wait could
+    // never succeed. It MUST short-circuit on the absent property rather than burn
+    // the ceiling: pre-fix this turn cost the full 2s; post-fix it costs ~0.
+    const adapter = new TranscriptlessAdapter();
+    adapter.responseTailSilence = 0.02;
+    adapter.transcriptGraceWait = 2.0; // the real default — would dominate if we waited
+
+    const start = Date.now();
+    const message = await defaultVoiceCall(adapter, inputWithUserTurn());
+    const elapsedMs = Date.now() - start;
+
+    // Audio-only turn (no transcript convention), and critically NO ceiling spent.
+    expect(transcriptOf(message)).toBeNull();
+    expect(elapsedMs).toBeLessThan(500); // well under the 2s ceiling → wait was skipped
   });
 });

--- a/javascript/src/voice/__tests__/transcript-grace-wait.test.ts
+++ b/javascript/src/voice/__tests__/transcript-grace-wait.test.ts
@@ -1,0 +1,182 @@
+/**
+ * #734 — transcript grace-wait in the default voice call() (AC5, AC3, AC1).
+ *
+ * ROOT CAUSE (verified on main): `drainAgentResponse` closes the agent turn on
+ * AUDIO silence (`responseTailSilence`) and NEVER waits for the transcript. A
+ * hosted-ElevenLabs agent delivers the turn's text on a SEPARATE socket event
+ * (`agent_response` → `lastAgentTranscript`) that can land AFTER the audio
+ * boundary. `attachAgentTurnTranscript` then snapshots `lastAgentTranscript` at
+ * drain-close; when the event hasn't landed, the field is `null`, no
+ * `{type:"text"}` part is attached, and the turn reaches the text-only
+ * user-simulator as a bare `[audio message]` → the simulator fabricates.
+ *
+ * These tests drive the REAL `defaultVoiceCall` runtime with a fake adapter that
+ * models the race precisely: `receiveAudio` yields transcript-LESS audio (raw
+ * PCM, as EL does), and `lastAgentTranscript` is set on a configurable DELAY
+ * (mimicking the separate `agent_response` event). No executor state is wired,
+ * so `call()` returns the merged assistant audio message directly and we assert
+ * on the transcript part it carries.
+ *
+ * - AC5 (falsifiability): a transcript that lands AFTER audio drain but WITHIN
+ *   the grace window is attached. FAILS on main (no wait → snapshot reads null →
+ *   no text part); PASSES with the grace-wait.
+ * - AC3 (no-regression): when the transcript is ALREADY set at drain-close, the
+ *   grace-wait short-circuits — `call()` returns without spending the ceiling
+ *   (timing assertion), and the transcript is still attached.
+ * - Bounded: a transcript that NEVER arrives terminates the turn after the
+ *   ceiling with no text part (so a genuine EL drop still ends the turn — the
+ *   STT fallback, AC2, then covers it downstream).
+ */
+import { describe, it, expect } from "vitest";
+
+import { AgentRole, type AgentInput } from "../../domain/agents";
+import { VoiceAgentAdapter } from "../adapter";
+import { defaultVoiceCall } from "../adapter.runtime";
+import {
+  AudioChunk,
+  silentChunk,
+  PCM16_SAMPLE_RATE,
+  PCM16_SAMPLE_WIDTH_BYTES,
+} from "../audio-chunk";
+import { AdapterCapabilities } from "../capabilities";
+
+/** A non-silent PCM16 chunk (mono, 24kHz) carrying NO transcript — raw EL audio. */
+function rawTone(durationSeconds: number): AudioChunk {
+  const numSamples = Math.round(durationSeconds * PCM16_SAMPLE_RATE);
+  const data = new Uint8Array(numSamples * PCM16_SAMPLE_WIDTH_BYTES);
+  const view = new DataView(data.buffer);
+  for (let i = 0; i < numSamples; i++) {
+    view.setInt16(i * 2, ((i * 97) % 20000) - 10000, true);
+  }
+  return new AudioChunk({ data }); // no transcript — mimics EL's raw PCM frames
+}
+
+/**
+ * Fake adapter modeling the EL race: audio drains with NO per-chunk transcript;
+ * `lastAgentTranscript` is populated on a delay (the separate `agent_response`
+ * event) — or never, when `transcriptDelayMs` is null.
+ */
+class RaceAdapter extends VoiceAgentAdapter {
+  override role = AgentRole.AGENT;
+  readonly capabilities = new AdapterCapabilities({
+    streamingTranscripts: false,
+    nativeVad: true,
+    dtmf: false,
+    interruption: false,
+    inputFormats: ["pcm16/24000"],
+    outputFormats: ["pcm16/24000"],
+  });
+
+  lastAgentTranscript: string | null = null;
+
+  private index = 0;
+  private readonly responses: AudioChunk[];
+
+  constructor(
+    private readonly transcript: string,
+    /** ms after drain-close that the transcript event lands; null = never. */
+    private readonly transcriptDelayMs: number | null,
+  ) {
+    super();
+    // One real audio frame, then end-of-stream so the drain loop exits fast.
+    this.responses = [rawTone(0.5)];
+  }
+
+  async connect(): Promise<void> {}
+  async disconnect(): Promise<void> {}
+  async sendAudio(): Promise<void> {}
+
+  async receiveAudio(_timeout: number): Promise<AudioChunk> {
+    if (this.index < this.responses.length) {
+      const chunk = this.responses[this.index++]!;
+      // On the LAST real chunk, schedule the transcript to land after drain —
+      // i.e. AFTER the audio-silence boundary, modeling the lost race.
+      if (this.index === this.responses.length && this.transcriptDelayMs !== null) {
+        setTimeout(() => {
+          this.lastAgentTranscript = this.transcript;
+        }, this.transcriptDelayMs);
+      }
+      return chunk;
+    }
+    return silentChunk(0);
+  }
+}
+
+/** Minimal AgentInput: one user turn, no executor state (recorder no-ops). */
+function inputWithUserTurn(): AgentInput {
+  return {
+    threadId: "t-734",
+    messages: [],
+    newMessages: [{ role: "user", content: "hello" }],
+    requestedRole: AgentRole.AGENT,
+    scenarioState: {} as AgentInput["scenarioState"],
+    scenarioConfig: {} as AgentInput["scenarioConfig"],
+  };
+}
+
+/** Pull the transcript text part (if any) from a returned assistant message. */
+function transcriptOf(message: unknown): string | null {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return null;
+  const text = content.find(
+    (p) =>
+      p &&
+      typeof p === "object" &&
+      (p as { type?: unknown }).type === "text" &&
+      typeof (p as { text?: unknown }).text === "string",
+  ) as { text?: string } | undefined;
+  return text?.text ?? null;
+}
+
+describe("#734 transcript grace-wait (defaultVoiceCall)", () => {
+  it("AC5: attaches a transcript that lands AFTER audio drain but within the grace window (FAILS on main)", async () => {
+    // Transcript lands 100ms after drain-close — past audio silence, well within
+    // a 2s grace ceiling. On main (no wait) the snapshot reads null → no text
+    // part → the message reaches the simulator as bare audio. With the fix the
+    // grace-wait polls until the transcript lands and attaches it.
+    const adapter = new RaceAdapter("the balance is forty two dollars", 100);
+    adapter.responseTailSilence = 0.02; // shrink drain so the transcript can't win
+    adapter.transcriptGraceWait = 2.0;
+
+    const message = await defaultVoiceCall(adapter, inputWithUserTurn());
+
+    expect(transcriptOf(message)).toBe("the balance is forty two dollars");
+  });
+
+  it("AC3: short-circuits with ZERO added latency when the transcript already won the race", async () => {
+    // Transcript is present the instant audio drains (delay 0 fires within the
+    // drain's own microtask window is not guaranteed — so set it eagerly here to
+    // model 'already set at drain-close', the happy path).
+    const adapter = new RaceAdapter("coherent reply", null);
+    adapter.responseTailSilence = 0.02;
+    // Long ceiling: if the wait did NOT short-circuit it would dominate the timing.
+    adapter.transcriptGraceWait = 5.0;
+    adapter.lastAgentTranscript = "coherent reply"; // already set at drain-close
+
+    const start = Date.now();
+    const message = await defaultVoiceCall(adapter, inputWithUserTurn());
+    const elapsedMs = Date.now() - start;
+
+    expect(transcriptOf(message)).toBe("coherent reply");
+    // The 5s ceiling must not be spent — the short-circuit returns immediately.
+    // Generous bound (well under the ceiling) to stay non-flaky under CI load.
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
+  it("bounded: a transcript that NEVER arrives terminates the turn after the ceiling with no text part", async () => {
+    // EL genuinely dropped the transcript for this turn. The grace-wait must not
+    // hang forever — it elapses the (small, for the test) ceiling and returns an
+    // audio-only turn. The STT fallback (AC2) then covers this downstream.
+    const adapter = new RaceAdapter("never sent", null);
+    adapter.responseTailSilence = 0.02;
+    adapter.transcriptGraceWait = 0.1; // small ceiling so the test is fast
+
+    const start = Date.now();
+    const message = await defaultVoiceCall(adapter, inputWithUserTurn());
+    const elapsedMs = Date.now() - start;
+
+    expect(transcriptOf(message)).toBeNull(); // audio-only turn, no fabricated text
+    expect(elapsedMs).toBeGreaterThanOrEqual(90); // waited ~the ceiling
+    expect(elapsedMs).toBeLessThan(2000); // but bounded, did not hang
+  });
+});

--- a/javascript/src/voice/__tests__/transcript-grace-wait.test.ts
+++ b/javascript/src/voice/__tests__/transcript-grace-wait.test.ts
@@ -27,7 +27,7 @@
  *   ceiling with no text part (so a genuine EL drop still ends the turn — the
  *   STT fallback, AC2, then covers it downstream).
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 
 import { AgentRole, type AgentInput } from "../../domain/agents";
 import { VoiceAgentAdapter } from "../adapter";
@@ -39,6 +39,9 @@ import {
   PCM16_SAMPLE_WIDTH_BYTES,
 } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
+
+/** Every RaceAdapter built this test — disposed in afterEach so no timer leaks. */
+const liveAdapters: RaceAdapter[] = [];
 
 /** A non-silent PCM16 chunk (mono, 24kHz) carrying NO transcript — raw EL audio. */
 function rawTone(durationSeconds: number): AudioChunk {
@@ -71,6 +74,16 @@ class RaceAdapter extends VoiceAgentAdapter {
 
   private index = 0;
   private readonly responses: AudioChunk[];
+  /** Handle for the delayed-transcript timer so teardown can clear it. */
+  private transcriptTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Clear any pending delayed-transcript timer (called on test teardown). */
+  dispose(): void {
+    if (this.transcriptTimer !== null) {
+      clearTimeout(this.transcriptTimer);
+      this.transcriptTimer = null;
+    }
+  }
 
   constructor(
     private readonly transcript: string,
@@ -80,6 +93,7 @@ class RaceAdapter extends VoiceAgentAdapter {
     super();
     // One real audio frame, then end-of-stream so the drain loop exits fast.
     this.responses = [rawTone(0.5)];
+    liveAdapters.push(this);
   }
 
   async connect(): Promise<void> {}
@@ -90,11 +104,14 @@ class RaceAdapter extends VoiceAgentAdapter {
     if (this.index < this.responses.length) {
       const chunk = this.responses[this.index++]!;
       // On the LAST real chunk, schedule the transcript to land after drain —
-      // i.e. AFTER the audio-silence boundary, modeling the lost race.
+      // i.e. AFTER the audio-silence boundary, modeling the lost race. Unref the
+      // timer so a leaked scheduling never keeps the process (or a later test)
+      // alive; `dispose()` clears it explicitly on teardown.
       if (this.index === this.responses.length && this.transcriptDelayMs !== null) {
-        setTimeout(() => {
+        this.transcriptTimer = setTimeout(() => {
           this.lastAgentTranscript = this.transcript;
         }, this.transcriptDelayMs);
+        this.transcriptTimer.unref?.();
       }
       return chunk;
     }
@@ -129,6 +146,11 @@ function transcriptOf(message: unknown): string | null {
 }
 
 describe("#734 transcript grace-wait (defaultVoiceCall)", () => {
+  afterEach(() => {
+    // Clear any pending delayed-transcript timers so nothing fires into a later test.
+    while (liveAdapters.length > 0) liveAdapters.pop()!.dispose();
+  });
+
   it("AC5: attaches a transcript that lands AFTER audio drain but within the grace window (FAILS on main)", async () => {
     // Transcript lands 100ms after drain-close — past audio silence, well within
     // a 2s grace ceiling. On main (no wait) the snapshot reads null → no text

--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -91,6 +91,9 @@ export class AgentSpeakingEvent {
 const SAFE_DEFAULT_RESPONSE_TIMEOUT_S = 30;
 const SAFE_DEFAULT_TAIL_SILENCE_S = 0.6;
 const SAFE_DEFAULT_MAX_DURATION_S = 30;
+const SAFE_DEFAULT_TRANSCRIPT_GRACE_WAIT_S = 2.0;
+/** Poll interval for the transcript grace-wait — fine enough to add no felt latency. */
+const TRANSCRIPT_GRACE_POLL_MS = 10;
 
 /**
  * Per-scenario VAD fallback registry. Keyed by adapter instance so the
@@ -281,6 +284,19 @@ export async function defaultVoiceCall(
   const merged = await drainAgentResponse(adapter, speakingEvent, () => {
     recorder.markAgentStart();
   });
+  // #734 — bounded grace-wait for the pending transcript BEFORE the back-fill
+  // reads it. Audio silence closed the turn above (`responseTailSilence`), but a
+  // live voice agent (hosted ElevenLabs) sends the turn's text on a SEPARATE
+  // socket event that can land AFTER the audio-silence boundary. Snapshotting
+  // `lastAgentTranscript` at drain-close would then read `null` → the turn
+  // reaches the text-only simulator as a bare `[audio message]` and it
+  // fabricates. Wait (bounded) for the transcript event instead of racing it.
+  // Gated on `merged` having audio: a no-audio turn is never labeled anyway
+  // (attachAgentTurnTranscript short-circuits on empty data), so there is
+  // nothing to wait for. Short-circuits the instant the transcript is present.
+  if (merged.data.length > 0 && !merged.transcript) {
+    await awaitAgentTranscript(adapter);
+  }
   // Carry the agent turn's NATIVE transcript onto the chunk when the merged
   // audio has none (#705). A live voice agent (hosted ElevenLabs, Gemini Live,
   // OpenAI Realtime) streams raw PCM frames with NO per-chunk transcript but
@@ -324,6 +340,45 @@ function attachAgentTurnTranscript(
     return new AudioChunk({ data: chunk.data, transcript: native });
   }
   return chunk;
+}
+
+/**
+ * Bounded grace-wait for the agent turn's native transcript (#734).
+ *
+ * Audio silence closes the turn in {@link drainAgentResponse}, but a live voice
+ * agent (hosted ElevenLabs) delivers the turn's text on a SEPARATE socket event
+ * (`agent_response` → `lastAgentTranscript`) that can land AFTER the audio
+ * boundary. This polls `lastAgentTranscript` up to `adapter.transcriptGraceWait`
+ * seconds so a transcript arriving within the window is present when
+ * {@link attachAgentTurnTranscript} reads it.
+ *
+ * Short-circuits (returns immediately, no timer, ZERO added latency) when the
+ * transcript is ALREADY set at entry — the common happy path where the
+ * transcript won the race (AC3, no-regression). Bounded so a genuine
+ * ElevenLabs drop (transcript never sent) still terminates the turn after the
+ * ceiling. A `transcriptGraceWait` of 0 disables the wait entirely.
+ *
+ * Duck-typed on `lastAgentTranscript` (symmetric with the read/reset) so it
+ * composes with every adapter following the harness convention without widening
+ * the base contract; an adapter that never exposes the field simply falls
+ * through to the ceiling once (its transcript is genuinely never coming).
+ */
+async function awaitAgentTranscript(adapter: VoiceAgentAdapter): Promise<void> {
+  const hasTranscript = (): boolean => {
+    const native = (adapter as { lastAgentTranscript?: string | null })
+      .lastAgentTranscript;
+    return typeof native === "string" && native.length > 0;
+  };
+  if (hasTranscript()) return;
+
+  const ceilingS = adapter.transcriptGraceWait ?? SAFE_DEFAULT_TRANSCRIPT_GRACE_WAIT_S;
+  if (ceilingS <= 0) return;
+
+  const deadline = Date.now() + ceilingS * 1000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, TRANSCRIPT_GRACE_POLL_MS));
+    if (hasTranscript()) return;
+  }
 }
 
 /**

--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -293,7 +293,10 @@ export async function defaultVoiceCall(
   // fabricates. Wait (bounded) for the transcript event instead of racing it.
   // Gated on `merged` having audio: a no-audio turn is never labeled anyway
   // (attachAgentTurnTranscript short-circuits on empty data), so there is
-  // nothing to wait for. Short-circuits the instant the transcript is present.
+  // nothing to wait for. awaitAgentTranscript itself short-circuits both when the
+  // transcript is already present AND when the adapter does not expose the
+  // `lastAgentTranscript` convention at all (Twilio/Pipecat/Composable) — so a
+  // transcript-less adapter pays ZERO added latency here.
   if (merged.data.length > 0 && !merged.transcript) {
     await awaitAgentTranscript(adapter);
   }
@@ -360,10 +363,24 @@ function attachAgentTurnTranscript(
  *
  * Duck-typed on `lastAgentTranscript` (symmetric with the read/reset) so it
  * composes with every adapter following the harness convention without widening
- * the base contract; an adapter that never exposes the field simply falls
- * through to the ceiling once (its transcript is genuinely never coming).
+ * the base contract.
+ *
+ * CRITICAL — only adapters that actually EXPOSE the `lastAgentTranscript`
+ * convention are waited on. An adapter that does NOT declare the field
+ * (Twilio/Pipecat return raw audio; Composable carries its text on a different
+ * field) can never populate it, so waiting on it would burn the full
+ * `transcriptGraceWait` ceiling EVERY turn for nothing — seconds of artificial
+ * latency across a long `proceed()` run. For those, the property is absent and
+ * we skip the wait entirely (property present-but-null → wait; property absent
+ * → no wait). This is why the base-class default (2.0s) is safe to ship on the
+ * shared `VoiceAgentAdapter`: it only ever costs a transcript-capable adapter.
  */
 async function awaitAgentTranscript(adapter: VoiceAgentAdapter): Promise<void> {
+  // Absent property → this adapter does not use the native-transcript convention;
+  // waiting could never succeed, so skip (zero added latency). Present-but-null →
+  // the transcript event is pending; fall through and wait for it.
+  if (!("lastAgentTranscript" in (adapter as object))) return;
+
   const hasTranscript = (): boolean => {
     const native = (adapter as { lastAgentTranscript?: string | null })
       .lastAgentTranscript;

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -84,6 +84,24 @@ export abstract class VoiceAgentAdapter extends AgentAdapter {
    */
   responseMaxDuration = 30.0;
 
+  /**
+   * Bounded grace-wait (seconds) for the agent turn's transcript AFTER audio
+   * drains (#734). Audio silence closes the turn (`responseTailSilence`), but a
+   * live voice agent (hosted ElevenLabs) delivers the turn's text on a SEPARATE
+   * socket event (`agent_response` → `lastAgentTranscript`). When that event
+   * lands after the audio-silence boundary, snapshotting `lastAgentTranscript`
+   * at drain-close reads `null` and the turn reaches the text-only simulator as
+   * a bare `[audio message]` — the simulator then fabricates.
+   *
+   * The default `call()` flow ({@link defaultVoiceCall}) polls this field up to
+   * this ceiling for a pending transcript before reading it. It short-circuits
+   * the INSTANT `lastAgentTranscript` is already set (zero added latency on the
+   * happy path — the common case where the transcript won the race) and only
+   * elapses when the transcript genuinely never arrives, so a real ElevenLabs
+   * drop still terminates the turn. Set to `0` to disable the wait.
+   */
+  transcriptGraceWait = 2.0;
+
   /** Open the transport and prepare to exchange audio. */
   abstract connect(): Promise<void>;
 

--- a/javascript/src/voice/adapters/composable.ts
+++ b/javascript/src/voice/adapters/composable.ts
@@ -199,7 +199,17 @@ export class ComposableVoiceAgent extends VoiceAgentAdapter {
       this.lastLlmResponse = responseText;
       this.history.push({ role: "assistant", content: responseText });
 
-      return synthesize(responseText, this.tts, this.ttsOptions);
+      const audio = await synthesize(responseText, this.tts, this.ttsOptions);
+      // Carry the LLM response text ON the returned chunk (#734/#735 P1). We
+      // already KNOW this turn's exact words (we generated them), so attaching
+      // them as the chunk transcript means attachAgentTurnTranscript labels the
+      // turn from the chunk directly — no grace-wait (defaultVoiceCall skips the
+      // wait when merged.transcript is set) and no simulator STT pre-pass
+      // re-transcribing our own synthesized reply. Only when there is real text.
+      if (responseText.length > 0 && audio.data.length > 0) {
+        return new AudioChunk({ data: audio.data, transcript: responseText });
+      }
+      return audio;
     })();
 
     const chunk = await withTimeout(

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -740,6 +740,12 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     // A real user turn is starting → lift the post-response pause so the closing
     // silence streams again once this speech drains (see pumpTick).
     this.awaitingUserTurn = false;
+    // #734 — a new user turn opens a new agent turn; clear the last-audio stamp so
+    // callbackAgentResponse measures transcript lag against THIS turn's audio only.
+    // Without this, a turn whose transcript arrives with no fresh audio frame would
+    // report lag against a PRIOR turn's audio, making transcriptLagMs/lostRacePreFix
+    // (AC4 telemetry) misleading.
+    this.lastAgentAudioAtMs = null;
     // Count the turn ONCE per non-empty sendAudio (not once per 20 ms frame) so the
     // STT assertion still counts turns, not frames.
     this.audioCommitCount += 1;

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -73,6 +73,7 @@ import type { ConversationClient } from "@elevenlabs/elevenlabs-js/api/resources
 import type { WebSocketFactory } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/interfaces/WebSocketInterface";
 
 import { AgentRole } from "../../domain/agents";
+import { Logger } from "../../utils/logger";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
 import { VoiceAgentAdapter } from "../adapter";
@@ -372,6 +373,20 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
   lastAgentTranscript: string | null = null;
 
   /**
+   * Wall-clock (ms) of the most-recent agent AUDIO frame for the current turn
+   * (#734). Set in {@link onAgentAudio}; read in `callbackAgentResponse` to log
+   * how far the `agent_response` TRANSCRIPT event lags the audio it describes.
+   * That per-turn lag is the direct measurement behind the grace-wait: a
+   * POSITIVE lag past `responseTailSilence` is a turn that would have lost the
+   * race (transcript arriving after audio-silence drain-close) — i.e. the
+   * late-vs-never signal the fix (AC4) makes observable in live runs.
+   */
+  private lastAgentAudioAtMs: number | null = null;
+
+  /** Debug logger for the #734 transcript-lag instrumentation (AC4). */
+  private readonly logger = new Logger("ElevenLabsAgentAdapter");
+
+  /**
    * How many user turns this adapter committed by streaming real PCM. The
    * voice-specific assertion keys on this together with {@link
    * lastUserTranscript}: a non-empty `user_transcript` after `audioCommitCount`
@@ -469,6 +484,19 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
         this.lastUserTranscript = transcript;
       },
       callbackAgentResponse: (response) => {
+        // #734 (AC4) — measure how far this transcript event lags the audio it
+        // describes. A lag exceeding `responseTailSilence` is a turn whose
+        // transcript would have LOST the drain-close race pre-fix; the grace-wait
+        // now covers it. Emitting the per-turn lag makes late-vs-never (the
+        // issue's open question) observable in a forced-race run. Debug-level:
+        // silent by default, surfaced with LOG_LEVEL=debug.
+        const audioAt = this.lastAgentAudioAtMs;
+        const lagMs = audioAt !== null ? Date.now() - audioAt : null;
+        this.logger.debug("agent_response transcript received", {
+          transcriptLagMs: lagMs,
+          responseTailSilenceMs: this.responseTailSilence * 1000,
+          lostRacePreFix: lagMs !== null && lagMs > this.responseTailSilence * 1000,
+        });
         this.lastAgentTranscript = response;
       },
       callbackAgentResponseCorrection: (_original, corrected) => {
@@ -512,6 +540,10 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     // user turn ({@link enqueueSpeech} clears the flag). Idempotent — the FIRST
     // agent frame of the response is the real transition; later frames re-assert it.
     this.awaitingUserTurn = true;
+    // #734 — stamp the last agent-audio arrival so callbackAgentResponse can log
+    // transcript-lag-vs-audio-drain. Every frame re-stamps; the field therefore
+    // holds the LAST audio frame of the turn, the tightest baseline for the lag.
+    this.lastAgentAudioAtMs = Date.now();
     // EL audio is PCM16 (even byte count); trim a stray odd byte defensively so the
     // AudioChunk invariant never throws.
     let pcm = audio;

--- a/javascript/src/voice/index.ts
+++ b/javascript/src/voice/index.ts
@@ -161,8 +161,10 @@ export {
 // "judge requests transcript" tool (no such tool, §7.3); STT is upstream.
 export {
   prepareJudgeInput,
+  transcribeAudioMessages,
   type JudgeAudioOptions,
   type JudgePreparedInput,
+  type TranscribeAudioMessagesArgs,
 } from "./judge-stt";
 
 export {

--- a/javascript/src/voice/judge-stt.ts
+++ b/javascript/src/voice/judge-stt.ts
@@ -51,6 +51,50 @@ interface PrepareJudgeInputArgs {
   logWarn?: (message: string) => void;
 }
 
+/** Arguments for the shared {@link transcribeAudioMessages} STT pre-pass. */
+export interface TranscribeAudioMessagesArgs {
+  /** Conversation history to transcribe over. */
+  messages: readonly ModelMessage[];
+  /** Per-run STT provider (from the resolved `cfg.voice.stt`). */
+  stt: STTProvider;
+  /**
+   * Keep the raw audio `file` part alongside the transcribed text when true;
+   * drop it (text-only) when false. Judge passes its multimodal knob here; the
+   * user-simulator passes `true` so `stripAudioContent`'s echo-safety reframing
+   * (which keys on a message having BOTH audio and text) still triggers.
+   */
+  includeAudio: boolean;
+  /** Warning sink — defaults to {@link console.warn}. */
+  logWarn?: (message: string) => void;
+}
+
+/**
+ * Shared STT pre-pass (#734): for every message carrying audio, attach the
+ * spoken words as a `{ type: "text" }` part — reusing an existing text sibling
+ * when present, else transcribing the audio chunk via the resolved
+ * {@link STTProvider}. Optionally keeps or drops the raw audio part.
+ *
+ * This is the single implementation behind BOTH the judge's
+ * {@link prepareJudgeInput} pre-pass and the user-simulator's STT fallback: EL
+ * can fail to send `agent_response` for a turn, leaving the simulator with a
+ * bare `[audio message]`; running this before `stripAudioContent` gives the
+ * text-only simulator real words instead. Extracting it here keeps the STT
+ * plumbing in ONE place rather than duplicating it into the simulator.
+ *
+ * The input array is never mutated — a new message list is returned. STT
+ * failures degrade gracefully (audio dropped on the text-only path, a warning
+ * logged) so the caller still processes the rest of the conversation.
+ */
+export async function transcribeAudioMessages(
+  args: TranscribeAudioMessagesArgs,
+): Promise<ModelMessage[]> {
+  const { messages, stt, includeAudio } = args;
+  const warn = args.logWarn ?? ((m: string) => console.warn(m));
+  return Promise.all(
+    messages.map((msg) => transcribeMessage(msg, stt, includeAudio, warn)),
+  );
+}
+
 function isAudioFilePart(part: unknown): boolean {
   if (!part || typeof part !== "object") return false;
   const p = part as Record<string, unknown>;
@@ -93,14 +137,13 @@ function hasTextPart(content: readonly unknown[]): boolean {
 export async function prepareJudgeInput(
   args: PrepareJudgeInputArgs,
 ): Promise<JudgePreparedInput> {
-  const { messages, stt, options } = args;
-  const includeAudio = options?.includeAudio ?? false;
-  const warn = args.logWarn ?? ((m: string) => console.warn(m));
-
-  const out = await Promise.all(
-    messages.map((msg) => transcribeMessage(msg, stt, includeAudio, warn)),
-  );
-  return { messages: out };
+  const messages = await transcribeAudioMessages({
+    messages: args.messages,
+    stt: args.stt,
+    includeAudio: args.options?.includeAudio ?? false,
+    logWarn: args.logWarn,
+  });
+  return { messages };
 }
 
 async function transcribeMessage(

--- a/javascript/src/voice/judge-stt.ts
+++ b/javascript/src/voice/judge-stt.ts
@@ -64,6 +64,19 @@ export interface TranscribeAudioMessagesArgs {
    * (which keys on a message having BOTH audio and text) still triggers.
    */
   includeAudio: boolean;
+  /**
+   * Optional cross-call transcript cache keyed by a STABLE audio key (the raw
+   * audio payload). Prevents re-transcribing the SAME audio on every call.
+   *
+   * The judge builds a transcript once per verdict and passes no cache. The
+   * user-simulator's STT fallback, by contrast, re-runs over the WHOLE history
+   * on EVERY `proceed()` turn: without a cache, an audio-only agent turn that
+   * stays in history is transcribed on turn N, again on N+1, N+2, … turning a
+   * single dropped `agent_response` into O(turns^2) STT calls (#735 P2). The
+   * simulator passes a per-instance Map so each distinct audio chunk hits the
+   * provider at most once for the life of the simulator instance.
+   */
+  transcriptCache?: Map<string, string>;
   /** Warning sink — defaults to {@link console.warn}. */
   logWarn?: (message: string) => void;
 }
@@ -88,10 +101,12 @@ export interface TranscribeAudioMessagesArgs {
 export async function transcribeAudioMessages(
   args: TranscribeAudioMessagesArgs,
 ): Promise<ModelMessage[]> {
-  const { messages, stt, includeAudio } = args;
+  const { messages, stt, includeAudio, transcriptCache } = args;
   const warn = args.logWarn ?? ((m: string) => console.warn(m));
   return Promise.all(
-    messages.map((msg) => transcribeMessage(msg, stt, includeAudio, warn)),
+    messages.map((msg) =>
+      transcribeMessage(msg, stt, includeAudio, warn, transcriptCache),
+    ),
   );
 }
 
@@ -146,34 +161,68 @@ export async function prepareJudgeInput(
   return { messages };
 }
 
+/**
+ * Stable cache key for an audio message: the raw base64 payload of its first
+ * audio `file` part. The same audio chunk re-sent across `proceed()` turns
+ * carries an identical payload, so this key collapses repeat transcription of
+ * one chunk to a single STT call (#735 P2). Returns `null` for the legacy
+ * `input_audio`/`audio` shapes (no cache — those are adapter-edge and rare).
+ */
+function audioCacheKey(content: readonly unknown[]): string | null {
+  for (const p of content) {
+    if (!p || typeof p !== "object") continue;
+    const part = p as Record<string, unknown>;
+    if (
+      part["type"] === "file" &&
+      typeof part["mediaType"] === "string" &&
+      (part["mediaType"] as string).startsWith("audio/") &&
+      typeof part["data"] === "string"
+    ) {
+      return part["data"] as string;
+    }
+  }
+  return null;
+}
+
 async function transcribeMessage(
   msg: ModelMessage,
   stt: STTProvider,
   includeAudio: boolean,
   warn: (message: string) => void,
+  transcriptCache?: Map<string, string>,
 ): Promise<ModelMessage> {
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) return msg;
   if (!content.some(isAudioFilePart)) return msg;
 
-  // Resolve a transcript: prefer an existing text part, else run STT.
+  // Resolve a transcript: prefer an existing text part, else the cross-call
+  // cache, else run STT (and cache the result).
   let transcript: string | undefined;
   if (hasTextPart(content)) {
     // buildTranscriptFromMessages already reads the existing text part; keep
     // the message text intact and only adjust audio passthrough below.
     transcript = undefined; // sentinel — no new text part needed
   } else {
-    const chunk = extractAudioChunk(msg);
-    if (chunk) {
-      try {
-        transcript = (await stt.transcribe(chunk)) || undefined;
-      } catch (e) {
-        warn(
-          `scenario.voice.judge-stt: STT failed for a ${String(
-            (msg as { role?: unknown }).role ?? "?",
-          )} audio message; dropping audio and continuing text-only: ` +
-            `${(e as Error).message ?? e}`,
-        );
+    const cacheKey = transcriptCache ? audioCacheKey(content) : null;
+    if (cacheKey !== null && transcriptCache!.has(cacheKey)) {
+      // Same audio already transcribed on an earlier call — reuse, no STT.
+      transcript = transcriptCache!.get(cacheKey) || undefined;
+    } else {
+      const chunk = extractAudioChunk(msg);
+      if (chunk) {
+        try {
+          transcript = (await stt.transcribe(chunk)) || undefined;
+          if (cacheKey !== null && transcript !== undefined) {
+            transcriptCache!.set(cacheKey, transcript);
+          }
+        } catch (e) {
+          warn(
+            `scenario.voice.judge-stt: STT failed for a ${String(
+              (msg as { role?: unknown }).role ?? "?",
+            )} audio message; dropping audio and continuing text-only: ` +
+              `${(e as Error).message ?? e}`,
+          );
+        }
       }
     }
   }

--- a/javascript/src/voice/judge-stt.ts
+++ b/javascript/src/voice/judge-stt.ts
@@ -212,10 +212,22 @@ async function transcribeMessage(
       if (chunk) {
         try {
           transcript = (await stt.transcribe(chunk)) || undefined;
-          if (cacheKey !== null && transcript !== undefined) {
-            transcriptCache!.set(cacheKey, transcript);
+          // Cache whenever STT actually RAN and RETURNED — including an empty
+          // result. `""` is the negative sentinel: the reuse branch above turns
+          // a cached `""` back into `undefined` (no text part), so remembering
+          // an empty transcript is correct AND stops the same dead chunk from
+          // re-hitting STT on every later proceed() turn (#735 P2). A different
+          // (good) transcript can only come from different bytes → a different
+          // key, so the sentinel can never suppress a real transcript.
+          if (cacheKey !== null) {
+            transcriptCache!.set(cacheKey, transcript ?? "");
           }
         } catch (e) {
+          // Remember the failure too: without this, a provider outage is
+          // re-attempted for the SAME chunk on every subsequent call (#735 P2).
+          if (cacheKey !== null) {
+            transcriptCache!.set(cacheKey, "");
+          }
           warn(
             `scenario.voice.judge-stt: STT failed for a ${String(
               (msg as { role?: unknown }).role ?? "?",

--- a/specs/voice-transcript-grace-wait.feature
+++ b/specs/voice-transcript-grace-wait.feature
@@ -1,0 +1,81 @@
+Feature: Voice user-simulator reacts to the agent's real transcript, not a fabrication
+  As a developer running a hosted-ElevenLabs voice scenario over many turns
+  I want the user-simulator to receive what the agent ACTUALLY said on every turn
+  So that the simulator's next turn is grounded in the conversation and it does
+  not fabricate replies about things the agent never said
+
+  # ROOT CAUSE (issue #734, verified on main): drainAgentResponse closes the
+  # agent turn on AUDIO silence (responseTailSilence) and never waits for the
+  # transcript. Hosted ElevenLabs delivers the turn's text on a SEPARATE
+  # agent_response socket event (sets lastAgentTranscript). When that event has
+  # not landed by drain-close, attachAgentTurnTranscript snapshots a null
+  # transcript, no {type:"text"} part is attached, and the turn reaches the
+  # text-only simulator as a bare "[audio message]" -> the simulator fabricates.
+  # The judge has an STT fallback (judge-stt); the simulator had none.
+
+  Background:
+    Given a hosted-ElevenLabs voice scenario whose agent audio always arrives
+    And the agent's transcript is delivered on a separate agent_response event
+
+  # AC1 — grace-wait (primary): wait for the transcript instead of racing it.
+  @unit @ts-grace-wait
+  Scenario: A transcript that lands after audio drain but within the grace window is attached
+    Given an agent turn whose audio drains before the transcript event lands
+    And the transcript event lands within the adapter's transcriptGraceWait ceiling
+    When defaultVoiceCall drains the agent response
+    Then it awaits lastAgentTranscript up to the bounded ceiling before reading it
+    And the arriving transcript is attached as a {type:"text"} part on the turn
+
+  # AC3 — no-regression: zero added latency when the transcript won the race.
+  @unit @ts-grace-wait
+  Scenario: The grace-wait short-circuits when the transcript is already present
+    Given an agent turn whose transcript is already set at drain-close
+    When defaultVoiceCall reaches the grace-wait
+    Then it returns immediately without spending the transcriptGraceWait ceiling
+    And the transcript is still attached to the turn
+
+  # AC1 (bounded) — a genuine ElevenLabs drop still terminates the turn.
+  @unit @ts-grace-wait
+  Scenario: A transcript that never arrives terminates the turn after the ceiling
+    Given an agent turn whose transcript event never lands
+    When defaultVoiceCall reaches the grace-wait
+    Then it elapses the bounded ceiling and returns an audio-only turn
+    And the call does not hang
+
+  # AC2 — STT fallback (safety net): cover the case EL never sends agent_response.
+  @unit @ts-sim-stt
+  Scenario: The simulator transcribes an audio-only agent turn before stripping audio
+    Given an agent turn that reaches the user-simulator as audio with no transcript
+    And a per-run STT provider resolved off scenarioConfig.voice
+    When the user-simulator prepares its LLM input
+    Then it transcribes the audio via the shared STT helper before stripAudioContent
+    And the simulator's LLM input carries the real transcript, not "[audio message]"
+
+  # AC2 — the STT plumbing is shared with the judge, not duplicated.
+  @unit @ts-sim-stt
+  Scenario: The simulator reuses the judge's STT pre-pass helper
+    Given the judge's prepareJudgeInput and the simulator both need audio transcribed
+    When either path runs its STT pre-pass
+    Then both delegate to the single shared transcribeAudioMessages helper
+
+  # AC4 — observability: per-turn transcript-lag-vs-audio-drain is measurable.
+  @integration @ts-grace-wait
+  Scenario: The ElevenLabs adapter logs transcript lag behind audio drain
+    Given a forced-race run (responseTailSilence shrunk so the transcript loses)
+    When the agent_response transcript event fires
+    Then the adapter debug-logs the transcript lag against the last agent-audio frame
+    And a lag exceeding responseTailSilence is flagged as a pre-fix lost race
+
+# --- AC Coverage Map ---
+# AC1 (grace-wait): javascript/src/voice/adapter.runtime.ts awaitAgentTranscript,
+#   javascript/src/voice/adapter.ts transcriptGraceWait field
+#   -> src/voice/__tests__/transcript-grace-wait.test.ts (AC5 delayed-transcript,
+#      short-circuit, bounded)
+# AC2 (STT fallback): javascript/src/agents/user-simulator-agent.ts +
+#   shared transcribeAudioMessages in javascript/src/voice/judge-stt.ts
+#   -> src/agents/__tests__/user-simulator-stt-fallback.test.ts
+# AC3 (no-regression): short-circuit timing test in transcript-grace-wait.test.ts;
+#   existing voice tests stay green; OpenAI-realtime path untouched.
+# AC4 (observability): javascript/src/voice/adapters/elevenlabs.ts callbackAgentResponse
+#   debug log (transcriptLagMs / lostRacePreFix).
+# AC5 (falsifiability): the AC1 delayed-transcript test fails on main, passes with the fix.


### PR DESCRIPTION
<!-- no-ui-surface -->
Backend-only — no UI surface.

**Reviewer cockpit**
- **Scariest thing** — the grace-wait adds an `await` between audio-drain and transcript-read on the shared `defaultVoiceCall` path (every voice adapter, not just EL). If it failed to short-circuit it would inject up to 2s of latency into every agent turn. Mitigated: it returns immediately when `lastAgentTranscript` is already set (the happy path) and is gated on the merged turn having audio but no transcript — a timing test locks the short-circuit.
- **Start here** — `javascript/src/voice/adapter.runtime.ts` `awaitAgentTranscript` + its one call site in `defaultVoiceCall`. That is the whole primary fix; everything else is safety net and instrumentation.

## Why

Closes #734.

In hosted-ElevenLabs voice scenarios the user-simulator **intermittently fabricated** — replying about things the agent never said. Root cause: `drainAgentResponse` closed the agent turn on **audio** silence and **never waited for the transcript**, which ElevenLabs delivers on a **separate** `agent_response` socket event. `attachAgentTurnTranscript` then snapshotted a `null` `lastAgentTranscript`, no `{type:"text"}` part was attached, and the turn reached the text-only simulator as a bare `[audio message]` -> it invented a plausible-but-wrong reply. The judge had an STT fallback; the simulator had none. Exposure scales with turn count and agent-reply latency, so short runs looked fine and long `proceed()` runs fabricated.

## What changed

- **Wait for the transcript instead of racing it (primary)** -> alternative was raising `responseTailSilence` -> rejected because a sufficiently-late transcript still loses the race; the drain never actually waited. New `transcriptGraceWait` field on `VoiceAgentAdapter` (default 2.0s, configurable like `responseTailSilence`); `defaultVoiceCall` bounded-polls `lastAgentTranscript` after audio drains. Short-circuits the instant it is already set (**zero happy-path latency**) and terminates after the ceiling so a genuine EL drop still ends the turn.
- **STT fallback for the simulator (safety net)** -> covers the case EL *never* sends `agent_response`. The simulator transcribes audio turns lacking a text sibling **before** `stripAudioContent`, reusing the judge's plumbing via a shared `transcribeAudioMessages` helper **extracted** from `judge-stt.ts` — not duplicated. Gated on an audio-without-transcript turn actually existing, so the happy path constructs no provider and pays no STT cost.
- **Lag instrumentation (observability)** -> the EL adapter debug-logs transcript-lag-vs-audio-drain per turn (`transcriptLagMs` / `lostRacePreFix`), making the issue's open "late-vs-never" question measurable in live runs.

## How it works

```
voice/adapter.ts               VoiceAgentAdapter.transcriptGraceWait = 2.0  (new bounded ceiling)
voice/adapter.runtime.ts       defaultVoiceCall -> drainAgentResponse (audio) ->
                                 awaitAgentTranscript(adapter)  <- NEW: bounded poll, short-circuits if set ->
                                 attachAgentTurnTranscript (reads lastAgentTranscript)
voice/judge-stt.ts             transcribeAudioMessages(...)  <- extracted shared STT pre-pass
                                 prepareJudgeInput now delegates to it (judge unchanged behaviorally)
agents/user-simulator-agent.ts call() -> hasAudioWithoutTranscript? -> transcribeAudioMessages(includeAudio:true) ->
                                 stripAudioContent  (echo-safety reframing preserved)
voice/adapters/elevenlabs.ts   callbackAgentResponse debug-logs lag vs last agent-audio frame
```

OpenAI-realtime path is untouched (it already accumulates a streaming transcript buffer).

## Human verification

Forced-race repro from the issue (before/after), on any multi-turn voice agent:

```ts
const el = scenario.elevenLabsAgent({ agentId, apiKey });
(el as any).responseTailSilence = 0.02;   // force the transcript to lose the race
// run a multi-turn voice scenario (proceed() over several turns)
// inspect the trace / the simulator's input messages
```

1. **Before this PR:** the trace shows many agent turns reaching the simulator as `[audio message]`; the simulator fabricates and the judge fails on incoherence.
2. **After this PR:** every turn where EL sends `agent_response` at all now carries `[the agent said: ...]` (grace-wait); any turn EL never transcribes carries STT-derived text (fallback). No `[audio message]` reaches the simulator.
3. Set `LOG_LEVEL=debug` to see the per-turn `transcriptLagMs` / `lostRacePreFix` lines confirming which turns would have lost the race pre-fix.

Live forced-race proof requires EL credentials and a multi-turn run; it is left as the reviewer re-verification recipe above. The deterministic proof below (stubbed race, fails-on-main) is what this session actually exercised.

## How I can prove I was successful

- **AC5 falsifiability — the delayed-`agent_response` test FAILS on main, PASSES with the fix** — *proven*. Reverting the source (keeping the tests) against `main` fails exactly the three race-dependent assertions; restoring the fix makes them pass:

```
--- new tests against MAIN source (fix reverted) ---
- Expected: "the balance is forty two dollars"
+ Received: null
 > src/voice/__tests__/transcript-grace-wait.test.ts:143  (AC1/AC5 delayed transcript)

AssertionError: expected 0 to be greater than or equal to 90
 > src/voice/__tests__/transcript-grace-wait.test.ts:179  (bounded wait — main never waits)

 (+ user-simulator-stt-fallback: STT never invoked on main)
 Test Files  2 failed (2)
      Tests  3 failed | 2 passed (5)     <- the 2 passing are the no-regression happy-path assertions
```

- **AC1 / AC2 / AC3 pass with the fix** — *proven*:

```
$ npx vitest run src/voice/__tests__/transcript-grace-wait.test.ts \
    src/agents/__tests__/user-simulator-stt-fallback.test.ts \
    src/voice/__tests__/judge-stt.test.ts
 Test Files  3 passed (3)
      Tests  11 passed (11)
```

- **No regression across the full suite** — *proven*:

```
$ npx vitest run               # entire JS suite
 Test Files  76 passed | 1 skipped (77)
      Tests  890 passed | 1 skipped (891)

$ pnpm run typecheck           # tsc --noEmit -> clean
$ npx eslint <changed files>   # exit 0 on all files this PR authored
```

The AC4 lag log is debug-level (silent unless `LOG_LEVEL=debug`); its emission is asserted indirectly via the code path and surfaced by the Human-verification recipe above (*claimed* — needs the live forced-race run to see the lines).

## Anything surprising?

- Per policy, PRs open as draft until CI is green; this one is opened **non-draft per the explicit task instruction**. CI has not yet run on the branch — flagging so the reviewer waits for green before merge.
- No screenshot artifact: this is a pure library/runtime change with no user-observable UI surface; the falsifiability before/after test output above is the proof floor for backend-only work.
