### PR TITLE
docs: update --debug references to --scenario-debug (#618)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ LANGWATCH_API_KEY="your-api-key"
 
 ## Debug mode
 
-You can enable debug mode by setting the `debug` field to `True` in the `Scenario.configure` method or in the specific scenario you are running, or by passing the `--debug` flag to pytest.
+You can enable debug mode by setting the `debug` field to `True` in the `Scenario.configure` method or in the specific scenario you are running, or by passing the `--scenario-debug` flag to pytest.
 
 Debug mode allows you to see the messages in slow motion step by step, and intervene with your own inputs to debug your agent from the middle of the conversation.
 
@@ -432,7 +432,7 @@ scenario.configure(default_model="openai/gpt-4.1-mini", debug=True)
 or
 
 ```bash
-pytest -s tests/test_vegetarian_recipe_agent.py --debug
+pytest -s tests/test_vegetarian_recipe_agent.py --scenario-debug
 ```
 
 ## Cache

--- a/docs/docs/pages/basics/debug-mode.mdx
+++ b/docs/docs/pages/basics/debug-mode.mdx
@@ -68,10 +68,10 @@ Enable debug mode from the command line:
 
 ```bash
 # Enable debug mode for all tests
-pytest tests/ --debug -s
+pytest tests/ --scenario-debug -s
 
 # Run specific test with debug mode
-pytest tests/test_my_agent.py::test_specific_scenario --debug -s
+pytest tests/test_my_agent.py::test_specific_scenario --scenario-debug -s
 ```
 
 :::tip
@@ -99,7 +99,7 @@ You have two options:
 Here's what a debug session looks like:
 
 ```bash
-$ pytest tests/test_weather_agent.py --debug -s
+$ pytest tests/test_weather_agent.py --scenario-debug -s
 
 [Scenario: weather query] [Debug Mode] Press enter to continue or type a message to send
 [Scenario: weather query] User: What's the weather like today?


### PR DESCRIPTION
## Ticket

Closes #618. PR #551 hard-renamed the scenario debug pytest flag `--debug` -> `--scenario-debug` (no backward-compat alias, to stop colliding with pytest's built-in `--debug`), but the docs still showed the old flag. A user copy-pasting a documented `pytest ... --debug` command now silently invokes pytest's built-in flag instead of scenario debug mode.

## Change

Update the five stale `--debug` references to `--scenario-debug`:

- `README.md`: the "passing the `--debug` flag to pytest" sentence and the `pytest -s ... --debug` example.
- `docs/docs/pages/basics/debug-mode.mdx`: the three `pytest ... --debug -s` examples.

Docs-only; the `debug=True` config field (a separate, still-valid API) is untouched.

## Evidence

- **Docs now match the CLI:** `python/scenario/pytest_plugin.py:251` registers `--scenario-debug` (its help text reads "Use --scenario-debug instead of --debug to avoid conflicting ..."), and there is no bare `--debug` scenario option in the plugin.
- **No stale flag remains:** `grep -nE '\-\-debug\b'` over `README.md` and `debug-mode.mdx` returns nothing (only `--scenario-debug`).

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.
