### PR TITLE
refactor(realtime): use the injectable Logger instead of console.* (#724)

### DIFF
--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -19,6 +19,7 @@ import {
 import { ResponseFormatter } from "./response-formatter";
 import type { AgentInput, AgentReturnTypes, AgentRole } from "../../domain";
 import { AgentAdapter } from "../../domain/agents";
+import { Logger } from "../../utils/logger";
 
 /**
  * Configuration for RealtimeAgentAdapter
@@ -96,6 +97,7 @@ export class RealtimeAgentAdapter extends AgentAdapter {
   private messageProcessor = new MessageProcessor();
   private responseFormatter = new ResponseFormatter();
   private audioEvents = new EventEmitter();
+  private readonly logger = new Logger("RealtimeAgentAdapter");
 
   /**
    * Creates a new RealtimeAgentAdapter instance
@@ -143,7 +145,7 @@ export class RealtimeAgentAdapter extends AgentAdapter {
    * @returns Agent response as audio message or text
    */
   async call(input: AgentInput): Promise<AgentReturnTypes> {
-    console.log(`🔊 [${this.name}] being called with role: ${this.role}`);
+    this.logger.debug(`[${this.name}] being called with role: ${this.role}`);
 
     const latestMessage = input.newMessages[input.newMessages.length - 1];
 
@@ -172,7 +174,7 @@ export class RealtimeAgentAdapter extends AgentAdapter {
    * Handles the initial response when no user message exists
    */
   private async handleInitialResponse(): Promise<AssistantModelMessage> {
-    console.log(`[${this.name}] First message, creating response`);
+    this.logger.debug(`[${this.name}] First message, creating response`);
 
     const sessionWithTransport = this.session as RealtimeSession & {
       transport?: {

--- a/javascript/src/agents/realtime/realtime-event-handler.ts
+++ b/javascript/src/agents/realtime/realtime-event-handler.ts
@@ -1,5 +1,7 @@
 import type { RealtimeSession } from "@openai/agents/realtime";
 
+import { Logger } from "../../utils/logger";
+
 /**
  * Event emitted when an audio response is completed
  */
@@ -43,6 +45,7 @@ export class RealtimeEventHandler {
   private responseResolver: ((value: AudioResponseEvent) => void) | null = null;
   private errorRejecter: ((error: Error) => void) | null = null;
   private listenersSetup = false;
+  private readonly logger = new Logger("RealtimeEventHandler");
 
   /**
    * Creates a new RealtimeEventHandler instance
@@ -87,7 +90,7 @@ export class RealtimeEventHandler {
     const transport = this.getTransport();
 
     if (!transport) {
-      console.error("❌ Transport not available on session");
+      this.logger.error("Transport not available on session");
       return;
     }
 
@@ -123,7 +126,7 @@ export class RealtimeEventHandler {
 
     // Handle transport errors
     transport.on("error", (error: unknown) => {
-      console.error(`❌ Transport error:`, error);
+      this.logger.error("Transport error", error);
       if (this.errorRejecter) {
         const errorObj =
           error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
## Ticket

Closes #724. The two realtime files still used raw `console.*` calls instead of the SDK's shared, level-aware `Logger` (a leftover follow-up from PR #669).

## Change

Route the four `console.*` calls through the shared `Logger` (`new Logger("<ClassName>")`), matching the convention already used by `user-simulator-agent`, `judge-agent`, and `event-bus`:

- `realtime-agent.adapter.ts`: two diagnostic `console.log` -> `logger.debug` (silent by default, gated behind `LOG_LEVEL` like the rest of the SDK, so the framework no longer prints unconditionally on every realtime call).
- `realtime-event-handler.ts`: two `console.error` -> `logger.error`.

Dropped the leftover emoji prefixes; the `Logger` already tags each line with its class context. No behavior change beyond routing through the shared logger.

## Evidence

- **No `console.*` remains** in either file (`grep` for `console.` returns nothing).
- **Behavior preserved:** `vitest run` on the realtime unit suites (`realtime-adapter-frames`, `realtime-response-formatter`, `connected-state`) -> `Test Files 3 passed (3)`, `Tests 9 passed (9)`.
- **Type-clean:** `pnpm typecheck` (tsc --noEmit) exits 0.
- **Scoped:** only the two files named in the ticket; the `Logger` import and one field per class plus the four call-site rewrites.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.
