### PR TITLE
chore(dependabot): weekly cadence and grouped dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,92 @@
 version: 2
+
+# Update policy (mirrors langwatch/langwatch):
+#   - Weekly (Monday) so version churn arrives as one predictable batch.
+#   - Coordinated dependency families are each grouped into one PR via
+#     `patterns`; the JS workspaces share one entry through `directories` so a
+#     shared dependency is bumped across them together. A `minor-and-patch`
+#     catch-all sweeps the long tail; ungrouped majors stay individual.
+#   - Security updates are NOT grouped (no group targets security-updates), so
+#     every advisory fix stays an independent, individually-mergeable PR that
+#     lands as soon as a patched version is available.
 updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/javascript"
+      - "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 20
+    groups:
+      opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - "@opentelemetry/*"
+          - "import-in-the-middle"
+      ai-sdk:
+        applies-to: version-updates
+        patterns:
+          - "@ai-sdk/*"
+          - "ai"
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      eslint:
+        applies-to: version-updates
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "eslint-plugin-*"
+          - "eslint-import-resolver-*"
+      typescript-native-preview:
+        applies-to: version-updates
+        patterns:
+          - "@typescript/native-preview"
+      types:
+        applies-to: version-updates
+        patterns:
+          - "@types/*"
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "uv"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 20
+    groups:
+      opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - "opentelemetry-*"
+          - "openinference-*"
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Brings scenario's Dependabot config in line with langwatch/langwatch: weekly cadence, grouped updates, and (new) coverage for npm and uv, not just github-actions.

## Changes

The config previously only ran `github-actions`. This adds:

- **npm** across `/javascript` and `/docs` (shared via `directories`), with family groups: `@opentelemetry/*`, `@ai-sdk/*` + `ai`, `vitest`, `eslint` (+ `typescript-eslint`), `@typescript/native-preview`, `@types/*`, plus a `minor-and-patch` catch-all. A shared dependency is bumped across both workspaces in one PR; ungrouped majors stay individual.
- **uv** for `/python`: `opentelemetry-*` / `openinference-*` family + `minor-and-patch`.
- **github-actions**: all bumps grouped into a single PR (currently 5 open individual PRs).

All weekly (Monday).

## Security updates stay immediate

No group targets `security-updates`, so every advisory fix is an independent, individually-mergeable PR (same policy as langwatch).

## No cooldown

Unlike langwatch, scenario does not enforce pnpm `minimumReleaseAge` or uv `exclude-newer`, so there is no 7-day resolution floor to mirror and no cooldown is added.

## Validation

Passes the official Dependabot JSON schema and will be checked by GitHub's own `.github/dependabot.yml` validation.

## Follow-up

Once merged, the 5 open individual github-actions PRs can be closed so they regenerate as one grouped PR (same queue-reset done in langwatch).