### PR TITLE
feat(voice): continuous ElevenLabs mic pump + is_connected guard (#740 slice A)

### DIFF
--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -217,16 +217,23 @@ class VoiceAgentAdapter(AgentAdapter):
         """
         # Uniform pre-turn connected-state gate (mirror TS
         # ``adapter.runtime.ts:249-254``): a call() issued before the
-        # executor's connect() — or after a dropped transport — fails once
-        # with a clear ``PendingTransportError`` naming the adapter, rather
-        # than a transport-specific null-deref or a silent hang. Checked ONCE,
-        # BEFORE send_audio/recv_audio. It does NOT suppress
-        # ``FirstChunkTimeoutError``: a connected adapter whose first chunk
-        # never arrives still surfaces that timeout from the drain below.
+        # executor's connect() — or after a dropped transport — fails once with
+        # a clear error naming the adapter, rather than a transport-specific
+        # null-deref or a silent hang. Checked ONCE, BEFORE send_audio/
+        # recv_audio. It does NOT suppress ``FirstChunkTimeoutError``: a
+        # connected adapter whose first chunk never arrives still surfaces that
+        # timeout from the drain below.
+        #
+        # We raise ``TransportNotConnectedError`` (a subclass of
+        # ``PendingTransportError``, so the TS-parity ``except
+        # PendingTransportError`` gate still catches it) whose message is
+        # actionable for a real, implemented adapter — "call connect()/reconnect"
+        # — rather than the base "implement your transport" guidance meant for
+        # unshipped stubs.
         if not self.is_connected():
-            from .adapters._stub import PendingTransportError
+            from .adapters._stub import TransportNotConnectedError
 
-            raise PendingTransportError(type(self).__name__)
+            raise TransportNotConnectedError(type(self).__name__)
         # Clear the speaking-event for this turn — set in _drain on first chunk.
         self._agent_speaking_event.clear()
         recorder = _AdapterRecorder(input)

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -131,6 +131,18 @@ class VoiceAgentAdapter(AgentAdapter):
             self._agent_speaking = ev
         return ev
 
+    def is_connected(self) -> bool:
+        """Whether the transport is open and ready to exchange audio.
+
+        Base default is ``True``: adapters without a persistent socket (or
+        that manage liveness elsewhere) are always considered ready, so the
+        pre-turn guard in :meth:`call` never blocks them. Transports with a
+        real socket override this — e.g. :class:`ElevenLabsAgentAdapter`
+        returns ``self._ws is not None and not self._ws.closed`` (parity with
+        the TS ``isConnected()`` override, ``adapters/elevenlabs.ts:531-534``).
+        """
+        return True
+
     @abstractmethod
     async def connect(self) -> None:
         """Open the transport and prepare to exchange audio."""
@@ -203,6 +215,18 @@ class VoiceAgentAdapter(AgentAdapter):
         Subclasses may override this for specialised flows but will usually
         inherit it.
         """
+        # Uniform pre-turn connected-state gate (mirror TS
+        # ``adapter.runtime.ts:249-254``): a call() issued before the
+        # executor's connect() — or after a dropped transport — fails once
+        # with a clear ``PendingTransportError`` naming the adapter, rather
+        # than a transport-specific null-deref or a silent hang. Checked ONCE,
+        # BEFORE send_audio/recv_audio. It does NOT suppress
+        # ``FirstChunkTimeoutError``: a connected adapter whose first chunk
+        # never arrives still surfaces that timeout from the drain below.
+        if not self.is_connected():
+            from .adapters._stub import PendingTransportError
+
+            raise PendingTransportError(type(self).__name__)
         # Clear the speaking-event for this turn — set in _drain on first chunk.
         self._agent_speaking_event.clear()
         recorder = _AdapterRecorder(input)

--- a/python/scenario/voice/adapters/_stub.py
+++ b/python/scenario/voice/adapters/_stub.py
@@ -30,3 +30,28 @@ class PendingTransportError(NotImplementedError):
             "after_words interruption."
         )
         self.adapter_name = adapter_name
+
+
+class TransportNotConnectedError(PendingTransportError):
+    """Raised by the pre-turn guard when a real adapter's transport is not
+    connected at ``call()`` time — the socket dropped, or ``connect()`` was
+    never called.
+
+    Subclasses :class:`PendingTransportError` so existing
+    ``except PendingTransportError`` handlers (and the uniform pre-turn gate
+    that mirrors the TS ``PendingTransportError`` throw) still catch it, but
+    carries an ACTIONABLE message: the transport IS implemented, so the fix is
+    to ``connect()``/reconnect, not to subclass and implement send/recv.
+    """
+
+    def __init__(self, adapter_name: str) -> None:
+        # Bypass PendingTransportError.__init__ (its message tells the user to
+        # implement a transport that already exists) and set an accurate one.
+        NotImplementedError.__init__(
+            self,
+            f"{adapter_name}: transport is not connected. The executor calls "
+            "connect() at scenario start and disconnect() at end; if you drive "
+            "the adapter directly, call connect() (or reconnect) before call(). "
+            "A dropped socket also lands here — check the transport/session logs.",
+        )
+        self.adapter_name = adapter_name

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -46,7 +46,8 @@ import asyncio
 import base64
 import json
 import logging
-from typing import Any, ClassVar, Literal, Optional
+from collections import deque
+from typing import Any, ClassVar, Deque, Literal, Optional
 
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
@@ -83,6 +84,22 @@ SILENCE_TAIL_BYTES = 16000
 #:   the pure-audio path and parity with the pre-#567 transport, but unreliable
 #:   for scripted turn 2+.
 TurnCommitMode = Literal["text", "silence"]
+
+#: One continuous-mic pump frame = 20 ms of PCM. Fixed at 960 bytes to match the
+#: TS reference (``PUMP_FRAME_BYTES``, ``adapters/elevenlabs.ts:107``); the pump
+#: only ever writes fixed-size frames so EL's server VAD sees a steady cadence.
+PUMP_FRAME_BYTES = 960
+
+#: Pump cadence (seconds): one :data:`PUMP_FRAME_BYTES` frame every 20 ms — real
+#: microphone cadence. Mirrors TS ``PUMP_INTERVAL_MS = 20``
+#: (``adapters/elevenlabs.ts:117``).
+PUMP_INTERVAL_S = 0.02
+
+#: The all-zero (silence) 20 ms frame. When the outbound queue is empty AND the
+#: user turn is still closing (before the agent responds), the pump feeds this so
+#: EL's server VAD has the audio→silence transition it measures end-of-turn
+#: against. Mirrors TS ``SILENCE_FRAME`` (``adapters/elevenlabs.ts:144``).
+SILENCE_FRAME = b"\x00" * PUMP_FRAME_BYTES
 
 
 class ElevenLabsAgentAdapter(VoiceAgentAdapter):
@@ -160,6 +177,20 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         self._silence_tail_bytes = silence_tail_bytes
         self._ws: Any = None
 
+        # ---- continuous mic pump state ----
+        # The pump is the SINGLE owner of idle silence on the wire: a
+        # background task ticks every :data:`PUMP_INTERVAL_S` and feeds one
+        # 20 ms frame — queued speech while the user is talking, the closing
+        # SILENCE_FRAME while the turn is still closing, and NOTHING once the
+        # agent has responded (the post-response pause, #705). Mirrors the TS
+        # pump (``adapters/elevenlabs.ts:563-668``), adapted to Python's raw-WS
+        # send seam (there is no ``inputCallback`` SDK seam here).
+        self._pump_task: Optional[asyncio.Task[None]] = None
+        self._outbound_frames: Deque[bytes] = deque()
+        #: SET when agent audio begins (pauses the idle mic so EL's idle prompt
+        #: never trips); CLEARED when a new user turn is enqueued.
+        self.awaiting_user_turn: bool = False
+
         # Transcript observability — updated on each transcript event.
         self.last_user_transcript: Optional[str] = None
         self.last_agent_transcript: Optional[str] = None
@@ -208,8 +239,30 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             list(agent_override.keys()) or "none",
         )
 
+        # Start the continuous mic pump now that the socket is open, so the
+        # interval never outlives the socket (mirror ``onAudioStart`` →
+        # ``startPump``, ``adapters/elevenlabs.ts:497,563``).
+        self.start_pump()
+
+    def is_connected(self) -> bool:
+        """Whether the WS session is open and ready to exchange audio.
+
+        The websockets-lib equivalent of the TS
+        ``conversation?.isSessionActive()`` check
+        (``adapters/elevenlabs.ts:531-534``): open iff we hold a socket that
+        is not closed.
+        """
+        return self._ws is not None and not self._ws.closed
+
     async def disconnect(self) -> None:
-        """Close the WebSocket if open."""
+        """Close the WebSocket if open.
+
+        The pump is stopped and awaited FIRST (mirror TS ``disconnect`` stop-
+        before-close, ``adapters/elevenlabs.ts:539``) so no frame is fed once
+        teardown begins — even if disconnect() races a close/error that has
+        already nulled the socket.
+        """
+        await self.stop_pump()
         if self._ws is not None:
             try:
                 await self._ws.close()
@@ -222,6 +275,103 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             finally:
                 self._ws = None
             logger.debug("ElevenLabsAgentAdapter: disconnected")
+
+    # ------------------------------------------------------- continuous mic pump
+
+    def start_pump(self) -> None:
+        """Start the continuous mic pump. Idempotent — a double call yields
+        exactly one running task (mirror ``startPump``,
+        ``adapters/elevenlabs.ts:588-595``)."""
+        if self._pump_task is None or self._pump_task.done():
+            self._pump_task = asyncio.ensure_future(self._pump_loop())
+
+    async def stop_pump(self) -> None:
+        """Stop the pump, drop any unsent frames, and reset the post-response
+        pause so a reconnect starts in the closing-silence state.
+
+        Cancels AND awaits the task so no orphan is left pending at loop close
+        (mirror ``stopPump``, ``adapters/elevenlabs.ts:601-612``).
+        """
+        task = self._pump_task
+        self._pump_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._outbound_frames.clear()
+        # Reset the post-response pause so a reconnect starts in the
+        # closing-silence state — the next user turn streams its silence again.
+        self.awaiting_user_turn = False
+
+    async def _pump_loop(self) -> None:
+        """Tick every :data:`PUMP_INTERVAL_S` until cancelled."""
+        while True:
+            await asyncio.sleep(PUMP_INTERVAL_S)
+            await self._pump_tick()
+
+    async def _pump_tick(self) -> None:
+        """One pump tick — one of three outcomes, gated on the session being
+        active so a frame that races a close cannot reach a dead socket
+        (mirror ``pumpTick``, ``adapters/elevenlabs.ts:640-668``):
+
+        * QUEUED SPEECH present → feed it (the user is speaking).
+        * else AWAITING the next user turn (:attr:`awaiting_user_turn`) → feed
+          NOTHING this tick (the #705 post-response pause, so EL's idle prompt
+          never trips in the inter-turn gap).
+        * else → feed one :data:`SILENCE_FRAME`: the closing silence after the
+          user's speech, which EL's server VAD measures end-of-turn against.
+        """
+        if not self.is_connected():
+            return
+
+        if self._outbound_frames:
+            frame = self._outbound_frames.popleft()
+        elif self.awaiting_user_turn:
+            return
+        else:
+            frame = SILENCE_FRAME
+
+        try:
+            b64 = base64.b64encode(frame).decode()
+            await self._ws.send(json.dumps({"user_audio_chunk": b64}))
+        except Exception:
+            # Raced a close between the active-check and the feed — drop the
+            # frame; the disconnect/close path tears the pump down. Swallowed
+            # so the background task never raises out (mirror the raced-close
+            # swallow, ``adapters/elevenlabs.ts:661-663``).
+            logger.debug("ElevenLabsAgentAdapter: pump tick raced a close; frame dropped")
+
+    def enqueue_speech(self, data: bytes) -> None:
+        """Slice a user turn's PCM into fixed 20 ms frames and enqueue them for
+        the pump; a non-empty turn also CLEARS :attr:`awaiting_user_turn` (a new
+        user turn is starting, so the closing silence must stream again once the
+        speech drains). Mirror ``enqueueSpeech``,
+        ``adapters/elevenlabs.ts:703-731``.
+        """
+        if not data:
+            # An empty chunk carries no speech: don't disturb the pause, don't
+            # enqueue a meaningless frame.
+            return
+        # A real user turn is starting → lift the post-response pause.
+        self.awaiting_user_turn = False
+        for offset in range(0, len(data), PUMP_FRAME_BYTES):
+            slice_ = data[offset : offset + PUMP_FRAME_BYTES]
+            if len(slice_) < PUMP_FRAME_BYTES:
+                # Pad the final partial frame to a full 20 ms with trailing
+                # zeros so the pump only ever feeds fixed-size frames.
+                slice_ = slice_ + b"\x00" * (PUMP_FRAME_BYTES - len(slice_))
+            self._outbound_frames.append(slice_)
+
+    def _on_agent_audio_begin(self) -> None:
+        """Agent turn audio has arrived → engage the post-response pause: the
+        pump stops streaming idle silence until the next user turn. Idempotent —
+        the first agent frame is the real transition; later frames re-assert it
+        (mirror ``onAgentAudio`` setting ``awaitingUserTurn``,
+        ``adapters/elevenlabs.ts:513-514``).
+        """
+        self.awaiting_user_turn = True
 
     # ------------------------------------------------------------------ I/O
 
@@ -265,6 +415,13 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             raise RuntimeError("ElevenLabsAgentAdapter: not connected")
 
         transcript = chunk.transcript.strip() if chunk.transcript else ""
+
+        # A real user turn is starting → lift the post-response pause so the
+        # pump streams the closing silence again after this turn (mirror
+        # ``enqueueSpeech`` clearing ``awaitingUserTurn``,
+        # ``adapters/elevenlabs.ts:710``). Empty chunks carry no turn.
+        if transcript or chunk.data:
+            self.awaiting_user_turn = False
 
         if self._turn_commit_mode == "text" and transcript:
             # Deterministic commit: send ONLY the user_message text turn (no
@@ -369,6 +526,10 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
                 # Ensure even byte count (PCM16 invariant).
                 if len(pcm) % 2 == 1:
                     pcm = pcm[:-1]
+                # Agent turn audio has arrived → engage the post-response pause
+                # so the pump stops streaming idle silence into the inter-turn
+                # gap (mirror ``onAgentAudio`` setting ``awaitingUserTurn``).
+                self._on_agent_audio_begin()
                 return AudioChunk(data=pcm)
 
             elif etype == "ping":

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -472,30 +472,51 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
 
         if self._turn_commit_mode == "text" and transcript:
             # Deterministic commit: send ONLY the user_message text turn (no
-            # racing user_audio_chunk). See method docstring for the rationale.
+            # racing user_audio_chunk). This is a single control frame, not
+            # audio, so it does not compete with the pump's audio cadence. See
+            # method docstring for the rationale.
             await self._send_user_message(transcript)
             return
 
-        # Legacy / fallback path: stream the speech then a silence tail and let
-        # server VAD try. Used when turn_commit_mode is "silence", or in "text"
-        # mode when the chunk carries no transcript to commit.
-        b64 = base64.b64encode(chunk.data).decode()
-        await self._ws.send(json.dumps({"user_audio_chunk": b64}))
-
-        await self._send_silence_tail()
+        # Legacy / fallback path (turn_commit_mode == "silence", or "text" mode
+        # with no transcript to commit): stream the speech then a closing
+        # silence tail and let server VAD try.
+        #
+        # The pump is the SINGLE owner of WS audio writes: rather than writing
+        # `chunk.data` and the 16KB silence tail DIRECTLY to `self._ws` (which
+        # would race the always-running background pump — two concurrent writers
+        # producing interleaved/oversized non-20ms `user_audio_chunk` frames),
+        # we ENQUEUE the speech and the closing-silence tail as fixed 960-byte
+        # pump frames. The pump drains them at the same 20ms cadence as every
+        # other frame, so there is exactly one writer and a consistent frame
+        # size on the wire. Returns promptly (continuous-mic model) — it does
+        # not block until the queue drains.
+        self.enqueue_speech(chunk.data)
+        self._enqueue_silence_tail()
 
     async def _send_user_message(self, text: str) -> None:
         """Explicit turn-commit: tell EL the user is done and force an agent
         response without relying on mic-style server VAD (issue #567). Wire
         shape matches the official SDK's ``user_message`` event.
+
+        This is a single control frame (`user_message`), not streamed audio,
+        so it does not contend with the pump's `user_audio_chunk` cadence.
         """
         await self._ws.send(json.dumps({"type": "user_message", "text": text}))
 
-    async def _send_silence_tail(self) -> None:
-        """Legacy end-of-turn nudge: a fixed zero-byte tail to coax server VAD."""
-        silence = b"\x00" * self._silence_tail_bytes
-        silence_b64 = base64.b64encode(silence).decode()
-        await self._ws.send(json.dumps({"user_audio_chunk": silence_b64}))
+    def _enqueue_silence_tail(self) -> None:
+        """Queue the legacy closing-silence tail as fixed 960-byte pump frames.
+
+        The legacy path coaxed server VAD with a fixed ``_silence_tail_bytes``
+        zero-byte blob written directly to the socket. To keep the pump the
+        single WS writer, express that same total silence as
+        ``ceil(_silence_tail_bytes / PUMP_FRAME_BYTES)`` all-zero 960-byte pump
+        frames on the outbound queue, drained at the 20ms cadence. Rounds UP so
+        the emitted silence is never less than the legacy tail.
+        """
+        num_frames = -(-self._silence_tail_bytes // PUMP_FRAME_BYTES)  # ceil div
+        for _ in range(num_frames):
+            self._outbound_frames.append(SILENCE_FRAME)
 
     async def recv_audio(self, timeout: float) -> AudioChunk:
         """

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -251,8 +251,34 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         ``conversation?.isSessionActive()`` check
         (``adapters/elevenlabs.ts:531-534``): open iff we hold a socket that
         is not closed.
+
+        Liveness is read from the connection ``state`` on modern
+        ``websockets`` (>=13, the ``websockets.asyncio.client.ClientConnection``
+        that :func:`websockets.connect` returns) — that class exposes a
+        ``state`` enum, NOT a ``closed`` attribute. We fall back to ``closed``
+        for the legacy ``WebSocketClientProtocol`` and for in-memory test
+        doubles that model ``closed``. Note ``is_connected()`` is a
+        best-effort *hint* for the pre-turn guard and the pump active-check;
+        it is never the sole guard on a send — the pump's send is wrapped in a
+        raced-close swallow, and ``recv_audio`` still handles ``ConnectionClosed``
+        directly, because a socket can drop between this check and the I/O.
         """
-        return self._ws is not None and not self._ws.closed
+        ws = self._ws
+        if ws is None:
+            return False
+        state = getattr(ws, "state", None)
+        if state is not None:
+            # Modern websockets: OPEN iff state is OPEN. CONNECTING/CLOSING/
+            # CLOSED all read as not-ready for a turn.
+            try:
+                from websockets.protocol import State
+
+                return state is State.OPEN
+            except Exception:
+                # State enum unavailable — compare by name as a last resort.
+                return getattr(state, "name", "") == "OPEN"
+        # Legacy protocol / test double exposing `closed`.
+        return not getattr(ws, "closed", False)
 
     async def disconnect(self) -> None:
         """Close the WebSocket if open.
@@ -299,6 +325,9 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             try:
                 await task
             except asyncio.CancelledError:
+                # Expected: awaiting a just-cancelled task re-raises the
+                # CancelledError here. Intentionally suppressed — we requested
+                # the cancel as part of an orderly pump shutdown.
                 pass
         self._outbound_frames.clear()
         # Reset the post-response pause so a reconnect starts in the
@@ -333,15 +362,33 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         else:
             frame = SILENCE_FRAME
 
+        import websockets  # for the ConnectionClosed close-race classes
+
         try:
             b64 = base64.b64encode(frame).decode()
             await self._ws.send(json.dumps({"user_audio_chunk": b64}))
-        except Exception:
-            # Raced a close between the active-check and the feed — drop the
-            # frame; the disconnect/close path tears the pump down. Swallowed
-            # so the background task never raises out (mirror the raced-close
+        except (
+            websockets.exceptions.ConnectionClosed,
+            ConnectionError,
+            OSError,
+            RuntimeError,
+        ):
+            # The EXPECTED close race: the socket closed between the
+            # active-check above and this feed. Drop the frame; the
+            # disconnect/close path tears the pump down (mirror the raced-close
             # swallow, ``adapters/elevenlabs.ts:661-663``).
             logger.debug("ElevenLabsAgentAdapter: pump tick raced a close; frame dropped")
+        except Exception:  # noqa: BLE001 — background task must never propagate
+            # An UNEXPECTED failure (serialization/protocol bug, not a close
+            # race). Do NOT silently swallow it as a close: surface it at
+            # WARNING so the bug is visible, but still don't propagate out of
+            # the background task (that would kill the pump loop and leave an
+            # unhandled-task exception). The next tick retries.
+            logger.warning(
+                "ElevenLabsAgentAdapter: unexpected error feeding pump frame; "
+                "dropping frame and continuing",
+                exc_info=True,
+            )
 
     def enqueue_speech(self, data: bytes) -> None:
         """Slice a user turn's PCM into fixed 20 ms frames and enqueue them for

--- a/python/tests/voice/test_adapters.py
+++ b/python/tests/voice/test_adapters.py
@@ -252,6 +252,11 @@ async def test_elevenlabs_hosted_adapter_connects_and_sends_pcm16():
     mock_ws.recv = fake_recv
     mock_ws.send = AsyncMock()
     mock_ws.close = AsyncMock()
+    # is_connected() reads the websockets connection state; give the mock an
+    # OPEN state so the pump considers the socket live and drains its queue.
+    from websockets.protocol import State
+
+    mock_ws.state = State.OPEN
 
     # Patch websockets.connect to return our mock.
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)) as mock_connect:
@@ -262,20 +267,27 @@ async def test_elevenlabs_hosted_adapter_connects_and_sends_pcm16():
         assert "agent_id=test_agent" in connect_url
         assert "api.elevenlabs.io" in connect_url
 
-        # send_audio should emit a base64-encoded user_audio_chunk message.
-        # connect() sends conversation_initiation_client_data first, then
-        # send_audio emits TWO chunks per call (speech + silence tail —
-        # see ElevenLabsAgentAdapter.send_audio for the empirical
-        # rationale). Walk all sent messages and assert the speech chunk
-        # is among them.
-        chunk = AudioChunk(data=b"\x10\x20" * 100)
+        # send_audio (no transcript → fallback path) ENQUEUES the speech +
+        # closing-silence tail onto the pump's outbound queue; the pump is the
+        # single WS writer and emits them as fixed 960-byte user_audio_chunk
+        # frames (no direct-write racing the background pump). Take manual pump
+        # control and drain deterministically, then assert the speech frame
+        # (the chunk's 200 bytes, zero-padded to 960) reached the wire.
+        await adapter.stop_pump()
+        chunk = AudioChunk(data=b"\x10\x20" * 100)  # 200 bytes
         await adapter.send_audio(chunk)
+        while adapter._outbound_frames:
+            await adapter._pump_tick()
         user_audio_decoded = []
         for call in mock_ws.send.call_args_list:
             payload = json.loads(call[0][0])
             if "user_audio_chunk" in payload:
                 user_audio_decoded.append(base64.b64decode(payload["user_audio_chunk"]))
-        assert chunk.data in user_audio_decoded
+        # Fixed 960-byte cadence; the first speech frame carries the chunk bytes.
+        assert user_audio_decoded, "expected pump to emit the enqueued frames"
+        assert all(len(f) == 960 for f in user_audio_decoded)
+        speech_frame = chunk.data + b"\x00" * (960 - len(chunk.data))
+        assert speech_frame in user_audio_decoded
 
         # recv_audio must skip metadata + transcript and return audio bytes.
         result = await adapter.recv_audio(timeout=5.0)

--- a/python/tests/voice/test_elevenlabs_pump.py
+++ b/python/tests/voice/test_elevenlabs_pump.py
@@ -26,7 +26,7 @@ import asyncio
 import base64
 import json
 import os
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/python/tests/voice/test_elevenlabs_pump.py
+++ b/python/tests/voice/test_elevenlabs_pump.py
@@ -225,7 +225,7 @@ async def test_pump_tick_three_way_gate_and_flag_transitions() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fallback_send_audio_routes_through_pump_no_direct_write() -> None:
+async def test_fallback_send_audio_routes_through_pump_no_direct_write():
     """P2 review fix: the pure-audio fallback path (silence mode / no-transcript)
     must NOT write audio directly to the WS while the background pump also runs
     — that would be two concurrent writers producing interleaved/oversized

--- a/python/tests/voice/test_elevenlabs_pump.py
+++ b/python/tests/voice/test_elevenlabs_pump.py
@@ -1,0 +1,559 @@
+"""
+sc#740 Slice A — ElevenLabs continuous mic pump + ``is_connected()`` guard.
+
+Python parity with ``javascript/src/voice/adapters/elevenlabs.ts`` ``pumpTick``
+(:606-634), ``awaitingUserTurn`` SET/CLEAR (:485/:676), ``isConnected()`` override
+(:531-534), ``startPump``/``stopPump`` (:563-582), disconnect stop-before-close
+(:539), and the raced-close swallow (:630-633); plus the pre-turn ``call()`` guard
+mirroring ``adapter.runtime.ts:249-254`` (``PendingTransportError`` throw).
+
+Python has NO ``inputCallback`` SDK seam (unlike TS). The pump writes raw WS JSON
+directly: ``self._ws.send(json.dumps({"user_audio_chunk": <b64>}))`` — the same
+send seam as ``elevenlabs.py:279``. A 20 ms frame is exactly 960 bytes of PCM
+(``PUMP_FRAME_BYTES``); the closing-silence frame is 960 all-zero bytes.
+
+Offline — no network, no real EL socket. The pump seam (``self._ws.send``) is
+mocked; the gated live server-VAD proof (A3b) is guarded by ``RUN_EL_HOSTED=1``.
+
+Timing discipline: cadence tests never sleep on wall-clock for a single 20 ms
+tick. They drive ``_pump_tick`` directly (deterministic) or let the loop run and
+assert on FRAME COUNT / CONTENT, not on precise 20 ms spacing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import warnings
+from typing import Any, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scenario.voice import AudioChunk, ElevenLabsAgentAdapter
+from scenario.voice.adapters.elevenlabs import (
+    PUMP_FRAME_BYTES,
+    PUMP_INTERVAL_S,
+    SILENCE_FRAME,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / helpers                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class FakePumpSocket:
+    """In-memory EL WS that records every ``send`` and models ``closed``.
+
+    Mirrors ``FakeElevenLabsSocket`` in ``test_elevenlabs_turn_commit.py`` but
+    exposes ``closed`` toggling so ``is_connected()`` (``_ws is not None and
+    not _ws.closed``) can be exercised across both transitions.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def recv(self) -> str:  # pragma: no cover - not exercised here
+        await asyncio.sleep(3600)
+        return ""
+
+    async def close(self) -> None:
+        self.closed = True
+
+    # ----- parsed views -----
+
+    @property
+    def user_audio_chunks(self) -> list[bytes]:
+        """base64-decoded PCM payload of every ``user_audio_chunk`` frame."""
+        out: list[bytes] = []
+        for s in self.sent:
+            msg = json.loads(s)
+            payload = msg.get("user_audio_chunk")
+            if isinstance(payload, str):
+                out.append(base64.b64decode(payload))
+        return out
+
+
+async def _connected_adapter(
+    **kwargs: Any,
+) -> tuple[ElevenLabsAgentAdapter, FakePumpSocket]:
+    """Build an EL adapter wired to a fresh fake socket, already connected.
+
+    ``connect()`` starts the pump; callers that want deterministic single-tick
+    control should ``stop_pump()`` first or drive ``_pump_tick`` directly.
+    """
+    socket = FakePumpSocket()
+    adapter = ElevenLabsAgentAdapter(agent_id="agent-test", api_key="xi-test", **kwargs)
+    with patch("websockets.connect", new=AsyncMock(return_value=socket)):
+        await adapter.connect()
+    return adapter, socket
+
+
+def _decoded(sent: list[str]) -> list[bytes]:
+    out: list[bytes] = []
+    for s in sent:
+        payload = json.loads(s).get("user_audio_chunk")
+        if isinstance(payload, str):
+            out.append(base64.b64decode(payload))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# A1 — frame format on the wire                                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pump_emits_960b_user_audio_chunk_frames() -> None:
+    """A1: after connect() a background task ticks ~20 ms and sends
+    ``{"user_audio_chunk": <b64>}`` frames whose decoded PCM is exactly 960 B.
+
+    Falsifier for "the pump is the SINGLE owner of idle silence": with ZERO
+    caller ``send_audio``, EVERY frame the wire receives after the one-time
+    connect init MUST be a 960B ``user_audio_chunk``. A second idle-silence
+    source (a stray ``_send_silence_tail``, a differently-shaped keepalive
+    frame, a wrong-size frame) would put a non-conforming send on the wire and
+    FAIL this test — the assertion is over the actual wire traffic, not a spy
+    on a method the idle path never calls.
+    """
+    adapter, socket = await _connected_adapter()
+    try:
+        # Snapshot the one-time connect init so we assert only on the pump's
+        # idle traffic. There is exactly one init frame
+        # (conversation_initiation_client_data).
+        init_sends = list(socket.sent)
+        assert len(init_sends) == 1
+        assert json.loads(init_sends[0]).get("type") == "conversation_initiation_client_data"
+
+        # Let the pump run briefly; assert on COUNT/CONTENT, not exact spacing.
+        deadline = asyncio.get_running_loop().time() + 0.1
+        while (
+            asyncio.get_running_loop().time() < deadline
+            and len(socket.sent) < len(init_sends) + 3
+        ):
+            await asyncio.sleep(PUMP_INTERVAL_S)
+
+        # Every wire send AFTER the connect init is a conforming pump frame.
+        idle_sends = socket.sent[len(init_sends):]
+        assert len(idle_sends) >= 3, f"expected >=3 pump frames, got {len(idle_sends)}"
+        for raw in idle_sends:
+            msg = json.loads(raw)
+            # Shape falsifier: ONLY the user_audio_chunk key — no keepalive
+            # frame, no user_message, no other silence-emitting shape.
+            assert set(msg.keys()) == {"user_audio_chunk"}, (
+                f"non-pump frame reached the wire during idle pumping: {msg!r}"
+            )
+            # Size falsifier: decoded payload is exactly one 20ms frame.
+            assert len(base64.b64decode(msg["user_audio_chunk"])) == 960
+    finally:
+        await adapter.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# A2 — three-way pumpTick gating + flag transitions                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pump_tick_three_way_gate_and_flag_transitions() -> None:
+    """A2: one frame per tick in each of the 3 states; flag SET at agent-audio
+    begins, CLEARED at enqueue-speech."""
+    adapter, socket = await _connected_adapter()
+    # Take manual control of ticks — no background racing.
+    await adapter.stop_pump()
+    socket.sent.clear()
+
+    # State (c): closing silence — no queued speech, not awaiting → 960B zeros.
+    assert adapter.awaiting_user_turn is False
+    await adapter._pump_tick()
+    assert len(socket.sent) == 1
+    assert _decoded(socket.sent)[-1] == SILENCE_FRAME
+    assert _decoded(socket.sent)[-1] == b"\x00" * 960
+
+    # Agent audio begins → flag SET (mirror elevenlabs.ts:485).
+    adapter._on_agent_audio_begin()
+    assert adapter.awaiting_user_turn is True
+
+    # State (b): awaiting user turn → send NOTHING this tick.
+    before = len(socket.sent)
+    await adapter._pump_tick()
+    assert len(socket.sent) == before, "awaiting_user_turn must pause the mic"
+
+    # New user turn enqueued → flag CLEARED (mirror elevenlabs.ts:676).
+    adapter.enqueue_speech(b"\x11" * PUMP_FRAME_BYTES)
+    assert adapter.awaiting_user_turn is False
+
+    # State (a): queued speech present → feed the queued speech frame.
+    before = len(socket.sent)
+    await adapter._pump_tick()
+    assert len(socket.sent) == before + 1
+    assert _decoded(socket.sent)[-1] == b"\x11" * PUMP_FRAME_BYTES
+
+    # send_audio — the PRIMARY runtime API — also clears the flag when a real
+    # user turn is committed (mirror elevenlabs.ts:710 enqueueSpeech clear).
+    # Re-arm the pause, then commit a turn via send_audio and assert it lifts.
+    adapter._on_agent_audio_begin()
+    assert adapter.awaiting_user_turn is True
+    await adapter.send_audio(AudioChunk(data=b"\x00" * 8, transcript="hello"))
+    assert adapter.awaiting_user_turn is False
+
+    await adapter.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# A3a — server-VAD transition on the wire (UNGATED)                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pump_emits_silence_transition_without_caller_writes() -> None:
+    """A3a: with the pump idle and ZERO caller send_audio, the wire carries
+    >=3 consecutive all-zero 960B frames — the audio→silence transition EL's
+    server VAD measures end-of-turn against."""
+    adapter, socket = await _connected_adapter()
+    try:
+        deadline = asyncio.get_running_loop().time() + 0.15
+        while (
+            asyncio.get_running_loop().time() < deadline
+            and len(socket.user_audio_chunks) < 3
+        ):
+            await asyncio.sleep(PUMP_INTERVAL_S)
+
+        frames = socket.user_audio_chunks
+        assert len(frames) >= 3
+        # All idle frames are the closing-silence frame (all-zero, 960B).
+        for payload in frames:
+            assert payload == b"\x00" * 960
+    finally:
+        await adapter.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# A3b — real EL server-VAD end-of-turn (GATED RUN_EL_HOSTED=1)                 #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.getenv("RUN_EL_HOSTED") != "1",
+    reason="gated live EL server-VAD proof; set RUN_EL_HOSTED=1 to run",
+)
+@pytest.mark.asyncio
+async def test_real_server_vad_end_of_turn() -> None:
+    """A3b: against a real EL session with NO caller send_audio, server-VAD
+    end-of-turn fires from the pump's closing silence alone and an agent
+    response is produced. GATED — does not run in CI."""
+    agent_id = os.environ["EL_AGENT_ID"]
+    api_key = os.environ["ELEVENLABS_API_KEY"]
+    adapter = ElevenLabsAgentAdapter(agent_id=agent_id, api_key=api_key)
+    async with adapter:
+        # No caller send_audio — the pump's closing silence must drive an
+        # agent turn on its own.
+        chunk = await adapter.recv_audio(timeout=45.0)
+        assert chunk.data, "expected agent audio from pump-driven server VAD"
+
+
+# --------------------------------------------------------------------------- #
+# A4 — is_connected predicate, both transitions                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_is_connected_predicate_both_transitions() -> None:
+    """A4: base default True; EL override True after connect (ws open),
+    False after disconnect (ws closed) AND False when ws is None."""
+    from scenario.voice.adapter import VoiceAgentAdapter
+
+    class _Base(VoiceAgentAdapter):
+        async def connect(self) -> None: ...
+        async def disconnect(self) -> None: ...
+        async def send_audio(self, chunk: AudioChunk) -> None: ...
+        async def recv_audio(self, timeout: float) -> AudioChunk:
+            return AudioChunk(data=b"")
+
+    assert _Base().is_connected() is True
+
+    adapter, socket = await _connected_adapter()
+    assert adapter.is_connected() is True  # ws open
+
+    await adapter.disconnect()
+    assert adapter.is_connected() is False  # ws None after disconnect
+
+    # Explicitly the closed-but-not-None transition too.
+    adapter2, socket2 = await _connected_adapter()
+    await adapter2.stop_pump()
+    socket2.closed = True
+    assert adapter2.is_connected() is False
+    await adapter2.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# A5 — pre-turn connection guard in call()                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_call_raises_pending_transport_when_disconnected() -> None:
+    """A5: call() checks is_connected() ONCE before send_audio/recv_audio;
+    when False it raises PendingTransportError naming the adapter, and neither
+    send_audio nor recv_audio is invoked."""
+    from scenario.voice.adapter import VoiceAgentAdapter
+    from scenario.voice.adapters._stub import PendingTransportError
+
+    class _Disconnected(VoiceAgentAdapter):
+        async def connect(self) -> None: ...
+        async def disconnect(self) -> None: ...
+        async def send_audio(self, chunk: AudioChunk) -> None: ...
+        async def recv_audio(self, timeout: float) -> AudioChunk:
+            return AudioChunk(data=b"")
+
+        def is_connected(self) -> bool:
+            return False
+
+    adapter = _Disconnected()
+    adapter.send_audio = AsyncMock()  # type: ignore[method-assign]
+    adapter.recv_audio = AsyncMock(return_value=AudioChunk(data=b""))  # type: ignore[method-assign]
+
+    class _Input:
+        new_messages: list[Any] = []
+
+    with pytest.raises(PendingTransportError) as excinfo:
+        await adapter.call(_Input())  # type: ignore[arg-type]
+
+    assert "_Disconnected" in str(excinfo.value)
+    adapter.send_audio.assert_not_awaited()
+    adapter.recv_audio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_call_guard_does_not_suppress_first_chunk_timeout() -> None:
+    """A5 (negative): the guard does NOT suppress FirstChunkTimeoutError — a
+    connected adapter whose first recv times out still surfaces it."""
+    from scenario.voice.adapter import FirstChunkTimeoutError, VoiceAgentAdapter
+
+    class _Connected(VoiceAgentAdapter):
+        response_timeout = 0.01
+
+        async def connect(self) -> None: ...
+        async def disconnect(self) -> None: ...
+        async def send_audio(self, chunk: AudioChunk) -> None: ...
+
+        async def recv_audio(self, timeout: float) -> AudioChunk:
+            raise asyncio.TimeoutError
+
+        def is_connected(self) -> bool:
+            return True
+
+    class _Input:
+        new_messages: list[Any] = []
+
+    with pytest.raises(FirstChunkTimeoutError):
+        await _Connected().call(_Input())  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# A6 — start/stop/reset lifecycle                                             #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pump_start_stop_reset_lifecycle() -> None:
+    """A6: start_pump idempotent (one task); stop_pump cancels the task, drops
+    unsent frames, resets awaiting_user_turn; reconnect starts in closing
+    silence (emits silence, not paused)."""
+    adapter, socket = await _connected_adapter()
+
+    # Idempotent start — a second start yields exactly one running task.
+    task_before = adapter._pump_task
+    adapter.start_pump()
+    assert adapter._pump_task is task_before
+    assert adapter._pump_task is not None and not adapter._pump_task.done()
+
+    # Enqueue frames + set the flag, then stop.
+    adapter.enqueue_speech(b"\x22" * PUMP_FRAME_BYTES)
+    adapter._on_agent_audio_begin()
+    assert adapter.awaiting_user_turn is True
+    assert len(adapter._outbound_frames) > 0
+
+    stopped = adapter._pump_task
+    await adapter.stop_pump()
+    assert stopped is not None and (stopped.cancelled() or stopped.done())
+    assert len(adapter._outbound_frames) == 0
+    assert adapter.awaiting_user_turn is False
+    assert adapter._pump_task is None
+
+    # Reconnect starts clean in closing-silence state.
+    adapter.start_pump()
+    socket.sent.clear()
+    await adapter._pump_tick()
+    assert _decoded(socket.sent)[-1] == b"\x00" * 960
+
+    await adapter.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# A7 — disconnect races pump: no post-teardown send, no raise                 #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_tick_racing_disconnect_no_send_no_raise() -> None:
+    """A7: stop_pump is ordered BEFORE ws close; a tick racing a closed/nulled
+    ws neither raises out of the task nor sends after teardown."""
+    adapter, socket = await _connected_adapter()
+
+    # A tick that fires with a closed ws must swallow and not send.
+    socket.closed = True
+    sent_before = len(socket.sent)
+    # Direct-drive a tick against the closed ws — must not raise, must not send.
+    await adapter._pump_tick()
+    assert len(socket.sent) == sent_before
+
+    # And a tick with a nulled ws also swallows.
+    adapter._ws = None
+    await adapter._pump_tick()
+
+    # Full disconnect: no send after it returns.
+    adapter, socket = await _connected_adapter()
+    await adapter.disconnect()
+    sent_after_disconnect = len(socket.sent)
+    # Any late tick attempt post-disconnect adds nothing (ws nulled).
+    await adapter._pump_tick()
+    assert len(socket.sent) == sent_after_disconnect
+
+
+@pytest.mark.asyncio
+async def test_tick_send_raising_mid_tick_is_swallowed_and_loop_survives() -> None:
+    """A7 (real race): the ws closes/raises BETWEEN the is_connected() check and
+    the ``await self._ws.send`` — i.e. ``send`` itself raises a
+    ConnectionClosed-equiv. The exception must NOT propagate out of the pump
+    task, and the background loop must keep running (re-enter and tick again).
+
+    This exercises the actual try/except swallow around the send, not the
+    pre-send gate: ``closed`` stays False so ``is_connected()`` passes and the
+    tick reaches the send, which raises.
+    """
+
+    class RaceClosedError(Exception):
+        """Stand-in for websockets.exceptions.ConnectionClosed on the send path."""
+
+    class RaceThenRecoverSocket(FakePumpSocket):
+        """Raises on the first N sends (the race), then succeeds — so we can
+        prove the loop survived the raise and keeps ticking afterwards."""
+
+        def __init__(self, raise_first: int) -> None:
+            super().__init__()
+            # Armed only AFTER connect() so the init send isn't the one that
+            # raises — we want the PUMP's send to hit the race window.
+            self._raise_left = 0
+            self._arm_raises = raise_first
+            self.raise_attempts = 0
+
+        def arm(self) -> None:
+            self._raise_left = self._arm_raises
+
+        async def send(self, data: str) -> None:
+            # closed stays False → is_connected() is True → the tick reaches
+            # here and this raise IS the race window.
+            if self._raise_left > 0:
+                self._raise_left -= 1
+                self.raise_attempts += 1
+                raise RaceClosedError("socket closed mid-send")
+            await super().send(data)
+
+    socket = RaceThenRecoverSocket(raise_first=2)
+    adapter = ElevenLabsAgentAdapter(agent_id="agent-test", api_key="xi-test")
+    with patch("websockets.connect", new=AsyncMock(return_value=socket)):
+        await adapter.connect()
+    # Stop the auto-started pump so the init send lands cleanly, then arm the
+    # race and drive ticks deterministically.
+    await adapter.stop_pump()
+    socket.arm()
+    adapter.start_pump()
+    try:
+        # is_connected() must be True while send raises — proving we hit the
+        # SEND swallow, not the pre-send gate.
+        assert adapter.is_connected() is True
+
+        # Direct-drive a tick whose send raises: must NOT propagate.
+        await adapter._pump_tick()  # would raise RaceClosedError if unswallowed
+        assert socket.raise_attempts >= 1
+
+        # The background loop must survive the raise and keep ticking: wait for
+        # a real (non-raising) frame to land after the raises drain.
+        deadline = asyncio.get_running_loop().time() + 0.2
+        while (
+            asyncio.get_running_loop().time() < deadline
+            and len(socket.user_audio_chunks) < 1
+        ):
+            await asyncio.sleep(PUMP_INTERVAL_S)
+
+        # The pump task never died (still running) and recovered onto the wire.
+        assert adapter._pump_task is not None and not adapter._pump_task.done()
+        assert len(socket.user_audio_chunks) >= 1
+        assert socket.raise_attempts >= 1, "the race window (send raising) was never exercised"
+    finally:
+        await adapter.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# A8 — task cleanup: no orphan                                                #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pump_task_cancelled_and_awaited_on_disconnect() -> None:
+    """A8: after disconnect the pump task is cancelled AND awaited (done), and
+    no pending-task warning is emitted."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        adapter, socket = await _connected_adapter()
+        task = adapter._pump_task
+        assert task is not None
+        await adapter.disconnect()
+        assert task.cancelled() or task.done()
+        assert adapter._pump_task is None
+        # Give the loop a beat to surface any destroy-pending warning.
+        await asyncio.sleep(0)
+
+    pending = [
+        w
+        for w in caught
+        if "was destroyed but it is pending" in str(w.message)
+        or "pending" in str(w.message).lower()
+        and "task" in str(w.message).lower()
+    ]
+    assert not pending, f"unexpected pending-task warning: {[str(w.message) for w in pending]}"
+
+
+# --------------------------------------------------------------------------- #
+# A-regression — non-EL / text runs create no pump task                       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_non_el_adapter_creates_no_pump_task() -> None:
+    """A-regression: a non-EL VoiceAgentAdapter has no pump task and its
+    is_connected() default is True (no pump machinery leaks into the base)."""
+    from scenario.voice.adapter import VoiceAgentAdapter
+
+    class _NonEL(VoiceAgentAdapter):
+        async def connect(self) -> None: ...
+        async def disconnect(self) -> None: ...
+        async def send_audio(self, chunk: AudioChunk) -> None: ...
+        async def recv_audio(self, timeout: float) -> AudioChunk:
+            return AudioChunk(data=b"")
+
+    adapter = _NonEL()
+    await adapter.connect()
+    # No pump attribute on the base — the pump is EL-only machinery.
+    assert not hasattr(adapter, "_pump_task") or adapter.__dict__.get("_pump_task") is None
+    assert adapter.is_connected() is True
+    await adapter.disconnect()

--- a/python/tests/voice/test_elevenlabs_pump.py
+++ b/python/tests/voice/test_elevenlabs_pump.py
@@ -224,6 +224,45 @@ async def test_pump_tick_three_way_gate_and_flag_transitions() -> None:
     await adapter.disconnect()
 
 
+@pytest.mark.asyncio
+async def test_fallback_send_audio_routes_through_pump_no_direct_write() -> None:
+    """P2 review fix: the pure-audio fallback path (silence mode / no-transcript)
+    must NOT write audio directly to the WS while the background pump also runs
+    — that would be two concurrent writers producing interleaved/oversized
+    frames. Instead it ENQUEUES speech + closing-silence tail as fixed 960-byte
+    pump frames, and the pump is the SINGLE writer emitting them at 20ms cadence.
+    """
+    adapter, socket = await _connected_adapter(turn_commit_mode="silence")
+    # Manual pump control for a deterministic assertion.
+    await adapter.stop_pump()
+    socket.sent.clear()
+
+    # Fallback path: raw speech, no transcript commit.
+    await adapter.send_audio(AudioChunk(data=b"\x33" * 100))
+
+    # send_audio itself wrote NOTHING to the socket — it only enqueued. The
+    # pump is the single writer; nothing raced onto the wire during the call.
+    assert socket.sent == [], "fallback must not write audio directly to the WS"
+    # Speech (1 padded 960B frame) + closing-silence tail frames are queued.
+    tail_frames = -(-adapter._silence_tail_bytes // PUMP_FRAME_BYTES)
+    assert len(adapter._outbound_frames) == 1 + tail_frames
+
+    # Drain via the pump: every emitted frame is exactly 960 bytes (fixed
+    # cadence), never an arbitrary-sized chunk or a 16KB blob.
+    while adapter._outbound_frames:
+        await adapter._pump_tick()
+    emitted = _decoded(socket.sent)
+    assert len(emitted) == 1 + tail_frames
+    assert all(len(f) == 960 for f in emitted), "pump must emit only 960B frames"
+    # First frame is the speech (padded), remainder are the closing silence.
+    assert emitted[0] == (b"\x33" * 100) + b"\x00" * (960 - 100)
+    assert all(f == b"\x00" * 960 for f in emitted[1:])
+    # Total closing silence covers at least the configured tail.
+    assert sum(len(f) for f in emitted[1:]) >= adapter._silence_tail_bytes
+
+    await adapter.disconnect()
+
+
 # --------------------------------------------------------------------------- #
 # A3a — server-VAD transition on the wire (UNGATED)                           #
 # --------------------------------------------------------------------------- #

--- a/python/tests/voice/test_elevenlabs_pump.py
+++ b/python/tests/voice/test_elevenlabs_pump.py
@@ -26,7 +26,6 @@ import asyncio
 import base64
 import json
 import os
-import warnings
 from typing import Any, Optional
 from unittest.mock import AsyncMock, patch
 
@@ -46,16 +45,34 @@ from scenario.voice.adapters.elevenlabs import (
 
 
 class FakePumpSocket:
-    """In-memory EL WS that records every ``send`` and models ``closed``.
+    """In-memory EL WS that records every ``send`` and models liveness the way
+    modern ``websockets`` does — via a ``state`` enum
+    (``websockets.protocol.State``), NOT a ``closed`` attribute.
 
-    Mirrors ``FakeElevenLabsSocket`` in ``test_elevenlabs_turn_commit.py`` but
-    exposes ``closed`` toggling so ``is_connected()`` (``_ws is not None and
-    not _ws.closed``) can be exercised across both transitions.
+    Modern ``websockets`` (>=13, the ``ClientConnection`` that
+    :func:`websockets.connect` returns on the version this repo pins) exposes
+    ``state`` and has NO ``closed`` attribute — so a fake that only modelled
+    ``closed`` would let a broken ``is_connected()`` (reading a nonexistent
+    ``.closed``) pass in tests while raising ``AttributeError`` against a live
+    socket. This fake exposes ``state`` (primary) and keeps a ``closed``
+    convenience setter/getter that drives it, so the test exercises the real
+    ``state`` code path. ``closed=True`` maps to ``State.CLOSED``.
     """
 
     def __init__(self) -> None:
         self.sent: list[str] = []
-        self.closed = False
+        from websockets.protocol import State
+
+        self._State = State
+        self.state = State.OPEN
+
+    @property
+    def closed(self) -> bool:
+        return self.state is self._State.CLOSED
+
+    @closed.setter
+    def closed(self, value: bool) -> None:
+        self.state = self._State.CLOSED if value else self._State.OPEN
 
     async def send(self, data: str) -> None:
         self.sent.append(data)
@@ -65,7 +82,7 @@ class FakePumpSocket:
         return ""
 
     async def close(self) -> None:
-        self.closed = True
+        self.state = self._State.CLOSED
 
     # ----- parsed views -----
 
@@ -272,15 +289,21 @@ async def test_is_connected_predicate_both_transitions() -> None:
     from scenario.voice.adapter import VoiceAgentAdapter
 
     class _Base(VoiceAgentAdapter):
-        async def connect(self) -> None: ...
-        async def disconnect(self) -> None: ...
-        async def send_audio(self, chunk: AudioChunk) -> None: ...
+        async def connect(self) -> None:
+            pass
+
+        async def disconnect(self) -> None:
+            pass
+
+        async def send_audio(self, chunk: AudioChunk) -> None:
+            pass
+
         async def recv_audio(self, timeout: float) -> AudioChunk:
             return AudioChunk(data=b"")
 
     assert _Base().is_connected() is True
 
-    adapter, socket = await _connected_adapter()
+    adapter, _socket = await _connected_adapter()
     assert adapter.is_connected() is True  # ws open
 
     await adapter.disconnect()
@@ -308,9 +331,15 @@ async def test_call_raises_pending_transport_when_disconnected() -> None:
     from scenario.voice.adapters._stub import PendingTransportError
 
     class _Disconnected(VoiceAgentAdapter):
-        async def connect(self) -> None: ...
-        async def disconnect(self) -> None: ...
-        async def send_audio(self, chunk: AudioChunk) -> None: ...
+        async def connect(self) -> None:
+            pass
+
+        async def disconnect(self) -> None:
+            pass
+
+        async def send_audio(self, chunk: AudioChunk) -> None:
+            pass
+
         async def recv_audio(self, timeout: float) -> AudioChunk:
             return AudioChunk(data=b"")
 
@@ -318,15 +347,21 @@ async def test_call_raises_pending_transport_when_disconnected() -> None:
             return False
 
     adapter = _Disconnected()
+    # Replace the real coroutines with spies to assert the guard short-circuits
+    # BEFORE either is awaited; method-assign is the intended test seam.
     adapter.send_audio = AsyncMock()  # type: ignore[method-assign]
     adapter.recv_audio = AsyncMock(return_value=AudioChunk(data=b""))  # type: ignore[method-assign]
 
     class _Input:
-        new_messages: list[Any] = []
+        def __init__(self) -> None:
+            self.new_messages: list[Any] = []
 
     with pytest.raises(PendingTransportError) as excinfo:
+        # _Input is a minimal AgentInput stub supplying only new_messages.
         await adapter.call(_Input())  # type: ignore[arg-type]
 
+    # Parity subclass: TransportNotConnectedError is-a PendingTransportError
+    # and names the adapter class.
     assert "_Disconnected" in str(excinfo.value)
     adapter.send_audio.assert_not_awaited()
     adapter.recv_audio.assert_not_awaited()
@@ -341,9 +376,14 @@ async def test_call_guard_does_not_suppress_first_chunk_timeout() -> None:
     class _Connected(VoiceAgentAdapter):
         response_timeout = 0.01
 
-        async def connect(self) -> None: ...
-        async def disconnect(self) -> None: ...
-        async def send_audio(self, chunk: AudioChunk) -> None: ...
+        async def connect(self) -> None:
+            pass
+
+        async def disconnect(self) -> None:
+            pass
+
+        async def send_audio(self, chunk: AudioChunk) -> None:
+            pass
 
         async def recv_audio(self, timeout: float) -> AudioChunk:
             raise asyncio.TimeoutError
@@ -352,9 +392,11 @@ async def test_call_guard_does_not_suppress_first_chunk_timeout() -> None:
             return True
 
     class _Input:
-        new_messages: list[Any] = []
+        def __init__(self) -> None:
+            self.new_messages: list[Any] = []
 
     with pytest.raises(FirstChunkTimeoutError):
+        # _Input is a minimal AgentInput stub supplying only new_messages.
         await _Connected().call(_Input())  # type: ignore[arg-type]
 
 
@@ -419,6 +461,9 @@ async def test_tick_racing_disconnect_no_send_no_raise() -> None:
     # And a tick with a nulled ws also swallows.
     adapter._ws = None
     await adapter._pump_tick()
+    # Tear down the first adapter's pump before reassigning so its task is
+    # cancelled+awaited (no orphan, no test-isolation bleed).
+    await adapter.stop_pump()
 
     # Full disconnect: no send after it returns.
     adapter, socket = await _connected_adapter()
@@ -441,9 +486,11 @@ async def test_tick_send_raising_mid_tick_is_swallowed_and_loop_survives() -> No
     tick reaches the send, which raises.
     """
 
-    class RaceClosedError(Exception):
-        """Stand-in for websockets.exceptions.ConnectionClosed on the send path."""
-
+    # A genuine close-race signal: the modern websockets client raises
+    # ConnectionClosed (an OSError subtype via ConnectionError) when a send
+    # lands on a socket that closed after the liveness check. Use ConnectionError
+    # so we exercise the adapter's EXPECTED-close-race branch, not the
+    # unexpected-error branch.
     class RaceThenRecoverSocket(FakePumpSocket):
         """Raises on the first N sends (the race), then succeeds — so we can
         prove the loop survived the raise and keeps ticking afterwards."""
@@ -460,12 +507,12 @@ async def test_tick_send_raising_mid_tick_is_swallowed_and_loop_survives() -> No
             self._raise_left = self._arm_raises
 
         async def send(self, data: str) -> None:
-            # closed stays False → is_connected() is True → the tick reaches
+            # state stays OPEN → is_connected() is True → the tick reaches
             # here and this raise IS the race window.
             if self._raise_left > 0:
                 self._raise_left -= 1
                 self.raise_attempts += 1
-                raise RaceClosedError("socket closed mid-send")
+                raise ConnectionError("socket closed mid-send")
             await super().send(data)
 
     socket = RaceThenRecoverSocket(raise_first=2)
@@ -483,7 +530,7 @@ async def test_tick_send_raising_mid_tick_is_swallowed_and_loop_survives() -> No
         assert adapter.is_connected() is True
 
         # Direct-drive a tick whose send raises: must NOT propagate.
-        await adapter._pump_tick()  # would raise RaceClosedError if unswallowed
+        await adapter._pump_tick()  # would raise ConnectionError if unswallowed
         assert socket.raise_attempts >= 1
 
         # The background loop must survive the raise and keep ticking: wait for
@@ -511,26 +558,31 @@ async def test_tick_send_raising_mid_tick_is_swallowed_and_loop_survives() -> No
 @pytest.mark.asyncio
 async def test_pump_task_cancelled_and_awaited_on_disconnect() -> None:
     """A8: after disconnect the pump task is cancelled AND awaited (done), and
-    no pending-task warning is emitted."""
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        adapter, socket = await _connected_adapter()
+    NO orphaned-task error surfaces via the loop exception handler.
+
+    asyncio reports "Task was destroyed but it is pending" and other
+    background-task failures through ``loop.set_exception_handler`` — NOT the
+    ``warnings`` module — so we install a temporary handler and assert it saw
+    nothing (rather than relying on ``warnings.catch_warnings``, which would
+    miss those messages).
+    """
+    loop = asyncio.get_running_loop()
+    captured: list[dict[str, Any]] = []
+    previous = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: captured.append(context))
+    try:
+        adapter, _socket = await _connected_adapter()
         task = adapter._pump_task
         assert task is not None
         await adapter.disconnect()
         assert task.cancelled() or task.done()
         assert adapter._pump_task is None
-        # Give the loop a beat to surface any destroy-pending warning.
+        # Give the loop a beat to surface any orphaned-task/destroy-pending error.
         await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous)
 
-    pending = [
-        w
-        for w in caught
-        if "was destroyed but it is pending" in str(w.message)
-        or "pending" in str(w.message).lower()
-        and "task" in str(w.message).lower()
-    ]
-    assert not pending, f"unexpected pending-task warning: {[str(w.message) for w in pending]}"
+    assert not captured, f"unexpected loop exceptions after disconnect: {captured}"
 
 
 # --------------------------------------------------------------------------- #
@@ -545,9 +597,15 @@ async def test_non_el_adapter_creates_no_pump_task() -> None:
     from scenario.voice.adapter import VoiceAgentAdapter
 
     class _NonEL(VoiceAgentAdapter):
-        async def connect(self) -> None: ...
-        async def disconnect(self) -> None: ...
-        async def send_audio(self, chunk: AudioChunk) -> None: ...
+        async def connect(self) -> None:
+            pass
+
+        async def disconnect(self) -> None:
+            pass
+
+        async def send_audio(self, chunk: AudioChunk) -> None:
+            pass
+
         async def recv_audio(self, timeout: float) -> AudioChunk:
             return AudioChunk(data=b"")
 

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -240,43 +240,78 @@ async def test_committed_user_message_is_server_accepted_shape():
 
 @pytest.mark.asyncio
 async def test_silence_mode_preserves_legacy_pure_audio_path():
-    """``turn_commit_mode="silence"`` keeps the legacy audio + silence-tail path."""
+    """``turn_commit_mode="silence"`` keeps the legacy audio + silence-tail
+    behaviour, now expressed as pump-queued fixed 960-byte frames (the pump is
+    the single WS audio writer — no direct-write racing the background pump)."""
     adapter, socket = await _connected_adapter(turn_commit_mode="silence")
+    # Deterministic drain: manual pump control, no background racing.
+    # Take manual pump control (stop the background task, clear its queue) so
+    # the drain below is deterministic; the pump is the single WS audio writer.
+    await adapter.stop_pump()
 
     await adapter.send_audio(_user_turn("Hello again."))
 
-    # Legacy path: speech chunk + a zero-byte silence tail, NO user_message.
+    # No user_message commit on the silence path.
     assert socket.user_messages == []
-    silence_tail = base64.b64encode(b"\x00" * 16000).decode()
-    assert silence_tail in socket.audio_chunks
-    assert len(socket.audio_chunks) == 2  # speech + silence
+    # Speech (1 padded frame) + 16000-byte tail as ceil(16000/960)=17 frames.
+    expected_frames = 1 + (-(-16000 // 960))
+    assert len(adapter._outbound_frames) == expected_frames
+    socket.sent.clear()
+    while adapter._outbound_frames:
+        await adapter._pump_tick()
+    emitted = [base64.b64decode(c) for c in socket.audio_chunks]
+    # Every emitted frame is the fixed 960-byte pump size.
+    assert emitted, "expected pump to emit the enqueued frames"
+    assert all(len(f) == 960 for f in emitted)
+    # The closing silence totals at least the legacy 16000-byte tail.
+    tail_zero_bytes = sum(len(f) for f in emitted if f == b"\x00" * 960)
+    assert tail_zero_bytes >= 16000
 
 
 @pytest.mark.asyncio
 async def test_text_mode_without_transcript_falls_back_to_silence_tail():
-    """``"text"`` mode with no transcript falls back to the silence tail."""
+    """``"text"`` mode with no transcript falls back to the silence tail —
+    now queued as fixed 960-byte pump frames, not a direct blob write."""
     adapter, socket = await _connected_adapter()  # default "text"
+    # Take manual pump control (stop the background task, clear its queue) so
+    # the drain below is deterministic; the pump is the single WS audio writer.
+    await adapter.stop_pump()
 
     # No transcript on the chunk (e.g. raw audio with no STT text upstream).
     await adapter.send_audio(AudioChunk(data=b"\x00" * 8))
 
     assert socket.user_messages == []
-    silence_tail = base64.b64encode(b"\x00" * 16000).decode()
-    assert silence_tail in socket.audio_chunks
+    # Speech (1 padded frame) + the closing-silence tail frames.
+    assert len(adapter._outbound_frames) == 1 + (-(-16000 // 960))
+    socket.sent.clear()
+    while adapter._outbound_frames:
+        await adapter._pump_tick()
+    emitted = [base64.b64decode(c) for c in socket.audio_chunks]
+    assert all(len(f) == 960 for f in emitted)
+    assert sum(len(f) for f in emitted if f == b"\x00" * 960) >= 16000
 
 
 @pytest.mark.asyncio
 async def test_silence_tail_bytes_resizes_the_fallback_tail():
-    """``silence_tail_bytes`` resizes the legacy fallback tail."""
+    """``silence_tail_bytes`` resizes the fallback tail — the number of queued
+    960-byte silence frames scales with it."""
     adapter, socket = await _connected_adapter(
         turn_commit_mode="silence", silence_tail_bytes=2400
     )
+    # Take manual pump control (stop the background task, clear its queue) so
+    # the drain below is deterministic; the pump is the single WS audio writer.
+    await adapter.stop_pump()
 
     await adapter.send_audio(_user_turn("size me"))
 
-    expected_tail = base64.b64encode(b"\x00" * 2400).decode()
-    assert expected_tail in socket.audio_chunks
-    assert base64.b64encode(b"\x00" * 16000).decode() not in socket.audio_chunks
+    # 2400-byte tail = ceil(2400/960) = 3 silence frames (vs 17 for 16000).
+    tail_frames_2400 = -(-2400 // 960)
+    tail_frames_16000 = -(-16000 // 960)
+    assert tail_frames_2400 == 3
+    # Speech frame (1) + 3 silence tail frames.
+    assert len(adapter._outbound_frames) == 1 + tail_frames_2400
+    # Materially fewer than the default 16000-byte tail would have queued.
+    assert (1 + tail_frames_2400) < (1 + tail_frames_16000)
 
 
 @pytest.mark.asyncio

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -295,7 +295,7 @@ async def test_text_mode_without_transcript_falls_back_to_silence_tail():
 async def test_silence_tail_bytes_resizes_the_fallback_tail():
     """``silence_tail_bytes`` resizes the fallback tail — the number of queued
     960-byte silence frames scales with it."""
-    adapter, socket = await _connected_adapter(
+    adapter, _socket = await _connected_adapter(
         turn_commit_mode="silence", silence_tail_bytes=2400
     )
     # Take manual pump control (stop the background task, clear its queue) so


### PR DESCRIPTION
## Summary

Slice A of the #740 Python voice parity work: the ElevenLabs **continuous mic pump** + the **`is_connected()` pre-turn guard**. Python parity with the TS reference (`javascript/src/voice/adapters/elevenlabs.ts` `pumpTick`/`startPump`/`stopPump`; `adapter.runtime.ts` pre-turn `PendingTransportError` throw).

This adapter uses a **raw WebSocket** connection (predating this slice), not the official SDK's `Conversation`/`AudioInterface` object — so the pump writes raw WS JSON directly (`self._ws.send(json.dumps({"user_audio_chunk": <b64>}))`), the same send seam as the legacy turn-commit path. The pump is the **single owner of idle silence** on the wire. (The `elevenlabs` SDK *does* ship an `input_callback` audio seam; adopting it — as the TS reference does — is a broader change this slice does not take on.) `is_connected()` is folded in because it is load-bearing in two TS reference paths (the pump active-check and the pre-turn `call()` guard), so shipping the pump without it would diverge from the reference.

**Files changed**
- `python/scenario/voice/adapters/elevenlabs.py` — pump constants, background asyncio pump task (started in `connect()`, stopped-before-close in `disconnect()`), 3-way `_pump_tick` gate, `awaiting_user_turn` flag, `is_connected()` override.
- `python/scenario/voice/adapter.py` — base `is_connected()` default `True`; pre-turn `PendingTransportError` guard in `call()`.
- `python/scenario/voice/adapters/_stub.py` — `TransportNotConnectedError` (actionable subclass of `PendingTransportError`).
- `python/tests/voice/test_elevenlabs_pump.py` — new test file (A1–A8 + regression; A3b gated).

## Acceptance criteria

- [x] **A1** frame format on the wire (960B `user_audio_chunk`, legacy silence-tail not double-feeding) — `test_pump_emits_960b_user_audio_chunk_frames`
- [x] **A2** three-way `pump_tick` gate + `awaiting_user_turn` transitions — `test_pump_tick_three_way_gate_and_flag_transitions`
- [x] **A3a** server-VAD silence transition on the wire, no caller writes (UNGATED) — `test_pump_emits_silence_transition_without_caller_writes`
- [ ] **A3b** real EL server-VAD end-of-turn (GATED `RUN_EL_HOSTED=1`, **skipped in CI** — no repo secret) — `test_real_server_vad_end_of_turn`. Test exists and is correctly gated; a live pass was asserted manually on an earlier revision but is **not re-verified at this HEAD** (see proof section).
- [x] **A4** `is_connected()` predicate, both transitions (base default True; EL open/closed/None) — `test_is_connected_predicate_both_transitions`
- [x] **A5** pre-turn connection guard in `call()` raises `PendingTransportError` before send/recv; does not suppress `FirstChunkTimeoutError` — `test_call_raises_pending_transport_when_disconnected` + `test_call_guard_does_not_suppress_first_chunk_timeout`
- [x] **A6** start/stop/reset lifecycle (idempotent start, stop drops frames + resets flag, reconnect closing-silence) — `test_pump_start_stop_reset_lifecycle`
- [x] **A7** disconnect races pump — stop-before-close, no post-teardown send, no raise — `test_tick_racing_disconnect_no_send_no_raise` + `test_tick_send_raising_mid_tick_is_swallowed_and_loop_survives`
- [x] **A8** task cleanup — no orphan (cancelled+awaited, no pending-task warning) — `test_pump_task_cancelled_and_awaited_on_disconnect`
- [x] **A-regression** non-EL/text runs create no pump task — `test_non_el_adapter_creates_no_pump_task` + text scenario suite green

## Backend-only

<!-- no-ui-surface -->

This is a backend transport change — **no visual surface**. It lives entirely in the ElevenLabs voice transport (`python/scenario/voice/`), touches no UI, and is verified via pytest + pyright, not a browser.

## Human verification

- `cd python && uv run pytest tests/voice/test_elevenlabs_pump.py -v` → **12 passed, 1 skipped** (A3b gated).
- `cd python && RUN_EL_HOSTED=1 EL_AGENT_ID=<id> ELEVENLABS_API_KEY=<key> uv run pytest tests/voice/test_elevenlabs_pump.py::test_real_server_vad_end_of_turn` against a live EL agent → an agent response is produced from the pump's closing silence alone, with zero caller `send_audio` (proves real server-VAD end-of-turn). Requires live EL credentials — not available in CI.
- Confirm no pump task leaks for non-EL adapters and text-only runs stay green: `uv run pytest tests/test_scenario.py -m "not integration"`.

## How I can prove I was successful

**Backend/transport change with no UI surface** (see `<!-- no-ui-surface -->` above) — proof is pytest + pyright, not a screenshot.

Commands run and results at **HEAD `3b487a9`** (this session):

- `uv run pytest tests/voice/test_elevenlabs_pump.py -q` → **12 passed, 1 skipped** in 0.28s (A3b `RUN_EL_HOSTED` unset) — **proven**.
- `uv run pytest tests/voice/test_elevenlabs_turn_commit.py tests/voice/test_adapters.py -q -m "not integration"` → **71 passed** (mock-based EL fallback/turn-commit + adapter regression; the pure-audio fallback routes through the pump as fixed 960B frames, no direct WS write) — **proven**.
- `uv run pyright scenario/voice/adapters/elevenlabs.py scenario/voice/adapter.py scenario/voice/adapters/_stub.py tests/voice/test_elevenlabs_pump.py` → **0 errors, 0 warnings** — **proven** (also confirmed by the whole-repo pyright gate in CI).
- Full CI at this HEAD: **1002 passed, 21 skipped, 0 failed** (`python-ci` `test` + whole-repo pyright) — **proven** (CI green).

- **A3b (live EL server-VAD end-of-turn):** **claimed, not re-verified at this HEAD.** The gated test exists and is correctly skipped in CI (no `ELEVENLABS_API_KEY` repo secret). A live pass was asserted on an earlier revision; the branch has since been rebased, so that evidence does not attach to the current HEAD. Re-run with `RUN_EL_HOSTED=1` against a live agent to re-confirm before relying on the live-VAD path.

## Notes for reviewers

Two non-blocking observations from review (full detail in the review-verdict comment on this PR, part of the broader #740 parity effort):

- **Silence-tail (`_enqueue_silence_tail`).** It reproduces silence the pump's steady-state `else` branch already emits, and the TS reference deprecated the bounded tail to a no-op; it only affects the non-default `silence`/no-transcript path. Aligning with TS (dropping the explicit tail) should be validated with a live `RUN_EL_HOSTED=1` run, since the tail's stall-tuning was measured on the now-removed direct-write path. Does not block this slice.
- **`is_connected()` scope.** Wired into the EL adapter this slice; the other socket adapters (`openai_realtime`/`pipecat`/`vapi`/`websocket`) inherit the base `True`, so the guard is a no-op for them until a later slice wires them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
