### PR TITLE
ci: guard secret-dependent steps against fork PR collection failures

### DIFF
--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
       - name: Test (Examples)
-        if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: pnpm -F vitest-examples test
         env:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}

--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -88,9 +88,9 @@ jobs:
         run: pnpm run test:ci
         working-directory: javascript
 
-      # Examples — skipped for Dependabot PRs since they don't have access to repo secrets
+      # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
       - name: Test (Examples)
-        if: github.actor != 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
         run: pnpm -F vitest-examples test
         env:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -90,8 +90,9 @@ jobs:
         run: uv run pyright .
         working-directory: python
 
-      # Examples — skipped for Dependabot PRs since they don't have access to repo secrets
+      # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
       - name: Test (Examples)
+        if: github.event.pull_request.head.repo.full_name == github.repository
         # Examples hit real LLMs over the network; they can legitimately take
         # well over the 60s per-test timeout that pytest.ini sets for the unit
         # suite. Override to 300s here so slow-but-correct runs don't get

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -92,7 +92,7 @@ jobs:
 
       # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
       - name: Test (Examples)
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         # Examples hit real LLMs over the network; they can legitimately take
         # well over the 60s per-test timeout that pytest.ini sets for the unit
         # suite. Override to 300s here so slow-but-correct runs don't get

--- a/python/examples/test_testing_remote_agents_sse.py
+++ b/python/examples/test_testing_remote_agents_sse.py
@@ -72,10 +72,6 @@ class SSEAgentAdapter(scenario.AgentAdapter):
                 return full_response
 
 
-# OpenAI client for LLM
-client = AsyncOpenAI()
-
-
 async def sse_handler(request: web.Request) -> web.StreamResponse:
     """
     HTTP endpoint that forwards OpenAI streaming chunks in SSE format.
@@ -95,6 +91,9 @@ async def sse_handler(request: web.Request) -> web.StreamResponse:
     response.headers["Cache-Control"] = "no-cache"
     response.headers["Connection"] = "keep-alive"
     await response.prepare(request)
+
+    # Instantiate client lazily so import-time collection doesn't require credentials
+    client = AsyncOpenAI()
 
     # Stream response using real LLM
     stream = await client.chat.completions.create(

--- a/python/examples/test_testing_remote_agents_stateful.py
+++ b/python/examples/test_testing_remote_agents_stateful.py
@@ -54,9 +54,6 @@ class StatefulAgentAdapter(scenario.AgentAdapter):
                 return result["response"]
 
 
-# OpenAI client for LLM
-client = AsyncOpenAI()
-
 # Server-side conversation storage (in production, use a database)
 conversations: Dict[str, List[Any]] = {}
 
@@ -80,6 +77,9 @@ async def stateful_handler(request: web.Request) -> web.Response:
 
     # Add user message to history
     history.append({"role": "user", "content": message})
+
+    # Instantiate client lazily so import-time collection doesn't require credentials
+    client = AsyncOpenAI()
 
     # Generate response with FULL history
     response = await client.chat.completions.create(

--- a/python/examples/test_testing_remote_agents_streaming.py
+++ b/python/examples/test_testing_remote_agents_streaming.py
@@ -47,10 +47,6 @@ class StreamingAgentAdapter(scenario.AgentAdapter):
                 return full_response
 
 
-# OpenAI client for LLM
-client = AsyncOpenAI()
-
-
 async def stream_handler(request: web.Request) -> web.StreamResponse:
     """
     HTTP endpoint that streams LLM responses chunk by chunk.
@@ -71,6 +67,9 @@ async def stream_handler(request: web.Request) -> web.StreamResponse:
     response.headers["Content-Type"] = "text/plain"
     response.headers["Transfer-Encoding"] = "chunked"
     await response.prepare(request)
+
+    # Instantiate client lazily so import-time collection doesn't require credentials
+    client = AsyncOpenAI()
 
     # Stream response using real LLM
     stream = await client.chat.completions.create(


### PR DESCRIPTION
**Low risk** — CI-condition and example-file changes only; no library code, no public API, no secrets touched.

## Why

Fork PRs get empty strings for repo secrets. The three remote-agent examples instantiated `AsyncOpenAI()` at **module level**, so pytest raised `OpenAIError: Missing credentials` during **collection** — before any test ran and before any skip marker could apply. `Test (Examples)` therefore hard-failed on every fork PR instead of being skipped. Diagnosed in [#691 (comment)](https://github.com/langwatch/scenario/pull/691#issuecomment-4912837200).

## What changed

- **Compound guard `actor != dependabot && (event_name != 'pull_request' || head.repo == github.repository)`** → the bare `head.repo.full_name == github.repository` form (what commit 1 shipped) → the bare form evaluates `null == 'langwatch/scenario'` on **push** events, which would have silently skipped `Test (Examples)` on every push to main. The `event_name` disjunct is what keeps push and `workflow_dispatch` running; commit 2 exists solely to fix this.
- **Lazy `AsyncOpenAI()` inside the request handlers** → a module-level `skipif` marker or a `conftest` collect-ignore → a marker cannot prevent an exception thrown at *import*, and collect-ignore would hide these examples from same-repo CI too. Lazy init keeps them fully exercised where secrets exist. Matches the existing pattern in `test_audio_to_text.py` and `helpers/openai_voice_agent.py` (`self.client = AsyncOpenAI()` inside `__init__`).
- **Defence in depth, not redundancy** → guard-only, or lazy-init-only → the guard stops the step on forks; lazy init stops import-time credential access anywhere else the examples are collected (local runs, future workflows). Either alone leaves a hole.
- **Dependabot guard added to python-ci** → leaving python-ci unguarded → python-ci's `Test (Examples)` previously had **no** `if:` at all, so it also failed on Dependabot PRs; the new condition brings it to parity with javascript-ci.

## How it works

```
.github/workflows/
├── python-ci.yml       Test (Examples) — gains the full compound if: (had none)
└── javascript-ci.yml   Test (Examples) — dependabot guard ANDed with the fork guard

python/examples/
├── test_testing_remote_agents_sse.py        module-level client → inside sse_handler()
├── test_testing_remote_agents_stateful.py   module-level client → inside stateful_handler()
└── test_testing_remote_agents_streaming.py  module-level client → inside stream_handler()
```

Guard truth table (`github.repository` = `langwatch/scenario`):

| Event | actor | head repo | Step runs? |
|---|---|---|---|
| push to main | any | *null* | yes |
| workflow_dispatch | any | *null* | yes |
| same-repo PR | human | langwatch/scenario | yes |
| fork PR | outsider | someone/scenario | **skipped** |
| Dependabot PR | dependabot[bot] | langwatch/scenario | **skipped** |

## Acceptance criteria

- [x] **Collection succeeds with empty credentials.** With `OPENAI_API_KEY=""`, `pytest examples/test_testing_remote_agents_{sse,stateful,streaming}.py --collect-only` exits 0 and reports `3 tests collected`. Fails if any `ERROR ... during collection` line or a non-zero exit appears. *Evidence: before/after transcript below.*
- [x] **The failure is real before the fix.** The same command on `main` exits non-zero with `3 errors during collection`, each an `openai.OpenAIError: Missing credentials` traced to a `client = AsyncOpenAI()` module-level line. Fails if collection succeeds pre-fix (would mean the fix addresses nothing). *Evidence: BEFORE half of the transcript below.*
- [x] **No module-level client remains.** `grep -n '^client = AsyncOpenAI()' python/examples/` returns zero matches on this branch. Fails if any of the three files still constructs at import scope. *Evidence: command output below.*
- [x] **Guard does not skip push or dispatch.** The condition evaluates true for `push` and `workflow_dispatch` (where `head.repo.full_name` is null) and false only for fork PRs and Dependabot. Fails if any row of the truth table above inverts. *Evidence: evaluated truth table below.*
- [x] **Both workflows still parse.** `yaml.safe_load` succeeds on both workflow files. Fails on any `YAMLError`.
- [ ] **Fork PR is skipped, not errored, in real CI.** `Test (Examples)` reports *skipped* on a genuine fork PR against this repo. **Not exercised** — needs a fork PR opened after merge; cannot be produced from a same-repo branch. See Human verification.

## How I can prove I was successful

**proven** — Falsifiability before/after. Same command, same empty credentials, only the three example files swapped between `main` and this branch:


```
### BEFORE (main) — empty secrets, as a fork PR sees them
ERROR examples/test_testing_remote_agents_sse.py - openai.OpenAIError: Missin...
ERROR examples/test_testing_remote_agents_stateful.py - openai.OpenAIError: M...
ERROR examples/test_testing_remote_agents_streaming.py - openai.OpenAIError: ...
!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
no tests collected, 3 errors in 1.69s

### AFTER (PR #739 lazy init) — same empty secrets
3 tests collected in 1.91s
```

The pre-fix traceback names the exact removed lines:

```
examples/test_testing_remote_agents_streaming.py:51: in <module>
    client = AsyncOpenAI()
openai/_client.py:700: in __init__
    raise OpenAIError(
E   openai.OpenAIError: Missing credentials.
```

**proven** — No module-level client remains on this branch:

```
$ grep -rn '^client = AsyncOpenAI()' python/examples/
(no matches)
```

**proven** — Guard truth table evaluated against the literal expression; all five rows match the table above (`ALL MATCH`), and the commit-1 bare form was confirmed to evaluate false on push — the regression commit 2 fixes.

**proven** — CI green on this PR: `test (3.12)`, `ci-checks (24.x)`, `python-complete`, `javascript-complete` all pass.

**claimed** — Both workflow files `yaml.safe_load` cleanly (asserted pre-commit; the green CI runs above are the stronger signal, since a malformed workflow would not have dispatched).

**missing** — Real fork-PR skip behavior; see the unticked AC. This is the one claim no same-repo branch can produce.

## Human verification

1. `git checkout main && cd python`
2. `OPENAI_API_KEY="" .venv/bin/python -m pytest examples/test_testing_remote_agents_sse.py --collect-only -q` → observe `errors during collection`.
3. `git checkout fix/python-ci-fork-guard` and repeat step 2 → observe `1 test collected`, exit 0.
4. After merge: open a PR from a fork and confirm `Test (Examples)` shows **skipped** (grey), not failed, on both python-ci and javascript-ci.
5. Confirm the next push to `main` still **runs** `Test (Examples)` — this is the regression commit 2 guards against.

## Anything surprising?

The fork guard alone would not have fixed local or non-CI collection, and the lazy init alone would still have burned a CI run attempting real network calls with empty keys. Both are needed. Also note python-ci's `Test (Examples)` had **no** `if:` condition before this PR — it was failing for Dependabot as well as forks, which the original diagnosis did not call out.



<!-- no-ui-surface -->

**Backend-only — no UI surface.** This PR changes CI workflow guards so that secret-dependent
example files fail closed on fork PRs instead of breaking test collection. There is no rendered
surface to screenshot: the observable behaviour *is* the test-collection outcome, which is
demonstrated above as a falsifiability pair (BEFORE on `main`: 3 collection errors with empty
secrets; AFTER: 3 tests collected, same command, same empty credentials).

*Declaration added by the orchardist to satisfy `pr-ready-check` C6, which requires either embedded
visual proof or an explicit backend-only declaration. The claim is a statement of fact about this
diff, not a waiver — no criterion was weakened.*
