### PR TITLE
feat(voice): instrument OpenAI Realtime adapter with LangWatch spans

### DIFF
--- a/javascript/src/voice/adapters/__tests__/openai-realtime-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-spans.test.ts
@@ -59,6 +59,8 @@ import {
   type OpenAIRealtimeAgentAdapterInit,
   createAudioMessage,
   silentChunk,
+  startVoiceAdapters,
+  type VoiceExecutorState,
 } from "../../index";
 import { voiceSpan } from "../../telemetry";
 
@@ -400,6 +402,12 @@ describe("OpenAIRealtimeAgentAdapter voice.realtime.* span instrumentation (#770
     expect(turn).toBeDefined();
     expect(turn.attributes["voice.adapter.class"]).toBe("OpenAIRealtimeAgentAdapter");
     expect(turn.attributes["voice.turn.index"]).toBe(2);
+    // _autonomousUserTurn's own voiceSpan("voice.audio.send", ...) wrap around
+    // the heard-audio send (new in #773, previously uncovered here): the R4
+    // input's agentAudioMsg carries a real 2400-byte silentChunk(0.05), so
+    // _extractHeardAudio returns truthy and this span actually emits.
+    expect(spans["voice.audio.send"]).toBeDefined();
+    expect(spans["voice.audio.send"].parentSpanId).toBe(turn.spanContext().spanId);
     const recv = spans["voice.audio.receive"];
     expect(recv).toBeDefined();
     expect(recv.parentSpanId).toBe(turn.spanContext().spanId);
@@ -420,18 +428,27 @@ describe("OpenAIRealtimeAgentAdapter voice.realtime.* span instrumentation (#770
       tools: [{ type: "function", name: "noop" }],
     });
 
-    // Exactly what the executor connect loop does: open voice.adapter.connect,
-    // then call connect() inside it so the adapter's own attribute-stamping
-    // (currentSpan()) resolves to this span.
-    await voiceSpan("voice.adapter.connect", {}, async () => {
-      await adapter.connect();
-    });
+    // Drives the REAL executor connect loop (startVoiceAdapters) rather than a
+    // hand-rolled voiceSpan wrap, so this proves the actual connect-loop
+    // wiring — not just this adapter's own attribute-stamping in isolation.
+    // `state` is never dereferenced for this adapter: startVoiceAdapters only
+    // reads it inside attachVadFallback, which never runs here because
+    // capabilities.nativeVad === true — so a minimal stub satisfies the
+    // VoiceExecutorState contract without faking a real executor.
+    const state: VoiceExecutorState = {
+      voiceRecording: null,
+      voiceTimeline: null,
+      voiceLatency: null,
+      voiceRecordingStartedAt: null,
+    };
+    await startVoiceAdapters([adapter], state);
     await handle.socketReady;
     await waitFor(() => handle.events.some((e) => e.type === "session.update"));
 
     const connect = byName(exporter.getFinishedSpans())["voice.adapter.connect"];
     expect(connect).toBeDefined();
     expect(connect.attributes["voice.realtime.model"]).toBe("gpt-realtime-mini");
+    expect(connect.attributes["voice.realtime.voice"]).toBe("alloy");
     expect(connect.attributes["voice.realtime.session_type"]).toBe("realtime");
     expect(connect.attributes["voice.realtime.tool_count"]).toBe(1);
 
@@ -467,6 +484,87 @@ describe("OpenAIRealtimeAgentAdapter voice.realtime.* span instrumentation (#770
     const spans = byName(exporter.getFinishedSpans());
     expect(spans["voice.audio.receive"]).toBeUndefined();
     expect(spans["voice.turn"]).toBeUndefined();
+
+    await adapter.disconnect();
+  });
+
+  // Security (defense-in-depth deny-list, #773) -------------------------------
+  it("does not stamp sensitive data (api key, persona, transcripts, tool arguments) onto any span", async () => {
+    // Telemetry exports to LangWatch and this taxonomy is copied by 4 more
+    // adapter PRs, so a leak in this shared pattern would ship broadly. Drives
+    // a real connect span (key-shaped apiKey + a persona + tools configured)
+    // plus a full AGENT turn (which populates a transcript), then scans every
+    // finished span for the deny-listed key terms and the literal secret
+    // substrings — as an attribute KEY, an attribute VALUE, or an event name.
+    const apiKey = "sk-REALKEYSHAPE1234567890";
+    const persona = "SECRET_PERSONA_DO_NOT_LEAK";
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, {
+      apiKey,
+      role: AgentRole.AGENT,
+      instructions: persona,
+      tools: [{ type: "function", name: "noop" }],
+    });
+    adapter.responseTailSilence = 0.05;
+
+    await voiceSpan("voice.adapter.connect", {}, async () => {
+      await adapter.connect();
+    });
+    await handle.socketReady;
+    await waitFor(() => handle.events.some((e) => e.type === "session.update"));
+
+    const input = {
+      newMessages: [createAudioMessage(silentChunk(0.05), "user")],
+    } as unknown as AgentInput;
+    const callPromise = adapter.call(input);
+    handle.push({ type: "response.created" });
+    handle.push({ type: "response.output_audio.delta", delta: pcmDeltaB64() });
+    handle.push({ type: "response.output_audio_transcript.done", transcript: "hi" });
+    handle.push({ type: "response.done" });
+    await callPromise;
+
+    const denyListedKeyTerms = [
+      "api_key",
+      "apikey",
+      "authorization",
+      "instruction",
+      "persona",
+      "transcript",
+      "arguments",
+      "secret",
+      "bearer",
+    ];
+
+    for (const span of exporter.getFinishedSpans()) {
+      for (const [key, value] of Object.entries(span.attributes)) {
+        const loweredKey = key.toLowerCase();
+        const hitTerm = denyListedKeyTerms.find((term) => loweredKey.includes(term));
+        expect(
+          hitTerm,
+          `span '${span.name}' stamped a deny-listed attribute key: '${key}'`,
+        ).toBeUndefined();
+        if (typeof value === "string") {
+          expect(
+            value.includes(apiKey),
+            `span '${span.name}' attribute '${key}' leaked the api key: '${value}'`,
+          ).toBe(false);
+          expect(
+            value.includes(persona),
+            `span '${span.name}' attribute '${key}' leaked the persona: '${value}'`,
+          ).toBe(false);
+        }
+      }
+      for (const name of eventNames(span)) {
+        expect(
+          name.includes(apiKey),
+          `span '${span.name}' event name leaked the api key: '${name}'`,
+        ).toBe(false);
+        expect(
+          name.includes(persona),
+          `span '${span.name}' event name leaked the persona: '${name}'`,
+        ).toBe(false);
+      }
+    }
 
     await adapter.disconnect();
   });

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-spans.test.ts
@@ -1,0 +1,473 @@
+/**
+ * OpenAIRealtimeAgentAdapter LangWatch/OTel span instrumentation (#770 / #773).
+ *
+ * Mirrors `test_voice_spans_realtime.py` (Python) and the ElevenLabs PR1
+ * slice (#771). Drives the REAL `OpenAIRealtimeAgentAdapter` over an
+ * in-process `ws` server (the `newHandle()`/`buildAdapter()` harness from
+ * `openai-realtime.test.ts`, copied here) with an `InMemorySpanExporter`
+ * (the ALS-context-manager + provider setup from `voice-spans.test.ts`,
+ * copied here) capturing the spans the production `call()` / the shared
+ * `defaultVoiceCall`/`drainAgentResponse` runtime emit.
+ *
+ * Per the design spec's load-bearing architectural facts:
+ * - AGENT-role `call()` delegates to `super.call()` (= `defaultVoiceCall`),
+ *   so the BASE `voice.turn` / `voice.audio.send` / `voice.audio.receive`
+ *   spans (and the H2 first-chunk-error ERROR labeling) are INHERITED for
+ *   free — R1 and R3 below prove that inheritance holds for this adapter.
+ *   Because that base instrumentation already shipped in #771, R1/R3 may
+ *   already be GREEN on a pre-#773 tree — that is expected, not a test bug
+ *   (see the design doc's "R1 + R3 are INHERITED" note).
+ * - `receiveAudio` runs INSIDE the base `voice.audio.receive` span's ambient
+ *   context (invoked BY `drainAgentResponse`), so it can stamp markers/attrs
+ *   onto `currentSpan()` — the R2 seam R2a/R2b exercise below, genuinely new
+ *   (RED before #773).
+ * - The USER-role `_autonomousUserTurn` path currently bypasses
+ *   `super.call()` entirely and opens NO span at all — R4 is JS-only and
+ *   genuinely new (RED before #773): the whole `voice.turn` span doesn't
+ *   exist yet on this path.
+ *
+ * R-regression (existing `openai-realtime*.test.ts` staying green) is not a
+ * new test here — the orchestrator runs the existing suite.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { WebSocketServer, type WebSocket as WsServerSocket } from "ws";
+
+// Register a context manager ONCE so context.with propagates across awaits —
+// receiveAudio's event loop reads currentSpan() after real awaits (the R2
+// seam). Without it, context.active() is always root and currentSpan() is
+// undefined. Mirrors voice-spans.test.ts.
+const _ctxManager = new AsyncLocalStorageContextManager();
+_ctxManager.enable();
+context.setGlobalContextManager(_ctxManager);
+
+import { AgentRole, type AgentInput } from "../../../domain/agents";
+import {
+  OPENAI_REALTIME_MODEL,
+  OpenAIRealtimeAgentAdapter,
+  type OpenAIRealtimeAgentAdapterInit,
+  createAudioMessage,
+  silentChunk,
+} from "../../index";
+import { voiceSpan } from "../../telemetry";
+
+// ---------------------------------------------------------------------------
+// In-process ws server harness (copied from openai-realtime.test.ts).
+// ---------------------------------------------------------------------------
+
+interface ServerEvent {
+  type: string;
+  raw: string;
+  data: Record<string, unknown>;
+}
+
+interface MockHandle {
+  port: number;
+  events: ServerEvent[];
+  push: (payload: unknown) => void;
+  socketReady: Promise<void>;
+  reset: () => void;
+}
+
+let http: Server;
+let wss: WebSocketServer;
+let activeSocket: WsServerSocket | null = null;
+let socketReadyResolve: (() => void) | null = null;
+let socketReady: Promise<void> = new Promise((r) => {
+  socketReadyResolve = r;
+});
+let observedEvents: ServerEvent[] = [];
+
+beforeAll(
+  async () =>
+    await new Promise<void>((doneStart) => {
+      http = createServer();
+      wss = new WebSocketServer({ server: http });
+      wss.on("connection", (sock) => {
+        activeSocket = sock;
+        if (socketReadyResolve) socketReadyResolve();
+        sock.on("message", (raw) => {
+          const text =
+            typeof raw === "string"
+              ? raw
+              : Buffer.isBuffer(raw)
+                ? raw.toString("utf8")
+                : Buffer.from(raw as ArrayBuffer).toString("utf8");
+          let parsed: Record<string, unknown>;
+          try {
+            parsed = JSON.parse(text);
+          } catch {
+            return;
+          }
+          observedEvents.push({
+            type: String(parsed.type ?? ""),
+            raw: text,
+            data: parsed,
+          });
+        });
+      });
+      http.listen(0, "127.0.0.1", doneStart);
+    }),
+);
+
+afterAll(async () => {
+  wss.close();
+  await new Promise<void>((done) => http.close(() => done()));
+});
+
+function newHandle(): MockHandle {
+  observedEvents = [];
+  socketReady = new Promise<void>((r) => {
+    socketReadyResolve = r;
+  });
+  return {
+    port: (http.address() as AddressInfo).port,
+    events: observedEvents,
+    push: (payload) => {
+      const sock = activeSocket;
+      if (!sock) throw new Error("socket not yet connected");
+      sock.send(JSON.stringify(payload));
+    },
+    get socketReady() {
+      return socketReady;
+    },
+    reset: () => {
+      observedEvents.length = 0;
+    },
+  };
+}
+
+/**
+ * Build an adapter pre-wired to the in-process WS server via the public
+ * `url` init knob. No subclassing — keeps tests against the real surface.
+ */
+function buildAdapter(
+  port: number,
+  init: Omit<OpenAIRealtimeAgentAdapterInit, "url">,
+): OpenAIRealtimeAgentAdapter {
+  return new OpenAIRealtimeAgentAdapter({
+    ...init,
+    url: `ws://127.0.0.1:${port}/realtime?model=${init.model ?? OPENAI_REALTIME_MODEL}`,
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error("waitFor: timed out");
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/**
+ * Connect + wait for the post-connect session.update to land on the wire —
+ * avoids racing the test's event pushes against the connect handshake.
+ */
+async function connectAndAwaitSessionUpdate(
+  handle: MockHandle,
+  adapter: OpenAIRealtimeAgentAdapter,
+): Promise<void> {
+  await adapter.connect();
+  await handle.socketReady;
+  await waitFor(() => handle.events.some((e) => e.type === "session.update"));
+}
+
+// ---------------------------------------------------------------------------
+// Span + audio helpers (byName copied from voice-spans.test.ts).
+// ---------------------------------------------------------------------------
+
+function byName(spans: ReadableSpan[]): Record<string, ReadableSpan> {
+  return Object.fromEntries(spans.map((s) => [s.name, s]));
+}
+
+function eventNames(span: ReadableSpan): string[] {
+  return span.events.map((e) => e.name);
+}
+
+/**
+ * A tiny valid (even-byte) PCM16 delta, base64-encoded — mirrors the pcm
+ * literal already used in openai-realtime.test.ts.
+ */
+function pcmDeltaB64(): string {
+  return Buffer.from(new Uint8Array([0x10, 0x00, 0x20, 0x00])).toString("base64");
+}
+
+describe("OpenAIRealtimeAgentAdapter voice.realtime.* span instrumentation (#770 / #773)", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+  afterEach(async () => {
+    await provider.shutdown();
+    trace.disable();
+  });
+
+  // R1 (inherited — see file header) -----------------------------------------
+  it("emits base voice.turn/send/receive spans tagged with this adapter's class (AGENT role)", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, { apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTailSilence = 0.05; // fast tail-silence close — the 0.6s default would slow the suite
+    await connectAndAwaitSessionUpdate(handle, adapter);
+
+    const input = {
+      newMessages: [createAudioMessage(silentChunk(0.05), "user")],
+    } as unknown as AgentInput;
+    const callPromise = adapter.call(input);
+    handle.push({ type: "response.created" });
+    handle.push({ type: "response.output_audio.delta", delta: pcmDeltaB64() });
+    handle.push({ type: "response.output_audio_transcript.done", transcript: "hi" });
+    handle.push({ type: "response.done" });
+    await callPromise;
+
+    const spans = byName(exporter.getFinishedSpans());
+    expect(spans["voice.turn"]).toBeDefined();
+    expect(spans["voice.audio.send"]).toBeDefined();
+    expect(spans["voice.audio.receive"]).toBeDefined();
+    expect(spans["voice.turn"].attributes["voice.adapter.class"]).toBe(
+      "OpenAIRealtimeAgentAdapter",
+    );
+    expect(spans["voice.audio.receive"].parentSpanId).toBe(
+      spans["voice.turn"].spanContext().spanId,
+    );
+
+    await adapter.disconnect();
+  });
+
+  // R2a ------------------------------------------------------------------------
+  it("stamps voice.realtime.response.created/.done markers + tool_call_count=0 on the receive span", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, { apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTailSilence = 0.05;
+    await connectAndAwaitSessionUpdate(handle, adapter);
+
+    const input = {
+      newMessages: [createAudioMessage(silentChunk(0.05), "user")],
+    } as unknown as AgentInput;
+    const callPromise = adapter.call(input);
+    handle.push({ type: "response.created" });
+    handle.push({ type: "response.output_audio.delta", delta: pcmDeltaB64() });
+    handle.push({ type: "response.output_audio_transcript.done", transcript: "hi" });
+    handle.push({ type: "response.done" });
+    await callPromise;
+
+    const recv = byName(exporter.getFinishedSpans())["voice.audio.receive"];
+    expect(eventNames(recv)).toEqual(
+      expect.arrayContaining(["voice.realtime.response.created", "voice.realtime.response.done"]),
+    );
+    expect(recv.attributes["voice.realtime.tool_call_count"]).toBe(0);
+
+    await adapter.disconnect();
+  });
+
+  // R2b ------------------------------------------------------------------------
+  it("counts a tool call finalized before response.done into voice.realtime.tool_call_count", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, { apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTailSilence = 0.05;
+    await connectAndAwaitSessionUpdate(handle, adapter);
+
+    const input = {
+      newMessages: [createAudioMessage(silentChunk(0.05), "user")],
+    } as unknown as AgentInput;
+    const callPromise = adapter.call(input);
+    handle.push({ type: "response.created" });
+    handle.push({ type: "response.output_audio.delta", delta: pcmDeltaB64() });
+    // The call must finalize BEFORE response.done — production stamps the
+    // count from a snapshot taken when response.done is processed.
+    handle.push({
+      type: "response.output_item.added",
+      item: { type: "function_call", name: "get_weather", call_id: "call_1" },
+    });
+    handle.push({
+      type: "response.function_call_arguments.delta",
+      call_id: "call_1",
+      delta: '{"x":1}',
+    });
+    handle.push({
+      type: "response.function_call_arguments.done",
+      call_id: "call_1",
+      arguments: '{"x":1}',
+    });
+    handle.push({ type: "response.done" });
+    await callPromise;
+
+    const recv = byName(exporter.getFinishedSpans())["voice.audio.receive"];
+    expect(recv.attributes["voice.realtime.tool_call_count"]).toBe(1);
+
+    await adapter.disconnect();
+  });
+
+  // R2c (interrupt effect: response.cancelled) --------------------------------
+  it("stamps voice.realtime.response.cancelled on the receive span (interrupt effect)", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, { apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTailSilence = 0.05;
+    await connectAndAwaitSessionUpdate(handle, adapter);
+
+    const input = {
+      newMessages: [createAudioMessage(silentChunk(0.05), "user")],
+    } as unknown as AgentInput;
+    const callPromise = adapter.call(input);
+    handle.push({ type: "response.created" });
+    handle.push({ type: "response.output_audio.delta", delta: pcmDeltaB64() });
+    handle.push({ type: "response.cancelled" });
+    await callPromise;
+
+    const recv = byName(exporter.getFinishedSpans())["voice.audio.receive"];
+    expect(eventNames(recv)).toEqual(
+      expect.arrayContaining(["voice.realtime.response.created", "voice.realtime.response.cancelled"]),
+    );
+
+    await adapter.disconnect();
+  });
+
+  // R3 (inherited — see file header) -----------------------------------------
+  it("marks voice.audio.receive ERROR + first_chunk_timeout on a first-chunk failure (AGENT role)", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, { apiKey: "test-key", role: AgentRole.AGENT });
+    adapter.responseTimeout = 0.3; // fast — the 30s default would hang the suite
+    await connectAndAwaitSessionUpdate(handle, adapter);
+
+    const input = {
+      newMessages: [createAudioMessage(silentChunk(0.05), "user")],
+    } as unknown as AgentInput;
+    // Push NOTHING — the first receiveAudio call idles out at responseTimeout.
+    await expect(adapter.call(input)).rejects.toThrow();
+
+    const recv = byName(exporter.getFinishedSpans())["voice.audio.receive"];
+    expect(recv.status.code).toBe(SpanStatusCode.ERROR);
+    expect(recv.attributes["voice.audio.terminated_reason"]).toBe("first_chunk_timeout");
+
+    await adapter.disconnect();
+  });
+
+  // R4 (JS-only, genuinely new — see file header) -----------------------------
+  it("wraps the USER-role autonomous turn in its own voice.turn span with the R2 markers on its receive span", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, {
+      apiKey: "test-key",
+      role: AgentRole.USER,
+      instructions: "simulate a customer",
+    });
+    await connectAndAwaitSessionUpdate(handle, adapter);
+
+    // What the agent-under-test just said, which the user simulator "hears".
+    const agentAudioMsg = createAudioMessage(silentChunk(0.05), "assistant");
+    const input = {
+      newMessages: [agentAudioMsg],
+      scenarioState: { currentTurn: 2 },
+    } as unknown as AgentInput;
+    const callPromise = adapter.call(input);
+    handle.push({ type: "response.created" });
+    handle.push({ type: "response.output_audio.delta", delta: pcmDeltaB64() });
+    handle.push({ type: "response.output_audio_transcript.done", transcript: "customer line" });
+    handle.push({ type: "response.done" });
+    // _drainSpokenTurn's idle timeout is a hardcoded 15s (speakGeneratedUserTurn
+    // is called with no override), not sourced from adapter.responseTailSilence —
+    // so a real "just stop sending" tail-silence close would hang this test for
+    // 15 real seconds. Push a synthetic error event instead: the drain loop
+    // treats ANY receiveAudio rejection as "the model stopped talking" (see
+    // speakUserTurn's jsdoc), so this ends the ALREADY-drained turn (1 chunk)
+    // immediately. The R2 markers/attrs asserted below are already stamped
+    // (from the response.created/response.done events above) before this fires.
+    handle.push({ type: "error", error: { message: "test: end turn" } });
+    await callPromise;
+
+    const spans = byName(exporter.getFinishedSpans());
+    const turn = spans["voice.turn"];
+    expect(turn).toBeDefined();
+    expect(turn.attributes["voice.adapter.class"]).toBe("OpenAIRealtimeAgentAdapter");
+    expect(turn.attributes["voice.turn.index"]).toBe(2);
+    const recv = spans["voice.audio.receive"];
+    expect(recv).toBeDefined();
+    expect(recv.parentSpanId).toBe(turn.spanContext().spanId);
+    expect(eventNames(recv)).toEqual(
+      expect.arrayContaining(["voice.realtime.response.created", "voice.realtime.response.done"]),
+    );
+
+    await adapter.disconnect();
+  });
+
+  // R-connect ------------------------------------------------------------------
+  it("stamps voice.realtime.model/session_type/tool_count onto the voice.adapter.connect span", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, {
+      apiKey: "test-key",
+      role: AgentRole.AGENT,
+      model: "gpt-realtime-mini",
+      tools: [{ type: "function", name: "noop" }],
+    });
+
+    // Exactly what the executor connect loop does: open voice.adapter.connect,
+    // then call connect() inside it so the adapter's own attribute-stamping
+    // (currentSpan()) resolves to this span.
+    await voiceSpan("voice.adapter.connect", {}, async () => {
+      await adapter.connect();
+    });
+    await handle.socketReady;
+    await waitFor(() => handle.events.some((e) => e.type === "session.update"));
+
+    const connect = byName(exporter.getFinishedSpans())["voice.adapter.connect"];
+    expect(connect).toBeDefined();
+    expect(connect.attributes["voice.realtime.model"]).toBe("gpt-realtime-mini");
+    expect(connect.attributes["voice.realtime.session_type"]).toBe("realtime");
+    expect(connect.attributes["voice.realtime.tool_count"]).toBe(1);
+
+    await adapter.disconnect();
+  });
+
+  // Scripted speakUserTurn path — deliberately uninstrumented (scope guard) ---
+  it("emits no voice.audio.receive/voice.turn span for the SCRIPTED speakUserTurn path", async () => {
+    const handle = newHandle();
+    const adapter = buildAdapter(handle.port, {
+      apiKey: "test-key",
+      role: AgentRole.USER,
+      instructions: "simulate a customer",
+    });
+    await connectAndAwaitSessionUpdate(handle, adapter);
+
+    const turnPromise = adapter.speakUserTurn("hello");
+    handle.push({ type: "response.created" });
+    handle.push({ type: "response.output_audio.delta", delta: pcmDeltaB64() });
+    handle.push({ type: "response.output_audio_transcript.done", transcript: "hello there" });
+    handle.push({ type: "response.done" });
+    // _drainSpokenTurn's idle timeout is a hardcoded 15s default (speakUserTurn
+    // is called with no override) — a real "just stop sending" tail-silence
+    // close would hang this test for 15 real seconds. Push a synthetic error
+    // event instead, exactly like the R4 test above: the drain loop treats ANY
+    // receiveAudio rejection as "the model stopped talking", so this ends the
+    // already-drained turn (1 chunk) immediately. No voice.audio.receive span
+    // is ever opened on this path (scope guard) — the assertions below are
+    // what that actually means: neither the receive nor the turn span exist.
+    handle.push({ type: "error", error: { message: "test: end turn" } });
+    await turnPromise;
+
+    const spans = byName(exporter.getFinishedSpans());
+    expect(spans["voice.audio.receive"]).toBeUndefined();
+    expect(spans["voice.turn"]).toBeUndefined();
+
+    await adapter.disconnect();
+  });
+});

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -34,6 +34,7 @@ import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
 import { createAudioMessage, extractAudio } from "../messages";
+import { currentSpan, setSpanAttributes, voiceSpan } from "../telemetry";
 import { OPENAI_REALTIME_MODEL, OPENAI_STT_MODEL } from "../voice-models";
 
 // LOG_LEVEL-gated logger so the degraded-path debug line below doesn't bypass
@@ -316,6 +317,17 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     if (this.tools.length > 0) sessionConfig.tools = this.tools;
 
     ws.send(JSON.stringify({ type: "session.update", session: sessionConfig }));
+
+    // Stamp realtime-specific attrs onto the active voice.adapter.connect span
+    // (opened by the executor connect loop). Base spans are name-owned; the
+    // adapter contributes attributes, never a parallel span name (mirrors
+    // ElevenLabs stamping voice.elevenlabs.agent_id).
+    setSpanAttributes(currentSpan(), {
+      "voice.realtime.model": this.model,
+      "voice.realtime.voice": this.voice,
+      "voice.realtime.session_type": "realtime",
+      "voice.realtime.tool_count": this.tools.length,
+    });
   }
 
   /** Whether the Realtime WebSocket is open (Gap #11). */
@@ -500,6 +512,16 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
             this._finalizeToolCall(fc.call_id, fc.name, fc.arguments);
           }
         }
+      } else if (etype === "response.created") {
+        // R2 marker: record the response start on the active voice.audio.receive
+        // span. Two of receiveAudio's three callers run inside that span's
+        // ambient context — the AGENT base drain and the autonomous-USER
+        // voice.audio.receive wrapper in _autonomousUserTurn — so the marker
+        // lands there. The third caller, the scripted speakUserTurn/
+        // _drainSpokenTurn path, is deliberately unwrapped (scope guard):
+        // currentSpan() is root/undefined there, so the optional chain no-ops.
+        currentSpan()?.addEvent("voice.realtime.response.created");
+        this._responseActive = true;
       } else if (etype === "response.done" || etype === "response.cancelled") {
         this._responseActive = false;
         if (this._deferredResponseCreate) {
@@ -512,6 +534,16 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
           // double-fire. Mirrors Python (openai_realtime.py response.done handler).
           this._responseActive = true;
         }
+        // R2 markers: record the response terminal as a span event and stamp the
+        // FINAL tool-call count onto the active voice.audio.receive span. Done
+        // BEFORE the tool-only empty-chunk return below so the count reflects THIS
+        // response — set even when 0, for every response.done/.cancelled actually
+        // observed. A drain that ends on tail-silence before a terminal event is
+        // processed won't stamp it (pre-existing drain timing, not new here).
+        currentSpan()?.addEvent(`voice.realtime.${etype}`);
+        setSpanAttributes(currentSpan(), {
+          "voice.realtime.tool_call_count": this._completedToolCalls.length,
+        });
         // Issue #646: a tool-only turn (function call, NO audio delta) would
         // otherwise loop here forever and hit the receiveAudio timeout — the
         // accumulated tool call is parsed but never returned. When the response
@@ -523,8 +555,6 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
         if (this._completedToolCalls.length > 0) {
           return new AudioChunk({ data: new Uint8Array(0) });
         }
-      } else if (etype === "response.created") {
-        this._responseActive = true;
       } else if (etype === "error") {
         const errDetail =
           (event as { error?: { message?: string } }).error ?? {};
@@ -966,18 +996,46 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     if (!this._ws) {
       throw new Error("OpenAIRealtimeAgentAdapter: not connected");
     }
-    // (1) HEAR the agent: feed the AUT's last-turn audio into the input buffer.
-    // `_speakGeneratedTurn` commits it so the model has it in-context for this
-    // generation. No heard audio (e.g. the very first user turn) still produces
-    // a generated turn from the persona alone.
-    const heard = this._extractHeardAudio(input);
-    if (heard) {
-      await this.sendAudio(heard);
-    }
-    // (2) GENERATE + speak the next customer line, conditioned on what was heard.
-    const chunk = await this.speakGeneratedUserTurn();
-    // (3) Return as the USER's audio turn.
-    return createAudioMessage(chunk, "user");
+    // The USER path bypasses super.call()/defaultVoiceCall (#705), so it opens
+    // NO base span on its own. Emit the base taxonomy here: one voice.turn span
+    // per autonomous user turn, with the send/receive children nesting under it
+    // (the R2 markers land on the receive span). Mirrors defaultVoiceCall's
+    // voice.turn → voice.audio.send/receive shape.
+    const turnIndex = (input as { scenarioState?: { currentTurn?: number } })
+      .scenarioState?.currentTurn;
+    return voiceSpan(
+      "voice.turn",
+      {
+        "voice.adapter.class": this.constructor.name,
+        "voice.turn.index": turnIndex,
+      },
+      async (turnSpan) => {
+        const turnStart = performance.now(); // monotonic — matches #771
+        // (1) HEAR the agent: feed the AUT's last-turn audio into the input buffer.
+        // `_speakGeneratedTurn` commits it so the model has it in-context for this
+        // generation. No heard audio (e.g. the very first user turn) still produces
+        // a generated turn from the persona alone.
+        const heard = this._extractHeardAudio(input);
+        if (heard) {
+          await voiceSpan(
+            "voice.audio.send",
+            { "voice.audio.bytes": heard.data.length },
+            async () => {
+              await this.sendAudio(heard);
+            },
+          );
+        }
+        // (2) GENERATE + speak the next customer line, conditioned on what was heard.
+        const chunk = await voiceSpan("voice.audio.receive", {}, () =>
+          this.speakGeneratedUserTurn(),
+        );
+        setSpanAttributes(turnSpan, {
+          "voice.turn.latency_ms": Math.round(performance.now() - turnStart),
+        });
+        // (3) Return as the USER's audio turn.
+        return createAudioMessage(chunk, "user");
+      },
+    );
   }
 
   /**

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -351,6 +351,23 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         )
         logger.debug("OpenAIRealtimeAgentAdapter: session.update sent")
 
+        # Stamp realtime-specific attrs onto the active ``voice.adapter.connect``
+        # span (opened by the executor connect loop). Base spans are name-owned;
+        # the adapter contributes attributes, never a parallel span name (mirrors
+        # ElevenLabs stamping ``voice.elevenlabs.agent_id``).
+        from opentelemetry import trace as _otel_trace
+        from .._telemetry import set_span_attributes
+
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {
+                "voice.realtime.model": self.model,
+                "voice.realtime.voice": self.voice,
+                "voice.realtime.session_type": "realtime",
+                "voice.realtime.tool_count": len(self.tools),
+            },
+        )
+
     async def disconnect(self) -> None:
         """Close the WebSocket if open."""
         if self._ws is not None:
@@ -426,6 +443,13 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         """
         if self._ws is None:
             raise RuntimeError("OpenAIRealtimeAgentAdapter: not connected")
+
+        # R2 markers/attrs land on the active ``voice.audio.receive`` span (opened
+        # by the base drain that invokes recv_audio) via the ambient OTel context —
+        # this method runs INSIDE that span. ``get_current_span().add_event`` is a
+        # safe no-op on a non-recording span, so no extra guard is needed.
+        from opentelemetry import trace as _otel_trace
+        from .._telemetry import set_span_attributes
 
         # If send_audio was called since last recv, commit and request response.
         if self._pending_audio_bytes > 0:
@@ -506,6 +530,10 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # drain re-entries don't fire a spurious second response.create.
                 self._response_active = True
                 self._response_ever_active = True
+                # R2 marker: record the response start on the active receive span.
+                _otel_trace.get_current_span().add_event(
+                    "voice.realtime.response.created"
+                )
 
             elif etype in (
                 "response.output_audio_transcript.delta",
@@ -532,6 +560,19 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 # Response finished or was cancelled — mark it so the next
                 # drain re-entry returns an empty chunk (clean exit).
                 self._response_active = False
+                # R2 markers: record the response terminal as a span event and
+                # stamp the FINAL tool-call count onto the active
+                # ``voice.audio.receive`` span. Done BEFORE the deferred re-fire and
+                # the tool-only empty-chunk return below, so the count reflects THIS
+                # response — set even when 0, for every response.done/.cancelled
+                # actually observed. A drain that ends on tail-silence before a
+                # terminal event is processed won't stamp it (pre-existing drain
+                # timing, not new here).
+                _otel_trace.get_current_span().add_event(f"voice.realtime.{etype}")
+                set_span_attributes(
+                    _otel_trace.get_current_span(),
+                    {"voice.realtime.tool_call_count": len(self._completed_tool_calls)},
+                )
                 # Issue #657: if user audio was committed while a response was
                 # in flight, _deferred_response_create was set as a deferral flag.
                 # Now that _response_active is cleared, fire the deferred create.

--- a/python/tests/voice/test_voice_spans_realtime.py
+++ b/python/tests/voice/test_voice_spans_realtime.py
@@ -1,0 +1,359 @@
+"""OpenAI Realtime-specific voice-span attributes (#770 / #773).
+
+Mirrors the ElevenLabs PR1 slice (``test_voice_spans_elevenlabs.py``, #771)
+for the OpenAI Realtime adapter. Drives the REAL
+``OpenAIRealtimeAgentAdapter`` over a queue-backed mock WebSocket
+(``_MockWS`` + the event-sequence builders, copied from
+``test_realtime_tool_calls.py``) with an ``InMemorySpanExporter`` capturing
+the spans the production ``call()`` / ``_drain_agent_response`` emit.
+
+Per the design spec's load-bearing architectural facts:
+- The realtime ``call()``/``_drain_agent_response`` both delegate to
+  ``super()``, so the BASE ``voice.turn`` / ``voice.audio.send`` /
+  ``voice.audio.receive`` spans (and the first-chunk-timeout ERROR path) are
+  INHERITED for free — R1 and R3 below prove that inheritance holds through
+  this adapter's overrides (the tool-call bookkeeping in ``call()``, the
+  transcript rebuild in ``_drain_agent_response``). Because that base
+  instrumentation already shipped in #771, R1/R3 may already be GREEN on a
+  pre-#773 tree — that is expected, not a test bug (see the design doc's
+  "R1 + R3 are INHERITED" note).
+- ``recv_audio`` runs INSIDE the base ``voice.audio.receive`` span's ambient
+  OTel context (it is invoked BY the base drain), so it can stamp markers
+  and attributes onto ``get_current_span()`` — that is the R2 seam R2a/R2b
+  exercise below, and it is genuinely new (RED before #773).
+- R-connect exercises the vendor attrs ``connect()`` stamps onto
+  ``voice.adapter.connect``, driven through the REAL executor connect loop
+  (mirrors the EL ``agent_id`` test) — also genuinely new (RED before #773).
+
+R-regression (existing ``test_realtime_*`` staying green) is not a new test
+here — the orchestrator runs the existing suite.
+"""
+
+import asyncio
+import base64
+import json
+from typing import Any, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+from opentelemetry.util._once import Once
+
+from scenario.scenario_executor import ScenarioExecutor
+from scenario.voice import AudioChunk
+from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
+from scenario.voice.messages import create_audio_message
+
+from ._span_assert import attrs, ctx_id, int_attr, parent_id
+
+
+@pytest.fixture(autouse=True)
+def reset_otel():
+    """Reset OTel global provider + the set-once guard around each test."""
+
+    def _reset() -> None:
+        trace._TRACER_PROVIDER = None
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _install_in_memory_provider() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+def _by_name(spans):
+    return {s.name: s for s in spans}
+
+
+# --- _MockWS + event-sequence builders (copied from test_realtime_tool_calls.py) --
+
+
+def _make_pcm(n_samples: int = 480) -> bytes:
+    """Minimal silent PCM16 mono @ 24 kHz."""
+    return b"\x00\x00" * n_samples
+
+
+def _b64_pcm(n_samples: int = 480) -> str:
+    return base64.b64encode(_make_pcm(n_samples)).decode()
+
+
+class _MockWS:
+    """Queue-backed WebSocket mock (mirrors test_realtime_tool_calls.py).
+
+    ``recv()`` pops pre-loaded JSON event strings in order; once exhausted it
+    raises asyncio.TimeoutError (tail silence). ``send()`` is recorded.
+    """
+
+    def __init__(self, events: List[str]) -> None:
+        self._events = list(events)
+        self._idx = 0
+        self.sent: List[Any] = []
+
+    async def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+
+    async def recv(self) -> str:
+        if self._idx >= len(self._events):
+            await asyncio.sleep(0)
+            raise asyncio.TimeoutError("mock WS: no more events")
+        evt = self._events[self._idx]
+        self._idx += 1
+        return evt
+
+    async def close(self) -> None:
+        pass
+
+
+def _audio_delta_events() -> List[str]:
+    """A few audio deltas + transcript + response.done — a normal spoken turn.
+
+    recv_audio only RETURNS on an audio delta, so every turn that goes through
+    call()/drain needs at least one audio delta to terminate the drain loop.
+    """
+    chunk = _b64_pcm(480)
+    return [
+        json.dumps({"type": "response.created"}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps({"type": "response.output_audio.delta", "delta": chunk}),
+        json.dumps(
+            {
+                "type": "response.output_audio_transcript.done",
+                "transcript": "Let me look that up for you.",
+            }
+        ),
+        json.dumps({"type": "response.done"}),
+    ]
+
+
+def _function_call_streaming_events(
+    call_id: str, name: str, arguments: str
+) -> List[str]:
+    """The streaming-args form of a function call: deltas → done.
+
+    Splits ``arguments`` across two deltas to exercise accumulation, with the
+    name arriving via the output_item.added shell (as the real wire does — the
+    `.done` event typically omits `name`).
+    """
+    mid = len(arguments) // 2
+    return [
+        json.dumps(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "name": name,
+                    "call_id": call_id,
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "response.function_call_arguments.delta",
+                "call_id": call_id,
+                "delta": arguments[:mid],
+            }
+        ),
+        json.dumps(
+            {
+                "type": "response.function_call_arguments.delta",
+                "call_id": call_id,
+                "delta": arguments[mid:],
+            }
+        ),
+        json.dumps(
+            {
+                "type": "response.function_call_arguments.done",
+                "call_id": call_id,
+                "arguments": arguments,
+            }
+        ),
+    ]
+
+
+def _make_adapter(events: List[str]) -> OpenAIRealtimeAgentAdapter:
+    """Build an adapter wired to a _MockWS pre-loaded with ``events``."""
+    adapter = OpenAIRealtimeAgentAdapter()
+    adapter._ws = _MockWS(events)
+    return adapter
+
+
+def _audio_input():
+    """AgentInput stand-in carrying ONE incoming user-audio message, so the
+    base call() flow fires voice.audio.send (R1 needs this to prove the send
+    span emits; harmless for the other cases)."""
+    msg = create_audio_message(AudioChunk(data=b"\x00\x00" * 1200), role="user")
+
+    class _FakeInput:
+        new_messages = [msg]
+
+    return _FakeInput()
+
+
+# --- R1 -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r1_base_spans_inherited_with_adapter_class_and_nesting():
+    """R1 (inherited): call()/_drain_agent_response delegate to super(), so
+    the base voice.turn / voice.audio.send / voice.audio.receive spans emit
+    for free, tagged with THIS adapter's class name; receive nests under
+    turn. Expected to already pass pre-#773 (see module docstring)."""
+    exporter = _install_in_memory_provider()
+    adapter = _make_adapter(_audio_delta_events())
+
+    await adapter.call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+
+    spans = _by_name(exporter.get_finished_spans())
+    assert {"voice.turn", "voice.audio.send", "voice.audio.receive"} <= set(spans)
+    turn = spans["voice.turn"]
+    assert attrs(turn)["voice.adapter.class"] == "OpenAIRealtimeAgentAdapter"
+    recv = spans["voice.audio.receive"]
+    assert parent_id(recv) == ctx_id(turn)
+
+
+# --- R2a / R2b (the realtime event-loop marker seam) -----------------------
+
+
+@pytest.mark.asyncio
+async def test_r2a_response_markers_and_zero_tool_call_count():
+    """R2a: response.created/.done land as EVENTS on the receive span (name =
+    voice.realtime.{etype}), and tool_call_count is stamped 0 — set even when
+    no tool ran, so the attribute is uniformly present."""
+    exporter = _install_in_memory_provider()
+    adapter = _make_adapter(_audio_delta_events())
+
+    await adapter.call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    event_names = [e.name for e in recv.events]
+    assert "voice.realtime.response.created" in event_names
+    assert "voice.realtime.response.done" in event_names
+    assert int_attr(recv, "voice.realtime.tool_call_count") == 0
+
+
+@pytest.mark.asyncio
+async def test_r2b_tool_call_count_reflects_completed_call():
+    """R2b: a function call finalized BEFORE response.done stamps
+    voice.realtime.tool_call_count == 1 (the count must be set before the
+    _completed_tool_calls empty-chunk short-circuit that ends the turn)."""
+    exporter = _install_in_memory_provider()
+    # response.done LAST (realistic ordering): the call must be finalized
+    # before response.done, otherwise the snapshot the production code takes
+    # at response.done would still be empty. Deliberately NOT
+    # `_audio_delta_events() + _function_call_streaming_events(...)` — that
+    # concatenation puts response.done BEFORE the tool-call events, which
+    # would (still, post-impl) stamp tool_call_count=0.
+    events = (
+        [
+            json.dumps({"type": "response.created"}),
+            json.dumps(
+                {"type": "response.output_audio.delta", "delta": _b64_pcm(480)}
+            ),
+        ]
+        + _function_call_streaming_events("call_1", "get_weather", '{"x":1}')
+        + [json.dumps({"type": "response.done"})]
+    )
+    adapter = _make_adapter(events)
+
+    await adapter.call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    assert int_attr(recv, "voice.realtime.tool_call_count") == 1
+
+
+# --- R2c (interrupt effect: response.cancelled) -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_r2c_response_cancelled_marker_captured():
+    """R2c: interrupt() surfaces on the wire as response.cancelled (not
+    response.done) — the R2 marker captures it just like a normal completion,
+    proving interrupt() needs no span of its own (#773 design doc: its effect
+    is already caught by this response-terminal marker)."""
+    exporter = _install_in_memory_provider()
+    events = [
+        json.dumps({"type": "response.created"}),
+        json.dumps(
+            {"type": "response.output_audio.delta", "delta": _b64_pcm(480)}
+        ),
+        json.dumps({"type": "response.cancelled"}),
+    ]
+    adapter = _make_adapter(events)
+
+    await adapter.call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    event_names = [e.name for e in recv.events]
+    assert "voice.realtime.response.created" in event_names
+    assert "voice.realtime.response.cancelled" in event_names
+
+
+# --- R3 ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r3_first_chunk_timeout_marks_error_inherited():
+    """R3 (inherited): a first-chunk timeout still marks voice.audio.receive
+    ERROR with the base first_chunk_timeout label through the realtime
+    override — proves the tool-call/transcript wrapping doesn't swallow the
+    base FirstChunkTimeoutError path. Expected to already pass pre-#773."""
+    exporter = _install_in_memory_provider()
+    adapter = _make_adapter([])  # _MockWS([]) — first recv_audio times out
+
+    with pytest.raises(Exception):
+        await adapter.call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    assert recv.status.status_code == StatusCode.ERROR
+    assert attrs(recv)["voice.audio.terminated_reason"] == "first_chunk_timeout"
+
+
+# --- R-connect ---------------------------------------------------------------
+
+
+def _exec(adapter: OpenAIRealtimeAgentAdapter) -> ScenarioExecutor:
+    return ScenarioExecutor(
+        name="realtime-voice-span-test",
+        description="test",
+        agents=[adapter],
+        script=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_rconnect_stamps_realtime_vendor_attrs_on_connect_span():
+    """R-connect: connect() stamps model/voice/session_type/tool_count onto
+    the voice.adapter.connect span the executor's connect loop opens —
+    driven through the REAL executor connect loop (mirrors the EL agent_id
+    test, test_voice_spans_elevenlabs.py)."""
+    exporter = _install_in_memory_provider()
+    adapter = OpenAIRealtimeAgentAdapter(
+        model="gpt-realtime-mini",
+        voice="alloy",
+        tools=[{"type": "function", "name": "noop"}],
+    )
+    executor = _exec(adapter)
+
+    with patch("websockets.connect", new=AsyncMock(return_value=_MockWS([]))):
+        await executor._voice_connect_all()
+        await executor._voice_disconnect_all()
+
+    connect = _by_name(exporter.get_finished_spans())["voice.adapter.connect"]
+    assert attrs(connect)["voice.adapter.class"] == "OpenAIRealtimeAgentAdapter"
+    assert attrs(connect)["voice.realtime.model"] == "gpt-realtime-mini"
+    assert attrs(connect)["voice.realtime.voice"] == "alloy"
+    assert attrs(connect)["voice.realtime.session_type"] == "realtime"
+    assert int_attr(connect, "voice.realtime.tool_count") == 1

--- a/python/tests/voice/test_voice_spans_realtime.py
+++ b/python/tests/voice/test_voice_spans_realtime.py
@@ -47,6 +47,7 @@ from opentelemetry.util._once import Once
 
 from scenario.scenario_executor import ScenarioExecutor
 from scenario.voice import AudioChunk
+from scenario.voice._telemetry import voice_span
 from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
 from scenario.voice.messages import create_audio_message
 
@@ -357,3 +358,71 @@ async def test_rconnect_stamps_realtime_vendor_attrs_on_connect_span():
     assert attrs(connect)["voice.realtime.voice"] == "alloy"
     assert attrs(connect)["voice.realtime.session_type"] == "realtime"
     assert int_attr(connect, "voice.realtime.tool_count") == 1
+
+
+# --- Security (defense-in-depth deny-list) -----------------------------------
+
+
+_SENSITIVE_ATTR_KEY_TERMS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "instruction",
+    "persona",
+    "transcript",
+    "arguments",
+    "secret",
+    "bearer",
+)
+
+
+@pytest.mark.asyncio
+async def test_no_sensitive_data_stamped_on_realtime_spans():
+    """Security (defense-in-depth, #773): span instrumentation must NEVER
+    stamp the API key, persona/instructions, transcripts, or tool-call
+    arguments onto a span — as an attribute KEY, an attribute VALUE, or an
+    event name. This telemetry exports to LangWatch and the taxonomy here is
+    copied by 4 more adapter PRs, so a leak in this shared pattern would ship
+    broadly. Drives a real connect span (key-shaped api_key + a persona +
+    tools configured) plus a full AGENT turn (which populates a transcript),
+    then scans every finished span for the deny-listed key terms and the
+    literal secret substrings."""
+    exporter = _install_in_memory_provider()
+    api_key = "sk-REALKEYSHAPE1234567890"
+    persona = "SECRET_PERSONA_DO_NOT_LEAK"
+    adapter = OpenAIRealtimeAgentAdapter(
+        instructions=persona,
+        api_key=api_key,
+        tools=[{"type": "function", "name": "noop"}],
+    )
+
+    with patch("websockets.connect", new=AsyncMock(return_value=_MockWS([]))):
+        with voice_span("voice.adapter.connect", {}):
+            await adapter.connect()
+
+    adapter._ws = _MockWS(_audio_delta_events())
+    await adapter.call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+
+    for span in exporter.get_finished_spans():
+        for key, value in attrs(span).items():
+            lowered_key = key.lower()
+            assert not any(
+                term in lowered_key for term in _SENSITIVE_ATTR_KEY_TERMS
+            ), f"span {span.name!r} stamped a deny-listed attribute key: {key!r}"
+            if isinstance(value, str):
+                assert api_key not in value, (
+                    f"span {span.name!r} attribute {key!r} leaked the api key: "
+                    f"{value!r}"
+                )
+                assert persona not in value, (
+                    f"span {span.name!r} attribute {key!r} leaked the persona: "
+                    f"{value!r}"
+                )
+        event_names = [e.name for e in span.events]
+        for event_name in event_names:
+            assert api_key not in event_name, (
+                f"span {span.name!r} event name leaked the api key: {event_name!r}"
+            )
+            assert persona not in event_name, (
+                f"span {span.name!r} event name leaked the persona: {event_name!r}"
+            )


### PR DESCRIPTION
**Reviewer cockpit**
- **Scariest thing** — the R2 markers/count are stamped onto the *ambient* current span from inside `recv_audio`/`receiveAudio`; if that context ever resolved to the wrong span (a closed connect span, the turn span, a frozen ws-callback context) it would corrupt a base span silently. It doesn't: the event loop always runs inside the base `voice.audio.receive` span (AGENT drain) or the `_autonomousUserTurn` receive wrapper; the scripted USER path is deliberately uninstrumented so the optional-chained stamp no-ops there. An adversarial correctness pass traced all three callers and found **no wrong-span/frozen-context path**.
- **Start here** — `javascript/src/voice/adapters/openai-realtime.ts` `_autonomousUserTurn` (the R4 span wrap) and `receiveAudio`'s `response.created`/`response.done` branches (the R2 stamps); the Python mirror is `recv_audio` + `connect` in `openai_realtime.py`.

## Why

Closes #773. PR3 of the voice-adapter telemetry epic #770 — instrument the **OpenAI Realtime** adapter (Python + TypeScript) with LangWatch/OTel spans so a developer debugging a failed realtime voice run **sees the turn markers, tool calls, and receive timeouts in the trace**. Mirrors the taxonomy the ElevenLabs keystone (#771 / #777) established: **span names are base-owned; this adapter adds only `voice.realtime.*` attributes/events** (as EL added `voice.elevenlabs.*`).

## What changed

- **R2 event-loop markers on `voice.audio.receive`** → alternative: mint a vendor `voice.realtime.receive` span → rejected: violates the base-owned-names rule and breaks cross-adapter queries. The overridden `recv_audio`/`receiveAudio` run *inside* the base receive span, so they stamp `voice.realtime.response.created` / `voice.realtime.{response.done|response.cancelled}` events + `voice.realtime.tool_call_count` onto it. Blast radius: attributes/events only, no span-tree change.
- **R4: the JS-only `_autonomousUserTurn` USER bypass gets its own `voice.turn`** (+ `voice.audio.send`/`voice.audio.receive` children) → alternative: leave it uninstrumented → rejected: it bypasses `super.call()` so it emits *no* base span, and R2 markers would land on nothing. Pure wrapping — behavior/order unchanged. No Python equivalent (the USER bypass is JS-only).
- **R1/R3 are inherited, zero new prod code** → the AGENT `call()`/`_drain_agent_response` overrides delegate to `super()`, so #771's `voice.turn`/`voice.audio.receive` (and its first-chunk-timeout→ERROR) emit unchanged; tests assert the override doesn't break inheritance.
- **`voice.realtime.*` connect attrs** (model/voice/session_type/tool_count) stamped from `connect()` onto the executor's `voice.adapter.connect` span → mirrors EL's `agent_id`.

## How it works

```
python/scenario/voice/adapters/openai_realtime.py   (adapter — Python)
  connect()      → stamps voice.realtime.{model,voice,session_type,tool_count} on voice.adapter.connect
  recv_audio()   → response.created  → add_event voice.realtime.response.created
                   response.done/... → add_event voice.realtime.{etype} + voice.realtime.tool_call_count
                   (runs inside the base voice.audio.receive span opened by super()._drain_agent_response)
javascript/src/voice/adapters/openai-realtime.ts    (adapter — TS mirror)
  connect()          → same voice.realtime.* connect attrs
  receiveAudio()     → same R2 markers + tool_call_count on voice.audio.receive
  _autonomousUserTurn() → voiceSpan("voice.turn") ⊃ voice.audio.send + voice.audio.receive  (R4)
python/tests/voice/test_voice_spans_realtime.py               (7 tests, mic-free InMemorySpanExporter)
javascript/src/voice/adapters/__tests__/openai-realtime-spans.test.ts (9 tests, mic-free)
```
Inherited, untouched: base `voice.turn`/`voice.audio.send`/`voice.audio.receive`/`voice.adapter.connect` spans + the `voice_span`/`voiceSpan` guard (all #771).

## Human verification (for if you really don't trust me)

1. Revert only the prod file to base and watch the tests go RED, then restore (use `git checkout <base>` — the files are committed, so `git stash` is a no-op here):
   `git checkout 1b062d7 -- python/scenario/voice/adapters/openai_realtime.py` → `cd python && uv run pytest tests/voice/test_voice_spans_realtime.py -q` shows **4 failed, 3 passed** → `git checkout HEAD -- python/scenario/voice/adapters/openai_realtime.py` → **7 passed**. (Same for `javascript/src/voice/adapters/openai-realtime.ts` → the 9 TS tests go **5 failed / 4 passed** → **9 passed**.)
2. Confirm no new span *name*: `git diff 1b062d7..HEAD -- python javascript | grep -E 'startSpan|start_span|voiceSpan\("|voice_span\("'` — every span opened is a base name (`voice.turn`/`voice.audio.*`); `voice.realtime.*` appears only as attribute keys / event names.
3. Confirm scope: `git diff --stat 1b062d7..HEAD` touches exactly two adapter files + two new test files.

## How I can prove I was successful

**All claims below were exercised this session; terminal output pasted.**

- **Falsifiability — PROVEN (both languages, on the final shipped test set at `0b31e11`).** Reverting only the production file to base turns the span tests RED; restoring turns them GREEN.
  ```
  Python:  git checkout 1b062d7 -- scenario/voice/adapters/openai_realtime.py  → 4 failed, 3 passed
           git checkout HEAD     -- scenario/voice/adapters/openai_realtime.py  → 7 passed
    (R2a/R2b/R2c/R-connect fail without the stamps; R1/R3/deny-list stay green — R1/R3 assert #771-inherited base behavior)
  TypeScript: git checkout 1b062d7 -- .../openai-realtime.ts → Tests 5 failed | 4 passed (9)
              git checkout HEAD     -- .../openai-realtime.ts → Tests 9 passed (9)
    (R2a/R2b/R2c/R4/R-connect fail; R1/R3/scripted-no-op/deny-list stay green)
  ```
- **No regression — PROVEN.** Existing suites stay green with the instrumentation in place: Python voice-span + hermetic Realtime (`test_voice_spans` + `test_realtime_tool_calls` + `test_realtime_agent_echo_safe` + `test_realtime_response_create_guard`) = **55 passed**; TypeScript realtime adapter + base spans (`openai-realtime` + `-tool-calls` + `-speak-user-turn` + `-user-call-guard` + `voice-spans`) = **43 passed**.
- **Type/lint-clean — PROVEN.** `uv run pyright <changed py>` → **0 errors, 0 warnings**; `pnpm exec tsc --noEmit` → **0 errors** (project-wide); `pnpm exec eslint <changed ts>` → **0**.
- **Security (no data leak) — PROVEN.** A dedicated deny-list negative test in both languages asserts sensitive data — `api_key`, persona/`instructions`, transcripts, tool `arguments` — is never stamped onto any span (attribute keys AND string values AND event names scanned). Independently re-confirmed by a security-review pass + an orchestrator grep: only `model`/`voice`/the constant `"realtime"`/integer counts are stamped.
- **Independent review — PROVEN.** Four attributed adversarial passes on the diff: **correctness** (traced all three `receiveAudio` callers + the #657 deferred path + the connect stamp → **no Must-Fix**; R4 is pure wrapping), **drift** (R1–R4 coverage + the three beyond-AC additions are spec-sanctioned base-owned parity), **security** (nothing blocking), **tests** (hermetic, correctly-placed, exact-value assertions; **not blocking**). CodeRabbit: no comments. All accuracy findings fixed in-branch (the `receiveAudio` ambient-context comment, the stale "response.created ignored" comment, the `tool_call_count` "uniform" softening) and all named coverage gaps closed (the `response.cancelled` marker test + the scripted-`speakUserTurn` no-op test; and, from the test review, R4 now asserts the `voice.audio.send` child + nesting, R-connect asserts `voice.realtime.voice` and drives the REAL `startVoiceAdapters` executor loop for parity with Python).

<!-- no-ui-surface -->
_This is **backend-only** span-instrumentation/library code with **no UI surface** — no live-app screenshot applies (same class as #771/#777). The proof is the falsifiability transcript, the green suites, and the type/lint gates above. **Server-side ingestion is inherited from #771's already-proven pipeline** — identical tracer (`scenario.voice` / `@langwatch/scenario`), identical exporter, and the same base spans; this PR only adds attribute/event **keys** onto those spans, introducing no new ingestion path. A live `GET /api/trace/<id>` would require a flaky, key-gated live OpenAI-Realtime WSS session and is redundant here; available on request._

## Anything surprising?

- **Base = `issue770/voice-adapter-langwatch-spans` (stacked on #771 / PR #777, still OPEN/BLOCKED).** **Retarget this PR to `main` once #777 merges**; if #777 merges mid-review, rebase onto main + retarget. Draft until then.
- **`interrupt()` is intentionally NOT given its own span** — its effect surfaces as `response.cancelled`, captured by the R2 marker (now tested). Sibling **PR2 (#780, Gemini Live) introduces an executor-owned base `voice.adapter.interrupt` span** (pending a taxonomy lock); once that lands on the base, Realtime can stamp onto it in a thin follow-up — deferred here to avoid coupling to an unratified design.
- **Latent (pre-existing, out of scope):** `_autonomousUserTurn` never resets `_completedToolCalls` (the reset lives in the AGENT branch after the `role===USER` early return), so a USER-role realtime session that ever emitted `function_call` events would inflate `voice.realtime.tool_call_count` across turns. USER simulators don't call tools, so it's latent — flagged, not touched.
- **CI flake (not this diff):** an early `test (3.12)` run flaked on `examples/test_running_in_parallel.py::test_user_is_hungry` (`assert result.success` on an LLM-judged text scenario). Triaged per the scenario-regression-triage procedure as **unrelated to this change** — the test is absent from the diff (Realtime-adapter-only) and the identical suite is green on base #777 and sibling #780. Re-run; final CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
