### PR TITLE
chore(lint): forbid non-null assertions in library src and gate it in CI (#751)

### DIFF
--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -72,6 +72,14 @@ jobs:
         run: pnpm lint:all
         working-directory: javascript
 
+      # Lints the shipped library source (src/, excluding tests) with the root
+      # package config, which the workspace-recursive lint:all does not cover.
+      # Enforces no-non-null-assertion (#751) and the rest of the config on the
+      # library; extending the gate to tests/examples is tracked in #565.
+      - name: Lint (library)
+        run: pnpm lint:lib
+        working-directory: javascript
+
       - name: Type check
         run: pnpm typecheck:all
         working-directory: javascript

--- a/javascript/eslint.config.mjs
+++ b/javascript/eslint.config.mjs
@@ -75,4 +75,15 @@ export default defineConfig([
       ],
     },
   },
+  {
+    // Forbid non-null assertions (`!`) in shipped library source. Tests and
+    // examples legitimately assert known-present fixtures, so the rule is
+    // scoped to non-test `src/` only; extending the lint gate to the rest of
+    // the package is tracked in #565.
+    files: ["src/**/*.ts"],
+    ignores: ["src/**/*.test.ts", "src/**/__tests__/**"],
+    rules: {
+      "@typescript-eslint/no-non-null-assertion": "error",
+    },
+  },
 ]);

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -18,6 +18,7 @@
     "watch": "pnpm run build -- --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
+    "lint:lib": "eslint 'src/**/*.ts' --ignore-pattern '**/*.test.ts' --ignore-pattern '**/__tests__/**'",
     "format": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -125,16 +125,19 @@ function collapseDiscoveryHistory(
   return out;
 }
 
-import { JudgeUtils } from "./judge-utils";
 import { estimateTokens, DEFAULT_TOKEN_THRESHOLD } from "./estimate-tokens";
+import { JudgeResult } from "./interfaces";
+import { judgeSpanCollector, JudgeSpanCollector } from "./judge-span-collector";
+import { judgeSpanDigestFormatter } from "./judge-span-digest-formatter";
+import { JudgeUtils } from "./judge-utils";
 import { expandTrace, grepTrace } from "./trace-tools";
 import { getProjectConfig } from "../../config";
 import { AgentInput, JudgeAgentAdapter, AgentRole, DEFAULT_MAX_TURNS } from "../../domain";
 import { modelSchema } from "../../domain/core/schemas/model.schema";
 import { Logger } from "../../utils/logger";
-import { createLLMInvoker } from "../llm-invoker.factory";
 import { resolveVoiceConfig } from "../../voice/config";
 import { prepareJudgeInput } from "../../voice/judge-stt";
+import { createLLMInvoker } from "../llm-invoker.factory";
 import {
   TestingAgentConfig,
   FinishTestArgs,
@@ -143,9 +146,6 @@ import {
 } from "../types";
 import { criterionToParamName } from "../utils";
 
-import { JudgeResult } from "./interfaces";
-import { judgeSpanCollector, JudgeSpanCollector } from "./judge-span-collector";
-import { judgeSpanDigestFormatter } from "./judge-span-digest-formatter";
 
 /**
  * Configuration for the judge agent.

--- a/javascript/src/agents/judge/judge-span-collector.ts
+++ b/javascript/src/agents/judge/judge-span-collector.ts
@@ -61,8 +61,9 @@ export class JudgeSpanCollector implements SpanProcessor {
         return true;
       }
       const parentId = getParentSpanId(span);
-      if (parentId && spanMap.has(parentId)) {
-        return belongsToThread(spanMap.get(parentId)!, visited);
+      const parentSpan = parentId ? spanMap.get(parentId) : undefined;
+      if (parentSpan) {
+        return belongsToThread(parentSpan, visited);
       }
       return false;
     };

--- a/javascript/src/agents/judge/judge-span-digest-formatter.ts
+++ b/javascript/src/agents/judge/judge-span-digest-formatter.ts
@@ -1,5 +1,6 @@
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
+import { deepTransform } from "./deep-transform";
 import {
   hrTimeToMs,
   formatDuration,
@@ -11,7 +12,6 @@ import {
 } from "./span-utils";
 import { StringDeduplicator } from "./string-deduplicator";
 import { truncateMediaUrl, truncateMediaPart } from "./truncate-media";
-import { deepTransform } from "./deep-transform";
 import { Logger } from "../../utils/logger";
 
 /**
@@ -147,11 +147,13 @@ export class JudgeSpanDigestFormatter {
     }
 
     for (const span of spans) {
-      const node = spanMap.get(span.spanContext().spanId)!;
+      const node = spanMap.get(span.spanContext().spanId);
+      if (!node) continue; // every span was inserted above; satisfies the type
       const parentId = getParentSpanId(span);
+      const parent = parentId ? spanMap.get(parentId) : undefined;
 
-      if (parentId && spanMap.has(parentId)) {
-        spanMap.get(parentId)!.children.push(node);
+      if (parent) {
+        parent.children.push(node);
       } else {
         roots.push(node);
       }

--- a/javascript/src/agents/judge/span-utils.ts
+++ b/javascript/src/agents/judge/span-utils.ts
@@ -175,8 +175,9 @@ export function buildHierarchy(nodes: SpanNode[]): SpanNode[] {
   const roots: SpanNode[] = [];
   for (const node of nodes) {
     const parentId = getParentSpanId(node.span);
-    if (parentId && bySpanId.has(parentId)) {
-      bySpanId.get(parentId)!.children.push(node);
+    const parent = parentId ? bySpanId.get(parentId) : undefined;
+    if (parent) {
+      parent.children.push(node);
     } else {
       roots.push(node);
     }

--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -120,8 +120,14 @@ export class RealtimeAgentAdapter extends AgentAdapter {
     params?: Parameters<RealtimeSession["connect"]>[0] | undefined
   ): Promise<void> {
     const { apiKey, ...rest } = params ?? {};
+    const resolvedApiKey = apiKey ?? process.env.OPENAI_API_KEY;
+    if (!resolvedApiKey) {
+      throw new Error(
+        "RealtimeAgentAdapter.connect requires an API key: pass params.apiKey or set OPENAI_API_KEY.",
+      );
+    }
     await this.session.connect({
-      apiKey: apiKey ?? process.env.OPENAI_API_KEY!,
+      apiKey: resolvedApiKey,
       ...rest,
     });
   }

--- a/javascript/src/agents/red-team/crescendo-strategy.ts
+++ b/javascript/src/agents/red-team/crescendo-strategy.ts
@@ -76,7 +76,7 @@ export class CrescendoStrategy implements RedTeamStrategy {
       }
     }
     // Should not be reached — last phase end is Infinity
-    const last = PHASES[PHASES.length - 1]!;
+    const last = PHASES[PHASES.length - 1];
     return { name: last.name, instructions: last.instructions };
   }
 

--- a/javascript/src/agents/red-team/goat-strategy.ts
+++ b/javascript/src/agents/red-team/goat-strategy.ts
@@ -11,16 +11,16 @@
  */
 
 import {
-  AttackerOutput,
-  JSON_OUTPUT_CONTRACT,
-  RedTeamStrategy,
-} from "./red-team-strategy";
-import {
   DEFAULT_GOAT_TECHNIQUES,
   Technique,
   extractChosenIds,
   renderCatalogue,
 } from "./goat-techniques";
+import {
+  AttackerOutput,
+  JSON_OUTPUT_CONTRACT,
+  RedTeamStrategy,
+} from "./red-team-strategy";
 
 export class GoatStrategy implements RedTeamStrategy {
   // Paper fidelity: GOAT does not pre-generate an attack plan.

--- a/javascript/src/agents/red-team/red-team-agent.ts
+++ b/javascript/src/agents/red-team/red-team-agent.ts
@@ -1,14 +1,14 @@
-import { generateText, LanguageModel } from "ai";
+import { generateText, LanguageModel, type ModelMessage } from "ai";
 
-import { BacktrackEntry, RedTeamStrategy } from "./red-team-strategy";
 import { CrescendoStrategy } from "./crescendo-strategy";
 import { GoatStrategy } from "./goat-strategy";
+import type { Technique as GoatTechnique } from "./goat-techniques";
 import {
   DEFAULT_METAPROMPT_TEMPLATE,
   renderMetapromptTemplate,
 } from "./metaprompt-template";
+import { BacktrackEntry, RedTeamStrategy } from "./red-team-strategy";
 import { AttackTechnique, DEFAULT_TECHNIQUES } from "./techniques";
-import type { Technique as GoatTechnique } from "./goat-techniques";
 import { AgentInput, UserSimulatorAgentAdapter } from "../../domain";
 import { AgentReturnTypes } from "../../domain/agents/types/agent-return.types";
 import { ScriptStep } from "../../domain/scenarios";
@@ -179,7 +179,7 @@ class RedTeamAgentImpl extends UserSimulatorAgentAdapter {
       && config.strategy.needsMetapromptPlan === false
     ) {
       const name = config.strategy.constructor?.name ?? "Strategy";
-      // eslint-disable-next-line no-console
+       
       console.warn(
         `[RedTeamAgent] ${name} does not use a metaprompt template `
           + "(needsMetapromptPlan=false); the value passed via "
@@ -430,7 +430,7 @@ Reply with exactly this JSON and nothing else:
     }
     const result = await generateText({
       model: this.model,
-      messages: this.attackerHistory as any,
+      messages: this.attackerHistory as ModelMessage[],
       temperature: this.temperature,
       maxOutputTokens: this.maxTokens,
     });
@@ -599,7 +599,7 @@ Reply with exactly this JSON and nothing else:
     const isMarker = (c: string) => MARKER_PREFIXES.some((p) => c.startsWith(p));
     if (this.attackerHistory.length === 0) {
       this.attackerHistory = [{ role: "system", content: systemPrompt }];
-    } else if (isMarker(this.attackerHistory[0]!.content)) {
+    } else if (isMarker(this.attackerHistory[0].content)) {
       // Slot 0 is a marker (e.g. backtrack added before first
       // prompt was set) — insert system prompt at front
       this.attackerHistory.unshift({ role: "system", content: systemPrompt });
@@ -618,7 +618,7 @@ Reply with exactly this JSON and nothing else:
     const reply = parsed.reply;
     const parseFailed = parsed.parseFailed;
     if (parseFailed) {
-      // eslint-disable-next-line no-console
+       
       console.warn(
         `[RedTeamAgent] turn ${currentTurn}: attacker output was not valid JSON; ` +
           `using full response as reply. Raw (first 200 chars): ${rawAttack.slice(0, 200)}`
@@ -643,7 +643,7 @@ Reply with exactly this JSON and nothing else:
       !looksAlreadyEncoded(reply)
     ) {
       const technique =
-        this.techniques[Math.floor(Math.random() * this.techniques.length)]!;
+        this.techniques[Math.floor(Math.random() * this.techniques.length)];
       targetText = technique.transform(reply);
       this.attackerHistory.push({
         role: "system",
@@ -757,7 +757,7 @@ export const redTeamGoat = (config: GoatConfig) => {
   }
   let resolvedEncoding = encodingTechniques;
   if (techniques !== undefined) {
-    // eslint-disable-next-line no-console
+     
     console.warn(
       "[redTeamGoat] `techniques` is deprecated — this name collides with "
         + "the GOAT semantic catalogue. Rename to `encodingTechniques` for "

--- a/javascript/src/domain/core/config.ts
+++ b/javascript/src/domain/core/config.ts
@@ -1,5 +1,5 @@
-import { z } from "zod/v4";
 import type { SetupObservabilityOptions } from "langwatch/observability/node";
+import { z } from "zod/v4";
 import { modelSchema } from "./schemas/model.schema";
 
 const headless =

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -8,6 +8,7 @@ import {
   ScenarioExecutionState,
   StateChangeEventType,
 } from "./scenario-execution-state";
+import { getGlobalSettings } from "../config/configure";
 import {
   type ScenarioResult,
   type ScenarioConfig,
@@ -24,6 +25,13 @@ import {
   DEFAULT_MAX_TURNS,
   DEFAULT_VERBOSE,
 } from "../domain";
+import {
+  isRealtimeUserAgent,
+  isVoiceUserSim,
+  USER_TURN_NO_AUDIO_FOR_VOICE_AUT,
+  type RealtimeUserAgent,
+  type VoiceUserSimulator,
+} from "../domain/agents/agent-shapes";
 import {
   ScenarioEvent,
   ScenarioEventType,
@@ -56,7 +64,6 @@ import {
   writeUserSegment,
 } from "../voice/adapter.runtime";
 import { AudioChunk } from "../voice/audio-chunk";
-import { getGlobalSettings } from "../config/configure";
 import {
   resolveVoiceConfig,
   type ResolvedVoiceConfig,
@@ -69,7 +76,6 @@ import {
   messageHasAudio,
 } from "../voice/messages";
 import { AudioPlaybackSink } from "../voice/playback";
-import { sleep } from "../voice/utils";
 import { computeLatencyMetrics } from "../voice/recording.runtime";
 import type {
   LatencyMetrics,
@@ -80,14 +86,8 @@ import {
   deriveInterruptResponseTime,
   markTruncatedAgentSegments,
 } from "../voice/segment-utils";
+import { sleep } from "../voice/utils";
 import type { VoiceExecutorState } from "../voice/voice-executor-state";
-import {
-  isRealtimeUserAgent,
-  isVoiceUserSim,
-  USER_TURN_NO_AUDIO_FOR_VOICE_AUT,
-  type RealtimeUserAgent,
-  type VoiceUserSimulator,
-} from "../domain/agents/agent-shapes";
 
 /**
  * Default bound (ms) on the barge-in wait for the agent to start speaking.
@@ -1060,7 +1060,7 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
           if (role === AgentRole.USER && outgoing.length > 0) {
             const pendingTask = this.pendingAgentTask;
             if (pendingTask && !pendingTask.done) {
-              await this.fireUserInterrupt(outgoing[outgoing.length - 1]!);
+              await this.fireUserInterrupt(outgoing[outgoing.length - 1]);
             }
           }
         }
@@ -2002,8 +2002,8 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
       //       queue before the interrupt fires; placing the sleep before
       //       voiceifyText causes entry.done=true for those adapters.
       // Mirrors maybeInjectInterruption (scenario-execution.ts, text-only path).
-      if ((bargeInDelayMs ?? 0) > 0) {
-        await sleep(bargeInDelayMs!);
+      if (bargeInDelayMs !== undefined && bargeInDelayMs > 0) {
+        await sleep(bargeInDelayMs);
       }
 
       // Capture the cursor at the barge-in instant. If the fast transport
@@ -2608,10 +2608,12 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     for (let idx = 0; idx < this.agents.length; idx++) {
       if (idx === fromAgentIdx) continue;
 
-      if (!this.pendingMessages.has(idx)) {
-        this.pendingMessages.set(idx, []);
+      let bucket = this.pendingMessages.get(idx);
+      if (!bucket) {
+        bucket = [];
+        this.pendingMessages.set(idx, bucket);
       }
-      this.pendingMessages.get(idx)!.push(message);
+      bucket.push(message);
       recipients.push(idx);
     }
 

--- a/javascript/src/integrations/vitest/reporter.ts
+++ b/javascript/src/integrations/vitest/reporter.ts
@@ -111,8 +111,12 @@ class VitestReporter implements Reporter {
     for (const event of events) {
       const runId =
         (event as { scenarioRunId?: string }).scenarioRunId ?? "unknown";
-      if (!runs.has(runId)) runs.set(runId, []);
-      runs.get(runId)!.push(event);
+      let bucket = runs.get(runId);
+      if (!bucket) {
+        bucket = [];
+        runs.set(runId, bucket);
+      }
+      bucket.push(event);
     }
 
     for (const [runId, runEvents] of Array.from(runs.entries())) {

--- a/javascript/src/red-team-report.ts
+++ b/javascript/src/red-team-report.ts
@@ -16,8 +16,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import type { ScenarioConfig } from "./domain/scenarios";
 import type { ScenarioResult, AgentAdapter } from "./domain";
+import type { ScenarioConfig } from "./domain/scenarios";
 
 let _batchDir: string | null = null;
 
@@ -145,7 +145,7 @@ export function saveRedTeamReport(opts: SaveOptions): string | null {
     fs.writeFileSync(destPath, JSON.stringify(payload, null, 2));
     return destPath;
   } catch (e) {
-    // eslint-disable-next-line no-console
+     
     console.warn(`[scenario] red-team report save failed: ${(e as Error).message}`);
     return null;
   }

--- a/javascript/src/runner/run.ts
+++ b/javascript/src/runner/run.ts
@@ -9,7 +9,9 @@
  */
 import { AssistantContent, ToolContent, ModelMessage } from "ai";
 import { Subscription } from "rxjs";
+import { judgeSpanCollector } from "../agents/judge/judge-span-collector";
 import { getEnv } from "../config";
+import { getProjectConfig } from "../config/get-project-config";
 import {
   allAgentRoles,
   AgentRole,
@@ -17,14 +19,12 @@ import {
   ScenarioConfig,
   ScenarioResult,
 } from "../domain";
-import type { VoiceConfig } from "../voice/config";
 import { EventBus } from "../events/event-bus";
 import { ScenarioExecution } from "../execution";
 import { proceed } from "../script";
-import { generateThreadId, getBatchRunId } from "../utils/ids";
-import { judgeSpanCollector } from "../agents/judge/judge-span-collector";
 import { ensureTracingInitialized } from "../tracing/setup";
-import { getProjectConfig } from "../config/get-project-config";
+import { generateThreadId, getBatchRunId } from "../utils/ids";
+import type { VoiceConfig } from "../voice/config";
 /**
  * Options for running a scenario.
  */
@@ -190,7 +190,7 @@ export async function run(cfg: ScenarioConfig, options?: RunOptions): Promise<Sc
       }
     } catch (e) {
       // Don't let reporting failures break the scenario run.
-      // eslint-disable-next-line no-console
+       
       console.warn(`[scenario] red-team auto-save skipped: ${(e as Error).message}`);
     }
 

--- a/javascript/src/tracing/setup.ts
+++ b/javascript/src/tracing/setup.ts
@@ -1,8 +1,8 @@
 import { trace } from "@opentelemetry/api";
+import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { LangWatchTraceExporter } from "langwatch/observability";
 import { setupObservability } from "langwatch/observability/node";
 import type { SetupObservabilityOptions } from "langwatch/observability/node";
-import { LangWatchTraceExporter } from "langwatch/observability";
-import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { judgeSpanCollector } from "../agents/judge/judge-span-collector";
 import { getEnv } from "../config";
 

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -13,11 +13,11 @@
  * OpenAI Realtime, Gemini Live, ElevenLabs).
  */
 
-import { AgentAdapter, type AgentInput } from "../domain/agents";
-import type { AgentReturnTypes } from "../domain/agents/types/agent-return.types";
+import { defaultVoiceCall } from "./adapter.runtime";
 import { AudioChunk } from "./audio-chunk";
 import { AdapterCapabilities, UnsupportedCapabilityError } from "./capabilities";
-import { defaultVoiceCall } from "./adapter.runtime";
+import { AgentAdapter, type AgentInput } from "../domain/agents";
+import type { AgentReturnTypes } from "../domain/agents/types/agent-return.types";
 
 /**
  * Minimal one-shot event the adapter sets when its first agent audio

--- a/javascript/src/voice/adapters/composable.ts
+++ b/javascript/src/voice/adapters/composable.ts
@@ -25,9 +25,9 @@ import {
 } from "ai";
 
 import { AgentRole } from "../../domain/agents";
+import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
-import { VoiceAgentAdapter } from "../adapter";
 import {
   ElevenLabsSTTProvider,
   type STTProvider,

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -57,26 +57,26 @@
 import { Buffer } from "node:buffer";
 
 import { openai } from "@ai-sdk/openai";
-import type { LanguageModel } from "ai";
 // The Conversation constructor types its `client` as the *base* Fern client
 // (`@elevenlabs/elevenlabs-js/Client`), NOT the root-export wrapper
 // (`@elevenlabs/elevenlabs-js`). The wrapper extends the base but, under TS
 // private-field nominal typing, is not assignable to it — so the hosted adapter
 // constructs the base client directly. (STT/TTS keep using the root wrapper.)
-import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js/Client";
 // EXPLICIT-FILE imports: a directory/package import of `.../conversation` resolves
 // to its `index.js` barrel, which fails under our ESM (`moduleResolution: bundler`)
 // build — import the concrete files instead.
-import { Conversation } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/Conversation";
 import { AudioInterface } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/AudioInterface";
+import { Conversation } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/Conversation";
 import type { ConversationClient } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/interfaces/ConversationClient";
 import type { WebSocketFactory } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/interfaces/WebSocketInterface";
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js/Client";
+import type { LanguageModel } from "ai";
 
 import { AgentRole } from "../../domain/agents";
 import { Logger } from "../../utils/logger";
+import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
-import { VoiceAgentAdapter } from "../adapter";
 import {
   COMPOSABLE_VOICE_LLM_MODEL,
   ELEVENLABS_DEFAULT_VOICE_ID,
@@ -565,7 +565,7 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
 
   /** Called when the SDK re-emits a WS `error` on the Conversation. */
   private onSessionError(err: Error): void {
-    // eslint-disable-next-line no-console
+     
     console.warn(`ElevenLabsAgentAdapter: session error: ${err.message}`);
     // Stop the pump so no frame is fed to a dead session, drain parked receivers so
     // the executor unwinds rather than hanging, and null the session so subsequent
@@ -789,6 +789,9 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
       // slow-but-responding agent), but at least 45s even for sub-second tail-probe
       // calls. In the real drain `timeout` is the 30s response budget or the 0.6s
       // tail probe, so the ceiling is 45s.
+      // Must stay `let`: the cleanup() closure below captures hardTimer before
+      // it is assigned, so declaration and assignment cannot be merged (const).
+      // eslint-disable-next-line prefer-const
       let hardTimer: ReturnType<typeof setTimeout>;
       const hardCeilingMs = Math.max(timeout, KEEPALIVE_HARD_CEILING_S) * 1000;
 
@@ -922,14 +925,14 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     const outFmt = meta.agent_output_audio_format as string | undefined;
     const inFmt = meta.user_input_audio_format as string | undefined;
     if (outFmt && outFmt !== "pcm_24000") {
-      // eslint-disable-next-line no-console
+       
       console.warn(
         `ElevenLabsAgentAdapter: agent_output_audio_format=${outFmt} differs ` +
           `from advertised pcm16/24000 capability; audio may pitch-shift or fail to decode.`,
       );
     }
     if (inFmt && inFmt !== "pcm_24000") {
-      // eslint-disable-next-line no-console
+       
       console.warn(
         `ElevenLabsAgentAdapter: user_input_audio_format=${inFmt} differs ` +
           `from advertised pcm16/24000 capability; the agent may not understand audio we send.`,

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -32,8 +32,8 @@ import { AgentRole } from "../../domain/agents";
 import { Logger } from "../../utils/logger";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
-import { createAudioMessage, extractAudio } from "../messages";
 import { AdapterCapabilities } from "../capabilities";
+import { createAudioMessage, extractAudio } from "../messages";
 import { OPENAI_REALTIME_MODEL, OPENAI_STT_MODEL } from "../voice-models";
 
 // LOG_LEVEL-gated logger so the degraded-path debug line below doesn't bypass

--- a/javascript/src/voice/adapters/pipecat.ts
+++ b/javascript/src/voice/adapters/pipecat.ts
@@ -332,8 +332,11 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
     // always followed by the recovery turn's `sendAudio`, making this the
     // correct reset point for the per-turn signal.
     this.interruptPhase = "idle";
-    const ws = this.ws!;
-    const streamSid = this.streamSid!;
+    const ws = this.ws;
+    const streamSid = this.streamSid;
+    if (!ws || streamSid === undefined) {
+      throw new Error("PipecatAgentAdapter: not connected");
+    }
     const mulaw = pcm16At24kToMulaw8k(chunk.data);
 
     const previous = this.sendLock;
@@ -366,7 +369,10 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
       this.interruptPhase = "idle";
       return new AudioChunk({ data: new Uint8Array(0) });
     }
-    const inbox = this.inbox!;
+    const inbox = this.inbox;
+    if (!inbox) {
+      throw new Error("PipecatAgentAdapter: not connected");
+    }
     const queued = inbox.queue.shift();
     if (queued) return queued;
     if (inbox.closed) {
@@ -407,7 +413,12 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
    */
   override async interrupt(): Promise<void> {
     this.assertConnected();
-    this.ws!.send(buildClearFrame(this.streamSid!));
+    const ws = this.ws;
+    const streamSid = this.streamSid;
+    if (!ws || streamSid === undefined) {
+      throw new Error("PipecatAgentAdapter: not connected");
+    }
+    ws.send(buildClearFrame(streamSid));
     // JS-side truncation: discard buffered audio so drainAgentResponse stops.
     if (this.inbox) {
       this.inbox.queue = [];

--- a/javascript/src/voice/adapters/twilio-logger.ts
+++ b/javascript/src/voice/adapters/twilio-logger.ts
@@ -28,15 +28,15 @@ function format(message: string, fields?: Record<string, unknown>): string {
 
 export const twilioLogger: VoiceLogger = {
   debug(message, fields) {
-    // eslint-disable-next-line no-console
+     
     console.debug(format(message, fields));
   },
   info(message, fields) {
-    // eslint-disable-next-line no-console
+     
     console.info(format(message, fields));
   },
   warn(message, fields) {
-    // eslint-disable-next-line no-console
+     
     console.warn(format(message, fields));
   },
 };

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -325,7 +325,7 @@ function parseFormUrlEncoded(body: string): Record<string, string> {
   for (const pair of body.split("&")) {
     if (!pair) continue;
     const [rawKey, rawValue = ""] = pair.split("=");
-    const key = decodeURIComponent(rawKey!.replace(/\+/g, " "));
+    const key = decodeURIComponent(rawKey.replace(/\+/g, " "));
     const value = decodeURIComponent(rawValue.replace(/\+/g, " "));
     params[key] = value;
   }
@@ -355,7 +355,10 @@ function adaptWsSocket(ws: WsWebSocket): MediaStreamWebSocket {
   const handleEnd = (): void => {
     if (closed) return;
     closed = true;
-    while (waiters.length > 0) waiters.shift()!.resolve(null);
+    while (waiters.length > 0) {
+      const waiter = waiters.shift();
+      if (waiter) waiter.resolve(null);
+    }
   };
   ws.on("close", handleEnd);
   ws.on("error", handleEnd);

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -18,12 +18,12 @@
  * codec live in `./twilio-shared.ts`.
  */
 
-import { sleep } from "../utils";
 
 import { AgentRole } from "../../domain/agents";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
+import { sleep } from "../utils";
 
 import { TwilioWebhookServer, type MediaStreamWebSocket } from "./twilio-server";
 import {
@@ -211,6 +211,11 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     attachStreamToSelf?: boolean;
   }): Promise<void> {
     this._assertConnected();
+    const rest = this._rest;
+    const publicBaseUrl = this.publicBaseUrl;
+    if (!rest || publicBaseUrl === undefined) {
+      throw new Error("TwilioAgentAdapter: not connected");
+    }
     this._enterMode("call");
     validateE164(args.to);
 
@@ -218,11 +223,11 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     const timeoutMs = args.timeoutMs ?? 120_000;
 
     if (attachStreamToSelf) {
-      this._calleePhoneNumberSid = await this._rest!.resolvePhoneNumberSid(args.to);
+      this._calleePhoneNumberSid = await rest.resolvePhoneNumberSid(args.to);
       this._priorCalleeVoiceUrl =
-        (await this._rest!.readVoiceUrl(this._calleePhoneNumberSid)) ?? undefined;
-      const webhookUrl = `${this.publicBaseUrl!.replace(/\/$/, "")}/twilio/voice`;
-      await this._rest!.writeVoiceUrl(this._calleePhoneNumberSid, webhookUrl);
+        (await rest.readVoiceUrl(this._calleePhoneNumberSid)) ?? undefined;
+      const webhookUrl = `${publicBaseUrl.replace(/\/$/, "")}/twilio/voice`;
+      await rest.writeVoiceUrl(this._calleePhoneNumberSid, webhookUrl);
     }
 
     const inlineALegTwiml =
@@ -231,7 +236,7 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
       `<Say voice="Polly.Joanna">${PLACE_CALL_A_LEG_SAY_TEXT}</Say>` +
       `<Pause length="120"/>` +
       `</Response>`;
-    this._callSid = await this._rest!.placeCall({
+    this._callSid = await rest.placeCall({
       to: args.to,
       from: this.phoneNumber,
       twiml: inlineALegTwiml,
@@ -244,12 +249,18 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
 
   async waitForCall(timeoutMs = 120_000): Promise<void> {
     this._assertConnected();
+    const rest = this._rest;
+    const publicBaseUrl = this.publicBaseUrl;
+    const phoneNumberSid = this._phoneNumberSid;
+    if (!rest || publicBaseUrl === undefined || phoneNumberSid === undefined) {
+      throw new Error("TwilioAgentAdapter: not connected for answering");
+    }
     this._enterMode("answer");
 
     this._priorVoiceUrl =
-      (await this._rest!.readVoiceUrl(this._phoneNumberSid!)) ?? undefined;
-    const webhookUrl = `${this.publicBaseUrl!.replace(/\/$/, "")}/twilio/voice`;
-    await this._rest!.writeVoiceUrl(this._phoneNumberSid!, webhookUrl);
+      (await rest.readVoiceUrl(phoneNumberSid)) ?? undefined;
+    const webhookUrl = `${publicBaseUrl.replace(/\/$/, "")}/twilio/voice`;
+    await rest.writeVoiceUrl(phoneNumberSid, webhookUrl);
     await this._streamConnected.promiseWithTimeout(timeoutMs);
   }
 
@@ -269,11 +280,16 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
 
   override async sendAudio(chunk: AudioChunk): Promise<void> {
     this._assertStreamLive();
+    const streamWs = this._streamWs;
+    const streamSid = this._streamSid;
+    if (!streamWs || streamSid === undefined) {
+      throw new Error("TwilioAgentAdapter: stream not live");
+    }
     const mulaw = pcm16_24kToMulaw8k(chunk.data);
     const frameSecs = TWILIO_FRAME_MS / 1000;
     for (const frame of iterMulawFrames(mulaw)) {
       if (frame.length === 0) continue;
-      this._streamWs!.send(buildMediaFrame(this._streamSid!, frame));
+      streamWs.send(buildMediaFrame(streamSid, frame));
       // Pace at real-time. Without pacing, the whole utterance arrives in
       // milliseconds, which trips bots' VAD into a clipped-utterance reading.
       await sleep(frameSecs * 1000);
@@ -296,7 +312,12 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
 
   override async interrupt(): Promise<void> {
     this._assertStreamLive();
-    this._streamWs!.send(buildClearFrame(this._streamSid!));
+    const streamWs = this._streamWs;
+    const streamSid = this._streamSid;
+    if (!streamWs || streamSid === undefined) {
+      throw new Error("TwilioAgentAdapter: stream not live");
+    }
+    streamWs.send(buildClearFrame(streamSid));
   }
 
   // ------------------------------------------------------------------ server callbacks

--- a/javascript/src/voice/effects/common.ts
+++ b/javascript/src/voice/effects/common.ts
@@ -28,7 +28,7 @@ export function pcm16ToInt16(b: Uint8Array): Int16Array {
 export function int16ToPcm16(arr: Int16Array | Float32Array): Uint8Array {
   const out = new Int16Array(arr.length);
   for (let i = 0; i < arr.length; i++) {
-    const v = arr[i]!;
+    const v = arr[i];
     // Clip to int16 range
     out[i] = Math.max(-32768, Math.min(32767, Math.round(v)));
   }
@@ -50,7 +50,7 @@ export function linearResample(arr: Int16Array, newLen: number): Int16Array {
   const denom = newLen - 1 || 1;
   for (let i = 0; i < newLen; i++) {
     const idx = Math.min(arr.length - 1, Math.floor((i * (arr.length - 1)) / denom));
-    out[i] = arr[idx]!;
+    out[i] = arr[idx];
   }
   return out;
 }

--- a/javascript/src/voice/effects/noise.ts
+++ b/javascript/src/voice/effects/noise.ts
@@ -117,7 +117,7 @@ function wavToInt16(buf: Uint8Array): Int16Array {
     for (let i = 0; i < frameCount; i++) {
       let sum = 0;
       for (let c = 0; c < channels; c++) {
-        sum += rawSamples[i * channels + c]!;
+        sum += rawSamples[i * channels + c];
       }
       mono[i] = Math.round(sum / channels);
     }
@@ -202,7 +202,7 @@ export function backgroundNoise(presetOrPath: string, volume = 0.3): EffectFn {
     const out = new Float32Array(signal.length);
     for (let i = 0; i < signal.length; i++) {
       const noiseIdx = i % sample.length;
-      out[i] = signal[i]! + sample[noiseIdx]! * volume;
+      out[i] = signal[i] + sample[noiseIdx] * volume;
     }
     return int16ToPcm16(out);
   };
@@ -221,7 +221,7 @@ export function static_(intensity = 0.05): EffectFn {
       // Box-Muller-free approximation: (Math.random() - 0.5) * 2 gives uniform
       // [-1, 1]; close enough for noise generation.
       const noise = (Math.random() - 0.5) * 2 * 32767 * intensity;
-      out[i] = signal[i]! + noise;
+      out[i] = signal[i] + noise;
     }
     return int16ToPcm16(out);
   };
@@ -257,7 +257,7 @@ export function multipleVoices(
     const out = new Float32Array(signal.length);
     for (let i = 0; i < signal.length; i++) {
       const babbleIdx = i % sample.length;
-      out[i] = signal[i]! + sample[babbleIdx]! * volume;
+      out[i] = signal[i] + sample[babbleIdx] * volume;
     }
     return int16ToPcm16(out);
   };

--- a/javascript/src/voice/effects/prosody.ts
+++ b/javascript/src/voice/effects/prosody.ts
@@ -16,7 +16,7 @@ export function lowVolume(factor = 0.5): EffectFn {
     const arr = pcm16ToInt16(audio);
     const out = new Float32Array(arr.length);
     for (let i = 0; i < arr.length; i++) {
-      out[i] = arr[i]! * factor;
+      out[i] = arr[i] * factor;
     }
     return int16ToPcm16(out);
   };
@@ -32,7 +32,7 @@ export function highVolume(factor = 1.5): EffectFn {
     const arr = pcm16ToInt16(audio);
     const out = new Float32Array(arr.length);
     for (let i = 0; i < arr.length; i++) {
-      out[i] = arr[i]! * factor;
+      out[i] = arr[i] * factor;
     }
     return int16ToPcm16(out);
   };

--- a/javascript/src/voice/effects/quality.ts
+++ b/javascript/src/voice/effects/quality.ts
@@ -33,7 +33,7 @@ export function phoneQuality(): EffectFn {
 
     // Zero-pad real input into the interleaved complex format expected by realTransform
     const realInput = new Array<number>(fftSize).fill(0);
-    for (let i = 0; i < n; i++) realInput[i] = arr[i]!;
+    for (let i = 0; i < n; i++) realInput[i] = arr[i];
 
     // forward transform → complex array (interleaved: [re0, im0, re1, im1, ...])
     const spectrum = fft.createComplexArray();
@@ -61,12 +61,12 @@ export function phoneQuality(): EffectFn {
     // Extract real parts, truncate to original length
     const filtered = new Float32Array(n);
     for (let i = 0; i < n; i++) {
-      filtered[i] = reconstructed[i * 2]!;
+      filtered[i] = reconstructed[i * 2];
     }
 
     // Mild tanh compression
     for (let i = 0; i < n; i++) {
-      filtered[i] = Math.tanh(filtered[i]! / 16000) * 16000;
+      filtered[i] = Math.tanh(filtered[i] / 16000) * 16000;
     }
 
     return int16ToPcm16(filtered);
@@ -137,9 +137,9 @@ export function echo(delayMs = 200, decay = 0.5): EffectFn {
 
     const out = new Float32Array(arr.length);
     for (let i = 0; i < arr.length; i++) {
-      out[i] = arr[i]!;
+      out[i] = arr[i];
       if (i >= delaySamples) {
-        out[i] += arr[i - delaySamples]! * decay;
+        out[i] += arr[i - delaySamples] * decay;
       }
     }
     return int16ToPcm16(out);
@@ -163,7 +163,7 @@ export function robotic(): EffectFn {
     for (let i = 0; i < arr.length; i++) {
       const t = i / sr;
       const carrier = Math.sin(2 * Math.PI * 100 * t);
-      out[i] = arr[i]! * carrier;
+      out[i] = arr[i] * carrier;
     }
     return int16ToPcm16(out);
   };

--- a/javascript/src/voice/factories.ts
+++ b/javascript/src/voice/factories.ts
@@ -13,27 +13,27 @@
  */
 
 import {
-  PipecatAgentAdapter,
-  type PipecatAgentAdapterInit,
-} from "./adapters/pipecat";
-import {
-  OpenAIRealtimeAgentAdapter,
-  type OpenAIRealtimeAgentAdapterInit,
-} from "./adapters/openai-realtime";
-import {
-  GeminiLiveAgentAdapter,
-  type GeminiLiveAgentAdapterInit,
-} from "./adapters/gemini-live";
-import {
-  TwilioAgentAdapter,
-  type TwilioAgentAdapterOptions,
-} from "./adapters/twilio";
-import {
   ElevenLabsAgentAdapter,
   type ElevenLabsAgentAdapterOptions,
   ComposableVoiceAgent,
   type ComposableVoiceAgentOptions,
 } from "./adapters";
+import {
+  GeminiLiveAgentAdapter,
+  type GeminiLiveAgentAdapterInit,
+} from "./adapters/gemini-live";
+import {
+  OpenAIRealtimeAgentAdapter,
+  type OpenAIRealtimeAgentAdapterInit,
+} from "./adapters/openai-realtime";
+import {
+  PipecatAgentAdapter,
+  type PipecatAgentAdapterInit,
+} from "./adapters/pipecat";
+import {
+  TwilioAgentAdapter,
+  type TwilioAgentAdapterOptions,
+} from "./adapters/twilio";
 
 /**
  * Pipecat agent (WebSocket Twilio-style or WebRTC). PRD §4.1 / §5.1.

--- a/javascript/src/voice/interruption.ts
+++ b/javascript/src/voice/interruption.ts
@@ -86,6 +86,6 @@ export class InterruptionConfig {
       this.phrases.length - 1,
       Math.floor(rng() * this.phrases.length),
     );
-    return this.phrases[idx]!;
+    return this.phrases[idx];
   }
 }

--- a/javascript/src/voice/judge-stt.ts
+++ b/javascript/src/voice/judge-stt.ts
@@ -204,9 +204,9 @@ async function transcribeMessage(
     transcript = undefined; // sentinel — no new text part needed
   } else {
     const cacheKey = transcriptCache ? audioCacheKey(content) : null;
-    if (cacheKey !== null && transcriptCache!.has(cacheKey)) {
+    if (cacheKey !== null && transcriptCache && transcriptCache.has(cacheKey)) {
       // Same audio already transcribed on an earlier call — reuse, no STT.
-      transcript = transcriptCache!.get(cacheKey) || undefined;
+      transcript = transcriptCache.get(cacheKey) || undefined;
     } else {
       const chunk = extractAudioChunk(msg);
       if (chunk) {
@@ -219,14 +219,14 @@ async function transcribeMessage(
           // re-hitting STT on every later proceed() turn (#735 P2). A different
           // (good) transcript can only come from different bytes → a different
           // key, so the sentinel can never suppress a real transcript.
-          if (cacheKey !== null) {
-            transcriptCache!.set(cacheKey, transcript ?? "");
+          if (cacheKey !== null && transcriptCache) {
+            transcriptCache.set(cacheKey, transcript ?? "");
           }
         } catch (e) {
           // Remember the failure too: without this, a provider outage is
           // re-attempted for the SAME chunk on every subsequent call (#735 P2).
-          if (cacheKey !== null) {
-            transcriptCache!.set(cacheKey, "");
+          if (cacheKey !== null && transcriptCache) {
+            transcriptCache.set(cacheKey, "");
           }
           warn(
             `scenario.voice.judge-stt: STT failed for a ${String(

--- a/javascript/src/voice/messages.ts
+++ b/javascript/src/voice/messages.ts
@@ -22,13 +22,13 @@
  * No STT/TTS, no provider-native shapes, no state.
  */
 
+import type { TextPart } from "ai";
 import { AudioChunk } from "./audio-chunk";
 import type {
   AudioFilePart,
   AudioMessage,
   AudioMessageRole,
 } from "./messages.types";
-import type { ModelMessage, TextPart } from "ai";
 
 /** Media type of the canonical in-message audio part (raw PCM16). */
 export const AUDIO_PCM16_MEDIA_TYPE = "audio/pcm16" as const;
@@ -42,7 +42,7 @@ function toBase64(data: Uint8Array): string {
     return Buffer.from(data).toString("base64");
   }
   let binary = "";
-  for (let i = 0; i < data.length; i++) binary += String.fromCharCode(data[i]!);
+  for (let i = 0; i < data.length; i++) binary += String.fromCharCode(data[i]);
   return btoa(binary);
 }
 

--- a/javascript/src/voice/playback.ts
+++ b/javascript/src/voice/playback.ts
@@ -24,12 +24,12 @@
 
 import { spawn } from "node:child_process";
 import type { ChildProcessByStdio } from "node:child_process";
-import type { Writable, Readable } from "node:stream";
 import { platform } from "node:os";
+import type { Writable, Readable } from "node:stream";
 
-import { resolveFfmpegPath } from "./ffmpeg";
 import type { AudioChunk } from "./audio-chunk";
 import { PCM16_SAMPLE_RATE } from "./audio-chunk";
+import { resolveFfmpegPath } from "./ffmpeg";
 
 // -----------------------------------------------------------------------
 // Platform audio driver selection (mirrors Python's _platform_audio_output_args)
@@ -161,12 +161,12 @@ export class AudioPlaybackSink {
    * Safe to call when the sink was never opened or already closed.
    */
   close(): Promise<void> {
-    if (!this._proc) {
+    const proc = this._proc;
+    if (!proc) {
       this._active = false;
       return Promise.resolve();
     }
     return new Promise<void>((resolve) => {
-      const proc = this._proc!;
       this._active = false;
       this._proc = null;
       try {

--- a/javascript/src/voice/stt/index.ts
+++ b/javascript/src/voice/stt/index.ts
@@ -33,9 +33,9 @@ export {
 export { pcm16ToWav } from "./wav";
 
 // --- Registration (side effects) ------------------------------------------
-import { registerSttProvider } from "./stt-provider";
-import { OpenAISTTProvider } from "./openai-stt";
 import { ElevenLabsSTTProvider } from "./elevenlabs-stt";
+import { OpenAISTTProvider } from "./openai-stt";
+import { registerSttProvider } from "./stt-provider";
 
 registerSttProvider("openai", (model) =>
   model ? new OpenAISTTProvider({ model }) : new OpenAISTTProvider(),

--- a/javascript/src/voice/tts/index.ts
+++ b/javascript/src/voice/tts/index.ts
@@ -31,9 +31,9 @@ export {
 } from "./elevenlabs-tts";
 
 // --- Registration (side effects) ------------------------------------------
-import { registerTtsProvider } from "./tts";
-import { openaiTts } from "./openai-tts";
 import { elevenLabsTts } from "./elevenlabs-tts";
+import { openaiTts } from "./openai-tts";
+import { registerTtsProvider } from "./tts";
 
 registerTtsProvider({ prefix: "openai", synth: openaiTts });
 registerTtsProvider({ prefix: "elevenlabs", synth: elevenLabsTts });

--- a/javascript/src/voice/vad.ts
+++ b/javascript/src/voice/vad.ts
@@ -135,7 +135,7 @@ export class WebRTCVadFallback {
   process(chunk: AudioChunk): void {
     const data = chunk.data;
     for (let i = 0; i < data.length; i++) {
-      this.buf.push(data[i]!);
+      this.buf.push(data[i]);
     }
     while (this.buf.length >= BYTES_PER_FRAME) {
       const frame = this.buf.slice(0, BYTES_PER_FRAME);
@@ -154,8 +154,8 @@ export class WebRTCVadFallback {
     const sampleCount = frame.length / 2;
     for (let i = 0; i < frame.length; i += 2) {
       // little-endian PCM16 → signed int16
-      const lo = frame[i]!;
-      const hi = frame[i + 1]!;
+      const lo = frame[i];
+      const hi = frame[i + 1];
       let sample = (hi << 8) | lo;
       if (sample & 0x8000) {
         sample = sample - 0x10000;


### PR DESCRIPTION
## Ticket

Closes #751. Progresses #565.

The root `@langwatch/scenario` package is not linted in CI (`lint:all` runs `pnpm -r` over the example packages only, not the root), and `@typescript-eslint/no-non-null-assertion` was not enabled, so non-null assertions (`!`) in library code passed review unchecked. This enables the rule for the shipped library, fixes the existing violations, and gates the library in CI.

Note: the issue's original root-cause line ("typescript-eslint imported but never wired") is stale on current `main` (the config already spreads `tseslint.configs.recommended`); the real gaps were the missing `no-non-null-assertion` rule and the fact that CI never lints the root package.

## Change

- **Enable the rule (scoped):** `@typescript-eslint/no-non-null-assertion: "error"` for non-test `src/**`. Tests and examples legitimately assert known-present fixtures, so they are excluded; the broader test/example cleanup stays with #565. Scoping to `src/` also means the existing example lint (`lint:all`) is unaffected.
- **Fix all 59 library violations (no behavior change):**
  - Redundant `!` on array / typed-array indexing dropped. `noUncheckedIndexedAccess` is off, so `arr[i]` is already the non-undefined element type and the assertion was a no-op.
  - `Map.get()`, optional-field, and env cases replaced with real guards / local captures that narrow the type and throw a clear error if the connection invariant is ever violated (judge span helpers, vitest reporter, scenario-execution, and the pipecat / twilio / playback adapters).
  - One justified `prefer-const` inline-disable where a `cleanup()` closure captures the timer handle before it is assigned (declaration and assignment cannot be merged).
- **Bring the library fully clean under the config:** auto-fix import ordering and type one stray `any` (`as ModelMessage[]`) so `src/` passes the whole config, not just the new rule.
- **Gate it in CI:** add a `lint:lib` script (`eslint 'src/**/*.ts'` excluding tests) and a "Lint (library)" step in `javascript-ci.yml`.

## Evidence

- **Rule enforced + fails on new `!` (AC2, before/after):** injecting a `!` into a library file makes `pnpm lint:lib` exit 1 flagging `no-non-null-assertion`; reverting returns it to exit 0.
- **Existing library passes (AC3):** `pnpm lint:lib` -> exit 0 (0 errors).
- **Existing CI unaffected:** `pnpm lint:all` -> exit 0 (rule scoped to `src/`, examples untouched).
- **No behavior change:** `vitest run src/` -> `Test Files 79 passed | 1 skipped`, `Tests 906 passed | 1 skipped`; `pnpm typecheck` exits 0.
- No lockfile churn; `actionlint` clean on the workflow change.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new library lint check to CI for JavaScript code.

* **Bug Fixes**
  * Improved runtime safety by adding clearer checks for missing connections, IDs, and stream state in voice and realtime flows.
  * Made several data-processing paths more defensive when handling missing values.
  * Reduced reliance on unsafe assumptions in agent, scenario, and reporting logic.

* **Chores**
  * Tightened linting rules and cleaned up formatting to support safer, more consistent code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->