### PR TITLE
feat(voice): instrument Gemini Live adapter with LangWatch spans

### DIFF
--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -2086,8 +2086,11 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
       if (adapter.capabilities.interruption) {
         try {
           // voice.adapter.interrupt — executor-owned base span (mirrors
-          // startVoiceAdapters / stopVoiceAdapters). The adapter stamps vendor
-          // outcome attrs onto it from inside its own interrupt().
+          // startVoiceAdapters / stopVoiceAdapters). Rule: executor-invoked + no
+          // shared base body to instrument — connect/disconnect are abstract,
+          // interrupt() is concrete but wholesale-overridden with no super(), so
+          // the call-site is the one seam. The adapter stamps vendor outcome
+          // attrs onto it from inside its own interrupt().
           await voiceSpan(
             "voice.adapter.interrupt",
             { "voice.adapter.class": adapter.constructor.name },

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -2085,7 +2085,16 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
       // 1. Native cancel first (Twilio clear / OpenAI Realtime response.cancel).
       if (adapter.capabilities.interruption) {
         try {
-          await adapter.interrupt();
+          // voice.adapter.interrupt — executor-owned base span (mirrors
+          // startVoiceAdapters / stopVoiceAdapters). The adapter stamps vendor
+          // outcome attrs onto it from inside its own interrupt().
+          await voiceSpan(
+            "voice.adapter.interrupt",
+            { "voice.adapter.class": adapter.constructor.name },
+            async () => {
+              await adapter.interrupt();
+            },
+          );
           nativeFired = true;
         } catch {
           // Best-effort: step 2 (push audio) is the load-bearing barge-in.

--- a/javascript/src/voice/adapters/__tests__/gemini-live-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/gemini-live-spans.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Span-instrumentation tests for GeminiLiveAgentAdapter (#770 / #772, PR2).
+ *
+ * Mic-free: an InMemorySpanExporter captures the spans the REAL production
+ * `defaultVoiceCall` / `drainAgentResponse` emit, plus the `voice.gemini.*`
+ * attributes the adapter stamps onto them; only the `@google/genai` SDK is
+ * mocked (via `vi.mock`), and server messages are injected by calling the
+ * captured `onmessage` callback. Combines the harness from
+ * `voice/__tests__/voice-spans.test.ts` (AsyncLocalStorage context bootstrap +
+ * per-test provider) with the fake-session pattern from
+ * `adapters/__tests__/gemini-live.test.ts`.
+ *
+ * Mirrors the Python `test_voice_spans_gemini.py` ACs that apply to TS:
+ * AC1, AC3, AC4, AC6, AC7, AC8, plus a parity check (AC10). AC2/AC5/AC9 are
+ * either py-executor-loop-shaped or py-only (typed timeout / FirstChunkTimeout
+ * cause); the TS-relevant surface is covered here + by voice-spans.test.ts.
+ *
+ * H2 note (see voice-spans.test.ts): TS has no typed timeout, so a first-chunk
+ * transport error (go_away) is best-effort labelled `first_chunk_timeout` — AC6
+ * asserts ERROR + propagation rather than the py `!= first_chunk_timeout`.
+ */
+
+import { Buffer } from "node:buffer";
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+
+// Register a context manager ONCE so context.with propagates across awaits — the
+// runtime + adapter read currentSpan() after awaits. Without it context.active()
+// is always root and currentSpan() is undefined. (Mirrors voice-spans.test.ts.)
+const _ctxManager = new AsyncLocalStorageContextManager();
+_ctxManager.enable();
+context.setGlobalContextManager(_ctxManager);
+
+// --------------------------------------------------------------------------
+// Mock @google/genai — capture the connect params (onmessage + the FakeSession)
+// so tests can inject server messages and inspect the wire sends. The factory
+// runs lazily at connect() time (dynamic import), after `captured` is defined.
+// --------------------------------------------------------------------------
+
+type FakeSessionHandle = {
+  sendRealtimeInput: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+interface CapturedConnect {
+  model?: string;
+  config?: Record<string, unknown>;
+  onmessage?: (msg: unknown) => void;
+  session?: FakeSessionHandle;
+}
+
+const captured: { last: CapturedConnect | null } = { last: null };
+
+vi.mock("@google/genai", () => {
+  class FakeSession {
+    sendRealtimeInput = vi.fn();
+    close = vi.fn();
+  }
+  return {
+    Modality: { AUDIO: "AUDIO" },
+    GoogleGenAI: class {
+      live = {
+        connect: async (params: {
+          model: string;
+          config: Record<string, unknown>;
+          callbacks?: { onmessage?: (msg: unknown) => void };
+        }) => {
+          const session = new FakeSession();
+          captured.last = {
+            model: params.model,
+            config: params.config,
+            onmessage: params.callbacks?.onmessage,
+            session,
+          };
+          return session;
+        },
+      };
+      constructor(_init: { apiKey?: string }) {}
+    },
+  };
+});
+
+import { GeminiLiveAgentAdapter } from "../gemini-live";
+import { AudioChunk } from "../../audio-chunk";
+import { createAudioMessage } from "../../messages";
+import { voiceSpan } from "../../telemetry";
+import type { AgentInput } from "../../../domain/agents";
+
+// 2400 samples @24kHz → 1600 samples @16kHz → 3200 bytes after the wire resample.
+const USER_BYTES = 4800;
+const WIRE_BYTES = 3200;
+
+function tone(nBytes: number): AudioChunk {
+  const data = new Uint8Array(nBytes);
+  for (let i = 0; i < data.length; i++) data[i] = (i % 250) + 1;
+  return new AudioChunk({ data });
+}
+
+function audioB64(): string {
+  // 4 bytes: two int16 zero samples, little-endian — survives the PCM16 invariant.
+  return Buffer.from(new Uint8Array([0, 0, 0, 0])).toString("base64");
+}
+
+function audioInput(incoming?: AudioChunk): AgentInput {
+  const newMessages = incoming ? [createAudioMessage(incoming, "user")] : [];
+  return { newMessages } as unknown as AgentInput;
+}
+
+function byName(spans: ReadableSpan[]): Record<string, ReadableSpan> {
+  return Object.fromEntries(spans.map((s) => [s.name, s]));
+}
+
+// Server-message shapes receiveAudio reads (camelCase, @google/genai convention).
+function audioMsg(): unknown {
+  return {
+    serverContent: {
+      modelTurn: { parts: [{ inlineData: { data: audioB64() } }] },
+      outputTranscription: { text: "hi" },
+    },
+  };
+}
+function turnCompleteMsg(): unknown {
+  return { serverContent: { turnComplete: true } };
+}
+function interruptedMsg(): unknown {
+  return { serverContent: { interrupted: true } };
+}
+function goAwayMsg(): unknown {
+  return { goAway: { reason: "server terminate" } };
+}
+
+async function connectAdapter(init?: {
+  model?: string;
+  voice?: string;
+}): Promise<{
+  adapter: GeminiLiveAgentAdapter;
+  onmessage: (msg: unknown) => void;
+  session: FakeSessionHandle;
+}> {
+  const adapter = new GeminiLiveAgentAdapter({ apiKey: "test-key", ...init });
+  captured.last = null;
+  await adapter.connect();
+  const c = captured.last as CapturedConnect | null;
+  if (!c?.onmessage || !c.session) {
+    throw new Error("connect() did not register onmessage / session");
+  }
+  return { adapter, onmessage: c.onmessage, session: c.session };
+}
+
+describe("voice.gemini.* span instrumentation (GeminiLiveAgentAdapter)", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    captured.last = null;
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+  afterEach(async () => {
+    await provider.shutdown();
+    trace.disable();
+  });
+
+  // AC1
+  it("AC1: a real call() emits {voice.turn, voice.audio.send, voice.audio.receive} with the Gemini class; greeting emits no send", async () => {
+    const { adapter, onmessage } = await connectAdapter();
+    onmessage(audioMsg());
+    onmessage(turnCompleteMsg());
+    await adapter.call(audioInput(tone(USER_BYTES)));
+
+    const spans = byName(exporter.getFinishedSpans());
+    expect(Object.keys(spans)).toEqual(
+      expect.arrayContaining([
+        "voice.turn",
+        "voice.audio.send",
+        "voice.audio.receive",
+      ]),
+    );
+    expect(spans["voice.turn"].attributes["voice.adapter.class"]).toBe(
+      "GeminiLiveAgentAdapter",
+    );
+
+    // A greeting (no incoming audio) emits NO voice.audio.send span.
+    exporter.reset();
+    onmessage(audioMsg());
+    onmessage(turnCompleteMsg());
+    await adapter.call(audioInput());
+    const names = exporter.getFinishedSpans().map((s) => s.name);
+    expect(names).not.toContain("voice.audio.send");
+    expect(names).toContain("voice.turn");
+    await adapter.disconnect();
+  });
+
+  // AC3
+  it("AC3: voice.audio.send carries voice.gemini.audio.wire_bytes = resampled length; empty resample → 0 + no markers", async () => {
+    const { adapter, session } = await connectAdapter();
+
+    // Non-empty: 4800-byte input → 3200-byte resample + 3 wire sends.
+    await voiceSpan(
+      "voice.audio.send",
+      { "voice.audio.bytes": USER_BYTES },
+      async () => {
+        await adapter.sendAudio(tone(USER_BYTES));
+      },
+    );
+    let send = byName(exporter.getFinishedSpans())["voice.audio.send"];
+    expect(send.attributes["voice.gemini.audio.wire_bytes"]).toBe(WIRE_BYTES);
+    expect(session.sendRealtimeInput.mock.calls.length).toBe(3);
+
+    // Empty resample: 2-byte input (1 sample) → wire_bytes 0, NO markers.
+    exporter.reset();
+    session.sendRealtimeInput.mockClear();
+    await voiceSpan(
+      "voice.audio.send",
+      { "voice.audio.bytes": 2 },
+      async () => {
+        await adapter.sendAudio(tone(2));
+      },
+    );
+    send = byName(exporter.getFinishedSpans())["voice.audio.send"];
+    expect(send.attributes["voice.gemini.audio.wire_bytes"]).toBe(0);
+    expect(session.sendRealtimeInput.mock.calls.length).toBe(0);
+    await adapter.disconnect();
+  });
+
+  // AC4
+  it("AC4: voice.audio.receive carries spurious_retry_count == K and turn_complete=true (K=0 on a clean turn)", async () => {
+    const { adapter, onmessage } = await connectAdapter();
+
+    // K = 0 — a clean turn.
+    onmessage(audioMsg());
+    onmessage(turnCompleteMsg());
+    await adapter.call(audioInput(tone(USER_BYTES)));
+    let recv = byName(exporter.getFinishedSpans())["voice.audio.receive"];
+    expect(recv.attributes["voice.gemini.spurious_retry_count"]).toBe(0);
+    expect(recv.attributes["voice.gemini.turn_complete"]).toBe(true);
+
+    // K = 3 — three scripted spurious interrupted→turnComplete pairs then real audio.
+    exporter.reset();
+    for (let i = 0; i < 3; i++) {
+      onmessage(interruptedMsg());
+      onmessage(turnCompleteMsg());
+    }
+    onmessage(audioMsg());
+    onmessage(turnCompleteMsg());
+    await adapter.call(audioInput(tone(USER_BYTES)));
+    recv = byName(exporter.getFinishedSpans())["voice.audio.receive"];
+    expect(recv.attributes["voice.gemini.spurious_retry_count"]).toBe(3);
+    expect(recv.attributes["voice.gemini.turn_complete"]).toBe(true);
+    await adapter.disconnect();
+  });
+
+  // AC6 (H2 asymmetry — see file header)
+  it("AC6: a go_away on the first chunk → voice.audio.receive ERROR and the error propagates", async () => {
+    const { adapter, onmessage } = await connectAdapter();
+    onmessage(goAwayMsg());
+    await expect(adapter.call(audioInput())).rejects.toThrow(/goAway/i);
+    const recv = byName(exporter.getFinishedSpans())["voice.audio.receive"];
+    expect(recv.status.code).toBe(SpanStatusCode.ERROR);
+    await adapter.disconnect();
+  });
+
+  // AC7
+  it("AC7: interrupt() stamps sentinel_fired when connected, no_op_not_connected when not", async () => {
+    const { adapter } = await connectAdapter();
+    await voiceSpan(
+      "voice.adapter.interrupt",
+      { "voice.adapter.class": adapter.constructor.name },
+      async () => {
+        await adapter.interrupt();
+      },
+    );
+    let span = byName(exporter.getFinishedSpans())["voice.adapter.interrupt"];
+    expect(span.attributes["voice.adapter.class"]).toBe("GeminiLiveAgentAdapter");
+    expect(span.attributes["voice.gemini.interrupt.outcome"]).toBe("sentinel_fired");
+    await adapter.disconnect();
+
+    // Not connected → the no-op branch.
+    exporter.reset();
+    const adapter2 = new GeminiLiveAgentAdapter({ apiKey: "k" });
+    await voiceSpan(
+      "voice.adapter.interrupt",
+      { "voice.adapter.class": adapter2.constructor.name },
+      async () => {
+        await adapter2.interrupt();
+      },
+    );
+    span = byName(exporter.getFinishedSpans())["voice.adapter.interrupt"];
+    expect(span.attributes["voice.gemini.interrupt.outcome"]).toBe(
+      "no_op_not_connected",
+    );
+  });
+
+  // AC8
+  it("AC8: exactly one voice.audio.receive span per turn; total voice.* span count invariant to spurious-retry count", async () => {
+    const { adapter, onmessage } = await connectAdapter();
+
+    onmessage(interruptedMsg());
+    onmessage(turnCompleteMsg());
+    onmessage(audioMsg());
+    onmessage(turnCompleteMsg());
+    await adapter.call(audioInput(tone(USER_BYTES)));
+    let vs = exporter
+      .getFinishedSpans()
+      .filter((s) => s.name.startsWith("voice."));
+    const count1 = vs.length;
+    expect(vs.filter((s) => s.name === "voice.audio.receive").length).toBe(1);
+
+    exporter.reset();
+    for (let i = 0; i < 3; i++) {
+      onmessage(interruptedMsg());
+      onmessage(turnCompleteMsg());
+    }
+    onmessage(audioMsg());
+    onmessage(turnCompleteMsg());
+    await adapter.call(audioInput(tone(USER_BYTES)));
+    vs = exporter.getFinishedSpans().filter((s) => s.name.startsWith("voice."));
+    const count3 = vs.length;
+    expect(vs.filter((s) => s.name === "voice.audio.receive").length).toBe(1);
+    expect(count1).toBe(count3);
+    await adapter.disconnect();
+  });
+
+  // AC10 — cross-language parity
+  it("AC10 (parity): the voice.* span-name set + voice.gemini.* attr keys match the Python taxonomy", async () => {
+    // Drive each phase inside the matching executor-owned base span (as the
+    // executor loops do in production) so every taxonomy element is emitted.
+    const adapter = new GeminiLiveAgentAdapter({ apiKey: "k", voice: "Algieba" });
+    captured.last = null;
+    await voiceSpan(
+      "voice.adapter.connect",
+      { "voice.adapter.class": adapter.constructor.name },
+      async () => {
+        await adapter.connect();
+      },
+    );
+    const c = captured.last as CapturedConnect | null;
+    const onmessage = c?.onmessage;
+    if (!onmessage) throw new Error("connect() did not register onmessage");
+    onmessage(audioMsg());
+    onmessage(turnCompleteMsg());
+    await adapter.call(audioInput(tone(USER_BYTES)));
+    await voiceSpan(
+      "voice.adapter.interrupt",
+      { "voice.adapter.class": adapter.constructor.name },
+      async () => {
+        await adapter.interrupt();
+      },
+    );
+    await voiceSpan(
+      "voice.adapter.disconnect",
+      { "voice.adapter.class": adapter.constructor.name },
+      async () => {
+        await adapter.disconnect();
+      },
+    );
+
+    const spans = exporter.getFinishedSpans();
+    const spanNames = new Set(
+      spans.map((s) => s.name).filter((n) => n.startsWith("voice.")),
+    );
+    const geminiKeys = new Set<string>();
+    for (const s of spans) {
+      for (const k of Object.keys(s.attributes)) {
+        if (k.startsWith("voice.gemini.")) geminiKeys.add(k);
+      }
+    }
+
+    expect([...spanNames].sort()).toEqual([
+      "voice.adapter.connect",
+      "voice.adapter.disconnect",
+      "voice.adapter.interrupt",
+      "voice.audio.receive",
+      "voice.audio.send",
+      "voice.turn",
+    ]);
+    // TS emits every Python voice.gemini.* key EXCEPT interrupt.drained_chunks:
+    // Python drains the cancelled turn with a 2s bound (pull iterator) and counts
+    // the drained messages; the JS SDK is a passive abort-sentinel (push callback)
+    // with no drain, so there is no count to report. Documented asymmetry.
+    expect([...geminiKeys].sort()).toEqual([
+      "voice.gemini.audio.wire_bytes",
+      "voice.gemini.interrupt.outcome",
+      "voice.gemini.model",
+      "voice.gemini.spurious_retry_count",
+      "voice.gemini.turn_complete",
+      "voice.gemini.voice",
+    ]);
+  });
+});

--- a/javascript/src/voice/adapters/gemini-live.ts
+++ b/javascript/src/voice/adapters/gemini-live.ts
@@ -310,8 +310,11 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
   async sendAudio(chunk: AudioChunk): Promise<void> {
     this.requireConnected();
     const pcm16k = resamplePcm16(chunk.data, CANONICAL_RATE, GEMINI_INPUT_RATE);
-    // New user turn → reset the per-turn spurious-retry counter so the count
-    // stamped at this turn's turnComplete reflects only THIS turn's drain.
+    // New user turn → reset the per-turn spurious-retry counter here, alongside
+    // iterHadAudio's own reset. receiveAudio() is per-chunk (queue-based, no
+    // per-drain hook like Python's fresh-iterator branch), so sendAudio is the
+    // per-turn seam. (A no-incoming turn skips this — a low-severity stale-count
+    // edge shared with iterHadAudio; tracked as a follow-up.)
     this.spuriousRetryCount = 0;
     if (pcm16k.length === 0) {
       // Sub-sample chunk resampled to empty: nothing to send. Stamp wire_bytes=0

--- a/javascript/src/voice/adapters/gemini-live.ts
+++ b/javascript/src/voice/adapters/gemini-live.ts
@@ -35,6 +35,7 @@ import { Buffer } from "node:buffer";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
+import { currentSpan, setSpanAttributes } from "../telemetry";
 import { GEMINI_LIVE_MODEL } from "../voice-models";
 
 /** Gemini Live ingests PCM16 at 16kHz. */
@@ -160,6 +161,13 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
   /** Tracks whether the current turn iterator has yielded any audio. */
   private iterHadAudio = false;
   /**
+   * Count of spurious interrupted→turnComplete re-entries during the CURRENT
+   * turn's drain (reset per turn in {@link sendAudio}). Stamped onto the
+   * inherited voice.audio.receive span at turnComplete — receiveAudio never
+   * opens a span of its own (exactly one receive span per turn).
+   */
+  private spuriousRetryCount = 0;
+  /**
    * Abort-sentinel flag. Set by `interrupt()` to signal that any in-flight
    * `receiveAudio()` should return the cut-off sentinel immediately. Cleared
    * by `receiveAudio()` when it observes the flag.
@@ -250,6 +258,13 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
       },
     });
     this.connected = true;
+    // Stamp Gemini-specific attrs onto the active voice.adapter.connect span
+    // (opened by the executor connect loop). Base spans are name-owned; the
+    // adapter contributes attributes, never a parallel voice.gemini.* span.
+    setSpanAttributes(currentSpan(), {
+      "voice.gemini.model": this.model,
+      "voice.gemini.voice": this.voice,
+    });
   }
 
   /** Whether the Gemini Live session is open (Gap #11). */
@@ -295,7 +310,21 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
   async sendAudio(chunk: AudioChunk): Promise<void> {
     this.requireConnected();
     const pcm16k = resamplePcm16(chunk.data, CANONICAL_RATE, GEMINI_INPUT_RATE);
-    if (pcm16k.length === 0) return;
+    // New user turn → reset the per-turn spurious-retry counter so the count
+    // stamped at this turn's turnComplete reflects only THIS turn's drain.
+    this.spuriousRetryCount = 0;
+    if (pcm16k.length === 0) {
+      // Sub-sample chunk resampled to empty: nothing to send. Stamp wire_bytes=0
+      // onto the active voice.audio.send span (base-owned name) and return
+      // WITHOUT emitting activity markers.
+      setSpanAttributes(currentSpan(), { "voice.gemini.audio.wire_bytes": 0 });
+      return;
+    }
+    // Stamp the resampled wire size onto the active voice.audio.send span; the
+    // base owns the span name, the adapter contributes voice.gemini.* attrs.
+    setSpanAttributes(currentSpan(), {
+      "voice.gemini.audio.wire_bytes": pcm16k.length,
+    });
 
     // New user turn — reset the per-turn transcript so the agent's first
     // reply text doesn't get permanently prefixed onto every subsequent turn.
@@ -462,6 +491,9 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
         // deliberate async delay between the spurious pair and the real
         // audio.
         if (sawInterrupted && !this.iterHadAudio && !pendingTranscript) {
+          // Spurious re-entry — count it so the running total lands on the
+          // inherited voice.audio.receive span at the real turnComplete below.
+          this.spuriousRetryCount++;
           // Reset iterator-scope state — as if session.receive() was
           // re-created (Python's pattern).
           sawInterrupted = false;
@@ -474,7 +506,14 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
           );
           continue;
         }
-        // Real end-of-turn — yield empty AudioChunk.
+        // Real end-of-turn — stamp Gemini attrs onto the active
+        // voice.audio.receive span (base-owned name; receiveAudio opens NO span
+        // of its own — exactly one receive span per turn), then yield the empty
+        // AudioChunk.
+        setSpanAttributes(currentSpan(), {
+          "voice.gemini.turn_complete": true,
+          "voice.gemini.spurious_retry_count": this.spuriousRetryCount,
+        });
         return new AudioChunk({
           data: new Uint8Array(0),
           transcript: pendingTranscript || undefined,
@@ -509,7 +548,19 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
    * stays set and `receiveAudio()` catches it at the top of its next iteration.
    */
   override async interrupt(): Promise<void> {
-    if (!this.connected) return;
+    if (!this.connected) {
+      // py/ts asymmetry (genuine SDK difference): Python's interrupt() DRAINS
+      // the cancelled turn with a 2s bound (pull iterator) and reports
+      // "drained_to_turn_complete" / "drain_timeout_2s"; the JS SDK delivers
+      // messages via a push callback, so interrupt() here is a passive
+      // abort-sentinel that flags + returns with NO drain (hence no
+      // drained_chunks count). Stamp the no-op outcome onto the active
+      // voice.adapter.interrupt span.
+      setSpanAttributes(currentSpan(), {
+        "voice.gemini.interrupt.outcome": "no_op_not_connected",
+      });
+      return;
+    }
     // Set the abort flag first — receiveAudio() checks this at the top of
     // each iteration, so even if the resolver wake-up races it, the flag
     // will be seen on the next loop pass.
@@ -521,6 +572,12 @@ export class GeminiLiveAgentAdapter extends VoiceAgentAdapter {
     const resolver = this.resolveNext;
     this.resolveNext = null;
     resolver?.({ interrupted: true });
+    // Stamp the sentinel outcome onto the active voice.adapter.interrupt span
+    // (base-owned name). See the py/ts asymmetry note above — no drain here,
+    // so no drained_chunks attribute (that is Python-only).
+    setSpanAttributes(currentSpan(), {
+      "voice.gemini.interrupt.outcome": "sentinel_fired",
+    });
   }
 
   // ------------------------------------------------------------- internal

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1343,9 +1343,13 @@ class ScenarioExecutor:
                 try:
                     # ``voice.adapter.interrupt`` — the executor-owned base span
                     # (mirrors ``_voice_connect_all`` / ``_voice_disconnect_all``).
-                    # Adapters stamp vendor outcome attrs onto it from inside their
-                    # own interrupt(); the span's OK/ERROR status is set BEFORE the
-                    # swallow below discards a transport error.
+                    # Rule for executor-owned spans: executor-invoked + no shared
+                    # base body to instrument. connect/disconnect are abstract;
+                    # interrupt() is concrete (default raises UnsupportedCapability)
+                    # but wholesale-overridden with no super(), so the call-site is
+                    # the one seam. Adapters stamp vendor outcome attrs onto it from
+                    # inside their own interrupt(); the span's OK/ERROR status is set
+                    # BEFORE the swallow below discards a transport error.
                     with voice_span(
                         "voice.adapter.interrupt",
                         {"voice.adapter.class": type(adapter).__name__},

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1338,8 +1338,19 @@ class ScenarioExecutor:
             #    the bot's buffered outbound audio on transports that honor
             #    it (Twilio ``clear``, OpenAI Realtime ``response.cancel``).
             if adapter.capabilities.interruption:
+                from .voice._telemetry import voice_span
+
                 try:
-                    await adapter.interrupt()
+                    # ``voice.adapter.interrupt`` — the executor-owned base span
+                    # (mirrors ``_voice_connect_all`` / ``_voice_disconnect_all``).
+                    # Adapters stamp vendor outcome attrs onto it from inside their
+                    # own interrupt(); the span's OK/ERROR status is set BEFORE the
+                    # swallow below discards a transport error.
+                    with voice_span(
+                        "voice.adapter.interrupt",
+                        {"voice.adapter.class": type(adapter).__name__},
+                    ):
+                        await adapter.interrupt()
                     native_interrupt_fired = True
                 except Exception:
                     # Best-effort native cancel — adapters' interrupt() may

--- a/python/scenario/voice/adapters/gemini_live.py
+++ b/python/scenario/voice/adapters/gemini_live.py
@@ -37,10 +37,13 @@ import logging
 import os
 from typing import Any, ClassVar, Optional
 
+from opentelemetry import trace as _otel_trace
+
 from ...config.voice_models import GEMINI_LIVE_MODEL
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
 from ..capabilities import AdapterCapabilities
+from .._telemetry import set_span_attributes
 
 
 logger = logging.getLogger("scenario.voice.gemini_live")
@@ -148,6 +151,11 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
         # (no audio at all) from a real mid-reply interrupt (audio
         # arrived before the interrupt landed).
         self._iter_had_audio: bool = False
+        # Count of spurious interrupt→turn_complete re-entries during the CURRENT
+        # turn's drain (reset per turn in ``send_audio``). Stamped onto the
+        # inherited ``voice.audio.receive`` span at turn_complete — recv_audio
+        # never opens a span of its own (exactly one receive span per turn).
+        self._spurious_retry_count: int = 0
 
         # Observability.
         self.last_agent_transcript: Optional[str] = None
@@ -254,6 +262,13 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
 
         self._session = await session_future
         self._recv_iter = None
+        # Stamp Gemini-specific attrs onto the active ``voice.adapter.connect``
+        # span (opened by the executor connect loop). Base spans are name-owned;
+        # the adapter contributes attributes, never a parallel voice.gemini.* span.
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {"voice.gemini.model": self.model, "voice.gemini.voice": self.voice},
+        )
         logger.debug("GeminiLiveAgentAdapter: connected model=%s", self.model)
 
     async def disconnect(self) -> None:
@@ -310,8 +325,24 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
         from google.genai import types  # noqa: PLC0415
 
         pcm_16k = _resample_pcm16(chunk.data, CANONICAL_RATE, GEMINI_INPUT_RATE)
+        # New user turn → reset the per-turn spurious-retry counter so the count
+        # stamped at this turn's turn_complete reflects only THIS turn's drain.
+        self._spurious_retry_count = 0
         if not pcm_16k:
+            # Sub-sample chunk resampled to empty: nothing to send. Stamp
+            # wire_bytes=0 onto the active ``voice.audio.send`` span (base-owned
+            # name) and return WITHOUT emitting activity markers.
+            set_span_attributes(
+                _otel_trace.get_current_span(),
+                {"voice.gemini.audio.wire_bytes": 0},
+            )
             return
+        # Stamp the resampled wire size onto the active ``voice.audio.send`` span;
+        # the base owns the span name, the adapter contributes voice.gemini.* attrs.
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {"voice.gemini.audio.wire_bytes": len(pcm_16k)},
+        )
         # New user turn → reset transcript and the per-turn receive
         # iterator so the next ``recv_audio`` enters
         # ``session.receive()`` fresh for this turn.
@@ -441,13 +472,28 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
                         and not self._iter_had_audio
                         and not pending_delta
                     ):
+                        # Spurious re-entry — count it so the running total lands
+                        # on the inherited ``voice.audio.receive`` span at the real
+                        # turn_complete below (additive across the N recv_audio
+                        # calls in one drain).
+                        self._spurious_retry_count += 1
                         self._recv_iter = self._session.receive().__aiter__()  # type: ignore[union-attr]
                         self._iter_had_audio = False
                         saw_interrupted = False
                         continue
-                    # Real end-of-turn — yield empty AudioChunk and reset
-                    # the iterator. The next ``recv_audio`` call (for the
-                    # next user turn) will re-enter ``session.receive()``.
+                    # Real end-of-turn — stamp Gemini attrs onto the active
+                    # ``voice.audio.receive`` span (base-owned name; recv_audio
+                    # opens NO span of its own — exactly one receive span per
+                    # turn), then yield the empty AudioChunk and reset the
+                    # iterator. The next ``recv_audio`` call (for the next user
+                    # turn) will re-enter ``session.receive()``.
+                    set_span_attributes(
+                        _otel_trace.get_current_span(),
+                        {
+                            "voice.gemini.turn_complete": True,
+                            "voice.gemini.spurious_retry_count": self._spurious_retry_count,
+                        },
+                    )
                     self._recv_iter = None
                     return AudioChunk(
                         data=b"",
@@ -474,7 +520,19 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
         block the executor's interrupt sequence.
         """
         if self._session is None or self._recv_iter is None:
+            # No active turn to drain. Stamp the no-op outcome onto the active
+            # ``voice.adapter.interrupt`` span (opened by the executor interrupt
+            # site) and return.
+            set_span_attributes(
+                _otel_trace.get_current_span(),
+                {
+                    "voice.gemini.interrupt.outcome": "no_op_not_connected",
+                    "voice.gemini.interrupt.drained_chunks": 0,
+                },
+            )
             return
+        drained_chunks = 0
+        outcome = "drained_to_turn_complete"
         try:
             async with asyncio.timeout(2.0):
                 while True:
@@ -482,6 +540,7 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
                         message = await self._recv_iter.__anext__()  # type: ignore[union-attr]
                     except StopAsyncIteration:
                         break
+                    drained_chunks += 1
                     sc = getattr(message, "server_content", None)
                     if sc is not None and sc.turn_complete:
                         break
@@ -489,7 +548,7 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
             # Bounded drain: if the server doesn't close out the turn within
             # 2s after we sent the activity_end, give up and proceed. The
             # finally block will still close the iterator.
-            pass
+            outcome = "drain_timeout_2s"
         finally:
             try:
                 await self._recv_iter.aclose()  # type: ignore[attr-defined]
@@ -498,6 +557,18 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
                 # or in an error state. Don't mask the original outcome.
                 pass
             self._recv_iter = None
+        # Stamp the interrupt outcome onto the active ``voice.adapter.interrupt``
+        # span (base-owned name; the adapter contributes voice.gemini.* attrs).
+        # py DRAINS the cancelled turn with a 2s bound (pull iterator); the TS
+        # mirror is a passive abort-sentinel (push callback) — see
+        # ``gemini-live.ts`` ``interrupt()`` for the genuine SDK asymmetry.
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {
+                "voice.gemini.interrupt.outcome": outcome,
+                "voice.gemini.interrupt.drained_chunks": drained_chunks,
+            },
+        )
 
     def _reset_turn_transcript(self) -> None:
         """Clear the running transcript before each new agent turn.

--- a/python/scenario/voice/adapters/gemini_live.py
+++ b/python/scenario/voice/adapters/gemini_live.py
@@ -325,9 +325,6 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
         from google.genai import types  # noqa: PLC0415
 
         pcm_16k = _resample_pcm16(chunk.data, CANONICAL_RATE, GEMINI_INPUT_RATE)
-        # New user turn → reset the per-turn spurious-retry counter so the count
-        # stamped at this turn's turn_complete reflects only THIS turn's drain.
-        self._spurious_retry_count = 0
         if not pcm_16k:
             # Sub-sample chunk resampled to empty: nothing to send. Stamp
             # wire_bytes=0 onto the active ``voice.audio.send`` span (base-owned
@@ -391,6 +388,10 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
         if self._recv_iter is None:
             self._recv_iter = self._session.receive().__aiter__()  # type: ignore[union-attr]
             self._iter_had_audio = False
+            # Reset the per-turn spurious-retry counter at drain start (alongside
+            # _iter_had_audio) so the count stamped at turn_complete reflects only
+            # THIS turn — correct even for a no-incoming turn that skips send_audio.
+            self._spurious_retry_count = 0
 
         async def _next_chunk() -> AudioChunk:
             pending_delta = ""

--- a/python/tests/voice/test_voice_spans_gemini.py
+++ b/python/tests/voice/test_voice_spans_gemini.py
@@ -1,0 +1,564 @@
+"""Gemini-Live voice-span attributes (#770 / #772, PR2 of the epic).
+
+Drives the REAL ``GeminiLiveAgentAdapter`` — its production ``connect`` /
+``send_audio`` / ``recv_audio`` / ``interrupt`` — against a faked ``genai.Client``
+whose session yields scripted ``server_content`` messages (the
+``test_gemini_live_echo_safe.py::test_wrapper_real_connect_call_disconnect_smoke``
+pattern), asserting the Gemini contributions onto the base/executor spans:
+
+  - ``voice.gemini.model`` / ``voice.gemini.voice`` on ``voice.adapter.connect``
+  - ``voice.gemini.audio.wire_bytes`` on ``voice.audio.send``
+  - ``voice.gemini.turn_complete`` / ``voice.gemini.spurious_retry_count`` on the
+    inherited ``voice.audio.receive`` span
+  - ``voice.gemini.interrupt.outcome`` / ``voice.gemini.interrupt.drained_chunks``
+    on the executor-owned ``voice.adapter.interrupt`` span
+
+Gemini overrides transport primitives ONLY, so it INHERITS ``voice.turn`` /
+``voice.audio.send`` / ``voice.audio.receive`` (base ``call``/``_drain_agent_response``)
+and the executor lifecycle spans for free — several ACs here are regression locks
+proving that inheritance rather than RED→GREEN of a new stamp.
+
+Vendor transport is faked at the network-client boundary (``genai.Client``),
+never by substituting a stub for adapter privates — the ban #697 exists for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, List
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+from opentelemetry.util._once import Once
+
+from scenario.config.voice_models import GEMINI_LIVE_MODEL
+from scenario.scenario_executor import ScenarioExecutor
+from scenario.voice.adapter import FirstChunkTimeoutError
+from scenario.voice.adapters.gemini_live import GeminiLiveAgentAdapter
+from scenario.voice.audio_chunk import AudioChunk
+from scenario.voice.testing import drive_call, make_agent_input
+from scenario.voice._telemetry import voice_span
+
+from ._span_assert import attrs, int_attr
+
+
+@pytest.fixture(autouse=True)
+def reset_otel():
+    def _reset() -> None:
+        trace._TRACER_PROVIDER = None
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _install_in_memory_provider() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+def _fresh_provider() -> InMemorySpanExporter:
+    """Reset the set-once guard and install a NEW provider (for multi-run tests)."""
+    trace._TRACER_PROVIDER = None
+    trace._TRACER_PROVIDER_SET_ONCE = Once()
+    return _install_in_memory_provider()
+
+
+def _by_name(spans):
+    return {s.name: s for s in spans}
+
+
+# --------------------------------------------------------------------------- #
+# Duck-typed Gemini Live server-message shapes (no google-genai import here).
+# Mirrors ``test_gemini_live_echo_safe.py`` — recv_audio reads message.go_away,
+# message.server_content{.interrupted,.output_transcription.text,.model_turn.parts,
+# .turn_complete}.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeInlineData:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+
+class _FakePart:
+    def __init__(self, data: bytes) -> None:
+        self.inline_data = _FakeInlineData(data)
+
+
+class _FakeModelTurn:
+    def __init__(self, parts: List[_FakePart]) -> None:
+        self.parts = parts
+
+
+class _FakeTranscription:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeServerContent:
+    def __init__(
+        self,
+        *,
+        output_transcription: Any = None,
+        model_turn: Any = None,
+        turn_complete: bool = False,
+        interrupted: bool = False,
+    ) -> None:
+        self.output_transcription = output_transcription
+        self.model_turn = model_turn
+        self.turn_complete = turn_complete
+        self.interrupted = interrupted
+
+
+class _FakeLiveServerMessage:
+    def __init__(self, server_content: Any) -> None:
+        self.go_away = None
+        self.server_content = server_content
+
+
+class _GoAwayMessage:
+    """A server-terminate message: recv_audio raises on ``go_away is not None``."""
+
+    def __init__(self) -> None:
+        self.go_away = "server terminate"
+        self.server_content = None
+
+
+class _FakeSession:
+    """Duck-typed ``AsyncSession``: ``receive()`` returns a fresh generator per
+    call that yields the NEXT scheduled turn's messages then stops — matching the
+    real one-turn-per-generator SDK contract that recv_audio re-enters on each
+    spurious pair and each new user turn."""
+
+    def __init__(self, turns: List[List[Any]]) -> None:
+        self._turns = list(turns)
+        self._turn_idx = 0
+        self.sent: List[Any] = []
+
+    def receive(self):
+        if self._turn_idx < len(self._turns):
+            msgs = self._turns[self._turn_idx]
+            self._turn_idx += 1
+        else:
+            msgs = []
+
+        async def _gen():
+            for m in msgs:
+                await asyncio.sleep(0)
+                yield m
+
+        return _gen()
+
+    async def send_realtime_input(self, **kwargs: Any) -> None:
+        self.sent.append(kwargs)
+
+    async def close(self) -> None:
+        pass
+
+
+class _HangSession:
+    """A session whose ``receive()`` never yields — forces a recv timeout."""
+
+    def __init__(self) -> None:
+        self.sent: List[Any] = []
+
+    async def send_realtime_input(self, **kwargs: Any) -> None:
+        self.sent.append(kwargs)
+
+    async def close(self) -> None:
+        pass
+
+    def receive(self):
+        async def _gen():
+            await asyncio.sleep(3600)
+            yield None  # pragma: no cover — never reached before the recv timeout
+
+        return _gen()
+
+
+def _make_pcm(n_samples: int = 2400) -> bytes:
+    """Silent PCM16 mono @24kHz (2400 samples → 3200 bytes after 24k→16k)."""
+    return b"\x00\x00" * n_samples
+
+
+def _real_audio_turn(transcript: str = "hello there") -> List[_FakeLiveServerMessage]:
+    """One agent turn: an audio+transcript message, then turn_complete."""
+    return [
+        _FakeLiveServerMessage(
+            _FakeServerContent(
+                output_transcription=_FakeTranscription(transcript),
+                model_turn=_FakeModelTurn([_FakePart(_make_pcm(2400))]),
+            )
+        ),
+        _FakeLiveServerMessage(_FakeServerContent(turn_complete=True)),
+    ]
+
+
+def _spurious_pair() -> List[_FakeLiveServerMessage]:
+    """The spurious empty-interrupt turn Gemini emits between turns:
+    ``interrupted`` then ``turn_complete`` with no audio/transcript."""
+    return [
+        _FakeLiveServerMessage(_FakeServerContent(interrupted=True)),
+        _FakeLiveServerMessage(_FakeServerContent(turn_complete=True)),
+    ]
+
+
+def _install_fake_client(monkeypatch, session) -> None:
+    """Monkeypatch ``genai.Client`` so the REAL ``connect()`` builds its real
+    LiveConnectConfig + background session task against ``session``."""
+    from google import genai
+
+    class _CM:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+    class _Live:
+        def connect(self, *, model, config):
+            return _CM()
+
+    class _Aio:
+        live = _Live()
+
+    class _Client:
+        def __init__(self, api_key=None):
+            self.aio = _Aio()
+
+    monkeypatch.setattr(genai, "Client", _Client)
+
+
+# --- AC1 ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac1_call_emits_voice_span_set_with_gemini_class(monkeypatch):
+    """AC1: a bare call() emits {voice.turn, voice.audio.send, voice.audio.receive}
+    with voice.turn carrying voice.adapter.class == 'GeminiLiveAgentAdapter'; a
+    no-incoming (greeting) turn emits NO voice.audio.send. All base-owned — Gemini
+    inherits call()/_drain_agent_response unchanged."""
+    exporter = _install_in_memory_provider()
+    _install_fake_client(monkeypatch, _FakeSession([_real_audio_turn()]))
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    await adapter.connect()
+    try:
+        await drive_call(
+            adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(2400)))
+        )
+    finally:
+        await adapter.disconnect()
+
+    spans = _by_name(exporter.get_finished_spans())
+    assert {"voice.turn", "voice.audio.send", "voice.audio.receive"} <= set(spans)
+    assert attrs(spans["voice.turn"])["voice.adapter.class"] == "GeminiLiveAgentAdapter"
+
+    # A greeting (no incoming audio) emits NO voice.audio.send span.
+    exporter2 = _fresh_provider()
+    _install_fake_client(monkeypatch, _FakeSession([_real_audio_turn()]))
+    adapter2 = GeminiLiveAgentAdapter(api_key="test-gk")
+    await adapter2.connect()
+    try:
+        await drive_call(adapter2, make_agent_input())  # greeting → no send
+    finally:
+        await adapter2.disconnect()
+    names2 = [s.name for s in exporter2.get_finished_spans()]
+    assert "voice.audio.send" not in names2
+    assert "voice.turn" in names2
+
+
+# --- AC2 ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac2_connect_span_carries_gemini_model_and_voice(monkeypatch):
+    """AC2: driving the executor connect/disconnect loops emits
+    voice.adapter.connect (carrying voice.gemini.model + voice.gemini.voice) and
+    voice.adapter.disconnect, both with the class attr."""
+    exporter = _install_in_memory_provider()
+    _install_fake_client(monkeypatch, _FakeSession([]))
+    adapter = GeminiLiveAgentAdapter(voice="Puck", api_key="test-gk")
+    executor = ScenarioExecutor(
+        name="gemini-connect-span", description="t", agents=[adapter], script=[]
+    )
+    await executor._voice_connect_all()
+    await executor._voice_disconnect_all()
+
+    spans = _by_name(exporter.get_finished_spans())
+    connect = spans["voice.adapter.connect"]
+    assert attrs(connect)["voice.adapter.class"] == "GeminiLiveAgentAdapter"
+    assert attrs(connect)["voice.gemini.model"] == GEMINI_LIVE_MODEL
+    assert attrs(connect)["voice.gemini.voice"] == "Puck"
+    disconnect = spans["voice.adapter.disconnect"]
+    assert attrs(disconnect)["voice.adapter.class"] == "GeminiLiveAgentAdapter"
+
+
+# --- AC3 ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac3_send_span_carries_gemini_wire_bytes(monkeypatch):
+    """AC3: voice.audio.send carries voice.gemini.audio.wire_bytes == the resampled
+    length (2400 samples @24k → 1600 @16k → 3200 bytes), and the turn was framed."""
+    exporter = _install_in_memory_provider()
+    session = _FakeSession([_real_audio_turn()])
+    _install_fake_client(monkeypatch, session)
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    await adapter.connect()
+    try:
+        await drive_call(
+            adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(2400)))
+        )
+    finally:
+        await adapter.disconnect()
+    send = _by_name(exporter.get_finished_spans())["voice.audio.send"]
+    assert int_attr(send, "voice.gemini.audio.wire_bytes") == 3200
+    # The real resample ran and framed a full turn: activity_start / audio / activity_end.
+    assert len(session.sent) == 3
+
+
+@pytest.mark.asyncio
+async def test_ac3_empty_resample_stamps_zero_and_sends_no_markers(monkeypatch):
+    """AC3 edge: a chunk that resamples to empty → voice.audio.send present with
+    wire_bytes==0 and the session receives NO activity_start/audio/activity_end."""
+    exporter = _install_in_memory_provider()
+    session = _FakeSession([_real_audio_turn()])
+    _install_fake_client(monkeypatch, session)
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    await adapter.connect()
+    try:
+        # 1 sample @24k → int(1*16000/24000)==0 → empty resample.
+        await drive_call(adapter, make_agent_input(user_audio=AudioChunk(data=b"\x00\x00")))
+    finally:
+        await adapter.disconnect()
+    send = _by_name(exporter.get_finished_spans())["voice.audio.send"]
+    assert int_attr(send, "voice.gemini.audio.wire_bytes") == 0
+    assert session.sent == []  # no activity_start / audio / activity_end
+
+
+# --- AC4 ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("k", [0, 1, 3])
+async def test_ac4_receive_span_carries_spurious_retry_count(monkeypatch, k):
+    """AC4: after a drain with K scripted spurious interrupt→turn_complete pairs
+    then real audio, voice.audio.receive carries voice.gemini.spurious_retry_count
+    == K and voice.gemini.turn_complete True (K==0 on a clean turn)."""
+    exporter = _install_in_memory_provider()
+    session = _FakeSession([_spurious_pair() for _ in range(k)] + [_real_audio_turn()])
+    _install_fake_client(monkeypatch, session)
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    await adapter.connect()
+    try:
+        await drive_call(
+            adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(2400)))
+        )
+    finally:
+        await adapter.disconnect()
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    assert int_attr(recv, "voice.gemini.spurious_retry_count") == k
+    assert attrs(recv)["voice.gemini.turn_complete"] is True
+
+
+# --- AC5 (inherited) ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac5_first_chunk_timeout_marks_error_and_chains_cause(monkeypatch):
+    """AC5 (inherited): a first-chunk recv timeout → voice.audio.receive ERROR +
+    terminated_reason=='first_chunk_timeout', and the original asyncio.TimeoutError
+    survives as FirstChunkTimeoutError.__cause__ — Gemini flows through the base
+    contract unchanged."""
+    exporter = _install_in_memory_provider()
+    _install_fake_client(monkeypatch, _HangSession())
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    adapter.response_timeout = 0.05  # keep the first-chunk wait short
+    await adapter.connect()
+    try:
+        with pytest.raises(FirstChunkTimeoutError) as excinfo:
+            await drive_call(adapter, make_agent_input())
+        assert isinstance(excinfo.value.__cause__, asyncio.TimeoutError)
+    finally:
+        await adapter.disconnect()
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    assert recv.status.status_code == StatusCode.ERROR
+    assert attrs(recv)["voice.audio.terminated_reason"] == "first_chunk_timeout"
+
+
+# --- AC6 (inherited) ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac6_go_away_marks_error_without_timeout_label(monkeypatch):
+    """AC6 (inherited): a go_away (server terminate) on the first chunk → the
+    RuntimeError propagates, voice.audio.receive is ERROR, and terminated_reason is
+    NOT 'first_chunk_timeout' (a real transport error, not a timeout)."""
+    exporter = _install_in_memory_provider()
+    _install_fake_client(monkeypatch, _FakeSession([[_GoAwayMessage()]]))
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    await adapter.connect()
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            await drive_call(adapter, make_agent_input())
+        assert "go_away" in str(excinfo.value)
+    finally:
+        await adapter.disconnect()
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    assert recv.status.status_code == StatusCode.ERROR
+    assert attrs(recv).get("voice.audio.terminated_reason") != "first_chunk_timeout"
+
+
+# --- AC7 ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac7a_executor_interrupt_site_opens_span_and_stamps_outcome():
+    """AC7: the executor interrupt site opens a voice.adapter.interrupt span (the
+    6th executor-owned base span) and the adapter stamps its outcome onto it. A
+    recv iterator that yields turn_complete immediately →
+    outcome=='drained_to_turn_complete' with an int drained_chunks."""
+    exporter = _install_in_memory_provider()
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    # interrupt() only needs a non-None session + a recv iterator to drain.
+    adapter._session = object()
+
+    async def _tc_gen():
+        yield _FakeLiveServerMessage(_FakeServerContent(turn_complete=True))
+
+    adapter._recv_iter = _tc_gen()
+    adapter._agent_speaking_event.set()  # don't wait 15s for speech
+
+    # Bare executor with just the state _fire_user_interrupt reads (the
+    # test_interruption.py pattern) — everything else is getattr-guarded.
+    executor = ScenarioExecutor.__new__(ScenarioExecutor)
+    executor.agents = [adapter]
+
+    async def _sleep():
+        await asyncio.sleep(10.0)
+
+    pending = asyncio.create_task(_sleep())
+    executor._pending_agent_task = pending
+
+    # Text-only voiced message → _extract_audio_from_message returns None, so the
+    # barge-in skips send_audio and isolates the native interrupt() span.
+    await ScenarioExecutor._fire_user_interrupt(
+        executor, {"role": "user", "content": "wait, stop"}
+    )
+
+    if not pending.done():
+        pending.cancel()
+        try:
+            await pending
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    span = _by_name(exporter.get_finished_spans())["voice.adapter.interrupt"]
+    assert attrs(span)["voice.adapter.class"] == "GeminiLiveAgentAdapter"
+    assert attrs(span)["voice.gemini.interrupt.outcome"] == "drained_to_turn_complete"
+    assert isinstance(attrs(span)["voice.gemini.interrupt.drained_chunks"], int)
+
+
+@pytest.mark.asyncio
+async def test_ac7b_interrupt_no_op_when_not_connected():
+    """AC7: interrupt() with no session stamps outcome=='no_op_not_connected' and
+    drained_chunks==0 onto the active voice.adapter.interrupt span."""
+    exporter = _install_in_memory_provider()
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")  # never connected → _session None
+    with voice_span(
+        "voice.adapter.interrupt",
+        {"voice.adapter.class": type(adapter).__name__},
+    ):
+        await adapter.interrupt()
+    span = _by_name(exporter.get_finished_spans())["voice.adapter.interrupt"]
+    assert attrs(span)["voice.gemini.interrupt.outcome"] == "no_op_not_connected"
+    assert int_attr(span, "voice.gemini.interrupt.drained_chunks") == 0
+
+
+# --- AC8 ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac8_one_receive_span_per_turn_count_invariant_to_spurious_retries(
+    monkeypatch,
+):
+    """AC8: exactly one voice.audio.receive span per turn, and the total voice.*
+    span count is invariant across a 1-spurious-retry and a 3-spurious-retry drain
+    (recv_audio stamps attributes, never opens spans — the taxonomy guard)."""
+
+    async def _run(k: int):
+        exporter = _fresh_provider()
+        session = _FakeSession(
+            [_spurious_pair() for _ in range(k)] + [_real_audio_turn()]
+        )
+        _install_fake_client(monkeypatch, session)
+        adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+        await adapter.connect()
+        try:
+            await drive_call(
+                adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(2400)))
+            )
+        finally:
+            await adapter.disconnect()
+        voice_spans = [
+            s for s in exporter.get_finished_spans() if s.name.startswith("voice.")
+        ]
+        receive_spans = [s for s in voice_spans if s.name == "voice.audio.receive"]
+        return len(voice_spans), len(receive_spans)
+
+    total_1, recv_1 = await _run(1)
+    total_3, recv_3 = await _run(3)
+    assert recv_1 == 1
+    assert recv_3 == 1
+    assert total_1 == total_3
+
+
+# --- AC9 (safety) ------------------------------------------------------------
+
+
+class _BoomProcessor(SimpleSpanProcessor):
+    def on_end(self, span) -> None:  # noqa: D401 - a misbehaving processor
+        raise RuntimeError("simulated span-export failure")
+
+
+@pytest.mark.asyncio
+async def test_ac9_span_export_failure_never_breaks_a_gemini_turn(monkeypatch, caplog):
+    """AC9 SAFETY: a SpanProcessor whose on_end raises does not break a Gemini turn;
+    call() still returns the assistant audio message (never-raise contract), and a
+    WARNING is logged by the scenario.voice logger."""
+    provider = TracerProvider()
+    provider.add_span_processor(_BoomProcessor(InMemorySpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    _install_fake_client(monkeypatch, _FakeSession([_real_audio_turn()]))
+    adapter = GeminiLiveAgentAdapter(api_key="test-gk")
+    await adapter.connect()
+    try:
+        with caplog.at_level(logging.WARNING, logger="scenario.voice"):
+            result = await drive_call(
+                adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(2400)))
+            )
+    finally:
+        await adapter.disconnect()
+
+    assert isinstance(result, dict) and result["role"] == "assistant"  # turn completed
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and r.name == "scenario.voice"
+        and "failed to export" in r.getMessage()
+    ]
+    assert warnings, "expected a scenario.voice WARNING for the swallowed span-end"


### PR DESCRIPTION
## Reviewer cockpit

- **Scariest thing** — the one production behavior change is the new `voice.adapter.interrupt` span wrapped around `await adapter.interrupt()` in the executor (both langs). If it altered the barge-in path's exception/timeout semantics, a user interrupt could hang or drop mid-turn. It does not: the wrap mirrors the proven `voice.adapter.connect`/`.disconnect` pattern — body exceptions propagate, only `span.end()` is guarded, status is set before the executor's existing swallow.
- **Start here** — `python/scenario/scenario_executor.py` interrupt call-site (the `voice.adapter.interrupt` wrap) and `python/scenario/voice/adapters/gemini_live.py` `interrupt()` (the outcome stamps). Everything else is attribute-stamping onto already-existing base spans.

## Why

Closes #772. Part of #770 (epic #370 Voice Agents), PR2 — the Gemini Live vendor slice on top of #771's base taxonomy (PR #777).

A failing Gemini voice run left no Gemini-specific signal in the trace: you could see a `voice.audio.receive` timeout but not *why Gemini's* turn ended, whether the spurious-empty-interrupt retry fired, or what a barge-in did. This PR stamps the Gemini vendor attributes onto #771's base spans and adds the one span the interrupt-with-timeout needs.

## What changed

- **`voice.gemini.*` attributes on the inherited base spans (not new span names)** → chose the #771 name-owned taxonomy (adapters add attributes, disambiguated by `voice.adapter.class`) over a `voice.gemini.*` span hierarchy → cross-adapter trace queries stay uniform; Gemini contributes `model`/`voice` on `connect`, `audio.wire_bytes` on `send`, `turn_complete`/`spurious_retry_count` on `receive`. Gemini overrides only transport primitives, so `voice.turn`/`voice.audio.send`/`voice.audio.receive`/`voice.adapter.connect`/`voice.adapter.disconnect` are inherited unchanged.
- **A new executor-owned `voice.adapter.interrupt` span** → the alternative (stamp the bounded-drain outcome onto `voice.turn`, as the issue's G4 first proposed) is **infeasible**: `adapter.interrupt()` runs in the executor's own task while `voice.turn` is bound to the agent-`call()` coroutine's task (`create_task`), so `get_current_span()` there never resolves to the turn span (verified). Mirroring how `connect`/`disconnect` are executor-owned, the interrupt span is opened at the executor call-site. The unifying rule is **executor-invoked + no shared base body to instrument**: connect/disconnect are `@abstractmethod`; `interrupt()` is *concrete* (a default that raises `UnsupportedCapabilityError`) but **wholesale-overridden with no `super()` call**, so base-body instrumentation would be bypassed by exactly the adapters that implement it. → **this is a taxonomy addition (6th `voice.*` name) and widens the blast radius to the executor files** — see "Anything surprising".
- **`voice.gemini.audio.wire_bytes` records the on-the-wire (16 kHz resampled) byte count** → the inherited `voice.audio.bytes` records the canonical 24 kHz input length; on a resample-to-empty chunk the base span would still show bytes > 0 while nothing hit the wire → `wire_bytes` (and `== 0` on the empty edge, with no activity markers sent) makes the real send observable.
- **Python + TypeScript in one PR** (near line-for-line ports) → the interrupt path is the one place they legitimately diverge (see below).

## How it works

```
voice/adapters/gemini_live.py  · gemini-live.ts    connect()  → voice.gemini.model / .voice        (on voice.adapter.connect)
                                                   send_audio → voice.gemini.audio.wire_bytes       (on voice.audio.send)
                                                   recv_audio → voice.gemini.turn_complete / .spurious_retry_count (on voice.audio.receive)
                                                   interrupt  → voice.gemini.interrupt.outcome / .drained_chunks   (on voice.adapter.interrupt)
scenario_executor.py           · scenario-execution.ts        new voice_span("voice.adapter.interrupt") wrap at the barge-in call-site
```
All stamping goes through #771's never-raise `set_span_attributes(get_current_span(), …)` / `setSpanAttributes(currentSpan(), …)`; no adapter opens a `voice.gemini.*`-named span.

## Test plan

- Python (13 tests): `cd python && uv run pytest tests/voice/test_voice_spans_gemini.py` → **13 passed** (0.76s).
- TypeScript (7 tests): `cd javascript && pnpm exec vitest run src/voice/adapters/__tests__/gemini-live-spans.test.ts` → **7 passed** (0.59s).
- Hermetic + mic-free: `InMemorySpanExporter` captures spans from the REAL Gemini `connect`/`call`/`recv`/`interrupt`/`disconnect` (only the `google.genai` transport is faked — no private test seams).

## Human verification

<!-- PLACEHOLDER — concrete steps after verification -->
1. Gemini span tests: `cd python && uv run pytest tests/voice/test_voice_spans_gemini.py` → N passed; `cd javascript && pnpm exec vitest run src/voice/adapters/__tests__/gemini-live-spans.test.ts` → N passed.
2. Falsifiability: `git stash push python/scenario/voice/adapters/gemini_live.py python/scenario/scenario_executor.py` → the Gemini span tests go RED; `git stash pop` → GREEN (same for the two TS prod files).
3. Types: `cd python && uv run pyright .` → 0 errors; `cd javascript && pnpm typecheck:all` → 0 errors.
4. Server-side landing: `GET https://app.langwatch.ai/api/trace/<id>` shows the `voice.gemini.*` attributes + the `voice.adapter.interrupt` span.

## How I can prove I was successful

**All claims below were exercised this session; terminal output/trace-id quoted.**

- **Falsifiability — PROVEN (both languages).** Stashing only the 4 prod files (leaving the tests) turns the new-behavior tests RED; restoring turns them GREEN.
  - Python: `git stash push <2 prod files>` → **8 failed, 5 passed** (AC2/AC3/AC4/AC7 fail; AC1/AC5/AC6/AC8/AC9 are inherited-behavior regression locks that stay green); `git stash pop` → **13 passed**.
  - TypeScript: stash the 2 TS prod files → **4 failed, 3 passed**; restore → **7 passed**.
- **Mic-free server-side landing — PROVEN.** A smoke harness emitted the spans through the REAL `voice_span`/`set_span_attributes` helpers under `langwatch.setup()`; fetched via the per-trace `GET /api/trace/<id>` (not `/search`):
  ```
  trace_id: 123b87998095a2228911efd993b8e36a
  HTTP 200; span names server-side:
    ['voice-772-gemini-landing', 'voice.adapter.connect', 'voice.adapter.disconnect',
     'voice.adapter.interrupt', 'voice.audio.receive', 'voice.audio.send', 'voice.turn']
  voice.adapter.interrupt (new 6th span) present: True
  connect span params.voice.gemini = { model: 'gemini-2.0-flash-live-001', voice: 'Puck' }
  interrupt span params.voice.gemini.interrupt.outcome = 'drained_to_turn_complete'
  ```
  (LangWatch nests dotted attribute keys under `params`, e.g. `params.voice.gemini.model`.)
- **No regression — PROVEN.** #771 base suites + existing Gemini suites stay green with the instrumentation in place: Python `test_voice_spans*` + `test_gemini_live_echo_safe` = **21 passed**; TS `voice-spans` + `gemini-live` adapter = **24 passed** (pre-change baselines were TS `gemini-live` 14, PY `echo_safe` 3).
- **Type-clean — PROVEN.** `uv run pyright .` → **0 errors, 0 warnings**; `npx tsc --noEmit` (lib) → **0 errors**; `pnpm typecheck:all` → **exit 0**; `eslint` on the 2 changed TS files → **0 errors** (an `import/order` slip introduced by the impl was fixed in this branch).
- **CI — Python green; JS gating steps run locally.** `test (3.12)` + `python-complete` **pass** on this draft (Python CI runs on drafts). JS `build`/`ci-checks` are draft-gated (skip), so I ran the JS CI gating steps locally: `build:all` **clean**, `typecheck:all` **0**, `lint:lib` **zero-delta** (3 pre-existing #771 errors in `adapter.runtime.ts`/`elevenlabs.ts`; my 2 changed files **0** — confirmed identical count on base `c48d978`), and `vitest run src/voice src/execution src/script` → **501 passed / 1 skipped**, including the interrupt/barge-in cluster **37 passed** (the direct regression surface for the executor `voice.adapter.interrupt` wrap). Real JS CI runs when the PR flips ready post-#777.
- **Independent review — PROVEN.** Two independent reviewers (principles-reviewer: correctness/test-gating; devils-advocate: design-soundness Pass 3) found **no blocking correctness bugs** and judged the design **sound**. Two non-blocking fixes applied in `857bb99`: (1) the Python spurious-retry counter now resets at drain start (was in `send_audio`), so a no-incoming turn can't stamp a stale count; (2) corrected the executor-span rationale — base `interrupt()` is *concrete* (not abstract); the rule is **executor-invoked + wholesale-overridden**. Remaining items are non-blocking Decide/New-Issue (verdict comment) — notably: Drew to bless `voice.adapter.interrupt` + a canonical taxonomy doc, and the cross-language `interrupt.outcome` value split (`drained_to_turn_complete` vs `sentinel_fired`) as a conscious query-shape choice.

<!-- no-ui-surface -->
_This is **backend-only** instrumentation/library code with **no UI surface** — no live-app screenshot applies; the proof is the falsifiability transcript, the server-side trace fetch, and the green suites above (mirrors #777)._

## Anything surprising?

- **This PR touches the executor**, not only the adapter files — the `voice.adapter.interrupt` span wraps the executor barge-in call-site. (Unlike the abstract `connect`/`disconnect`, base `interrupt()` is *concrete* — a default that raises `UnsupportedCapabilityError` — but Gemini wholesale-overrides it with no `super()`, so there is still no shared base body to instrument; the executor call-site is the one seam.) It **extends the #771 taxonomy with a 6th span name** — the taxonomy is the contract later adapter PRs copy, so this needs a deliberate lock in review.
- **Gemini is the first adapter to actually hit the interrupt call-site** — ElevenLabs never sets `capabilities.interruption=True`, so PR1 never exercised it; a stale example docstring (`examples/voice/gemini_live_interruption.py`) claims Gemini advertises `interruption=False`, but the code sets `True`.
- **Python and TS `interrupt()` genuinely diverge** (SDK shape: py pull-iterator vs ts push-callback): Python does a bounded 2 s drain-to-`turn_complete` (outcomes `drained_to_turn_complete` / `drain_timeout_2s` / `no_op_not_connected` + `drained_chunks`); TS is a passive abort-sentinel (outcomes `sentinel_fired` / `no_op_not_connected`, no drain/timeout). The `outcome` values are language-split by design, documented not unified — same shape as #771's `terminated_reason` py:`max_duration` / ts:`hard_ceiling` split.
- **Base retargeted to `main` after #777 merges.** This PR is currently based on `issue770/voice-adapter-langwatch-spans` (#777, ElevenLabs); it will be rebased + retargeted once that lands.
