### PR TITLE
test(voice): drive adapter tests through the production wrapper, not test seams

### DIFF
--- a/javascript/src/voice/__tests__/helpers/drive-production.ts
+++ b/javascript/src/voice/__tests__/helpers/drive-production.ts
@@ -1,0 +1,83 @@
+/**
+ * Wrapper-level test harness for voice adapters — the tier-1 seam that drives
+ * an agent turn through the REAL production `adapter.call()` wrapper. JS
+ * mirror of `python/scenario/voice/testing/wrapper_harness.py`.
+ *
+ * WHY wrapper-level (not seam-level) tests are load-bearing: PR #697's P0 hid
+ * because the seam tests drove adapter internals *by name* while production
+ * crashed in the wrapper that wires those internals together. A wrapper-level
+ * test stubs nothing between the test and the adapter's outermost production
+ * entry point, so a fix (or a regression) that only manifests on the real
+ * `call()` / `connect()` flow cannot hide behind a test seam.
+ *
+ * Vendor transports should be faked at the NETWORK CLIENT boundary (an
+ * in-process `ws` server, a scripted `MediaStreamWebSocket`), never by
+ * assigning adapter privates — that private-poke seam is exactly what this
+ * harness exists to avoid.
+ */
+
+import { AgentRole, type AgentInput } from "../../../domain/agents";
+import type { AgentReturnTypes } from "../../../domain/agents/types/agent-return.types";
+import type { VoiceAgentAdapter } from "../../adapter";
+import type { TwilioAgentAdapter } from "../../adapters/twilio";
+import type { MediaStreamWebSocket } from "../../adapters/twilio-server";
+import type { AudioChunk } from "../../audio-chunk";
+import { createAudioMessage } from "../../messages";
+
+/**
+ * Build the minimal {@link AgentInput} that {@link driveCall} feeds the real
+ * `call()`.
+ *
+ * With `userAudio`, the input carries one user audio message so the real
+ * `sendAudio` edge runs; without it, `call()` is an agent-initiated turn that
+ * goes straight to the drain. Carries no scenario state, so segment recording
+ * degrades to a no-op (mirrors Python's `make_agent_input`).
+ */
+export function makeAgentInput(userAudio?: AudioChunk): AgentInput {
+  const newMessages = userAudio ? [createAudioMessage(userAudio, "user")] : [];
+  return {
+    threadId: "wrapper-harness",
+    messages: [...newMessages],
+    newMessages,
+    requestedRole: AgentRole.AGENT,
+    scenarioState: {} as AgentInput["scenarioState"],
+    scenarioConfig: {} as AgentInput["scenarioConfig"],
+  };
+}
+
+/**
+ * Drive one agent turn through the REAL production wrapper — `adapter.call()`.
+ *
+ * This is the generic tier-1 entry for wrapper-level adapter tests: nothing
+ * between the test and the adapter's outermost production entry point is
+ * stubbed, so a fix (or a regression) that only manifests on the real `call()`
+ * flow — sendAudio framing, drain loop, transcript attachment, recorder
+ * bookkeeping — cannot hide behind a test seam. (The bug class that hid PR
+ * #697's P0: tests drove internals by name while production crashed in the
+ * wrapper that wires them together.)
+ */
+export async function driveCall(
+  adapter: VoiceAgentAdapter,
+  input?: AgentInput,
+): Promise<AgentReturnTypes> {
+  return adapter.call(input ?? makeAgentInput());
+}
+
+/**
+ * Run the Twilio production per-connection wrapper
+ * (`TwilioWebhookServer.runStreamSession` — what the real `/twilio/stream`
+ * route delegates to) to its terminal over the given socket double. JS mirror
+ * of Python's `drive_twilio_production`.
+ *
+ * On return, the adapter's stream transport/SID have been nulled by the
+ * wrapper's `finally` — exactly as in production after a call ends. Used for
+ * the terminations a real socket cannot produce (a `receiveText` that rejects
+ * with a non-disconnect error; a second session on the same connected
+ * adapter).
+ */
+export async function driveTwilioProduction(
+  adapter: TwilioAgentAdapter,
+  ws: MediaStreamWebSocket,
+): Promise<void> {
+  await adapter._driveStreamSession(ws);
+}

--- a/javascript/src/voice/__tests__/helpers/drive-production.ts
+++ b/javascript/src/voice/__tests__/helpers/drive-production.ts
@@ -51,10 +51,14 @@ export function makeAgentInput(userAudio?: AudioChunk): AgentInput {
  * This is the generic tier-1 entry for wrapper-level adapter tests: nothing
  * between the test and the adapter's outermost production entry point is
  * stubbed, so a fix (or a regression) that only manifests on the real `call()`
- * flow — sendAudio framing, drain loop, transcript attachment, recorder
- * bookkeeping — cannot hide behind a test seam. (The bug class that hid PR
- * #697's P0: tests drove internals by name while production crashed in the
- * wrapper that wires them together.)
+ * flow — sendAudio framing, drain loop, transcript attachment — cannot hide
+ * behind a test seam. (The bug class that hid PR #697's P0: tests drove
+ * internals by name while production crashed in the wrapper that wires them
+ * together.)
+ *
+ * NOT covered: segment recording. {@link makeAgentInput} carries an empty
+ * `scenarioState`, so the recorder degrades to a no-op. Pass an input carrying
+ * a real `scenarioState` if the recorder timeline is what you mean to exercise.
  */
 export async function driveCall(
   adapter: VoiceAgentAdapter,

--- a/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
@@ -21,8 +21,9 @@
  * drives `mediaStreamLoop` (or the `_driveMediaStream` seam) alone leaves those
  * set, so `receiveAudio`'s `_assertStreamLive` gate never fires — which is why
  * an earlier version of this suite went green on a fix that still threw in
- * production (reviewer P2 blocker on PR #697). These tests use the
- * `_driveStreamSession` seam, which runs the SAME `runStreamSession` wrapper
+ * production (reviewer P2 blocker on PR #697). These tests use the shared
+ * wrapper harness's `driveTwilioProduction` (`__tests__/helpers/drive-production`),
+ * which runs the SAME `runStreamSession` wrapper
  * production uses — loop plus the transport-nulling `finally`. The regression
  * the fix targets is the drain's *second* `receiveAudio` call (the tail-silence
  * probe) landing after that reset: pre-fix it throws "no live media stream";
@@ -32,7 +33,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 
-import { defaultVoiceCall } from "../../adapter.runtime";
+import { driveCall, driveTwilioProduction } from "../../__tests__/helpers/drive-production";
 import { AudioChunk } from "../../audio-chunk";
 import { extractAudio } from "../../messages";
 import { TwilioAgentAdapter } from "../twilio";
@@ -161,7 +162,7 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     const adapter = await connectedAdapter();
     // start → stop, no media: the "stop" branch flushes nothing. Driven through
     // the REAL production wrapper, which nulls _streamWs/_streamSid on return.
-    await adapter._driveStreamSession(scriptedSocket([startFrame(), stopFrame()]));
+    await driveTwilioProduction(adapter, scriptedSocket([startFrame(), stopFrame()]));
 
     // Production nulled the transport — the condition that threw pre-fix.
     expect(adapter._streamWsForTest).toBeNull();
@@ -180,7 +181,7 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
   it("socket close mid-stream: both drain calls return empty after production teardown", async () => {
     const adapter = await connectedAdapter();
     // Only a start frame, then the socket closes (receiveText → null).
-    await adapter._driveStreamSession(scriptedSocket([startFrame()]));
+    await driveTwilioProduction(adapter, scriptedSocket([startFrame()]));
 
     expect(adapter._streamWsForTest).toBeNull();
     expect(adapter._streamSidForTest).toBeUndefined();
@@ -197,7 +198,8 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     // 160 bytes of µ-law (~20ms) — under the 100ms batch threshold, so the
     // "stop" flush is what enqueues it: exactly the trailing-audio path.
     const mulaw = new Uint8Array(160).fill(0x7f);
-    await adapter._driveStreamSession(
+    await driveTwilioProduction(
+      adapter,
       scriptedSocket([startFrame(), buildMediaFrame(STREAM_SID, mulaw), stopFrame()]),
     );
 
@@ -222,7 +224,7 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     // socket's pending read rejects, the session surfaces the error, and the
     // drain still terminates cleanly instead of hanging or asserting liveness.
     const sock = controllableSocket();
-    const session = adapter._driveStreamSession(sock);
+    const session = driveTwilioProduction(adapter, sock);
     sock.push(startFrame());
     sock.push(new Error("boom: transport failure"));
     await expect(session).rejects.toThrow("boom: transport failure");
@@ -241,7 +243,7 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     const adapter = await connectedAdapter();
     // Session 1 completes silently: its finally marks the call ended and
     // enqueues the terminal sentinel. Drain it fully.
-    await adapter._driveStreamSession(scriptedSocket([startFrame(), stopFrame()]));
+    await driveTwilioProduction(adapter, scriptedSocket([startFrame(), stopFrame()]));
     const s1 = await adapter.receiveAudio(RECV_TIMEOUT_S);
     expect(s1.data.length).toBe(0);
 
@@ -249,7 +251,7 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
     // reconnect / back-to-back call) and is mid-call: started, nothing
     // buffered yet.
     const sock = controllableSocket();
-    const session2 = adapter._driveStreamSession(sock);
+    const session2 = driveTwilioProduction(adapter, sock);
     sock.push(startFrame("MZ695b", "CA695b"));
     await vi.waitFor(() => expect(adapter._streamWsForTest).not.toBeNull());
 
@@ -278,7 +280,7 @@ describe("Twilio silent / tool-only stop (#695 dead-recv-loop)", () => {
  * `runStreamSession` by name; these tests drive nothing by name. They start the
  * adapter's REAL http+ws server, connect a REAL `ws` client to the REAL
  * `/twilio/stream` upgrade path — so `_handleStreamSocket` and `adaptWsSocket`
- * run — and let the REAL production consumer (`defaultVoiceCall` →
+ * run — and let the REAL production consumer (`driveCall` → `adapter.call()` →
  * `drainAgentResponse`, what every agent turn runs) read the result.
  *
  * A fix that only works when a test calls the wrapper by name cannot pass here,
@@ -325,11 +327,6 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     });
   }
 
-  /** No incoming audio → `defaultVoiceCall` goes straight to the drain. */
-  function agentTurnInput(): Parameters<typeof defaultVoiceCall>[1] {
-    return { newMessages: [] } as unknown as Parameters<typeof defaultVoiceCall>[1];
-  }
-
   async function routeAdapter(): Promise<TwilioAgentAdapter> {
     const adapter = await connectedAdapter(); // starts the REAL http+ws server
     // Small drain budgets so a hang (the original #695 symptom) fails inside the
@@ -354,8 +351,8 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     const adapter = await routeAdapter();
     const client = await startCall(adapter);
 
-    const call = defaultVoiceCall(adapter, agentTurnInput());
-    // `defaultVoiceCall` reaches its first `receiveAudio` synchronously, so the
+    const call = driveCall(adapter);
+    // The real `call()` reaches its first `receiveAudio` synchronously, so the
     // drain's queue waiter is already parked by the time the call above returns
     // its promise. This sleep is belt-and-braces: it keeps the test honest if a
     // future `await` is ever introduced ahead of the first receive.
@@ -372,7 +369,7 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     const adapter = await routeAdapter();
     const client = await startCall(adapter);
 
-    const call = defaultVoiceCall(adapter, agentTurnInput());
+    const call = driveCall(adapter);
     await sleep(50);
     client.close(); // Twilio drops the media socket, no stop frame
 
@@ -385,7 +382,7 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     const adapter = await routeAdapter();
     const client = await startCall(adapter);
 
-    const call = defaultVoiceCall(adapter, agentTurnInput());
+    const call = driveCall(adapter);
     await sleep(50);
     // 160 bytes µ-law (~20ms) is under the 100ms batch threshold, so the "stop"
     // flush is what enqueues it: exactly the trailing-audio path.
@@ -402,7 +399,7 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     // The tightest form of the P0: the route already nulled the transport when
     // the drain makes its FIRST receiveAudio call — the next agent turn after
     // the caller hung up. Pre-fix this throws "no live media stream" out of
-    // defaultVoiceCall, with the terminal sentinel unread in the queue.
+    // the real call() flow, with the terminal sentinel unread in the queue.
     const adapter = await routeAdapter();
     const client = await startCall(adapter);
 
@@ -410,7 +407,7 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     await awaitTeardown(adapter);
     expect(adapter._streamSidForTest).toBeUndefined();
 
-    const message = await defaultVoiceCall(adapter, agentTurnInput());
+    const message = await driveCall(adapter);
     expect(audioBytes(message)).toBe(0);
     client.close();
   }, 15_000);
@@ -435,7 +432,7 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
 
     // Session 2: a Twilio reconnect / back-to-back call.
     const second = await startCall(adapter);
-    const call = defaultVoiceCall(adapter, agentTurnInput());
+    const call = driveCall(adapter);
     setTimeout(() => {
       // 800 bytes µ-law == the 100ms flush threshold: flushes immediately.
       second.send(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
@@ -456,7 +453,7 @@ describe("Twilio real /twilio/stream route (#695 P0, no seam)", () => {
     client.send(stopFrame());
     await awaitTeardown(adapter);
 
-    const message = await defaultVoiceCall(adapter, agentTurnInput());
+    const message = await driveCall(adapter);
     expect(audioBytes(message)).toBeGreaterThan(0); // recovered, not lost
     client.close();
   }, 15_000);

--- a/python/scenario/voice/testing/__init__.py
+++ b/python/scenario/voice/testing/__init__.py
@@ -1,14 +1,47 @@
 """
-Test-harness helpers for voice adapters that need public HTTP/S endpoints
-(webhooks, WebSockets) — specifically ``TwilioAgentAdapter``.
+Test-harness helpers for voice adapters.
 
-Not imported by default from ``scenario.voice``. Users opt-in via
-``from scenario.voice.testing import CloudflareTunnel, TwilioHarness``.
+Two families live here, neither imported by default from ``scenario.voice``:
+
+- Public-endpoint helpers (``CloudflareTunnel``, ``TwilioHarness``) for adapters
+  that need public HTTP/S endpoints (webhooks, WebSockets) — specifically
+  ``TwilioAgentAdapter``.
+- The wrapper harness (``drive_call`` / ``make_agent_input`` / ``WrapperCallInput``
+  plus the Twilio real-route helpers) that drives an agent turn through the REAL
+  production ``adapter.call()`` wrapper — the tier-1 seam that catches bugs which
+  only manifest in the outermost production entry point (see PR #697 and
+  ``wrapper_harness`` for the rationale).
+
+Users opt-in via e.g. ``from scenario.voice.testing import CloudflareTunnel,
+TwilioHarness`` or ``from scenario.voice.testing import drive_call,
+make_agent_input``.
 """
 
 from __future__ import annotations
 
 from .tunnel import CloudflareTunnel, TunnelUnavailableError
 from .twilio_harness import TwilioHarness
+from .wrapper_harness import (
+    WrapperCallInput,
+    drive_call,
+    drive_twilio_production,
+    free_port,
+    make_agent_input,
+    make_connected_twilio_adapter,
+    serve_real_twilio_route,
+    wait_for_twilio_stream_teardown,
+)
 
-__all__ = ["CloudflareTunnel", "TunnelUnavailableError", "TwilioHarness"]
+__all__ = [
+    "CloudflareTunnel",
+    "TunnelUnavailableError",
+    "TwilioHarness",
+    "drive_call",
+    "make_agent_input",
+    "WrapperCallInput",
+    "make_connected_twilio_adapter",
+    "serve_real_twilio_route",
+    "drive_twilio_production",
+    "wait_for_twilio_stream_teardown",
+    "free_port",
+]

--- a/python/scenario/voice/testing/__init__.py
+++ b/python/scenario/voice/testing/__init__.py
@@ -6,10 +6,10 @@ Two families live here, neither imported by default from ``scenario.voice``:
 - Public-endpoint helpers (``CloudflareTunnel``, ``TwilioHarness``) for adapters
   that need public HTTP/S endpoints (webhooks, WebSockets) — specifically
   ``TwilioAgentAdapter``.
-- The wrapper harness (``drive_call`` / ``make_agent_input`` / ``WrapperCallInput``
-  plus the Twilio real-route helpers) that drives an agent turn through the REAL
-  production ``adapter.call()`` wrapper — the tier-1 seam that catches bugs which
-  only manifest in the outermost production entry point (see PR #697 and
+- The wrapper harness (``drive_call`` / ``make_agent_input`` plus the Twilio
+  real-route helpers) that drives an agent turn through the REAL production
+  ``adapter.call()`` wrapper — the tier-1 seam that catches bugs which only
+  manifest in the outermost production entry point (see PR #697 and
   ``wrapper_harness`` for the rationale).
 
 Users opt-in via e.g. ``from scenario.voice.testing import CloudflareTunnel,
@@ -22,7 +22,6 @@ from __future__ import annotations
 from .tunnel import CloudflareTunnel, TunnelUnavailableError
 from .twilio_harness import TwilioHarness
 from .wrapper_harness import (
-    WrapperCallInput,
     drive_call,
     drive_twilio_production,
     free_port,
@@ -38,7 +37,6 @@ __all__ = [
     "TwilioHarness",
     "drive_call",
     "make_agent_input",
-    "WrapperCallInput",
     "make_connected_twilio_adapter",
     "serve_real_twilio_route",
     "drive_twilio_production",

--- a/python/scenario/voice/testing/wrapper_harness.py
+++ b/python/scenario/voice/testing/wrapper_harness.py
@@ -1,0 +1,197 @@
+"""
+Wrapper-level test harness for voice adapters — the tier-1 seam that drives an
+agent turn through the REAL production ``adapter.call()`` wrapper.
+
+WHY wrapper-level (not seam-level) tests are load-bearing: PR #697's P0 hid
+because the seam tests drove adapter internals *by name* while production
+crashed in the wrapper that wires those internals together. A wrapper-level
+test stubs nothing between the test and the adapter's outermost production
+entry point, so a fix (or a regression) that only manifests on the real
+``call()`` / ``connect()`` flow cannot hide behind a test seam.
+
+This module EXTRACTS the proven Twilio harness from
+``tests/voice/test_twilio_silent_stop_drain.py`` — whose module docstring tells
+the full two-layer measurement story (the REAL-route anti-drift gate
+``TestRealRoute`` plus the wrapper-level tests it proves are equivalent) — and
+adds the generic ``drive_call`` / ``make_agent_input`` entry points that
+generalise the same tier-1 idea to the non-Twilio adapters.
+
+Vendor transports should be faked at the NETWORK CLIENT boundary (monkeypatched
+``websockets.connect`` / ``genai.Client``), never by assigning adapter privates
+like ``_ws`` or ``_session`` — that private-poke seam is exactly what this
+harness exists to avoid.
+
+Not imported by default from ``scenario.voice``. Users opt-in via
+``from scenario.voice.testing import drive_call, make_agent_input``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from contextlib import asynccontextmanager, suppress
+from typing import Any, AsyncIterator, List, Optional, cast
+
+from ..adapter import VoiceAgentAdapter
+from ..adapters import TwilioAgentAdapter
+from ..adapters._twilio_server import TwilioWebhookServer
+from ..audio_chunk import AudioChunk
+from ..messages import create_audio_message
+
+
+# ------------------------------------------------------- generic wrapper drive
+
+
+class WrapperCallInput:
+    """Minimal duck-typed AgentInput for direct production-wrapper `call()` tests.
+
+    Mirrors the established `_FakeInput` seam (tests/voice/test_realtime_tool_calls.py):
+    carries no scenario_state, so `_AdapterRecorder` degrades to a no-op; when
+    `new_messages` is empty, `call()` sends no user audio and goes straight to
+    draining the agent response.
+    """
+
+    def __init__(self, new_messages: Optional[List[Any]] = None) -> None:
+        self.new_messages: List[Any] = list(new_messages or [])
+
+
+def make_agent_input(user_audio: Optional[AudioChunk] = None) -> WrapperCallInput:
+    """Build the minimal input `drive_call` feeds the real `call()`.
+
+    With `user_audio`, the input carries one user audio message so the real
+    `send_audio` edge runs; without it, `call()` is an agent-initiated turn
+    that goes straight to the drain.
+    """
+    if user_audio is None:
+        return WrapperCallInput()
+    return WrapperCallInput([create_audio_message(user_audio, role="user")])
+
+
+async def drive_call(adapter: VoiceAgentAdapter, agent_input: Optional[Any] = None) -> Any:
+    """Drive one agent turn through the REAL production wrapper — `adapter.call()`.
+
+    This is the generic tier-1 entry for wrapper-level adapter tests: nothing
+    between the test and the adapter's outermost production entry point is
+    stubbed, so a fix (or a regression) that only manifests on the real
+    `call()` flow — send_audio framing, drain loop, transcript attachment,
+    recorder bookkeeping — cannot hide behind a test seam. (The bug class that
+    hid PR #697's P0: tests drove internals by name while production crashed
+    in the wrapper that wires them together.)
+
+    Vendor transports should be faked at the NETWORK CLIENT boundary (e.g.
+    monkeypatched `websockets.connect` / `genai.Client`), never by assigning
+    adapter privates like `_ws` or `_session`.
+    """
+    return await adapter.call(cast(Any, agent_input if agent_input is not None else make_agent_input()))
+
+
+# ------------------------------------------------------- Twilio real-route harness
+
+
+def make_connected_twilio_adapter(http_port: int = 0) -> TwilioAgentAdapter:
+    """Construct an adapter with just enough state for the production
+    ``run_stream_session`` wrapper + ``recv_audio`` — without going through
+    ``connect()`` (which would need live Twilio REST credentials to resolve the
+    phone-number SID).
+
+    Everything the media-stream path touches is the real object: the webhook
+    server, its FastAPI app, and its ``/twilio/stream`` route. Only ``_rest`` is
+    a stand-in, and only ``_assert_connected``'s ``is not None`` check reads it.
+    """
+    adapter = TwilioAgentAdapter(
+        account_sid="AC" + "0" * 32,
+        auth_token="secret",
+        phone_number="+14155556959",
+        public_base_url="https://example695.trycloudflare.com",
+        http_port=http_port,
+    )
+    # Stand-in for the REST client: only _assert_connected's `is not None`
+    # check reads it, and constructing a real one needs live Twilio credentials.
+    adapter._rest = object()  # type: ignore[assignment]  # sentinel; never called
+    adapter._inbound_queue = asyncio.Queue()
+    adapter._stream_connected = asyncio.Event()
+    adapter._server_shutdown = asyncio.Event()
+    adapter._webhook_server = TwilioWebhookServer(adapter)
+    return adapter
+
+
+def free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+async def _wait_for_bind(port: int, server_task: "asyncio.Task[None]") -> None:
+    """Wait until the port accepts, failing loudly if uvicorn died instead.
+
+    ``free_port`` reserves then releases a port, so another listener can win
+    the race. uvicorn reacts to a failed bind with ``sys.exit(1)`` — a
+    ``SystemExit``,
+    which is a ``BaseException`` and therefore slips past the ``suppress(Exception)``
+    in ``TwilioWebhookServer.run()``. Without this check the connect below would
+    succeed against the *other* listener and the test would fail much later with a
+    bare ``SystemExit`` instead of "address already in use".
+    """
+    for _ in range(200):
+        if server_task.done():
+            # Re-raise whatever killed the server (SystemExit, OSError, …).
+            server_task.result()
+            raise AssertionError("uvicorn exited before binding")
+        try:
+            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            return
+        except OSError:
+            await asyncio.sleep(0.05)
+    raise AssertionError(f"uvicorn never bound 127.0.0.1:{port}")
+
+
+@asynccontextmanager
+async def serve_real_twilio_route(
+    adapter: TwilioAgentAdapter,
+) -> AsyncIterator[str]:
+    """Boot the adapter's REAL uvicorn server and yield the ``ws://`` URL of the
+    REAL ``/twilio/stream`` route.
+
+    This is the production entry point end to end: uvicorn → FastAPI →
+    ``_stream()`` → ``run_stream_session`` → ``media_stream_loop``. No seam, no
+    socket double. A fix that only works when a test calls the wrapper by name
+    cannot pass through here.
+    """
+    assert adapter._webhook_server is not None
+    server_task = asyncio.create_task(adapter._webhook_server.run())
+    try:
+        await _wait_for_bind(adapter.http_port, server_task)
+        yield f"ws://127.0.0.1:{adapter.http_port}/twilio/stream"
+    finally:
+        assert adapter._server_shutdown is not None
+        adapter._server_shutdown.set()
+        with suppress(Exception):
+            await asyncio.wait_for(server_task, timeout=5.0)
+
+
+async def wait_for_twilio_stream_teardown(adapter: TwilioAgentAdapter) -> None:
+    """Wait until the route handler's ``finally`` has nulled the transport."""
+    for _ in range(200):
+        if adapter._stream_ws is None:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("production route never tore the transport down")
+
+
+async def drive_twilio_production(adapter: TwilioAgentAdapter, ws: Any) -> None:
+    """Run the production per-connection wrapper
+    (``TwilioWebhookServer.run_stream_session`` — what the ``/twilio/stream``
+    route delegates to, as ``TestRealRoute`` in
+    ``tests/voice/test_twilio_silent_stop_drain.py`` proves) to its terminal
+    over the given socket double.
+
+    On return, ``adapter._stream_ws`` / ``_stream_sid`` have been nulled by the
+    wrapper's ``finally`` — exactly as in production after a call ends. Used for
+    the terminations a real socket cannot produce (a ``receive_text`` that raises
+    a non-disconnect error; a second session on the same connected adapter).
+    """
+    assert adapter._webhook_server is not None
+    await adapter._webhook_server.run_stream_session(ws)

--- a/python/scenario/voice/testing/wrapper_harness.py
+++ b/python/scenario/voice/testing/wrapper_harness.py
@@ -73,10 +73,15 @@ async def drive_call(adapter: VoiceAgentAdapter, agent_input: Optional[Any] = No
     This is the generic tier-1 entry for wrapper-level adapter tests: nothing
     between the test and the adapter's outermost production entry point is
     stubbed, so a fix (or a regression) that only manifests on the real
-    `call()` flow — send_audio framing, drain loop, transcript attachment,
-    recorder bookkeeping — cannot hide behind a test seam. (The bug class that
-    hid PR #697's P0: tests drove internals by name while production crashed
-    in the wrapper that wires them together.)
+    `call()` flow — send_audio framing, drain loop, transcript attachment —
+    cannot hide behind a test seam. (The bug class that hid PR #697's P0:
+    tests drove internals by name while production crashed in the wrapper
+    that wires them together.)
+
+    NOT covered: segment recording. `make_agent_input` carries no
+    `scenario_state`, so `_AdapterRecorder` degrades to a no-op (see
+    `adapter.py`). Pass an input that carries a real `scenario_state` if the
+    recorder timeline is what you mean to exercise.
 
     Vendor transports should be faked at the NETWORK CLIENT boundary (e.g.
     monkeypatched `websockets.connect` / `genai.Client`), never by assigning

--- a/python/scenario/voice/testing/wrapper_harness.py
+++ b/python/scenario/voice/testing/wrapper_harness.py
@@ -17,9 +17,17 @@ adds the generic ``drive_call`` / ``make_agent_input`` entry points that
 generalise the same tier-1 idea to the non-Twilio adapters.
 
 Vendor transports should be faked at the NETWORK CLIENT boundary (monkeypatched
-``websockets.connect`` / ``genai.Client``), never by assigning adapter privates
-like ``_ws`` or ``_session`` — that private-poke seam is exactly what this
-harness exists to avoid.
+``websockets.connect`` / ``genai.Client``), never by **substituting a stub
+transport** for adapter privates like ``_ws`` or ``_session`` — injecting a
+fake transport under the wrapper is the seam that let #697's P0 hide, and is
+exactly what this harness exists to avoid.
+
+That ban is on transport *substitution*, not on field assignment as such.
+``make_connected_twilio_adapter`` does assign several privates, but it builds
+the **real** collaborators into them (a real ``TwilioWebhookServer``, real
+queues/events) because the real ``connect()`` would need live Twilio REST
+credentials to resolve the phone-number SID. The media-stream path it then
+drives is production code end to end. See that function's docstring.
 
 Not imported by default from ``scenario.voice``. Users opt-in via
 ``from scenario.voice.testing import drive_call, make_agent_input``.
@@ -32,6 +40,7 @@ import socket
 from contextlib import asynccontextmanager, suppress
 from typing import Any, AsyncIterator, List, Optional, cast
 
+from ...types import AgentInput
 from ..adapter import VoiceAgentAdapter
 from ..adapters import TwilioAgentAdapter
 from ..adapters._twilio_server import TwilioWebhookServer
@@ -42,32 +51,43 @@ from ..messages import create_audio_message
 # ------------------------------------------------------- generic wrapper drive
 
 
-class WrapperCallInput:
+class _WrapperCallInput:
     """Minimal duck-typed AgentInput for direct production-wrapper `call()` tests.
 
     Mirrors the established `_FakeInput` seam (tests/voice/test_realtime_tool_calls.py):
     carries no scenario_state, so `_AdapterRecorder` degrades to a no-op; when
     `new_messages` is empty, `call()` sends no user audio and goes straight to
     draining the agent response.
+
+    Private: callers construct it through `make_agent_input`, which hands back an
+    `AgentInput`-typed value so the public surface carries a real contract rather
+    than leaking `Any`.
     """
 
     def __init__(self, new_messages: Optional[List[Any]] = None) -> None:
         self.new_messages: List[Any] = list(new_messages or [])
 
 
-def make_agent_input(user_audio: Optional[AudioChunk] = None) -> WrapperCallInput:
+def make_agent_input(user_audio: Optional[AudioChunk] = None) -> AgentInput:
     """Build the minimal input `drive_call` feeds the real `call()`.
 
     With `user_audio`, the input carries one user audio message so the real
     `send_audio` edge runs; without it, `call()` is an agent-initiated turn
     that goes straight to the drain.
+
+    The returned object is duck-typed, not a real `AgentInput` — `call()` only
+    reads `new_messages` and `getattr(input, "scenario_state", None)`. The cast
+    is the single contained white lie, so callers still get a typed contract.
     """
-    if user_audio is None:
-        return WrapperCallInput()
-    return WrapperCallInput([create_audio_message(user_audio, role="user")])
+    messages: List[Any] = (
+        [create_audio_message(user_audio, role="user")] if user_audio is not None else []
+    )
+    return cast(AgentInput, _WrapperCallInput(messages))
 
 
-async def drive_call(adapter: VoiceAgentAdapter, agent_input: Optional[Any] = None) -> Any:
+async def drive_call(
+    adapter: VoiceAgentAdapter, agent_input: Optional[AgentInput] = None
+) -> Any:
     """Drive one agent turn through the REAL production wrapper — `adapter.call()`.
 
     This is the generic tier-1 entry for wrapper-level adapter tests: nothing
@@ -84,10 +104,15 @@ async def drive_call(adapter: VoiceAgentAdapter, agent_input: Optional[Any] = No
     recorder timeline is what you mean to exercise.
 
     Vendor transports should be faked at the NETWORK CLIENT boundary (e.g.
-    monkeypatched `websockets.connect` / `genai.Client`), never by assigning
-    adapter privates like `_ws` or `_session`.
+    monkeypatched `websockets.connect` / `genai.Client`), never by substituting
+    a stub transport for adapter privates like `_ws` or `_session`.
+
+    Returns `Any`, not `AgentReturnTypes`: the real return is that TypedDict
+    union, but callers here inspect the assistant message directly
+    (`result["content"]`), which the union forbids. The INPUT contract is the
+    one that prevents caller mistakes, and it is typed.
     """
-    return await adapter.call(cast(Any, agent_input if agent_input is not None else make_agent_input()))
+    return await adapter.call(agent_input if agent_input is not None else make_agent_input())
 
 
 # ------------------------------------------------------- Twilio real-route harness
@@ -103,10 +128,15 @@ def make_connected_twilio_adapter(http_port: int = 0) -> TwilioAgentAdapter:
     server, its FastAPI app, and its ``/twilio/stream`` route. Only ``_rest`` is
     a stand-in, and only ``_assert_connected``'s ``is not None`` check reads it.
     """
+    # All credential-shaped values are deliberately non-credentials: this module
+    # ships inside the published package, so a literal like `auth_token="secret"`
+    # would read as a real leak to a downstream secret scanner grepping
+    # site-packages. The phone number is inside NANPA's reserved fiction block
+    # (555-0100..555-0199) so it can never route to a real subscriber.
     adapter = TwilioAgentAdapter(
         account_sid="AC" + "0" * 32,
-        auth_token="secret",
-        phone_number="+14155556959",
+        auth_token="not-a-real-token",
+        phone_number="+14155550195",
         public_base_url="https://example695.trycloudflare.com",
         http_port=http_port,
     )

--- a/python/tests/voice/test_gemini_live_echo_safe.py
+++ b/python/tests/voice/test_gemini_live_echo_safe.py
@@ -608,15 +608,31 @@ async def test_wrapper_real_connect_call_disconnect_smoke(monkeypatch):
     assert isinstance(config, types.LiveConnectConfig), (
         f"connect() did not build a real LiveConnectConfig; got {type(config)!r}"
     )
-    assert (
-        config.realtime_input_config.automatic_activity_detection.disabled is True
-    ), "automatic activity detection must be disabled (manual turn framing)"
+    # Narrow each optional link explicitly: the SDK types every level of these
+    # chains as Optional, and a bare `a.b.c.d` both trips pyright and reports a
+    # chained AttributeError instead of naming the level connect() failed to set.
+    realtime_input = config.realtime_input_config
+    assert realtime_input is not None, "connect() did not set realtime_input_config"
+    activity_detection = realtime_input.automatic_activity_detection
+    assert activity_detection is not None, (
+        "connect() did not set automatic_activity_detection"
+    )
+    assert activity_detection.disabled is True, (
+        "automatic activity detection must be disabled (manual turn framing)"
+    )
+
     assert config.output_audio_transcription is not None, "output transcription not enabled"
     assert config.input_audio_transcription is not None, "input transcription not enabled"
-    assert (
-        config.speech_config.voice_config.prebuilt_voice_config.voice_name
-        == adapter.voice
-    ), "configured voice != adapter.voice"
+
+    speech_config = config.speech_config
+    assert speech_config is not None, "connect() did not set speech_config"
+    voice_config = speech_config.voice_config
+    assert voice_config is not None, "connect() did not set speech_config.voice_config"
+    prebuilt_voice = voice_config.prebuilt_voice_config
+    assert prebuilt_voice is not None, "connect() did not set prebuilt_voice_config"
+    assert prebuilt_voice.voice_name == adapter.voice, (
+        f"configured voice != adapter.voice; got {prebuilt_voice.voice_name!r}"
+    )
     assert config.system_instruction == "You are an interviewer.", (
         f"system_instruction not carried through; got {config.system_instruction!r}"
     )

--- a/python/tests/voice/test_gemini_live_echo_safe.py
+++ b/python/tests/voice/test_gemini_live_echo_safe.py
@@ -56,6 +56,8 @@ import pytest
 import scenario
 from scenario.config import ScenarioConfig
 from scenario.voice.adapters.gemini_live import GeminiLiveAgentAdapter
+from scenario.voice.audio_chunk import AudioChunk
+from scenario.voice.testing import drive_call, make_agent_input
 from scenario.user_simulator_agent import UserSimulatorAgent
 
 
@@ -530,4 +532,129 @@ async def test_gemini_transcript_surfaces_as_assistant_text_part():
     dumped = json.dumps([dict(m) for m in result.messages])
     assert "scenario_origin" not in dumped, (
         "Marker key 'scenario_origin' leaked into result.messages"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wrapper-level smoke — REAL .connect() + .call() over a faked genai.Client
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wrapper_real_connect_call_disconnect_smoke(monkeypatch):
+    """Wrapper-level smoke closing the 0-``.connect()`` gap.
+
+    The suite's other tests override ``connect``/``disconnect``/``send_audio``
+    wholesale (justified for the echo path, but they leave connect, disconnect,
+    and the send framing dark — gemini_live.py:167-257 had zero coverage). Here
+    we fake ONLY ``genai.Client`` and drive the REAL connect (builds the real
+    ``LiveConnectConfig``, spawns the real ``_session_lifetime`` background task
+    holding the fake CM open), the REAL ``send_audio`` (real 24k→16k resample +
+    activity framing), the REAL ``recv_audio``, and the REAL disconnect (which
+    joins the background task).
+    """
+    from google import genai
+    from google.genai import types
+
+    session = _FakeSession([_agent_turn_messages(QUESTION)])
+    captured: dict = {}
+
+    class _FakeConnectCM:
+        """Async context manager standing in for ``client.aio.live.connect(...)``."""
+
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+    class _FakeLive:
+        def connect(self, *, model, config):
+            captured["model"] = model
+            captured["config"] = config
+            return _FakeConnectCM()
+
+    class _FakeAio:
+        live = _FakeLive()
+
+    class _FakeClient:
+        def __init__(self, api_key=None):
+            captured["api_key"] = api_key
+            self.aio = _FakeAio()
+
+    monkeypatch.setattr(genai, "Client", _FakeClient)
+
+    adapter = GeminiLiveAgentAdapter(
+        api_key="test-gk-not-real",
+        system_instruction="You are an interviewer.",
+    )
+
+    await adapter.connect()               # REAL connect: real config + background task
+    session_task = adapter._session_task  # capture before disconnect joins it
+    result = await drive_call(
+        adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(2400)))
+    )
+    await adapter.disconnect()            # REAL teardown joins the background task
+
+    # 1. Real client construction: key + model reached the SDK boundary.
+    assert captured["api_key"] == "test-gk-not-real", (
+        f"genai.Client got the wrong api_key: {captured.get('api_key')!r}"
+    )
+    assert captured["model"] == adapter.model, (
+        f"live.connect got model {captured.get('model')!r}, expected {adapter.model!r}"
+    )
+
+    # 2. The REAL LiveConnectConfig connect() built, asserted structurally.
+    config = captured["config"]
+    assert isinstance(config, types.LiveConnectConfig), (
+        f"connect() did not build a real LiveConnectConfig; got {type(config)!r}"
+    )
+    assert (
+        config.realtime_input_config.automatic_activity_detection.disabled is True
+    ), "automatic activity detection must be disabled (manual turn framing)"
+    assert config.output_audio_transcription is not None, "output transcription not enabled"
+    assert config.input_audio_transcription is not None, "input transcription not enabled"
+    assert (
+        config.speech_config.voice_config.prebuilt_voice_config.voice_name
+        == adapter.voice
+    ), "configured voice != adapter.voice"
+    assert config.system_instruction == "You are an interviewer.", (
+        f"system_instruction not carried through; got {config.system_instruction!r}"
+    )
+
+    # 3. send_audio framing order over the REAL resample: start / blob / end.
+    assert len(session.sent) == 3, (
+        f"expected 3 send_realtime_input calls (start/blob/end); got {session.sent}"
+    )
+    assert "activity_start" in session.sent[0], f"entry 0 not activity_start: {session.sent[0]}"
+    assert "audio" in session.sent[1], f"entry 1 not an audio blob: {session.sent[1]}"
+    blob = session.sent[1]["audio"]
+    assert blob.mime_type == "audio/pcm;rate=16000", (
+        f"blob mime_type wrong; got {blob.mime_type!r}"
+    )
+    # 2400 samples @24k → 1600 samples @16k → 3200 bytes: the real resampler ran.
+    assert len(blob.data) == 3200, (
+        f"resampled blob is {len(blob.data)} bytes, expected 3200 (24k→16k did not run)"
+    )
+    assert "activity_end" in session.sent[2], f"entry 2 not activity_end: {session.sent[2]}"
+
+    # 4. The assistant turn carries non-empty audio AND the surfaced transcript.
+    content = result.get("content") if isinstance(result, dict) else None
+    assert isinstance(content, list), f"result is not an assistant audio message: {result!r}"
+    audio_parts = [
+        p for p in content if isinstance(p, dict) and p.get("type") == "input_audio"
+    ]
+    text_parts = [
+        p for p in content if isinstance(p, dict) and p.get("type") == "text"
+    ]
+    assert audio_parts and audio_parts[0]["input_audio"].get("data"), (
+        "assistant turn has no non-empty input_audio part"
+    )
+    assert any(QUESTION in (p.get("text") or "") for p in text_parts), (
+        f"transcript {QUESTION!r} not surfaced as a text part through the real recv path"
+    )
+
+    # 5. Disconnect tore the session down and joined the background task.
+    assert adapter._session is None, "disconnect() did not clear adapter._session"
+    assert session_task is not None and session_task.done(), (
+        "the _session_lifetime background task did not finish after disconnect()"
     )

--- a/python/tests/voice/test_realtime_agent_echo_safe.py
+++ b/python/tests/voice/test_realtime_agent_echo_safe.py
@@ -40,6 +40,7 @@ import pytest
 import scenario
 from scenario.config import ScenarioConfig
 from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
+from scenario.voice.testing import drive_call
 from scenario.user_simulator_agent import UserSimulatorAgent
 
 
@@ -97,6 +98,9 @@ class _MockWS:
         self._events = list(events)
         self._idx = 0
         self.sent: List[Any] = []
+        # Observable disconnect: set True by close() so the wrapper-level smoke
+        # test can assert the real disconnect() reached the transport.
+        self.closed = False
 
     async def send(self, msg: Any) -> None:
         self.sent.append(msg)
@@ -111,7 +115,7 @@ class _MockWS:
         return evt
 
     async def close(self) -> None:
-        pass
+        self.closed = True
 
 
 class _CommandDrivenMockWS:
@@ -750,3 +754,105 @@ async def test_no_spurious_response_create_on_user_first():
     assert len(assistant_turns) == 1, (
         f"Expected exactly 1 assistant turn, got {len(assistant_turns)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Wrapper-level smoke — REAL .connect() + .call() over a faked network client
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wrapper_real_connect_call_disconnect_smoke(monkeypatch):
+    """Wrapper-level (real ``.connect()`` + ``.call()``) smoke test closing the
+    seam-only gap.
+
+    Every other test in this suite replaces ``connect`` wholesale (assigning
+    ``adapter._ws`` directly), so the real ``session.update`` handshake
+    (openai_realtime.py:305-343) had ZERO coverage before this test. Here we fake
+    ONLY the network-client boundary — ``websockets.connect`` — and drive the
+    REAL connect handshake, the REAL ``call()`` drain, and the REAL disconnect
+    over that fake transport.
+    """
+    import websockets
+
+    mock_ws = _MockWS(_agent_event_sequence(QUESTION))
+    captured: dict = {}
+
+    async def _fake_connect(url, additional_headers=None, **kw):
+        captured["url"] = url
+        captured["headers"] = dict(additional_headers or {})
+        return mock_ws
+
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+
+    adapter = OpenAIRealtimeAgentAdapter(
+        api_key="test-sk-not-real",
+        instructions="You are an interviewer.",
+        speaks_first=True,
+    )
+
+    await adapter.connect()             # REAL connect: URL, auth header, session.update
+    result = await drive_call(adapter)  # REAL call(): drain + transcript override
+    await adapter.disconnect()
+
+    # 1. Real endpoint URL + real auth header over the fake transport.
+    assert captured["url"] == f"wss://api.openai.com/v1/realtime?model={adapter.model}", (
+        f"connect() did not build the real Realtime URL; got {captured.get('url')!r}"
+    )
+    assert captured["headers"].get("Authorization") == "Bearer test-sk-not-real", (
+        f"connect() did not send the Bearer auth header; headers={captured.get('headers')!r}"
+    )
+
+    # 2. The session.update handshake — asserted structurally (the exact code the
+    #    seam tests skipped).
+    assert mock_ws.sent, "connect() sent nothing — session.update handshake missing"
+    handshake = json.loads(mock_ws.sent[0])
+    assert handshake.get("type") == "session.update", (
+        f"first send was not session.update; got {handshake.get('type')!r}"
+    )
+    session = handshake["session"]
+    assert session.get("type") == "realtime", (
+        f"session.type != 'realtime'; got {session.get('type')!r}"
+    )
+    assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}, (
+        f"input format wrong; got {session['audio']['input'].get('format')!r}"
+    )
+    assert session["audio"]["input"]["turn_detection"] is None, (
+        "server VAD not disabled (turn_detection should be None)"
+    )
+    assert session["audio"]["output"]["voice"] == adapter.voice, (
+        f"output voice != adapter.voice; got {session['audio']['output'].get('voice')!r}"
+    )
+    assert session.get("instructions"), (
+        "instructions absent from the session.update handshake"
+    )
+
+    # 3. Ordering: the session.update send precedes any response.create send.
+    sent_types = [
+        json.loads(s).get("type") for s in mock_ws.sent if isinstance(s, str)
+    ]
+    assert "session.update" in sent_types and "response.create" in sent_types, (
+        f"expected both session.update and response.create in sends; got {sent_types}"
+    )
+    assert sent_types.index("session.update") < sent_types.index("response.create"), (
+        f"session.update must precede response.create; sent order={sent_types}"
+    )
+
+    # 4. The assistant turn carries non-empty audio AND the surfaced transcript.
+    content = result.get("content") if isinstance(result, dict) else None
+    assert isinstance(content, list), f"result is not an assistant audio message: {result!r}"
+    audio_parts = [
+        p for p in content if isinstance(p, dict) and p.get("type") == "input_audio"
+    ]
+    text_parts = [
+        p for p in content if isinstance(p, dict) and p.get("type") == "text"
+    ]
+    assert audio_parts and audio_parts[0]["input_audio"].get("data"), (
+        "assistant turn has no non-empty input_audio part"
+    )
+    assert any(QUESTION in (p.get("text") or "") for p in text_parts), (
+        f"transcript {QUESTION!r} not surfaced as a text part through the real drain"
+    )
+
+    # 5. Disconnect is observable and clears the socket reference.
+    assert mock_ws.closed is True, "disconnect() did not close the websocket"
+    assert adapter._ws is None, "disconnect() did not clear adapter._ws"

--- a/python/tests/voice/test_realtime_response_create_guard.py
+++ b/python/tests/voice/test_realtime_response_create_guard.py
@@ -39,6 +39,8 @@ from typing import Any, List
 import pytest
 
 from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
+from scenario.voice.audio_chunk import AudioChunk
+from scenario.voice.testing import drive_call, make_agent_input
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +77,9 @@ class _MockWS:
         self.sent: List[Any] = []
         # Interleaved chronological log: ("sent"|"recv", type_str)
         self.log: List[tuple[str, str]] = []
+        # Observable disconnect (mirrors the echo-safe suite's _MockWS): set True
+        # by close() so the wrapper-level test can see the real disconnect land.
+        self.closed = False
 
     async def send(self, msg: Any) -> None:
         self.sent.append(msg)
@@ -99,7 +104,7 @@ class _MockWS:
         return evt
 
     async def close(self) -> None:
-        pass
+        self.closed = True
 
     # --- helpers for assertions ---
 
@@ -467,4 +472,80 @@ async def test_deferred_path_clears_agent_turn_pending():
     # Sanity: it really was the deferral branch (flag set), not the else branch.
     assert adapter._deferred_response_create is True, (
         "expected the deferral branch (_deferred_response_create=True) to be taken"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wrapper-level twin of AC5 — commit-then-create ordering on the REAL call path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wrapper_normal_path_full_call_flow(monkeypatch):
+    """Wrapper-level twin of AC5: the commit-then-create ordering proven on the
+    PRODUCTION path — reached through the REAL ``connect()`` + ``call()`` flow
+    rather than a direct ``recv_audio`` with an injected ``_ws``.
+
+    Fakes ONLY the network-client boundary (``websockets.connect``); connect's
+    ``session.update`` handshake, ``send_audio``'s ``input_audio_buffer.append``,
+    and ``recv_audio``'s ``commit`` → ``response.create`` preamble all run for
+    real. The transcript event keeps ``_ensure_transcript`` off the network.
+    """
+    import websockets
+
+    events = [
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": _b64_pcm(480)}),
+        json.dumps(
+            {"type": "response.output_audio_transcript.done", "transcript": "I can help you."}
+        ),
+        json.dumps({"type": "response.done"}),
+    ]
+    mock_ws = _MockWS(events)
+
+    async def _fake_connect(url, additional_headers=None, **kw):
+        return mock_ws
+
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+
+    adapter = OpenAIRealtimeAgentAdapter(api_key="test-sk-not-real")  # user-first
+
+    await adapter.connect()
+    result = await drive_call(
+        adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(480)))
+    )
+    await adapter.disconnect()
+
+    # 1. AC5's invariant on the production path: session.update, then append,
+    #    then commit, then response.create — strictly increasing, one each.
+    sent = mock_ws.sent_types()
+    for t in (
+        "session.update",
+        "input_audio_buffer.append",
+        "input_audio_buffer.commit",
+        "response.create",
+    ):
+        assert t in sent, f"expected {t!r} in sends; got {sent}"
+    i_update = mock_ws.first_index_of("session.update")
+    i_append = mock_ws.first_index_of("input_audio_buffer.append")
+    i_commit = mock_ws.first_index_of("input_audio_buffer.commit")
+    i_create = mock_ws.first_index_of("response.create")
+    assert i_update < i_append < i_commit < i_create, (
+        f"expected session.update < append < commit < create; sent order={sent}"
+    )
+    assert mock_ws.count_of("input_audio_buffer.commit") == 1, (
+        f"expected exactly 1 input_audio_buffer.commit; sent={sent}"
+    )
+    assert mock_ws.count_of("response.create") == 1, (
+        f"expected exactly 1 response.create; sent={sent}"
+    )
+
+    # 2. The full flow resolves to an assistant message with non-empty audio.
+    content = result.get("content") if isinstance(result, dict) else None
+    assert isinstance(content, list), f"result is not an assistant audio message: {result!r}"
+    audio_parts = [
+        p for p in content if isinstance(p, dict) and p.get("type") == "input_audio"
+    ]
+    assert audio_parts and audio_parts[0]["input_audio"].get("data"), (
+        "assistant turn has no non-empty input_audio part"
     )

--- a/python/tests/voice/test_twilio_silent_stop_drain.py
+++ b/python/tests/voice/test_twilio_silent_stop_drain.py
@@ -52,22 +52,33 @@ its first chunk, so it lands there on every call termination. Pre-fix that call
 raises ``RuntimeError: no live media stream``; post-fix it returns an empty
 chunk. The tests assert BOTH the first ``recv_audio`` (the sentinel) and the
 second (the post-teardown drain probe) behave cleanly.
+
+The reusable Twilio real-route harness (``make_connected_twilio_adapter``,
+``serve_real_twilio_route``, ``drive_twilio_production``,
+``wait_for_twilio_stream_teardown``, ``free_port``) now lives in the shared
+``scenario.voice.testing.wrapper_harness`` module; this suite imports it and
+keeps only the Twilio-specific socket doubles (``_ScriptedWS`` /
+``_ControllableWS``) and frame builders local.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-import socket
-from contextlib import asynccontextmanager, suppress
-from typing import Any, AsyncIterator, Optional
+from typing import Any, Optional
 
 import pytest
 import websockets
 
 from scenario.voice import AudioChunk, TwilioAgentAdapter
-from scenario.voice.adapters._twilio_server import TwilioWebhookServer
 from scenario.voice.adapters._twilio_shared import build_media_frame
+from scenario.voice.testing.wrapper_harness import (
+    drive_twilio_production,
+    free_port,
+    make_connected_twilio_adapter,
+    serve_real_twilio_route,
+    wait_for_twilio_stream_teardown,
+)
 
 # recv_audio is handed a long nominal budget (what an un-fixed adapter would
 # hang for); the outer ceiling fails the test fast if the empty-chunk terminal
@@ -128,104 +139,12 @@ class _ScriptedWS:
         self.sent.append(text)
 
 
-def _make_connected_adapter(http_port: int = 0) -> TwilioAgentAdapter:
-    """Construct an adapter with just enough state for the production
-    ``run_stream_session`` wrapper + ``recv_audio`` — without going through
-    ``connect()`` (which would need live Twilio REST credentials to resolve the
-    phone-number SID).
-
-    Everything the media-stream path touches is the real object: the webhook
-    server, its FastAPI app, and its ``/twilio/stream`` route. Only ``_rest`` is
-    a stand-in, and only ``_assert_connected``'s ``is not None`` check reads it.
-    """
-    adapter = TwilioAgentAdapter(
-        account_sid="AC" + "0" * 32,
-        auth_token="secret",
-        phone_number="+14155556959",
-        public_base_url="https://example695.trycloudflare.com",
-        http_port=http_port,
-    )
-    # Stand-in for the REST client: only _assert_connected's `is not None`
-    # check reads it, and constructing a real one needs live Twilio credentials.
-    adapter._rest = object()  # type: ignore[assignment]  # sentinel; never called
-    adapter._inbound_queue = asyncio.Queue()
-    adapter._stream_connected = asyncio.Event()
-    adapter._server_shutdown = asyncio.Event()
-    adapter._webhook_server = TwilioWebhookServer(adapter)
-    return adapter
-
-
 # ---------------------------------------------------------------- real route
-
-
-def _free_port() -> int:
-    sock = socket.socket()
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-    sock.close()
-    return port
-
-
-async def _wait_for_bind(port: int, server_task: "asyncio.Task[None]") -> None:
-    """Wait until the port accepts, failing loudly if uvicorn died instead.
-
-    ``_free_port`` reserves then releases a port, so another listener can win the
-    race. uvicorn reacts to a failed bind with ``sys.exit(1)`` — a ``SystemExit``,
-    which is a ``BaseException`` and therefore slips past the ``suppress(Exception)``
-    in ``TwilioWebhookServer.run()``. Without this check the connect below would
-    succeed against the *other* listener and the test would fail much later with a
-    bare ``SystemExit`` instead of "address already in use".
-    """
-    for _ in range(200):
-        if server_task.done():
-            # Re-raise whatever killed the server (SystemExit, OSError, …).
-            server_task.result()
-            raise AssertionError("uvicorn exited before binding")
-        try:
-            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
-            writer.close()
-            return
-        except OSError:
-            await asyncio.sleep(0.05)
-    raise AssertionError(f"uvicorn never bound 127.0.0.1:{port}")
-
-
-@asynccontextmanager
-async def _serve_real_route(
-    adapter: TwilioAgentAdapter,
-) -> AsyncIterator[str]:
-    """Boot the adapter's REAL uvicorn server and yield the ``ws://`` URL of the
-    REAL ``/twilio/stream`` route.
-
-    This is the production entry point end to end: uvicorn → FastAPI →
-    ``_stream()`` → ``run_stream_session`` → ``media_stream_loop``. No seam, no
-    socket double. A fix that only works when a test calls the wrapper by name
-    cannot pass through here.
-    """
-    assert adapter._webhook_server is not None
-    server_task = asyncio.create_task(adapter._webhook_server.run())
-    try:
-        await _wait_for_bind(adapter.http_port, server_task)
-        yield f"ws://127.0.0.1:{adapter.http_port}/twilio/stream"
-    finally:
-        assert adapter._server_shutdown is not None
-        adapter._server_shutdown.set()
-        with suppress(Exception):
-            await asyncio.wait_for(server_task, timeout=5.0)
-
-
-async def _await_teardown(adapter: TwilioAgentAdapter) -> None:
-    """Wait until the route handler's ``finally`` has nulled the transport."""
-    for _ in range(200):
-        if adapter._stream_ws is None:
-            return
-        await asyncio.sleep(0.01)
-    raise AssertionError("production route never tore the transport down")
 
 
 @pytest.fixture
 def route_adapter() -> TwilioAgentAdapter:
-    adapter = _make_connected_adapter(http_port=_free_port())
+    adapter = make_connected_twilio_adapter(http_port=free_port())
     # Small drain budgets: a hang (the original #695 symptom) then fails inside
     # ROUTE_CEILING rather than stalling the suite.
     adapter.response_timeout = 5.0
@@ -251,7 +170,7 @@ class TestRealRoute:
         self, route_adapter: TwilioAgentAdapter
     ) -> None:
         """A silent / tool-only turn: ``stop`` frame, no audio ever buffered."""
-        async with _serve_real_route(route_adapter) as url:
+        async with serve_real_twilio_route(route_adapter) as url:
             async with websockets.connect(url) as client:
                 await client.send(_start_frame())
                 assert route_adapter._stream_connected is not None
@@ -271,7 +190,7 @@ class TestRealRoute:
         self, route_adapter: TwilioAgentAdapter
     ) -> None:
         """Twilio drops the media socket with no ``stop`` frame and no audio."""
-        async with _serve_real_route(route_adapter) as url:
+        async with serve_real_twilio_route(route_adapter) as url:
             async with websockets.connect(url) as client:
                 await client.send(_start_frame())
                 assert route_adapter._stream_connected is not None
@@ -294,7 +213,7 @@ class TestRealRoute:
         through the real route — the sentinel terminates the drain after it, and
         does not replace it.
         """
-        async with _serve_real_route(route_adapter) as url:
+        async with serve_real_twilio_route(route_adapter) as url:
             async with websockets.connect(url) as client:
                 await client.send(_start_frame())
                 assert route_adapter._stream_connected is not None
@@ -323,7 +242,7 @@ class TestRealRoute:
         Pre-fix this raises ``RuntimeError: no live media stream`` immediately,
         with the terminal sentinel sitting unread in the queue.
         """
-        async with _serve_real_route(route_adapter) as url:
+        async with serve_real_twilio_route(route_adapter) as url:
             async with websockets.connect(url) as client:
                 await client.send(_start_frame())
                 assert route_adapter._stream_connected is not None
@@ -331,7 +250,7 @@ class TestRealRoute:
                     route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
                 )
                 await client.send(_stop_frame())
-            await _await_teardown(route_adapter)
+            await wait_for_twilio_stream_teardown(route_adapter)
             assert route_adapter._stream_ws is None
             assert route_adapter._stream_sid is None
 
@@ -360,7 +279,7 @@ class TestRealRoute:
         route_adapter.response_tail_silence = 0.2
         speak_after = 0.6
 
-        async with _serve_real_route(route_adapter) as url:
+        async with serve_real_twilio_route(route_adapter) as url:
             # Session 1: caller hangs up between turns; nothing consumes it.
             async with websockets.connect(url) as first:
                 await first.send(_start_frame())
@@ -369,7 +288,7 @@ class TestRealRoute:
                     route_adapter._stream_connected.wait(), timeout=ROUTE_CEILING
                 )
                 await first.send(_stop_frame())
-            await _await_teardown(route_adapter)
+            await wait_for_twilio_stream_teardown(route_adapter)
             assert route_adapter._inbound_queue is not None
             assert route_adapter._inbound_queue.qsize() == 1  # sentinel, unread
 
@@ -407,7 +326,7 @@ class TestRealRoute:
         liveness assert fired first and that audio was dropped on the floor along
         with the crash.
         """
-        async with _serve_real_route(route_adapter) as url:
+        async with serve_real_twilio_route(route_adapter) as url:
             async with websockets.connect(url) as client:
                 await client.send(_start_frame())
                 assert route_adapter._stream_connected is not None
@@ -416,7 +335,7 @@ class TestRealRoute:
                 )
                 await client.send(build_media_frame(STREAM_SID, bytes([0x7F]) * 160))
                 await client.send(_stop_frame())
-            await _await_teardown(route_adapter)
+            await wait_for_twilio_stream_teardown(route_adapter)
 
             merged = await asyncio.wait_for(
                 route_adapter._drain_agent_response(), timeout=ROUTE_CEILING
@@ -454,21 +373,6 @@ class _ControllableWS:
         self.sent.append(text)
 
 
-async def _drive_production(adapter: TwilioAgentAdapter, ws: Any) -> None:
-    """Run the production per-connection wrapper
-    (``TwilioWebhookServer.run_stream_session`` — what the ``/twilio/stream``
-    route delegates to, as ``TestRealRoute`` proves) to its terminal over the
-    given socket double.
-
-    On return, ``adapter._stream_ws`` / ``_stream_sid`` have been nulled by the
-    wrapper's ``finally`` — exactly as in production after a call ends. Used for
-    the terminations a real socket cannot produce (a ``receive_text`` that raises
-    a non-disconnect error; a second session on the same connected adapter).
-    """
-    assert adapter._webhook_server is not None
-    await adapter._webhook_server.run_stream_session(ws)
-
-
 @pytest.mark.asyncio
 async def test_stop_without_trailing_audio_drains_through_production_teardown():
     """A ``"stop"`` frame with no buffered audio (silent / tool-only turn),
@@ -477,10 +381,10 @@ async def test_stop_without_trailing_audio_drains_through_production_teardown():
     return cleanly. Pre-fix the second call raises ``RuntimeError: no live media
     stream`` (the transport was nulled by the wrapper's ``finally``).
     """
-    adapter = _make_connected_adapter()
+    adapter = make_connected_twilio_adapter()
     ws = _ScriptedWS([_start_frame(), _stop_frame()])
 
-    await _drive_production(adapter, ws)
+    await drive_twilio_production(adapter, ws)
 
     # Production nulled the transport in run_stream_session's finally — the
     # very condition that made recv_audio crash pre-fix.
@@ -512,11 +416,11 @@ async def test_socket_close_drains_through_production_teardown():
     """
     from starlette.websockets import WebSocketDisconnect
 
-    adapter = _make_connected_adapter()
+    adapter = make_connected_twilio_adapter()
     ws = _ScriptedWS([_start_frame()], close_with=WebSocketDisconnect(code=1000))
 
     # run_stream_session catches WebSocketDisconnect — it does NOT propagate.
-    await _drive_production(adapter, ws)
+    await drive_twilio_production(adapter, ws)
 
     assert adapter._stream_ws is None
     assert adapter._stream_sid is None
@@ -541,7 +445,7 @@ async def test_normal_audio_turn_still_drains_through_production_teardown():
     of it — even though the real production wrapper has already nulled the
     transport state by the time the drain reads.
     """
-    adapter = _make_connected_adapter()
+    adapter = make_connected_twilio_adapter()
     # 160 bytes of µ-law (~20ms). Under the 100ms batch threshold, so the
     # "stop" flush is what enqueues it — exactly the trailing-audio path.
     mulaw = bytes([0x7F]) * 160
@@ -549,7 +453,7 @@ async def test_normal_audio_turn_still_drains_through_production_teardown():
         [_start_frame(), build_media_frame(STREAM_SID, mulaw), _stop_frame()]
     )
 
-    await _drive_production(adapter, ws)
+    await drive_twilio_production(adapter, ws)
 
     assert adapter._stream_ws is None  # production teardown ran
 
@@ -578,13 +482,13 @@ async def test_transport_error_drains_through_production_teardown():
     ``finally`` nulled the transport first, so both drain ``recv_audio`` calls
     still return cleanly.
     """
-    adapter = _make_connected_adapter()
+    adapter = make_connected_twilio_adapter()
     ws = _ScriptedWS(
         [_start_frame()], close_with=RuntimeError("boom: transport failure")
     )
 
     with pytest.raises(RuntimeError, match="boom: transport failure"):
-        await _drive_production(adapter, ws)
+        await drive_twilio_production(adapter, ws)
 
     assert adapter._stream_ws is None  # teardown ran on the throw path
     assert adapter._stream_sid is None
@@ -610,10 +514,10 @@ async def test_second_session_stale_flag_does_not_truncate_first_turn():
     new call's first agent turn. With the loop-entry reset it waits for the
     real audio.
     """
-    adapter = _make_connected_adapter()
+    adapter = make_connected_twilio_adapter()
 
     # Session 1 completes silently and is fully drained.
-    await _drive_production(adapter, _ScriptedWS([_start_frame(), _stop_frame()]))
+    await drive_twilio_production(adapter, _ScriptedWS([_start_frame(), _stop_frame()]))
     s1 = await asyncio.wait_for(
         adapter.recv_audio(timeout=RECV_TIMEOUT), timeout=OUTER_CEILING
     )
@@ -621,7 +525,7 @@ async def test_second_session_stale_flag_does_not_truncate_first_turn():
 
     # Session 2 begins mid-call: started, nothing buffered yet.
     ws2 = _ControllableWS()
-    session2 = asyncio.create_task(_drive_production(adapter, ws2))
+    session2 = asyncio.create_task(drive_twilio_production(adapter, ws2))
     ws2.push(_start_frame("MZ695b", "CA695b"))
     for _ in range(200):  # wait until the loop re-armed the transport
         if adapter._stream_ws is not None:
@@ -656,7 +560,7 @@ async def test_recv_audio_with_nulled_queue_raises_connection_error():
     ``AttributeError`` — pinning the reordering guard the cascade keeps ahead
     of the queue reads.
     """
-    adapter = _make_connected_adapter()
+    adapter = make_connected_twilio_adapter()
     adapter._inbound_queue = None
 
     with pytest.raises(RuntimeError, match="inbound queue is gone"):


### PR DESCRIPTION
<!-- no-ui-surface -->

> **Scariest thing** — This PR's own harness has a residual blind spot: `drive_call` builds an input with **no `scenario_state`**, so `_AdapterRecorder` degrades to a **no-op** (`python/scenario/voice/adapter.py:310`). Segment-recording regressions still hide from these tests. The docstrings originally claimed the opposite; `7a209c0` corrects them. If you only read one thing, read that claim and decide whether "documented gap" is good enough for you.
> **Start here** — `python/scenario/voice/testing/wrapper_harness.py` → `drive_call()`. It is the whole thesis in ~15 lines: fake at the **network-client boundary**, never by substituting a stub transport for adapter privates.

## Why

Closes #766.

PR #697 shipped a P0 — a dead recv-loop hang on a silent/tool-only Twilio stop — that survived **five reviews and green CI**. It hid because the voice-adapter tests drove adapter **internals by name** (test seams) while production crashed in the **wrapper** that wires those internals together. The tests were green; production was broken; green CI was not evidence.

#697 already built and proved the right pattern — it just lived inline in one Twilio test file where nothing else could reuse it. This PR extracts it and points it at the two highest-risk seam-only suites.

## What changed

- **Fake at the network-client boundary, not the adapter's privates** → the alternative was to keep assigning `adapter._ws` / `adapter._session` directly, which is what every existing test does. Consequence: the new tests exercise the real `connect()` handshake (`session.update`, auth header, endpoint URL) and the real `send_audio` framing (including the genuine 24k→16k resample). Cost: each new test must stand up a plausible fake transport, which is more code than poking a private.

- **Ship the harness inside the package (`scenario.voice.testing`), not in `tests/`** → the alternative was a test-only conftest helper. Consequence: `drive_call` / `make_agent_input` become importable public API that adapter authors (and users writing their own adapters) can build on; the blast radius is that these names are now something we have to keep working. **Note the asymmetry**: the JS mirror made the opposite call and lives under `src/voice/__tests__/helpers/`, outside the package `exports`. Worth a reviewer's opinion.

- **Generalise to `drive_call(adapter, input)` rather than per-adapter helpers** → the alternative was one bespoke harness per adapter. Consequence: one entry point covers the 8 non-Twilio adapters; the cost is the duck-typed `_WrapperCallInput`, which carries no `scenario_state` and therefore silently skips the recorder (see *Scariest thing*).

- **Deferred the CI seam-gate** → it would have doubled this PR's surface. Tracked in #764; that is the piece that stops *new* seam-only tests from reintroducing the bug class.

## How it works

```
python/scenario/voice/testing/
  wrapper_harness.py          NEW — the shared harness
    drive_call(adapter,input) generic tier-1: drives the REAL adapter.call()
    make_agent_input(audio)   minimal AgentInput (no scenario_state — see caveat)
    make_connected_twilio_adapter / serve_real_twilio_route / drive_twilio_production
                              tier-2: boots REAL uvicorn -> REAL /twilio/stream route
  __init__.py                 re-exports the above alongside CloudflareTunnel/TwilioHarness

python/tests/voice/
  test_realtime_agent_echo_safe.py       + wrapper smoke: REAL connect->call->disconnect
  test_realtime_response_create_guard.py + wrapper twin of AC5 (commit-then-create ordering)
  test_gemini_live_echo_safe.py          + wrapper smoke: REAL connect->call->disconnect
  test_twilio_silent_stop_drain.py       migrated onto the extracted harness (net simpler)

javascript/src/voice/__tests__/helpers/
  drive-production.ts         NEW — JS mirror: driveCall / makeAgentInput / driveTwilioProduction
```

Two tiers. **Tier-1** (`drive_call`) drives the adapter's outermost production entry point in-process. **Tier-2** (Twilio only) boots the real uvicorn server and connects to the real `/twilio/stream` route — uvicorn → FastAPI → `run_stream_session` → `media_stream_loop`, no seam anywhere. The Twilio suite keeps a `TestRealRoute` anti-drift class that proves tier-1 and tier-2 stay equivalent.

## Test plan

```bash
# Python — CI parity (this is exactly what python-ci runs)
cd python && CI=true uv run pytest tests/ -m "not integration" && uv run pyright .

# JavaScript — CI parity
cd javascript && pnpm build:all && pnpm lint:lib && pnpm lint:all && pnpm typecheck:all && pnpm run test:ci
```

The three new wrapper tests are **hermetic** — no API keys, no network, no skips. They fake `websockets.connect` / `genai.Client` and nothing else:

- `test_realtime_agent_echo_safe.py::test_wrapper_real_connect_call_disconnect_smoke`
- `test_realtime_response_create_guard.py::test_wrapper_normal_path_full_call_flow`
- `test_gemini_live_echo_safe.py::test_wrapper_real_connect_call_disconnect_smoke`

## Human verification

For a skeptical reviewer who wants to re-derive the central claim independently:

1. Check out this branch. Open `python/scenario/voice/adapters/openai_realtime.py` and find `"turn_detection": None` (line 326).
2. Change it to `"turn_detection": {"type": "server_vad"}`. This is a realistic regression — a real `connect()` handshake that silently re-enables server-side VAD.
3. Run the **pre-existing seam tests only**:
   `cd python && .venv/bin/python -m pytest tests/voice/test_realtime_agent_echo_safe.py tests/voice/test_realtime_response_create_guard.py -k "not wrapper" -q`
   → **17 passed.** They do not notice.
4. Run the **new wrapper tests only**: same command with `-k "wrapper"`
   → **1 failed** (`test_wrapper_real_connect_call_disconnect_smoke`).
5. Revert the mutation; both go green.

That difference — step 3 blind, step 4 catching it — is the entire point of this PR.

The same holds for Gemini: flip `disabled=True` → `False` in `gemini_live.py` (~line 213) and `test_gemini_live_echo_safe.py::test_wrapper_real_connect_call_disconnect_smoke` fails with *"automatic activity detection must be disabled"*.

## How I can prove I was successful

**No UI surface.** This change adds tests plus a test-only harness module; it modifies **zero production code paths**. Per the falsifiability-test-stands-alone rule, the mutation test below is the proof, and I checked that no user-observable surface exists to demonstrate — every path in `git diff --name-only origin/main...HEAD` lives under `**/testing/**`, `**/__tests__/**`, or `python/tests/**`:

```
javascript/src/voice/__tests__/helpers/drive-production.ts
javascript/src/voice/adapters/__tests__/twilio-silent-stop-drain.test.ts
python/scenario/voice/testing/__init__.py
python/scenario/voice/testing/wrapper_harness.py
python/tests/voice/test_gemini_live_echo_safe.py
python/tests/voice/test_realtime_agent_echo_safe.py
python/tests/voice/test_realtime_response_create_guard.py
python/tests/voice/test_twilio_silent_stop_drain.py
```

### 1. The seam gap is real, and this PR closes it — `proven`

Mutated real production `openai_realtime.py:326`, `"turn_detection": None` → `{"type": "server_vad"}`, then ran each cohort:

```
### OLD seam tests only (-k "not wrapper") — MUTATED production:
17 passed, 2 deselected, 2 warnings in 5.45s

### NEW wrapper tests only (-k wrapper) — MUTATED production:
FAILED tests/voice/test_realtime_agent_echo_safe.py::test_wrapper_real_connect_call_disconnect_smoke
  assert {'type': 'server_vad'} is None
1 failed, 1 passed, 17 deselected, 2 warnings in 0.17s
```

| Cohort | Under a real `connect()` regression |
|---|---|
| 17 pre-existing seam tests | **all pass** — blind |
| new wrapper connect test | **fails** — catches it |

Re-ran after the review-round refactor (`156d55d`) — still discriminates. Mutation reverted each time; working tree clean.

### 2. The new tests are hermetic — not skipped, not key-gated — `proven`

The strongest evidence is **CI itself**: `test (3.12)` on this PR has no `OPENAI_API_KEY` / `GEMINI_API_KEY` secret, and its pytest step reports

```
1008 passed, 21 skipped, 34 deselected, 510 warnings, 2 rerun in 144.68s
```

with all three wrapper tests among the passes. They run on every PR, not only in the nightly integration job. Locally, with the keys unset:

```
tests/voice/test_gemini_live_echo_safe.py::test_wrapper_real_connect_call_disconnect_smoke PASSED
tests/voice/test_realtime_agent_echo_safe.py::test_wrapper_real_connect_call_disconnect_smoke PASSED
tests/voice/test_realtime_response_create_guard.py::test_wrapper_normal_path_full_call_flow PASSED
3 passed in 0.73s
```

The security review independently confirmed the monkeypatch targets: both adapters resolve `websockets.connect` / `genai.Client` as attribute lookups **at call time**, so the patches intercept before any socket opens — and both tests pass an explicit fake key, so even a future import-shape refactor could not send a developer's real key over the wire.

### 3. CI green at `156d55d` — `proven`

All gating checks pass: `python-complete`, `javascript-complete`, `docs-complete`, `test (3.12)`, `ci-checks (24.x)`. (`build`, `firefighting`, `dismiss-firefighting-approval` report `skipping` — none is a gating job; their aggregators pass.)

Locally at CI parity: `pyright .` → **0 errors**; `pytest tests/voice/ -m "not integration"` → **429 passed, 11 skipped, 34 deselected**; JS `build:all` / `lint:lib` / `lint:all` / `typecheck:all` / `test:ci` all exit 0 (`Tests 922 passed | 1 skipped`).

### 4. Recorder path is exercised — `missing`

Not proven, and not claimed. `drive_call` skips `_AdapterRecorder` entirely (no `scenario_state`). Documented in the docstrings as of `7a209c0` rather than papered over. Closing it needs an input carrying a real `scenario_state`; it is out of scope here.

## Anything surprising?

- **`scenario.voice.testing` is shipped, not test-only.** The harness lives inside the published package (`pyproject: include = ["scenario*"]`), so `drive_call`, `make_agent_input`, and the Twilio real-route helpers are now public API. That is deliberate — `CloudflareTunnel` / `TwilioHarness` already set the precedent — but it is new surface to keep working, and the JS mirror deliberately did **not** do this. A reviewer should weigh in.

- **`make_connected_twilio_adapter` still assigns privates** (`_rest`, `_inbound_queue`, `_webhook_server`, …). It has to: a real `connect()` needs live Twilio REST credentials to resolve the phone-number SID. The rule the harness enforces is narrower than "never touch privates" — it is *never substitute a stub transport under the wrapper*. Building real collaborators into their fields is fine; the media-stream path it drives is production code end to end. Consequence: Twilio is the one adapter whose real `connect()` is still uncovered → tracked in #768.

- **Two local-only hangs that are not CI failures.** `test_agent_wait_false.py` is `skipif(CI == "true")` — skipped in CI by design — and hangs locally (at the base commit too). `test_angry_customer_e2e.py` is integration-marked and deselected in CI. Neither is touched here; if you run the voice suite locally *without* `CI=true -m "not integration"`, you will hit both.

- **`tests/test_red_team_agent.py` fails locally, passes in CI.** Three `AttributeError: Mock object has no attribute 'messages'` failures reproduce identically at the base commit `e675224` on this aarch64 box, and CI is green on them. Pre-existing local-env artifact, unrelated to this branch.

- **The CI seam-gate is deliberately not here.** Tracked as a follow-up in #764.
