### PR TITLE
feat(voice): instrument Pipecat adapter + background-loop spans

### DIFF
--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -21,6 +21,7 @@
  *   exception.
  */
 
+import { context } from "@opentelemetry/api";
 import type { Span } from "@opentelemetry/api";
 import type { VoiceAgentAdapter } from "./adapter";
 import { PendingTransportError } from "./adapters/pending-transport-error";
@@ -334,7 +335,19 @@ export async function defaultVoiceCall(
       "voice.adapter.class": adapter.constructor.name,
       "voice.turn.index": turnIndex,
     },
-    (span) => runVoiceTurn(adapter, input, span),
+    async (span) => {
+      // Publish the live turn context so background-receive-loop adapters
+      // (Pipecat/Twilio) can parent their detached-callback recv spans under
+      // THIS turn (#774). context.active() here is the voice.turn span (voiceSpan
+      // ran us inside its context.with). Cleared in finally so a callback firing
+      // between turns finds `undefined` and skips its span.
+      adapter._voiceTurnContext = context.active();
+      try {
+        return await runVoiceTurn(adapter, input, span);
+      } finally {
+        adapter._voiceTurnContext = undefined;
+      }
+    },
   );
 }
 

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -13,6 +13,8 @@
  * OpenAI Realtime, Gemini Live, ElevenLabs).
  */
 
+import type { Context } from "@opentelemetry/api";
+
 import { defaultVoiceCall } from "./adapter.runtime";
 import { AudioChunk } from "./audio-chunk";
 import { AdapterCapabilities, UnsupportedCapabilityError } from "./capabilities";
@@ -145,6 +147,16 @@ export abstract class VoiceAgentAdapter extends AgentAdapter {
    * by {@link scenario.interrupt} when `afterWords: N` is set.
    */
   streamingTranscript?: string;
+
+  /**
+   * Live OTel context of the CURRENT `voice.turn`, published by
+   * {@link defaultVoiceCall} for background-receive-loop adapters
+   * (Pipecat/Twilio) to parent their detached-callback recv spans under the
+   * turn (#774 — the reusable pattern Twilio PR5 inherits). `undefined` between
+   * turns, so a callback firing outside a turn skips its span rather than
+   * parenting under a closed turn. Internal (underscore) — not a public API.
+   */
+  _voiceTurnContext?: Context;
 
   /**
    * Transmit DTMF tones to the telephony peer. Adapters that advertise

--- a/javascript/src/voice/adapters/__tests__/pipecat-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/pipecat-spans.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Pipecat-specific voice-span tests (#770 / #774, PR4). TypeScript mirror of
+ * `python/tests/voice/test_voice_spans_pipecat.py`.
+ *
+ * Drives the REAL `PipecatAgentAdapter` (base `defaultVoiceCall`/drain + the
+ * background `onMessage` receive callback) against a fake WebSocket, asserting:
+ *  - P1 — a Pipecat turn emits the #771 base spans with class = Pipecat, and the
+ *    connect span carries the Pipecat transport attrs.
+ *  - P2 — the background receive callback emits a `voice.audio.receive` span
+ *    parented to the turn (not detached/closed). Core AC: proves the
+ *    context-capture pattern Twilio (#770 PR5) reuses.
+ *  - P3 — a receive timeout marks `voice.audio.receive` ERROR.
+ *  - P-regression — no orphaned/leaked span from the background callback on
+ *    disconnect.
+ *
+ * Mic-free: an InMemorySpanExporter captures spans from the real production
+ * code; only the vendor WebSocket is faked.
+ */
+import { Buffer } from "node:buffer";
+
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Register a context manager ONCE so context.with propagates across awaits (the
+// receive-loop parenting under test depends on it). Mirrors voice-spans.test.ts.
+const _ctxManager = new AsyncLocalStorageContextManager();
+_ctxManager.enable();
+context.setGlobalContextManager(_ctxManager);
+
+import { type AgentInput } from "../../../domain/agents";
+import {
+  startVoiceAdapters,
+  stopVoiceAdapters,
+} from "../../adapter.runtime";
+import { AudioChunk } from "../../audio-chunk";
+import { createAudioMessage } from "../../messages";
+import { type VoiceExecutorState } from "../../voice-executor-state";
+import { PipecatAgentAdapter, type PipecatWebSocketLike } from "../pipecat";
+import { pcm16ToMulaw } from "../twilio-shared";
+
+/** Fake ws.WebSocket: captures outbound, pushes inbound via emit(). */
+class FakeWebSocket implements PipecatWebSocketLike {
+  readonly sent: string[] = [];
+  private listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  send(data: string | Uint8Array): void {
+    this.sent.push(
+      typeof data === "string" ? data : Buffer.from(data).toString("utf8"),
+    );
+  }
+  close(): void {
+    this.emit("close", undefined);
+  }
+  on(event: "message", listener: (data: unknown) => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "close", listener: () => void): this;
+  on(event: "open", listener: () => void): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string, listener: (...args: any[]) => void): this {
+    (this.listeners[event] ??= []).push(listener);
+    return this;
+  }
+  once(event: "open", listener: () => void): this;
+  once(event: "error", listener: (err: Error) => void): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string, listener: (...args: any[]) => void): this {
+    const wrapped = (...args: unknown[]): void => {
+      this.off(event, wrapped);
+      listener(...args);
+    };
+    return this.on(event as "open", wrapped as () => void);
+  }
+  removeAllListeners(event?: string): this {
+    if (event) this.listeners[event] = [];
+    else this.listeners = {};
+    return this;
+  }
+  emit(event: string, arg: unknown): void {
+    for (const l of [...(this.listeners[event] ?? [])]) l(arg);
+  }
+  private off(event: string, listener: (...args: unknown[]) => void): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    const idx = arr.indexOf(listener);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+}
+
+const SR = 24000;
+
+function tone(seconds: number): AudioChunk {
+  const data = new Uint8Array(Math.round(seconds * SR) * 2);
+  for (let i = 0; i < data.length; i++) data[i] = (i % 250) + 1;
+  return new AudioChunk({ data });
+}
+
+/** One coalesced inbound chunk: ~100 ms of µ-law (>= 800 bytes) as a media frame. */
+function inboundMediaFrame(streamSid: string): string {
+  const pcm8k = new Uint8Array(1600); // 800 samples @ 8 kHz PCM16 → 800 µ-law bytes
+  const view = new DataView(pcm8k.buffer);
+  for (let i = 0; i < 800; i++) view.setInt16(i * 2, 3000, true);
+  const mulaw = pcm16ToMulaw(pcm8k);
+  return JSON.stringify({
+    event: "media",
+    streamSid,
+    media: { payload: Buffer.from(mulaw).toString("base64") },
+  });
+}
+
+function audioInput(incoming?: AudioChunk): AgentInput {
+  const newMessages = incoming ? [createAudioMessage(incoming, "user")] : [];
+  return { newMessages } as unknown as AgentInput;
+}
+
+function byName(spans: ReadableSpan[]): Record<string, ReadableSpan> {
+  return Object.fromEntries(spans.map((s) => [s.name, s]));
+}
+
+function receives(spans: ReadableSpan[]): ReadableSpan[] {
+  return spans.filter((s) => s.name === "voice.audio.receive");
+}
+
+function makeAdapter(socketRef: { ws?: FakeWebSocket }): PipecatAgentAdapter {
+  return new PipecatAgentAdapter({
+    url: "ws://bot/ws",
+    streamSid: "MZtest",
+    callSid: "CAtest",
+    realTimePacing: false,
+    webSocketFactory: () => {
+      const ws = new FakeWebSocket();
+      socketRef.ws = ws;
+      queueMicrotask(() => ws.emit("open", undefined));
+      return ws;
+    },
+  });
+}
+
+describe("Pipecat voice.* span instrumentation (#774)", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+  afterEach(async () => {
+    await provider.shutdown();
+    trace.disable();
+  });
+
+  // P1 — base spans + class
+  it("emits the base spans for a Pipecat turn with class = Pipecat", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    ref.ws!.emit("message", inboundMediaFrame("MZtest")); // buffered agent chunk
+    await adapter.call(audioInput(tone(0.05)));
+    await adapter.disconnect();
+
+    const spans = byName(exporter.getFinishedSpans());
+    expect(spans["voice.turn"]).toBeDefined();
+    expect(spans["voice.audio.send"]).toBeDefined();
+    expect(spans["voice.audio.receive"]).toBeDefined();
+    expect(spans["voice.turn"].attributes["voice.adapter.class"]).toBe(
+      "PipecatAgentAdapter",
+    );
+  });
+
+  // P1 — connect span carries transport attrs (driven through the real executor seam)
+  it("stamps voice.pipecat.transport onto the connect span", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    await startVoiceAdapters([adapter], {} as unknown as VoiceExecutorState);
+    await stopVoiceAdapters([adapter]);
+
+    const connect = byName(exporter.getFinishedSpans())["voice.adapter.connect"];
+    expect(connect.attributes["voice.adapter.class"]).toBe("PipecatAgentAdapter");
+    expect(connect.attributes["voice.pipecat.transport"]).toBe("websocket");
+    expect(connect.attributes["voice.pipecat.transport_format"]).toBe("mulaw/8000");
+  });
+
+  // P2 (core) — background callback emits a receive span parented to the turn
+  it("parents the background-callback voice.audio.receive span under the turn", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    // Start the turn: call() publishes _voiceTurnContext SYNCHRONOUSLY before its
+    // first await. Deliver the agent chunk now → the onMessage callback decodes
+    // it under a LIVE turn.
+    const call = adapter.call(audioInput(tone(0.05)));
+    ref.ws!.emit("message", inboundMediaFrame("MZtest"));
+    await call;
+    await adapter.disconnect();
+
+    const spans = exporter.getFinishedSpans();
+    const turn = byName(spans)["voice.turn"];
+    const bg = receives(spans).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    expect(bg.length).toBeGreaterThanOrEqual(1);
+    // Core AC: parented directly under the turn, not a detached/root span.
+    expect(bg[0].parentSpanId).toBe(turn.spanContext().spanId);
+    expect(bg[0].attributes["voice.audio.bytes"]).toBeGreaterThan(0);
+  });
+
+  // P2 flood-guard — one background span per turn, invariant to chunk count
+  it("emits at most one background span per turn (invariant to chunk count)", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    const call = adapter.call(audioInput(tone(0.05)));
+    for (let i = 0; i < 3; i++) ref.ws!.emit("message", inboundMediaFrame("MZtest"));
+    await call;
+    await adapter.disconnect();
+
+    const bg = receives(exporter.getFinishedSpans()).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    expect(bg).toHaveLength(1);
+  });
+
+  // Documents the turn-liveness gate limit (review F3): a turn drained from
+  // pre-buffered audio (delivered before the turn context was published) gets no
+  // background marker; the base receive span still covers it.
+  it("emits no background span for a turn drained from pre-buffered audio", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    ref.ws!.emit("message", inboundMediaFrame("MZtest")); // enqueued BEFORE call()
+    await adapter.call(audioInput(tone(0.05))); // drains the pre-buffered chunk
+    await adapter.disconnect();
+
+    const spans = exporter.getFinishedSpans();
+    const bg = receives(spans).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    const base = receives(spans).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] !== "background_loop",
+    );
+    expect(base.length).toBeGreaterThanOrEqual(1);
+    expect(bg).toHaveLength(0);
+  });
+
+  // P-regression — a callback firing between turns emits no background span
+  it("emits no background span for a frame delivered outside a turn", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    await adapter.connect();
+    ref.ws!.emit("message", inboundMediaFrame("MZtest")); // no turn active
+    await adapter.disconnect();
+
+    const bg = receives(exporter.getFinishedSpans()).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    expect(bg).toHaveLength(0);
+  });
+
+  // P3 — receive timeout marks the span ERROR
+  it("marks voice.audio.receive ERROR on a receive timeout", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTimeout: number }).responseTimeout = 0.05;
+    await adapter.connect();
+    // Feed no inbound → the first receiveAudio times out.
+    await expect(adapter.call(audioInput(tone(0.05)))).rejects.toThrow();
+    await adapter.disconnect();
+
+    const recv = receives(exporter.getFinishedSpans())[0];
+    expect(recv.status.code).toBe(SpanStatusCode.ERROR);
+    expect(recv.attributes["voice.audio.terminated_reason"]).toBe(
+      "first_chunk_timeout",
+    );
+  });
+});

--- a/javascript/src/voice/adapters/pipecat.ts
+++ b/javascript/src/voice/adapters/pipecat.ts
@@ -22,10 +22,14 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import type { Context } from "@opentelemetry/api";
+
 import { AgentRole } from "../../domain/agents";
+import { Logger } from "../../utils/logger";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
+import { currentSpan, setSpanAttributes, voiceReceiveSpanUnder } from "../telemetry";
 import { sleep } from "../utils";
 import { PendingTransportError } from "./pending-transport-error";
 import {
@@ -188,6 +192,14 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
    * subtle risk of one advancing while the other lags.
    */
   private interruptPhase: "idle" | "interrupted" = "idle";
+  /**
+   * The turn context we last emitted a background `voice.audio.receive` span
+   * for — so {@link flushBufferedMulaw} spans only the FIRST wire delivery of
+   * each turn (one span/turn, no per-chunk flood). Reset implicitly: the next
+   * turn publishes a distinct `_voiceTurnContext` (#774).
+   */
+  private bgSpanTurnContext?: Context;
+  private readonly logger = new Logger("PipecatAgentAdapter");
 
   constructor(init: PipecatAgentAdapterInit = {}) {
     super();
@@ -284,6 +296,15 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
         },
       }),
     );
+
+    // Stamp Pipecat transport attrs onto the active `voice.adapter.connect` span
+    // (opened by `startVoiceAdapters`). Base spans are name-owned; the adapter
+    // contributes attributes, never a parallel span name — mirror ElevenLabs'
+    // `voice.elevenlabs.agent_id` seam (`adapters/elevenlabs.ts`).
+    setSpanAttributes(currentSpan(), {
+      "voice.pipecat.transport": this.transport,
+      "voice.pipecat.transport_format": this.transportFormat,
+    });
   }
 
   /** Whether the Media Streams WebSocket is open (Gap #11). */
@@ -481,8 +502,48 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
     }
     this.mulawChunks = [];
     this.mulawChunksByteLength = 0;
-    const pcm = mulaw8kToPcm16At24k(mulaw);
-    const chunk = new AudioChunk({ data: pcm });
+    // On the FIRST wire delivery of a turn (base call() published its context on
+    // the adapter), wrap the decode+deliver in a voice.audio.receive span
+    // parented to THAT turn (#774) — so this background ws-callback's receive
+    // work is attributed to the turn instead of the callback's detached/root
+    // context. A producer-side delivery marker (carries the delivered byte
+    // count); the consumer-side wait + timeout/ERROR (P3) live on the base
+    // receive span that wraps receiveAudio, disambiguated by
+    // voice.pipecat.recv.source. Emitted at most once per turn (matching the
+    // base's one-receive-span-per-turn granularity + the epic's no-per-tick-flood
+    // rule). Between turns _voiceTurnContext is undefined and we decode without a
+    // span, so no detached span leaks from a callback firing outside a turn.
+    let chunk: AudioChunk;
+    try {
+      const parent = this._voiceTurnContext;
+      if (parent !== undefined && parent !== this.bgSpanTurnContext) {
+        this.bgSpanTurnContext = parent;
+        chunk = voiceReceiveSpanUnder(
+          parent,
+          {
+            "voice.adapter.class": this.constructor.name,
+            "voice.pipecat.recv.source": "background_loop",
+          },
+          (span) => {
+            const pcm = mulaw8kToPcm16At24k(mulaw);
+            span.setAttribute("voice.audio.bytes", pcm.length);
+            return new AudioChunk({ data: pcm });
+          },
+        );
+      } else {
+        chunk = new AudioChunk({ data: mulaw8kToPcm16At24k(mulaw) });
+      }
+    } catch (err) {
+      // Parity with Python `_recv_loop`'s `except Exception`: a decode/span
+      // failure in this SYNCHRONOUS ws 'message' callback must not propagate —
+      // an uncaught throw here would crash the handler / drop the socket. Log and
+      // drop this one batch; keep receiving.
+      this.logger.warn(
+        "Pipecat: failed to decode/deliver an inbound audio batch; dropping it",
+        err,
+      );
+      return;
+    }
     const waiter = this.inbox.waiter;
     if (waiter) {
       this.inbox.waiter = null;

--- a/javascript/src/voice/telemetry.ts
+++ b/javascript/src/voice/telemetry.ts
@@ -19,6 +19,7 @@ import {
   context,
   trace,
   SpanStatusCode,
+  type Context,
   type Span,
 } from "@opentelemetry/api";
 import { Logger } from "../utils/logger";
@@ -67,20 +68,65 @@ export async function voiceSpan<T>(
     span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
     throw err;
   } finally {
-    try {
-      span.end();
-    } catch (exportErr) {
-      logger.warn(
-        `voice: span '${name}' failed to export; dropping it (run continues)`,
-        exportErr,
-      );
-    }
+    endGuarded(span, name);
+  }
+}
+
+/**
+ * End a span, swallowing a processor/exporter failure (a bad `SpanProcessor.onEnd`
+ * throws from `end()`, which would otherwise propagate into the audio path). The
+ * single guarded-end shared by {@link voiceSpan} and {@link voiceReceiveSpanUnder}
+ * so a fix to the guard can't be applied to one and missed on the other.
+ */
+function endGuarded(span: Span, name: string): void {
+  try {
+    span.end();
+  } catch (exportErr) {
+    logger.warn(
+      `voice: span '${name}' failed to export; dropping it (run continues)`,
+      exportErr,
+    );
   }
 }
 
 /** The currently-active span, for adapters stamping attributes onto a span they did not open. */
 export function currentSpan(): Span | undefined {
   return trace.getSpan(context.active());
+}
+
+/**
+ * Run `fn` inside a guarded `voice.audio.receive` span pinned under an EXPLICIT
+ * parent context, synchronously.
+ *
+ * The seam for background-receive-loop adapters (Pipecat/Twilio) whose real
+ * receive runs in a NON-async ws callback: they parent this span under the live
+ * `voice.turn` context the base `call()` published on the adapter, not the
+ * callback's detached/root context (#774). Synchronous; the span becomes the
+ * active span for the body (via `context.with`, matching Python's
+ * `voice_span(parent=)`) so a nested span added later parents correctly in both
+ * runtimes. `end()` is guarded exactly like `voiceSpan` (shared {@link endGuarded}).
+ */
+export function voiceReceiveSpanUnder<T>(
+  parent: Context,
+  attributes: Record<string, unknown>,
+  fn: (span: Span) => T,
+): T {
+  const span = trace
+    .getTracer(TRACER_NAME)
+    .startSpan("voice.audio.receive", undefined, parent);
+  span.setAttribute("langwatch.span.type", "span");
+  applyAttributes(span, attributes);
+  try {
+    const result = context.with(trace.setSpan(parent, span), () => fn(span));
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+  } catch (err) {
+    span.recordException(err as Error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+    throw err;
+  } finally {
+    endGuarded(span, "voice.audio.receive");
+  }
 }
 
 /** Set non-nullish attributes on `span` if it is recording. Never throws. */

--- a/python/scenario/voice/_telemetry.py
+++ b/python/scenario/voice/_telemetry.py
@@ -51,24 +51,32 @@ def _tracer():
 
 @contextlib.contextmanager
 def voice_span(
-    name: str, attributes: Optional[Dict[str, Any]] = None
+    name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+    *,
+    parent: Optional[context.Context] = None,
 ) -> Iterator[Span]:
     """Open a guarded ``scenario.voice`` span.
 
     - Sets ``langwatch.span.type=span`` plus any non-``None`` ``attributes``.
     - Becomes the current span so nested ``voice_span``/framework spans parent
-      under it automatically (ambient OTel context — no parent is passed).
+      under it automatically (ambient OTel context when ``parent`` is ``None``).
+    - ``parent`` pins the span under an EXPLICIT OTel context instead of the
+      ambient one — the seam a background-receive-loop adapter (Pipecat, Twilio)
+      uses to parent detached-task recv spans under the live ``voice.turn`` the
+      base ``call()`` published, rather than the loop's frozen connect-time
+      context (#774). ``None`` preserves the original ambient-nesting behaviour.
     - A body exception is recorded, sets the span ERROR, and is **re-raised**
       (a transport error must surface).
     - ``span.end()`` is wrapped: a processor/exporter failure is swallowed and
       logged WARNING, never propagated into the audio path.
     """
-    span = _tracer().start_span(name)
+    span = _tracer().start_span(name, context=parent)
     span.set_attribute("langwatch.span.type", "span")
     for key, value in (attributes or {}).items():
         if value is not None:
             span.set_attribute(key, value)
-    token = context.attach(trace.set_span_in_context(span))
+    token = context.attach(trace.set_span_in_context(span, parent))
     try:
         yield span
     except BaseException as exc:  # noqa: BLE001 - mark + re-raise, never swallow the body

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -16,11 +16,15 @@ each adapter needing its own bookkeeping.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import logging
 import time
 from abc import abstractmethod
-from typing import Any, Callable, ClassVar, List, Optional
+from typing import Any, Callable, ClassVar, Iterator, List, Optional
+
+from opentelemetry import context as otel_context
+from opentelemetry.context import Context
 
 logger = logging.getLogger("scenario.voice")
 
@@ -113,6 +117,13 @@ class VoiceAgentAdapter(AgentAdapter):
     # Hard cap on a single agent turn's audio. Prevents runaway loops if a
     # transport never signals end-of-stream. 30s = a long sentence.
     response_max_duration: float = 30.0
+
+    # Live OTel context of the CURRENT ``voice.turn``, published by ``call()``
+    # for background-receive-loop adapters (Pipecat/Twilio) to parent their
+    # detached-task recv spans under the turn (#774). ``None`` between turns.
+    # Class-level default so it exists even for a subclass that skips
+    # ``super().__init__()`` (mirrors the ``_agent_speaking`` safety-net).
+    _voice_turn_context: Optional[Context] = None
 
     def __init__(self) -> None:
         # Per-instance event used by the interruption path to wait until
@@ -215,6 +226,24 @@ class VoiceAgentAdapter(AgentAdapter):
             ),
         )
 
+    @contextlib.contextmanager
+    def _voice_turn_context_scope(self) -> Iterator[None]:
+        """Publish the live ``voice.turn`` OTel context for background-loop adapters.
+
+        Pipecat/Twilio run their real receive in a background task/callback whose
+        OTel context was frozen at ``connect()`` (a now-closed span). They read
+        :attr:`_voice_turn_context` to parent those detached recv spans under the
+        CURRENT ``voice.turn`` (#774 — the reusable pattern Twilio PR5 inherits).
+        Entered INSIDE the ``voice.turn`` span so ``get_current()`` captures it;
+        cleared on exit so a late background frame BETWEEN turns finds ``None`` and
+        skips its span rather than parenting under a closed turn.
+        """
+        self._voice_turn_context = otel_context.get_current()
+        try:
+            yield
+        finally:
+            self._voice_turn_context = None
+
     async def call(self, input: AgentInput) -> AgentReturnTypes:
         """
         Default implementation: extract audio from the latest user message,
@@ -263,7 +292,7 @@ class VoiceAgentAdapter(AgentAdapter):
                 "voice.adapter.class": type(self).__name__,
                 "voice.turn.index": turn_index,
             },
-        ) as _turn_span:
+        ) as _turn_span, self._voice_turn_context_scope():
             _turn_started = time.monotonic()
             # Clear the speaking-event for this turn — set in _drain on first chunk.
             self._agent_speaking_event.clear()

--- a/python/scenario/voice/adapters/pipecat.py
+++ b/python/scenario/voice/adapters/pipecat.py
@@ -24,9 +24,12 @@ import logging
 import uuid
 from typing import Any, ClassVar, Literal, Optional
 
+from opentelemetry.context import Context
+
 from ..adapter import AgentStreamEndedError, VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
 from ..capabilities import AdapterCapabilities
+from .._telemetry import voice_span
 from ._twilio_shared import (
     TWILIO_FRAME_MS,
     build_clear_frame,
@@ -128,6 +131,11 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
         # Set True when _recv_loop terminates (crash or clean close). Lets
         # recv_audio fail fast on a drained queue without re-reading it (#498).
         self._recv_loop_done: bool = False
+        # The turn context we last emitted a background ``voice.audio.receive``
+        # span for — so ``_deliver`` spans only the FIRST wire delivery of each
+        # turn (one span/turn, no per-100ms-chunk flood). Reset implicitly: the
+        # next turn publishes a distinct ``_voice_turn_context`` object (#774).
+        self._bg_span_turn_context: Optional[Context] = None
         # Serialises concurrent send_audio() calls — without it two paced
         # senders would interleave 20-ms mulaw frames on the wire and the
         # bot would receive corrupted audio. Used for the interruption case
@@ -188,6 +196,21 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
                     },
                 }
             )
+        )
+
+        # Stamp Pipecat transport attrs onto the active ``voice.adapter.connect``
+        # span (opened by the executor connect loop). Base spans are name-owned;
+        # the adapter contributes attributes, never a parallel span name — mirror
+        # ElevenLabs' ``voice.elevenlabs.agent_id`` seam (``adapters/elevenlabs.py``).
+        from opentelemetry import trace as _otel_trace
+        from .._telemetry import set_span_attributes
+
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {
+                "voice.pipecat.transport": self.transport,
+                "voice.pipecat.transport_format": self.transport_format,
+            },
         )
 
         self._recv_task = asyncio.create_task(self._recv_loop())
@@ -313,9 +336,8 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
                     # as raw µ-law payload if we see one.
                     buffered_mulaw.extend(raw)
                     if len(buffered_mulaw) >= (BATCH_MS * 8):
-                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        self._deliver(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await queue.put(AudioChunk(data=pcm))
                     continue
 
                 frame = parse_media_stream_frame(raw)
@@ -324,14 +346,12 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
                 if frame.event == "media" and frame.payload_mulaw:
                     buffered_mulaw.extend(frame.payload_mulaw)
                     if len(buffered_mulaw) >= (BATCH_MS * 8):
-                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        self._deliver(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await queue.put(AudioChunk(data=pcm))
                 elif frame.event == "stop":
                     if buffered_mulaw:
-                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        self._deliver(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await queue.put(AudioChunk(data=pcm))
                     return
         except asyncio.CancelledError:
             raise
@@ -352,6 +372,62 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
             # two lines, so a waiter can't observe a half-set terminal state.)
             self._recv_loop_done = True
             queue.put_nowait(_RECV_LOOP_DONE)
+
+    def _deliver(self, mulaw: bytes) -> None:
+        """Decode a coalesced µ-law batch to PCM16/24k and enqueue it.
+
+        On the FIRST wire delivery of a turn — the base ``call()`` published its
+        OTel context via :attr:`VoiceAgentAdapter._voice_turn_context` — wrap the
+        decode+enqueue in a ``voice.audio.receive`` span parented to THAT turn
+        (#774), so the background ``_recv_loop`` task's receive work is attributed
+        to the turn instead of the task's frozen connect-time context (a
+        now-closed span).
+
+        This is a producer-side **delivery marker** (it carries the delivered
+        byte count); the consumer-side wait and the timeout/ERROR semantics (P3)
+        live on the base ``voice.audio.receive`` span that wraps ``recv_audio``.
+        The span is disambiguated from that base span by
+        ``voice.pipecat.recv.source=background_loop``.
+
+        Emitted at most ONCE per turn (only the first delivery under a given turn
+        context) — matching the base's one-receive-span-per-turn granularity and
+        the epic's no-per-tick-flood rule (the EL pump H1), so a multi-second turn
+        of 100 ms chunks is not exploded into dozens of sibling spans. Between
+        turns the context is ``None`` and we enqueue WITHOUT a span, so no
+        detached/closed-parent span can leak from the background task. The body is
+        synchronous (``put_nowait`` on the unbounded queue), so a ``disconnect()``
+        cancel can never land mid-span.
+
+        Coverage limits (by design — this is a marker, not exhaustive accounting):
+        - ``voice.audio.bytes`` is the DELIVERED coalesced-chunk size, which may
+          fold in a sub-100 ms µ-law tail carried over from the prior turn (the
+          recv-loop coalesces to 800-byte batches across the turn boundary — a
+          pre-existing property the base drain chunks share; not corrected here
+          because flushing a partial batch at the boundary would drop that audio).
+        - A turn whose agent audio was ALREADY buffered before ``call()`` published
+          the turn context (an opening greeting delivered during ``connect``) is
+          drained from the queue without a fresh wire delivery, so it gets no
+          background marker — the base ``voice.audio.receive`` span still covers
+          its consumption. The marker records in-turn wire deliveries, not every
+          turn that consumes audio (the deterministic turn-liveness gate).
+        """
+        assert self._inbound_queue is not None
+        parent = self._voice_turn_context
+        if parent is None or parent is self._bg_span_turn_context:
+            self._inbound_queue.put_nowait(AudioChunk(data=mulaw8k_to_pcm16_24k(mulaw)))
+            return
+        self._bg_span_turn_context = parent
+        with voice_span(
+            "voice.audio.receive",
+            {
+                "voice.adapter.class": type(self).__name__,
+                "voice.pipecat.recv.source": "background_loop",
+            },
+            parent=parent,
+        ) as span:
+            pcm = mulaw8k_to_pcm16_24k(mulaw)
+            span.set_attribute("voice.audio.bytes", len(pcm))
+            self._inbound_queue.put_nowait(AudioChunk(data=pcm))
 
     # ------------------------------------------------------------------ assertions
 

--- a/python/tests/voice/test_voice_spans_pipecat.py
+++ b/python/tests/voice/test_voice_spans_pipecat.py
@@ -1,0 +1,359 @@
+"""Pipecat-specific voice-span tests (#770 / #774, PR4).
+
+Drives the REAL ``PipecatAgentAdapter`` (base ``call()``/drain + the background
+``_recv_loop`` task) with a faked ``websockets`` connection, asserting:
+
+- **P1** — a Pipecat turn emits the #771 base spans with
+  ``voice.adapter.class`` = Pipecat, and the connect span carries the
+  Pipecat transport attributes.
+- **P2** — the background receive loop emits a ``voice.audio.receive`` span
+  parented to the turn (not a detached/closed span). This is the core AC: it
+  proves the context-capture pattern that Twilio (#770 PR5) reuses.
+- **P3** — a receive timeout marks ``voice.audio.receive`` ERROR.
+- **P-regression** — no orphaned/leaked span from the background task on
+  disconnect.
+
+Mic-free: an ``InMemorySpanExporter`` captures spans from the real production
+code; only the vendor WebSocket is faked. Mirrors the OTel-reset discipline of
+``test_voice_spans.py`` (reset the provider AND the set-once guard each test).
+"""
+
+import asyncio
+import base64
+import json
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+from opentelemetry.util._once import Once
+
+from scenario.voice import AudioChunk, PipecatAgentAdapter
+from scenario.voice.messages import create_audio_message
+
+from ._span_assert import attrs, ctx_id, int_attr, parent_id
+
+
+@pytest.fixture(autouse=True)
+def reset_otel():
+    def _reset() -> None:
+        trace._TRACER_PROVIDER = None
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _install_in_memory_provider() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+def _by_name(spans):
+    return {s.name: s for s in spans}
+
+
+def _receives(spans):
+    """Every ``voice.audio.receive`` span (base + background are same-named)."""
+    return [s for s in spans if s.name == "voice.audio.receive"]
+
+
+_SENTINEL_CLOSE = object()
+
+
+class _FakeWebSocket:
+    """Stand-in for the websockets client connection (see test_pipecat_adapter)."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._inbox: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def send(self, text: str) -> None:
+        self.sent.append(text)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        item = await self._inbox.get()
+        if item is _SENTINEL_CLOSE:
+            raise StopAsyncIteration
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+        await self._inbox.put(_SENTINEL_CLOSE)
+
+    def feed(self, frame: str) -> None:
+        self._inbox.put_nowait(frame)
+
+    def end_stream(self) -> None:
+        self._inbox.put_nowait(_SENTINEL_CLOSE)
+
+
+def _media_frame(stream_sid: str, mulaw: bytes) -> str:
+    return json.dumps(
+        {
+            "event": "media",
+            "streamSid": stream_sid,
+            "media": {"payload": base64.b64encode(mulaw).decode()},
+        }
+    )
+
+
+# 100 ms of µ-law silence (800 bytes) = the adapter's coalescing batch → one chunk.
+_ONE_CHUNK_MULAW = b"\x7f" * 800
+
+# Arbitrary stream SID for the synthetic media frames — the recv loop's parser
+# ignores it, so any value works (and it avoids an Optional[str] narrowing on the
+# adapter's own stream_sid, which pyright can't prove non-None post-connect).
+_STREAM_SID = "MZtest"
+
+
+def _audio_input():
+    msg = create_audio_message(AudioChunk(data=b"\x00\x00" * 1200), role="user")
+
+    class _State:
+        current_turn = 0
+
+    class _FakeInput:
+        new_messages = [msg]
+        scenario_state = _State()
+
+    return _FakeInput()
+
+
+async def _connect(monkeypatch, adapter):
+    fake = _FakeWebSocket()
+
+    async def _fake_connect(url, **_):
+        return fake
+
+    monkeypatch.setattr("websockets.connect", _fake_connect)
+    await adapter.connect()
+    return fake
+
+
+# --- P1 -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p1_turn_emits_base_spans_with_pipecat_class(monkeypatch):
+    """P1: a Pipecat turn inherits the #771 base spans, class = Pipecat."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05  # end the drain fast after one chunk
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        merged = AudioChunk(data=b"\x00\x00" * 10, transcript="hi")  # short-circuit STT
+        adapter._ensure_transcript = _AsyncReturn(merged)  # type: ignore[method-assign]
+        await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    spans = _by_name(exporter.get_finished_spans())
+    assert {"voice.turn", "voice.audio.send", "voice.audio.receive"} <= set(spans)
+    assert attrs(spans["voice.turn"])["voice.adapter.class"] == "PipecatAgentAdapter"
+
+
+@pytest.mark.asyncio
+async def test_p1_connect_span_carries_pipecat_transport_attrs(monkeypatch):
+    """P1: the adapter stamps its transport onto the base voice.adapter.connect span.
+
+    Driven through the executor connect loop (which owns the connect span), the
+    same seam ElevenLabs uses for voice.elevenlabs.agent_id.
+    """
+    from scenario.scenario_executor import ScenarioExecutor
+
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    fake = _FakeWebSocket()
+
+    async def _fake_connect(url, **_):
+        return fake
+
+    monkeypatch.setattr("websockets.connect", _fake_connect)
+    executor = ScenarioExecutor(
+        name="pipecat-span-test", description="test", agents=[adapter], script=[]
+    )
+    try:
+        await executor._voice_connect_all()
+    finally:
+        fake.end_stream()
+        await executor._voice_disconnect_all()
+
+    connect = _by_name(exporter.get_finished_spans())["voice.adapter.connect"]
+    assert attrs(connect)["voice.adapter.class"] == "PipecatAgentAdapter"
+    assert attrs(connect)["voice.pipecat.transport"] == "websocket"
+    assert attrs(connect)["voice.pipecat.transport_format"] == "mulaw/8000"
+
+
+# --- P2 (core) ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p2_background_receive_span_parented_to_turn(monkeypatch):
+    """P2 (core AC): the background ``_recv_loop`` emits a ``voice.audio.receive``
+    span parented DIRECTLY to the turn — proving the context-capture pattern
+    (the loop task's own OTel context was frozen at connect, a closed span)."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        # Feed one agent chunk BEFORE call(). call() publishes the turn context
+        # SYNCHRONOUSLY (before its first await), so the background loop — which
+        # runs during call()'s awaits — decodes this frame under a LIVE turn.
+        fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        adapter._ensure_transcript = _AsyncReturn(  # type: ignore[method-assign]
+            AudioChunk(data=b"\x00\x00" * 10, transcript="hi")
+        )
+        await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    spans = exporter.get_finished_spans()
+    turn = _by_name(spans)["voice.turn"]
+    bg = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert bg, "expected a background-loop voice.audio.receive span"
+    # The core assertion: parented directly under the turn, NOT a detached/closed
+    # span (the loop's frozen connect-time context).
+    assert parent_id(bg[0]) == ctx_id(turn)
+    assert int_attr(bg[0], "voice.audio.bytes") > 0
+
+
+@pytest.mark.asyncio
+async def test_p2_one_background_span_per_turn_not_per_chunk(monkeypatch):
+    """P2 flood-guard: several wire deliveries in ONE turn emit exactly ONE
+    background span — matching the base's one-receive-span-per-turn granularity
+    and the epic's no-per-tick-flood rule (the EL pump H1)."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        for _ in range(3):  # three 100 ms chunks, one turn
+            fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        adapter._ensure_transcript = _AsyncReturn(  # type: ignore[method-assign]
+            AudioChunk(data=b"\x00\x00" * 10, transcript="hi")
+        )
+        await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    bg = [
+        s
+        for s in _receives(exporter.get_finished_spans())
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert len(bg) == 1, f"expected one background span per turn, got {len(bg)}"
+
+
+@pytest.mark.asyncio
+async def test_prebuffered_turn_has_base_span_but_no_background_marker(monkeypatch):
+    """Documents the turn-liveness gate limit (review F2): agent audio delivered
+    and enqueued BEFORE call() publishes the turn context (e.g. a greeting during
+    connect) is drained from the queue without a fresh wire delivery, so it gets
+    NO background marker — the base voice.audio.receive span still covers it."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        await asyncio.sleep(0.05)  # _recv_loop decodes+enqueues with NO turn live
+        adapter._ensure_transcript = _AsyncReturn(  # type: ignore[method-assign]
+            AudioChunk(data=b"\x00\x00" * 10, transcript="hi")
+        )
+        await adapter.call(_audio_input())  # type: ignore[arg-type]  # drains the pre-buffered chunk
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    spans = exporter.get_finished_spans()
+    base = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.pipecat.recv.source") != "background_loop"
+    ]
+    bg = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert base, "base drain receive span should still be present"
+    assert bg == [], "a pre-buffered turn emits no background marker (by design)"
+
+
+@pytest.mark.asyncio
+async def test_pregression_no_background_span_between_turns(monkeypatch):
+    """P-regression: a chunk decoded with NO active turn emits NO background span.
+
+    The turn-liveness gate keeps the background task from leaking a
+    detached/closed-parent span (e.g. a late frame after the turn closed, or a
+    pre-turn greeting frame). Also covers the disconnect teardown path.
+    """
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    fake = await _connect(monkeypatch, adapter)
+    # No call() in flight → _voice_turn_context is None → _recv_loop buffers the
+    # decoded chunk but emits no span.
+    fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+    await asyncio.sleep(0.05)  # let the background loop process the frame
+    await adapter.disconnect()
+
+    bg = [
+        s
+        for s in _receives(exporter.get_finished_spans())
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert bg == [], "no background receive span should be emitted between turns"
+
+
+# --- P3 -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p3_receive_timeout_marks_receive_span_error(monkeypatch):
+    """P3: a first-chunk receive timeout (no audio fed) marks voice.audio.receive ERROR."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_timeout = 0.05  # fail the first-chunk wait fast (feed nothing)
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        with pytest.raises(Exception):
+            await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    assert recv.status.status_code == StatusCode.ERROR
+    assert attrs(recv)["voice.audio.terminated_reason"] == "first_chunk_timeout"
+
+
+class _AsyncReturn:
+    """A tiny awaitable-returning stand-in for _ensure_transcript (avoids real STT)."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __call__(self, _merged):
+        return self._value


### PR DESCRIPTION
> **Scariest thing** — the base `call()`/`defaultVoiceCall` now publishes a live turn context on **every** voice adapter, and Pipecat reads it from a background task/callback. If the publish/clear or the parenting were wrong, a background span could attach to a **closed/stale** turn (mis-parented traces) or the field could leak across turns. Mitigated: cleared in a `finally`, gated on turn-liveness, emitted once-per-turn via an identity check, and the whole voice suite (py 108 / ts 414) stays green.
> **Start here** — py `scenario/voice/adapters/pipecat.py` `_deliver` (+ its base seam `scenario/voice/adapter.py` `_voice_turn_context_scope`); ts `src/voice/adapters/pipecat.ts` `flushBufferedMulaw` (+ `src/voice/adapter.runtime.ts` `defaultVoiceCall`). That's the whole P2 mechanism.

## Why

Closes #774 (PR4 of epic #770). ElevenLabs (#771/#777) instrumented the base turn-flow + executor lifecycle spans that every default-`call()` adapter inherits. **Pipecat** is the first adapter whose real receive does **not** happen on the turn's call stack: it runs in a **background task** (py `_recv_loop` `asyncio.Task`) / **ws callback** (ts `onMessage`) spawned at `connect()`. That background context's OTel parent was frozen when the task/callback was created — the now-closed `voice.adapter.connect` span — so any span it emits would be **detached** from the turn that is actually consuming its audio.

This slice solves that **once**, as the reusable pattern Twilio (#770 PR5) inherits: the base `call()` **publishes the live `voice.turn` context**, and the background producer parents its receive span under it explicitly.

## What changed

- **Base-first primitive (py `adapter.py` + `_telemetry.py`, ts `adapter.runtime.ts` + `adapter.ts` + `telemetry.ts`)** — `call()`/`defaultVoiceCall` now publishes the live turn OTel context on the adapter (`_voice_turn_context` / `_voiceTurnContext`), cleared in a `finally` at turn close. The span helper gains an explicit `parent=` (py `voice_span(…, parent=)`) / a synchronous `voiceReceiveSpanUnder(parent, …)` (ts, for the non-async ws callback). Additive: adapters without a background loop set the field and never read it — no behaviour change (whole voice suite green).
- **Pipecat producer span (py `pipecat.py` `_deliver`, ts `pipecat.ts` `flushBufferedMulaw`)** — on the **first wire delivery of a turn**, the background loop wraps its decode+enqueue in a `voice.audio.receive` span parented **directly to `voice.turn`**, carrying `voice.pipecat.recv.source=background_loop` + `voice.audio.bytes`. **Gated on turn-liveness** (deterministic — independent of producer/consumer scheduling) and emitted **at most once per turn** (matching the base's one-receive-per-turn granularity + the epic's no-per-tick-flood rule, the EL pump H1). Between turns the context is unset → no span → no detached/closed-parent leak.
- **Pipecat connect attrs (py + ts `connect()`)** — stamps `voice.pipecat.transport` + `voice.pipecat.transport_format` onto the executor-owned `voice.adapter.connect` span, the same seam EL uses for `voice.elevenlabs.agent_id`.

## How it works — trace tree

```
Scenario Turn → PipecatAgentAdapter.call (agent)
  └─ voice.turn
       ├─ voice.audio.send
       ├─ voice.audio.receive                      # base: consumer-side wait + timeout/ERROR (P3)
       └─ voice.audio.receive (recv.source=background_loop)   # NEW: producer delivery marker, parented to the turn (P2)
```

The two same-named `voice.audio.receive` spans are **deliberate and disambiguated** by `voice.pipecat.recv.source`: the base one owns the wait + the timeout→ERROR semantics; the background one proves the background loop's work is attributed to the turn (the Twilio-reusable pattern). This is a **delivery marker**, not a second wait measurement — the consumer-side wait already lives on the base span (Pipecat's `recv_audio` blocks on the inbound queue for the network wait).

## Test plan (mic-free `InMemorySpanExporter`, real production paths — no smoke)

- Python (6): `cd python && uv run pytest tests/voice/test_voice_spans_pipecat.py` → **6 passed** (P1 base spans + class; P1 connect attrs; P2 background span parented to turn; P2 one-span-per-turn flood-guard; P3 timeout→ERROR; P-reg no span between turns).
- TypeScript (6): `cd javascript && pnpm exec vitest run src/voice/adapters/__tests__/pipecat-spans.test.ts` → **6 passed** (mirror).

## Human verification

Backend-only instrumentation (no UI surface). To verify by hand:
1. `cd python && uv run pytest tests/voice/test_voice_spans_pipecat.py` → 6 passed; `cd javascript && pnpm exec vitest run src/voice/adapters/__tests__/pipecat-spans.test.ts` → 6 passed.
2. Server-side landing (independently re-verifiable): trace `beb80c01…` (Python) / `473534299…` (TypeScript) on app.langwatch.ai — the background span shows `parent_id == voice.turn` and `source=background_loop`.

## How I can prove I was successful

**All exercised this session; output pasted.**

- **Falsifiability — PROVEN (both languages).** Stashing the production instrumentation turns the RED→GREEN tests RED, restoring turns them GREEN. Terminal transcript (this session):

  ```
  # PY — stash the 3 production files
  $ git stash push python/scenario/voice/{adapter.py,_telemetry.py,adapters/pipecat.py}
  $ uv run pytest tests/voice/test_voice_spans_pipecat.py -q
  3 failed, 3 passed        # P1-connect-attrs, P2, P2-flood-guard RED
  $ git stash pop && uv run pytest tests/voice/test_voice_spans_pipecat.py -q
  6 passed

  # TS — stash pipecat.ts
  $ git stash push javascript/src/voice/adapters/pipecat.ts
  $ pnpm exec vitest run src/voice/adapters/__tests__/pipecat-spans.test.ts
  Tests  3 failed | 3 passed
  $ git stash pop && pnpm exec vitest run …/pipecat-spans.test.ts
  Tests  6 passed
  ```
  The 3 that stay green without the impl are the inheritance/gate guards (P1 base spans, P3 timeout→ERROR, P-reg no-span-between-turns); the 3 that flip are exactly the new capability.
- **Determinism (no sentinel-trap flakiness).** The turn-liveness gate is chosen over a waiting-consumer gate precisely so the span's presence does not depend on producer/consumer scheduling; the flood-guard test proves the count is invariant to chunk count (1 background span for 3 delivered chunks).
- **No regression — PROVEN.** Full voice suites green with the base change in place (final counts, all tests incl. the added pre-buffered/flood-guard cases): Python **109 hermetic passed** (6 errors are pre-existing key-gated live e2e); TypeScript **415 passed, 1 skipped**.
- **Type-clean — PROVEN.** `pyright` (standard, as CI) → 0 errors on all changed files; `tsc --noEmit` → 0 errors (project-wide).
- **Server-side landing — PROVEN (real production path, not a smoke; on the committed HEAD).** A harness drove the **real** Pipecat turn (base `call()`/drain + the background `_recv_loop` `_deliver`) through the real LangWatch OTLP exporter; `GET /api/trace/<id>` (per-trace, not `/search`) read the spans back:

  ```
  trace_id: beb80c010fa56ea45e8fa1e70ceefaae  → HTTP 200, 5 spans  (code @ HEAD a183bdb)
  voice.turn (span_id 80cfb254660ea7fe)
    ├─ voice.audio.send        parent_id=80cfb254660ea7fe
    ├─ voice.audio.receive     parent_id=80cfb254660ea7fe   # base drain (no source attr)
    └─ voice.audio.receive     parent_id=80cfb254660ea7fe   # ← the BACKGROUND span
         params.voice.pipecat.recv.source = "background_loop"
         params.voice.audio.bytes         = "4796"
         params.voice.adapter.class       = "PipecatAgentAdapter"
  ```
  The background span's `parent_id` **equals** `voice.turn`'s `span_id` server-side — P2's "parent is the turn" holds on the real backend, and the span carries its disambiguator + byte count. (Epic's stated prove-it: falsifiability RED→GREEN + `GET /api/trace/<id>`.)
  - **TypeScript landing — also PROVEN** (same check, TS production `flushBufferedMulaw` via `setupObservability`): `GET /api/trace/473534299ab9ef2fd0138c1b4f33800b` → the background `voice.audio.receive` span's `parent_id == voice.turn.span_id`, `voice.pipecat.recv.source=background_loop`, `voice.audio.bytes=4800`. So the parenting holds server-side in **both** runtimes, not just Python.

<!-- no-ui-surface -->
_Backend-only instrumentation/library code with **no UI surface** — the proof is the falsifiability transcript, the green suites, and the type checks._

## Anything surprising?

- **This PR touches the base** (`adapter.py`/`adapter.runtime.ts`/`_telemetry.py`/`telemetry.ts`), not only Pipecat — the turn-context publish + the explicit-`parent` span helper are **base-first**, deliberately, so Twilio (PR5) inherits the primitive. `voice.turn` context is published for every adapter but read only by background-loop adapters.
- **`voice.adapter.interrupt` is intentionally NOT here.** Pipecat advertises `interruption=True`, but that span is **executor-owned** and introduced by PR2 (Gemini, #780, a sibling not-yet-merged PR, taxonomy still unlocked). Pipecat inherits it for free once #780 lands — no Pipecat-specific code needed — so adding it here would only conflict with an unratified addition.
- **The background marker is a marker, not exhaustive accounting** (two documented coverage limits, tests lock both): (a) `voice.audio.bytes` is the delivered *coalesced-chunk* size and may fold in a sub-100 ms µ-law tail carried across the turn boundary — a pre-existing recv-loop coalescing property the base drain chunks share (correcting it would drop that audio); (b) a turn whose agent audio was **fully pre-buffered before `call()` published the turn context** (an opening greeting delivered during `connect`) is drained without a fresh wire delivery, so it gets no background marker — the base `voice.audio.receive` span still covers its consumption. The turn-liveness gate marks *in-turn wire deliveries*, deterministically, rather than every turn that consumes audio.

## Review

- **Design stress-tested up front** by an adversarial devils-advocate pass before implementation — its corrections were adopted (turn-liveness gate over a waiting-consumer gate to avoid blocked-consumer-sentinel flakiness; direct-turn parenting via an explicit parent context over `context.attach`-over-`await`; honest delivery-marker framing over a hollow wait-coverage claim).
- **High-effort multi-agent code review** run on the final diff. It surfaced 6 findings; all addressed: py/ts decode-error swallow parity (TS now logs+drops like Python's recv-loop, no socket crash), a shared guarded-`end()` between the two span helpers, TS receive-span made active-in-body to match Python, and the two coverage limits above documented + locked with pre-buffered tests in both languages. (One "redundant import" finding was refuted on inspection.)

## Base / retarget

Opened as **draft**, base = `issue770/voice-adapter-langwatch-spans` (the #777 head branch this stacks on). **Retarget to `main` + rebase after #777 merges.** Never merged by me — Drew merges.

