### PR TITLE
feat(tracing): stamp scenario SDK name+version as trace attributes (#744)

### DIFF
--- a/python/scenario/_tracing/__init__.py
+++ b/python/scenario/_tracing/__init__.py
@@ -9,6 +9,14 @@ via setup_scenario_tracing().
 from .setup import setup_scenario_tracing, ensure_tracing_initialized, _reset_tracing_for_tests
 from .judge_span_collector import judge_span_collector, JudgeSpanCollector
 from .filters import scenario_only, with_custom_scopes, SpanFilter
+from .sdk_metadata import (
+    ATTR_SCENARIO_SDK_NAME,
+    ATTR_SCENARIO_SDK_VERSION,
+    SCENARIO_SDK_NAME,
+    SCENARIO_SDK_VERSION,
+    scenario_sdk_attributes,
+    sdk_version,
+)
 
 __all__ = [
     "judge_span_collector",
@@ -18,4 +26,10 @@ __all__ = [
     "scenario_only",
     "with_custom_scopes",
     "SpanFilter",
+    "ATTR_SCENARIO_SDK_NAME",
+    "ATTR_SCENARIO_SDK_VERSION",
+    "SCENARIO_SDK_NAME",
+    "SCENARIO_SDK_VERSION",
+    "scenario_sdk_attributes",
+    "sdk_version",
 ]

--- a/python/scenario/_tracing/sdk_metadata.py
+++ b/python/scenario/_tracing/sdk_metadata.py
@@ -1,0 +1,54 @@
+"""SDK identity constants for scenario trace attributes.
+
+Mirrors the TypeScript implementation in
+``javascript/src/tracing/sdk-metadata.ts`` (merged PR #736).
+
+These constants are stamped on every ``Scenario Turn`` root span so a trace
+can be identified as produced by ``langwatch-scenario`` without asking the
+user to re-derive it.
+"""
+
+from importlib.metadata import version, PackageNotFoundError
+
+# ---------------------------------------------------------------------------
+# Attribute key constants (shared so callers never type string literals)
+# ---------------------------------------------------------------------------
+
+ATTR_SCENARIO_SDK_NAME = "scenario.sdk.name"
+"""OpenTelemetry attribute key for the scenario SDK name."""
+
+ATTR_SCENARIO_SDK_VERSION = "scenario.sdk.version"
+"""OpenTelemetry attribute key for the scenario SDK version."""
+
+# ---------------------------------------------------------------------------
+# Values
+# ---------------------------------------------------------------------------
+
+SCENARIO_SDK_NAME: str = "langwatch-scenario"
+"""The distribution name of the Python scenario SDK."""
+
+
+def sdk_version() -> str:
+    """Return the installed ``langwatch-scenario`` package version.
+
+    Reads from ``importlib.metadata`` at call time so it reflects the
+    actual installed version rather than a hardcoded literal.
+
+    Falls back to ``"unknown"`` when the package metadata is not available
+    (e.g. editable installs without a dist-info directory) so a missing
+    version never crashes a run.
+    """
+    try:
+        return version(SCENARIO_SDK_NAME)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+#: Pre-computed version string — resolved once at module import.
+SCENARIO_SDK_VERSION: str = sdk_version()
+
+#: Convenience dict of both SDK-identity attributes, computed once.
+scenario_sdk_attributes: dict[str, str] = {
+    ATTR_SCENARIO_SDK_NAME: SCENARIO_SDK_NAME,
+    ATTR_SCENARIO_SDK_VERSION: SCENARIO_SDK_VERSION,
+}

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -85,6 +85,12 @@ import litellm
 import langwatch
 import langwatch.telemetry.context
 from langwatch.telemetry.tracing import LangWatchTrace
+from scenario._tracing.sdk_metadata import (
+    ATTR_SCENARIO_SDK_NAME,
+    ATTR_SCENARIO_SDK_VERSION,
+    SCENARIO_SDK_NAME,
+    SCENARIO_SDK_VERSION,
+)
 
 
 def _extract_text_content(content: object) -> str:
@@ -457,6 +463,8 @@ class ScenarioExecutor:
         if self._trace.root_span is not None:
             attrs = {
                 "langwatch.origin": "simulation",
+                ATTR_SCENARIO_SDK_NAME: SCENARIO_SDK_NAME,
+                ATTR_SCENARIO_SDK_VERSION: SCENARIO_SDK_VERSION,
                 "scenario.run_id": self._scenario_run_id,
             }
             for role, tier_value in getattr(self, '_modality_resolutions', {}).items():

--- a/python/tests/test_sdk_version_attributes.py
+++ b/python/tests/test_sdk_version_attributes.py
@@ -76,7 +76,7 @@ def in_memory_exporter():
     processor = SimpleSpanProcessor(exporter)
     if not hasattr(provider, "add_span_processor"):
         pytest.skip(f"Active tracer provider {type(provider)} is not mutable")
-    provider.add_span_processor(processor)  # type: ignore[attr-defined]
+    provider.add_span_processor(processor)  # type: ignore[attr-defined]  # hasattr guard above confirms TracerProvider is a concrete SDK provider with add_span_processor; the abstract base omits it
     try:
         yield exporter
     finally:

--- a/python/tests/test_sdk_version_attributes.py
+++ b/python/tests/test_sdk_version_attributes.py
@@ -1,0 +1,197 @@
+"""Unit tests for scenario SDK name+version stamped on trace spans.
+
+Mirrors the TypeScript test in
+``javascript/src/execution/__tests__/scenario-sdk-version-attribute.test.ts``
+(merged PR #736).
+
+AC from issue #744:
+- Both attributes stamped on the top-level ``Scenario Turn`` span on EVERY run.
+- ``scenario.sdk.name`` == ``"langwatch-scenario"``
+- ``scenario.sdk.version`` == ``importlib.metadata.version("langwatch-scenario")``
+- Version is NOT hardcoded — read from package metadata.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from importlib.metadata import version as pkg_version
+
+import pytest
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import scenario
+from scenario._tracing import ensure_tracing_initialized
+from scenario._tracing.sdk_metadata import (
+    ATTR_SCENARIO_SDK_NAME,
+    ATTR_SCENARIO_SDK_VERSION,
+    SCENARIO_SDK_NAME,
+)
+from scenario.agent_adapter import AgentAdapter
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
+
+
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+class _EchoAgent(AgentAdapter):
+    role = AgentRole.AGENT
+
+    async def call(self, _input: AgentInput) -> AgentReturnTypes:
+        return {"role": "assistant", "content": "Hello, I can help you."}
+
+
+class _EchoUser(AgentAdapter):
+    role = AgentRole.USER
+
+    async def call(self, _input: AgentInput) -> AgentReturnTypes:
+        return "Hi there"
+
+
+class _InstantJudge(AgentAdapter):
+    role = AgentRole.JUDGE
+
+    async def call(self, _input: AgentInput) -> AgentReturnTypes:
+        return ScenarioResult(
+            success=True,
+            messages=[],
+            reasoning="ok",
+            passed_criteria=["ran to completion"],
+        )
+
+
+@pytest.fixture()
+def in_memory_exporter():
+    """Attach a fresh InMemorySpanExporter to the active tracer provider."""
+    from opentelemetry import trace
+
+    ensure_tracing_initialized(None)
+    provider = trace.get_tracer_provider()
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    if not hasattr(provider, "add_span_processor"):
+        pytest.skip(f"Active tracer provider {type(provider)} is not mutable")
+    provider.add_span_processor(processor)  # type: ignore[attr-defined]
+    try:
+        yield exporter
+    finally:
+        processor.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sdk_name_and_version_stamped_on_scenario_turn_span(in_memory_exporter):
+    """Both scenario.sdk.name and scenario.sdk.version appear on the turn span."""
+    result = await scenario.arun(
+        name="sdk-version-attr-test",
+        description="verify SDK identity attributes on the Scenario Turn span",
+        agents=[_EchoAgent(), _EchoUser(), _InstantJudge()],
+        script=[
+            scenario.user("hello"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+    assert result.success, f"scenario failed unexpectedly: {result.reasoning}"
+
+    finished = in_memory_exporter.get_finished_spans()
+    turn_spans = [s for s in finished if s.name == "Scenario Turn"]
+    assert turn_spans, "no 'Scenario Turn' spans were emitted"
+
+    expected_version = pkg_version("langwatch-scenario")
+
+    for span in turn_spans:
+        assert ATTR_SCENARIO_SDK_NAME in span.attributes, (
+            f"Span '{span.name}' is missing attribute '{ATTR_SCENARIO_SDK_NAME}'"
+        )
+        assert ATTR_SCENARIO_SDK_VERSION in span.attributes, (
+            f"Span '{span.name}' is missing attribute '{ATTR_SCENARIO_SDK_VERSION}'"
+        )
+        assert span.attributes[ATTR_SCENARIO_SDK_NAME] == SCENARIO_SDK_NAME, (
+            f"Expected sdk.name={SCENARIO_SDK_NAME!r}, "
+            f"got {span.attributes[ATTR_SCENARIO_SDK_NAME]!r}"
+        )
+        assert span.attributes[ATTR_SCENARIO_SDK_VERSION] == expected_version, (
+            f"Expected sdk.version={expected_version!r}, "
+            f"got {span.attributes[ATTR_SCENARIO_SDK_VERSION]!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_sdk_version_matches_package_metadata(in_memory_exporter):
+    """scenario.sdk.version on the span equals importlib.metadata.version()."""
+    await scenario.arun(
+        name="sdk-version-metadata-match",
+        description="sdk.version on span must match importlib.metadata",
+        agents=[_EchoAgent(), _EchoUser(), _InstantJudge()],
+        script=[
+            scenario.user("hi"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+
+    finished = in_memory_exporter.get_finished_spans()
+    turn_spans = [s for s in finished if s.name == "Scenario Turn"]
+    assert turn_spans
+
+    emitted = turn_spans[0].attributes.get(ATTR_SCENARIO_SDK_VERSION)
+    assert isinstance(emitted, str) and emitted, (
+        f"sdk.version must be a non-empty string, got {emitted!r}"
+    )
+    # Must be semver-shaped (N.N.N...)
+    assert re.match(r"^\d+\.\d+\.\d+", emitted), (
+        f"sdk.version {emitted!r} is not semver-shaped"
+    )
+    # Must equal what importlib.metadata reports
+    assert emitted == pkg_version("langwatch-scenario"), (
+        f"Emitted version {emitted!r} != installed version "
+        f"{pkg_version('langwatch-scenario')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sdk_attrs_stamped_on_every_turn_span_in_multi_turn(in_memory_exporter):
+    """SDK attributes appear on ALL turn spans, not just the first."""
+    turn_count = 0
+
+    class _CountingJudge(AgentAdapter):
+        role = AgentRole.JUDGE
+
+        async def call(self, _input: AgentInput) -> AgentReturnTypes:
+            nonlocal turn_count
+            turn_count += 1
+            if turn_count >= 2:
+                return ScenarioResult(
+                    success=True,
+                    messages=[],
+                    reasoning="done after 2 turns",
+                    passed_criteria=["multi-turn complete"],
+                )
+            return "keep going"
+
+    await scenario.arun(
+        name="sdk-version-multi-turn",
+        description="sdk.* present on every turn span across multiple turns",
+        agents=[_EchoAgent(), _EchoUser(), _CountingJudge()],
+        script=[scenario.proceed()],
+    )
+
+    finished = in_memory_exporter.get_finished_spans()
+    turn_spans = [s for s in finished if s.name == "Scenario Turn"]
+    assert len(turn_spans) >= 2, (
+        f"Expected at least 2 turn spans for multi-turn, got {len(turn_spans)}"
+    )
+
+    expected_version = pkg_version("langwatch-scenario")
+    for span in turn_spans:
+        assert span.attributes.get(ATTR_SCENARIO_SDK_NAME) == SCENARIO_SDK_NAME
+        assert span.attributes.get(ATTR_SCENARIO_SDK_VERSION) == expected_version


### PR DESCRIPTION
## Summary

- Stamps `scenario.sdk.name` and `scenario.sdk.version` on every `Scenario Turn` root span in the **Python SDK**, mirroring the merged TypeScript PR #736.
- New canonical constants module `python/scenario/_tracing/sdk_metadata.py` (mirrors `javascript/src/tracing/sdk-metadata.ts`).
- Version read via `importlib.metadata.version("langwatch-scenario")` — not hardcoded; graceful fallback to `"unknown"` on `PackageNotFoundError`.
- Attributes stamped at span creation inside `_new_turn()`, structurally covering all exit paths.

## Acceptance criteria

- [x] **AC1** — Both attributes stamped on `Scenario Turn` span on every run (all exit paths): stamped at `start_span` time in `_new_turn()` so any exit path that ends the trace has the attributes.
- [x] **AC2** — `scenario.sdk.name` = `"langwatch-scenario"`; `scenario.sdk.version` = installed package version: confirmed by `test_sdk_name_and_version_stamped_on_scenario_turn_span`.
- [x] **AC3** — Attribute keys as constants in a single canonical home: `python/scenario/_tracing/sdk_metadata.py` exports `ATTR_SCENARIO_SDK_NAME`, `ATTR_SCENARIO_SDK_VERSION`, `SCENARIO_SDK_NAME`, `SCENARIO_SDK_VERSION`.
- [x] **AC4** — Version from `importlib.metadata.version("langwatch-scenario")`, not hardcoded: `sdk_metadata.py` line `version("langwatch-scenario")`; test `test_sdk_version_matches_package_metadata` asserts equality to `pkg_version("langwatch-scenario")`.
- [x] **AC5** — Unit test asserting both attributes present + version equals package metadata version: `python/tests/test_sdk_version_attributes.py` (3 tests, all pass).

## Evidence

```
uv run pytest tests/test_sdk_version_attributes.py -v
# → 3 passed in 10.54s

uv run pytest tests/test_arun_multi_turn_traces.py tests/test_tracing_filters.py tests/test_tracing_setup.py tests/test_judge_span_collector.py -v
# → 38 passed in 6.25s

uv run pyright scenario/_tracing/sdk_metadata.py scenario/scenario_executor.py tests/test_sdk_version_attributes.py
# → 0 errors, 0 warnings, 0 informations
```

## Human verification

Reviewer can confirm by:
1. Checking `python/scenario/_tracing/sdk_metadata.py` for the four constants + `importlib.metadata.version` call with `PackageNotFoundError` fallback.
2. Checking `scenario_executor.py` `_new_turn()` — the `ATTR_SCENARIO_SDK_NAME`/`ATTR_SCENARIO_SDK_VERSION` attribute keys are now in the `attrs` dict passed to `root_span.set_attributes()`.
3. Running `uv run pytest tests/test_sdk_version_attributes.py -v` — all 3 tests pass.

## How I can prove I was successful

This is a backend/tracing-only change. There is no UI to screenshot. Evidence is: 3 new tests pass, 38 regression tests pass, pyright clean. The emitted attributes are observable on any LangWatch trace dashboard by filtering span attributes for `scenario.sdk.name`.

Closes #744. Parity with TS #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- no-ui-surface -->
**Backend-only / tracing change** — adds SDK-version trace attributes on the span; no UI surface. Verified via unit tests + pyright; no browser/visual proof applicable.
