### PR TITLE
refactor(voice/tests): hoist AudioUserSimulator fixture to fixtures/ (#524)

### DIFF
--- a/javascript/src/voice/__tests__/fixtures/audio-user-simulator.ts
+++ b/javascript/src/voice/__tests__/fixtures/audio-user-simulator.ts
@@ -1,0 +1,45 @@
+import {
+  AgentRole,
+  type AgentInput,
+  type AgentReturnTypes,
+  UserSimulatorAgentAdapter,
+} from "../../../domain";
+import type { AudioChunk } from "../../audio-chunk";
+
+/**
+ * Build a user-role message carrying an audio (`input_audio` / pcm16) content
+ * block from a chunk's bytes.
+ *
+ * Cast through unknown: the audio shape is locally typed as `AudioMessageParam`
+ * but the executor's `ModelMessage` union accepts assistant arrays only.
+ * `ConvertModelMessagesToAguiMessages` JSON-stringifies the content, so the
+ * audio survives downstream.
+ */
+export function audioMessageContent(chunk: AudioChunk): AgentReturnTypes {
+  const base64 = Buffer.from(chunk.data).toString("base64");
+  return {
+    role: "user",
+    content: [
+      {
+        type: "input_audio",
+        input_audio: { data: base64, format: "pcm16" },
+      },
+    ],
+  } as unknown as AgentReturnTypes;
+}
+
+/**
+ * User simulator that returns an audio-shaped message so the default voice
+ * `call()` actually flows bytes through `sendAudio`. Without this, the user
+ * turn arrives as text and `extractAudioFromLastMessage` yields null, so no
+ * user-side audio hook fires.
+ */
+export class AudioUserSimulator extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  constructor(private readonly chunk: AudioChunk) {
+    super();
+  }
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return audioMessageContent(this.chunk);
+  }
+}

--- a/javascript/src/voice/__tests__/hooks.test.ts
+++ b/javascript/src/voice/__tests__/hooks.test.ts
@@ -21,16 +21,11 @@ import { fileURLToPath } from "node:url";
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect, it } from "vitest";
 
-import {
-  AgentRole,
-  type AgentInput,
-  type AgentReturnTypes,
-  UserSimulatorAgentAdapter,
-} from "../../domain";
 import { agent, succeed, user } from "../../script";
 import { ScenarioExecution } from "../../execution/scenario-execution";
 import { AudioChunk, silentChunk } from "../audio-chunk";
 import type { VoiceEvent } from "../recording.types";
+import { AudioUserSimulator } from "./fixtures/audio-user-simulator";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -57,35 +52,6 @@ function pcm16Chunk(durationSeconds: number, sample = 0x0010): AudioChunk {
     data[i + 1] = (sample >> 8) & 0xff;
   }
   return new AudioChunk({ data });
-}
-
-/**
- * User simulator that returns an audio-shaped message so the default
- * voice call() actually flows bytes through `sendAudio`. Without this,
- * the user turn arrives as text and `extractAudioFromLastMessage`
- * yields null → no user-side audio hook fires.
- */
-class AudioUserSimulator extends UserSimulatorAgentAdapter {
-  role = AgentRole.USER;
-  constructor(private readonly chunk: AudioChunk) {
-    super();
-  }
-  async call(_input: AgentInput): Promise<AgentReturnTypes> {
-    const base64 = Buffer.from(this.chunk.data).toString("base64");
-    // Cast through unknown — the audio shape is locally typed as
-    // AudioMessageParam but the executor's ModelMessage union accepts
-    // assistant arrays only. ConvertModelMessagesToAguiMessages
-    // JSON-stringifies the content, so the audio survives downstream.
-    return {
-      role: "user",
-      content: [
-        {
-          type: "input_audio",
-          input_audio: { data: base64, format: "pcm16" },
-        },
-      ],
-    } as unknown as AgentReturnTypes;
-  }
 }
 
 // -------------------------------------------------------------------------

--- a/javascript/src/voice/__tests__/vad-fallback.test.ts
+++ b/javascript/src/voice/__tests__/vad-fallback.test.ts
@@ -19,17 +19,12 @@ import { fileURLToPath } from "node:url";
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { beforeEach, expect, vi, type MockInstance } from "vitest";
 
-import {
-  AgentRole,
-  type AgentInput,
-  type AgentReturnTypes,
-  UserSimulatorAgentAdapter,
-} from "../../domain";
 import { agent, succeed, user } from "../../script";
 import { ScenarioExecution } from "../../execution/scenario-execution";
 import { AudioChunk } from "../audio-chunk";
 import type { VoiceEvent } from "../recording.types";
 import { WebRTCVadFallback } from "../vad";
+import { AudioUserSimulator } from "./fixtures/audio-user-simulator";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -56,29 +51,6 @@ function speechChunk(durationSeconds: number): AudioChunk {
     data[2 * i + 1] = (u >> 8) & 0xff;
   }
   return new AudioChunk({ data });
-}
-
-function audioMessageContent(chunk: AudioChunk): AgentReturnTypes {
-  const base64 = Buffer.from(chunk.data).toString("base64");
-  return {
-    role: "user",
-    content: [
-      {
-        type: "input_audio",
-        input_audio: { data: base64, format: "pcm16" },
-      },
-    ],
-  } as unknown as AgentReturnTypes;
-}
-
-class AudioUserSimulator extends UserSimulatorAgentAdapter {
-  role = AgentRole.USER;
-  constructor(private readonly chunk: AudioChunk) {
-    super();
-  }
-  async call(_input: AgentInput): Promise<AgentReturnTypes> {
-    return audioMessageContent(this.chunk);
-  }
 }
 
 // Reset VAD warning state before every step so the one-shot-warning


### PR DESCRIPTION
## Ticket

Closes #524. `AudioUserSimulator` was duplicated between two retrofitted voice test files, and the `fixtures/` directory that already holds `fake-adapter.ts` never got this fixture.

## Change

Added `javascript/src/voice/__tests__/fixtures/audio-user-simulator.ts` exporting:

- `audioMessageContent(chunk)` — builds a user-role `input_audio`/pcm16 message from a chunk's bytes.
- `class AudioUserSimulator` — a user simulator whose `call()` returns that audio message so the default voice path flows real bytes.

`hooks.test.ts` and `vad-fallback.test.ts` now import both from the fixture, and their inline `AudioUserSimulator` (plus `vad-fallback`'s local `audioMessageContent`, plus the domain imports that only those blocks used) are removed. The canonical version keeps `vad-fallback`'s cleaner extracted-helper shape; behavior is identical.

## Evidence

- **Behavior preserved:** `vitest run src/voice/__tests__/hooks.test.ts src/voice/__tests__/vad-fallback.test.ts` -> `Test Files 2 passed (2)`, `Tests 19 passed (19)`, no `ScenarioNotCalledError` (the shared fixture resolves cleanly in both bound suites).
- **Type-clean:** `pnpm typecheck` (tsc --noEmit) exits 0.
- **No dangling references:** neither test file retains a local `AudioUserSimulator` / `audioMessageContent` definition or an unused `../../domain` import.
- **Scoped:** one new fixture file plus the two importing test files; no production code touched.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.
