### PR TITLE
feat(voice): instrument voice.stt.transcribe span (#776)

### DIFF
--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -78,6 +78,7 @@ import {
 import { AudioPlaybackSink } from "../voice/playback";
 import { computeLatencyMetrics } from "../voice/recording.runtime";
 import type {
+  AudioSegment,
   LatencyMetrics,
   VoiceEvent,
   VoiceRecording,
@@ -781,43 +782,81 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     // "per-run, not per-turn" in the trace SHAPE. Python's mirror is per-turn
     // under voice.turn; the shared voice.stt.transcribe span carries the same
     // attributes at each language's position, disambiguated by voice.stt.scope.
+    //
+    // Correlation attrs mirror newTurn()'s "Scenario Turn" root (scenario.run_id
+    // / thread_id / origin) so this per-run batch — its own trace, since it has
+    // no run-root parent — is attributable to the run in the dashboard (grouped
+    // by scenario.run_id), not an anonymous orphan trace.
     await voiceSpan(
       "voice.stt.backfill",
-      { "voice.stt.scope": "run", "voice.stt.segment_count": targets.length },
+      {
+        "voice.stt.scope": "run",
+        "voice.stt.segment_count": targets.length,
+        "langwatch.origin": "simulation",
+        "scenario.run_id": this.scenarioRunId ?? "",
+        [attributes.ATTR_LANGWATCH_THREAD_ID]: this.state.threadId,
+      },
       async () => {
-        await Promise.all(
-          targets.map(async (seg) => {
-            try {
-              // One span per STT provider call — attribute-parity with Python's
-              // per-turn voice.stt.transcribe. A provider failure marks THIS
-              // span ERROR and re-throws into the catch below, which keeps the
-              // run alive (best-effort STT — behaviour unchanged).
-              await voiceSpan(
-                "voice.stt.transcribe",
-                {
-                  "voice.stt.scope": "run",
-                  "voice.stt.speaker": seg.speaker,
-                  "voice.stt.audio_bytes": seg.audio.length,
-                },
-                async (span) => {
-                  const chunk = new AudioChunk({ data: seg.audio });
-                  const text = (await stt.transcribe(chunk)).trim();
-                  if (text) {
-                    seg.transcript = text;
-                    span.setAttribute("voice.stt.transcript_chars", text.length);
-                  }
-                },
-              );
-            } catch (err) {
-              this.logger.warn(
-                `voice: STT back-fill failed for a ${seg.speaker} segment; ` +
-                  `manifest transcript left unset (${(err as Error).message})`,
-              );
-            }
-          }),
-        );
+        await Promise.all(targets.map((seg) => this.transcribeSegment(seg, stt)));
       },
     );
+  }
+
+  /**
+   * Back-fill ONE segment's transcript under a `voice.stt.transcribe` span
+   * (attribute-parity with Python's per-turn span; #776).
+   *
+   * The per-segment try/catch is LOAD-BEARING for finally-safety, not just
+   * best-effort transcripts: it keeps a provider failure from rejecting the
+   * batch's `Promise.all`, which would re-throw out of
+   * `backfillSegmentTranscripts` in `execute()`'s `finally` and MASK the
+   * scenario result / primary exception. Do not remove it.
+   */
+  private async transcribeSegment(
+    seg: AudioSegment,
+    stt: ResolvedVoiceConfig["stt"],
+  ): Promise<void> {
+    try {
+      await voiceSpan(
+        "voice.stt.transcribe",
+        {
+          "voice.stt.scope": "run",
+          "voice.stt.speaker": seg.speaker,
+          "voice.stt.audio_bytes": seg.audio.length,
+        },
+        async (span) => {
+          const chunk = new AudioChunk({ data: seg.audio });
+          let text: string;
+          try {
+            text = (await stt.transcribe(chunk)).trim();
+          } catch (err) {
+            // Sanitize BEFORE the span records it: provider SDK errors
+            // (OpenAI/ElevenLabs) can embed the raw response body — and a key
+            // fragment on a 401 — in `.message`, which `voiceSpan`'s
+            // `recordException` would EXPORT to telemetry. Log the detail
+            // locally at debug (non-exported); surface a minimal,
+            // provider-agnostic error so the span still marks ERROR without
+            // leaking (mirrors `ElevenLabsSTTProvider` in voice/stt).
+            this.logger.debug(
+              `voice: STT provider error on a ${seg.speaker} segment`,
+              err,
+            );
+            throw new Error(
+              `STT provider failed: ${(err as Error)?.constructor?.name ?? "Error"}`,
+            );
+          }
+          if (text) {
+            seg.transcript = text;
+            span.setAttribute("voice.stt.transcript_chars", text.length);
+          }
+        },
+      );
+    } catch (err) {
+      this.logger.warn(
+        `voice: STT back-fill failed for a ${seg.speaker} segment; ` +
+          `manifest transcript left unset (${(err as Error).message})`,
+      );
+    }
   }
 
   /**

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -86,6 +86,7 @@ import {
   deriveInterruptResponseTime,
   markTruncatedAgentSegments,
 } from "../voice/segment-utils";
+import { voiceSpan } from "../voice/telemetry";
 import { sleep } from "../voice/utils";
 import type { VoiceExecutorState } from "../voice/voice-executor-state";
 
@@ -772,19 +773,50 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
         (s.transcriptTruncated || !s.transcript || s.transcript.trim() === ""),
     );
     if (targets.length === 0) return;
-    await Promise.all(
-      targets.map(async (seg) => {
-        try {
-          const chunk = new AudioChunk({ data: seg.audio });
-          const text = (await stt.transcribe(chunk)).trim();
-          if (text) seg.transcript = text;
-        } catch (err) {
-          this.logger.warn(
-            `voice: STT back-fill failed for a ${seg.speaker} segment; ` +
-              `manifest transcript left unset (${(err as Error).message})`,
-          );
-        }
-      }),
+    // voice.stt.backfill — a per-RUN batch span parenting one
+    // voice.stt.transcribe child per segment (#776). TS transcribes per-run in
+    // this finally (no per-turn STT, unlike Python's _ensure_transcript), and
+    // there is no run-root span here to nest under — so the batch span groups
+    // the otherwise-orphaned per-run spans into one coherent trace and encodes
+    // "per-run, not per-turn" in the trace SHAPE. Python's mirror is per-turn
+    // under voice.turn; the shared voice.stt.transcribe span carries the same
+    // attributes at each language's position, disambiguated by voice.stt.scope.
+    await voiceSpan(
+      "voice.stt.backfill",
+      { "voice.stt.scope": "run", "voice.stt.segment_count": targets.length },
+      async () => {
+        await Promise.all(
+          targets.map(async (seg) => {
+            try {
+              // One span per STT provider call — attribute-parity with Python's
+              // per-turn voice.stt.transcribe. A provider failure marks THIS
+              // span ERROR and re-throws into the catch below, which keeps the
+              // run alive (best-effort STT — behaviour unchanged).
+              await voiceSpan(
+                "voice.stt.transcribe",
+                {
+                  "voice.stt.scope": "run",
+                  "voice.stt.speaker": seg.speaker,
+                  "voice.stt.audio_bytes": seg.audio.length,
+                },
+                async (span) => {
+                  const chunk = new AudioChunk({ data: seg.audio });
+                  const text = (await stt.transcribe(chunk)).trim();
+                  if (text) {
+                    seg.transcript = text;
+                    span.setAttribute("voice.stt.transcript_chars", text.length);
+                  }
+                },
+              );
+            } catch (err) {
+              this.logger.warn(
+                `voice: STT back-fill failed for a ${seg.speaker} segment; ` +
+                  `manifest transcript left unset (${(err as Error).message})`,
+              );
+            }
+          }),
+        );
+      },
     );
   }
 

--- a/javascript/src/voice/__tests__/fixtures/audio-user-simulator.ts
+++ b/javascript/src/voice/__tests__/fixtures/audio-user-simulator.ts
@@ -5,6 +5,7 @@ import {
   UserSimulatorAgentAdapter,
 } from "../../../domain";
 import type { AudioChunk } from "../../audio-chunk";
+import { createAudioMessage } from "../../messages";
 
 /**
  * Build a user-role message carrying an audio (`input_audio` / pcm16) content
@@ -40,6 +41,13 @@ export class AudioUserSimulator extends UserSimulatorAgentAdapter {
     super();
   }
   async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    // A chunk that carries a transcript → a full audio message, so the transcript
+    // reaches the recorded user segment (which is then NOT an STT back-fill
+    // target). An audio-only chunk → the bare `input_audio` content-part (the
+    // original behavior; the recorded segment has no transcript → a target).
+    if (this.chunk.transcript) {
+      return createAudioMessage(this.chunk, "user") as unknown as AgentReturnTypes;
+    }
     return audioMessageContent(this.chunk);
   }
 }

--- a/javascript/src/voice/__tests__/voice-spans-stt.test.ts
+++ b/javascript/src/voice/__tests__/voice-spans-stt.test.ts
@@ -1,0 +1,221 @@
+/**
+ * STT span tests (#776) — the per-run back-fill path.
+ *
+ * Python transcribes PER-TURN inside call() (`_ensure_transcript`), so its
+ * `voice.stt.transcribe` span nests under `voice.turn`. TypeScript has NO
+ * per-turn STT: `runVoiceTurn` attaches the adapter's NATIVE transcript (not
+ * STT), and the actual STT-provider run is a PER-RUN back-fill
+ * (`backfillSegmentTranscripts`) in `execute()`'s `finally`, over the recording
+ * segments, OUTSIDE any turn span. Per the #776 decision this emits
+ * `voice.stt.transcribe` (scope=run) nested under a `voice.stt.backfill` batch
+ * span (the batch parent groups the otherwise-orphaned per-run spans and encodes
+ * "per-run, not per-turn" in the trace shape).
+ *
+ * Mic-free / offline: drives the REAL `ScenarioExecution.execute()` (the same
+ * path `scenario.run()` takes) with a fake voice adapter, a fake STT provider,
+ * and a fake judge. No network, no real keys.
+ */
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Register a context manager ONCE so context.with propagates across awaits — the
+// back-fill children read context.active() (the batch span) after an await.
+const _ctxManager = new AsyncLocalStorageContextManager();
+_ctxManager.enable();
+context.setGlobalContextManager(_ctxManager);
+
+import {
+  AgentRole,
+  type AgentInput,
+  type AgentReturnTypes,
+  JudgeAgentAdapter,
+  UserSimulatorAgentAdapter,
+} from "../../domain";
+import { ScenarioExecution } from "../../execution/scenario-execution";
+import { agent, judge, user } from "../../script";
+import { AudioChunk } from "../audio-chunk";
+import { createAudioMessage } from "../messages";
+import type { STTProvider } from "../stt";
+import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+
+const SR = 24000; // PCM16 mono 24kHz
+
+/** Non-silent PCM16 chunk carrying an optional transcript. */
+function tone(seconds: number, transcript?: string): AudioChunk {
+  const data = new Uint8Array(Math.round(seconds * SR) * 2);
+  for (let i = 0; i < data.length; i++) data[i] = (i % 250) + 1;
+  return new AudioChunk({ data, transcript });
+}
+
+/** In-process STT stub: returns a fixed text, or throws when `boom` is set. */
+class FakeSTT implements STTProvider {
+  calls = 0;
+  constructor(private opts: { text?: string; boom?: boolean } = {}) {}
+  async transcribe(_audio: AudioChunk): Promise<string> {
+    this.calls++;
+    if (this.opts.boom) throw new Error("stt down");
+    return this.opts.text ?? "transcribed text";
+  }
+}
+
+/** User simulator that emits an AUDIO message so the agent records a user turn. */
+class AudioUserSimulator extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  constructor(private userTranscript?: string) {
+    super();
+  }
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return createAudioMessage(
+      tone(0.12, this.userTranscript),
+      "user",
+    ) as unknown as AgentReturnTypes;
+  }
+}
+
+/** Fake judge that concludes the run successfully on the judge() step. */
+class PassingJudge extends JudgeAgentAdapter {
+  criteria: string[] = ["Agent responds"];
+  async call(input: AgentInput) {
+    if (!input.judgmentRequest) return null;
+    return {
+      success: true,
+      reasoning: "voice turn completed",
+      metCriteria: [...this.criteria],
+      unmetCriteria: [],
+    };
+  }
+}
+
+function buildExecution(
+  stt: STTProvider,
+  agentReply: AudioChunk,
+  transcriptlessUser = false,
+): ScenarioExecution {
+  // Default: the user audio carries a transcript, so ONLY the agent reply is a
+  // back-fill target. `transcriptlessUser` drops it so the user segment is a
+  // target too (used to prove voice.stt.speaker + segment_count scale).
+  const userTranscript = transcriptlessUser
+    ? undefined
+    : "I need help with my account";
+  const adapter = new FakeVoiceAdapter({ responses: [agentReply] });
+  return new ScenarioExecution(
+    {
+      name: "voice / stt back-fill spans",
+      description: "#776 per-run STT back-fill spans",
+      agents: [adapter, new AudioUserSimulator(userTranscript), new PassingJudge()],
+      voice: { stt },
+    },
+    [user(), agent(), judge()],
+    "test-batch-id",
+  );
+}
+
+function byName(spans: ReadableSpan[]): Record<string, ReadableSpan> {
+  return Object.fromEntries(spans.map((s) => [s.name, s]));
+}
+
+describe("voice.stt.* back-fill spans (#776)", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+  afterEach(async () => {
+    await provider.shutdown();
+    trace.disable();
+  });
+
+  it("emits voice.stt.transcribe (scope=run) nested under voice.stt.backfill", async () => {
+    const stt = new FakeSTT({ text: "the agent said this" });
+    // Agent reply is AUDIO-ONLY (no transcript, no lastAgentTranscript) → its
+    // recording segment is a back-fill target; the user segment already carries
+    // its transcript so it is not.
+    await buildExecution(stt, tone(0.2)).execute();
+    const spans = byName(exporter.getFinishedSpans());
+
+    expect(spans["voice.stt.backfill"]).toBeDefined();
+    expect(spans["voice.stt.transcribe"]).toBeDefined();
+
+    const t = spans["voice.stt.transcribe"];
+    expect(t.attributes["voice.stt.scope"]).toBe("run");
+    expect(t.attributes["voice.stt.speaker"]).toBe("agent");
+    expect(t.attributes["voice.stt.audio_bytes"]).toBeGreaterThan(0);
+    expect(t.attributes["voice.stt.transcript_chars"]).toBe(
+      "the agent said this".length,
+    );
+    expect(t.attributes["langwatch.span.type"]).toBe("span");
+    // The per-run position: nested under the batch span, NOT under a turn span.
+    expect(t.parentSpanId).toBe(
+      spans["voice.stt.backfill"].spanContext().spanId,
+    );
+    expect(
+      spans["voice.stt.backfill"].attributes["voice.stt.segment_count"],
+    ).toBe(1);
+    expect(spans["voice.stt.backfill"].attributes["voice.stt.scope"]).toBe(
+      "run",
+    );
+    expect(stt.calls).toBe(1);
+  });
+
+  it("labels each segment's speaker and scales segment_count (user + agent targets)", async () => {
+    const stt = new FakeSTT({ text: "text" });
+    // BOTH the user audio (no transcript) and the agent reply (no transcript)
+    // are back-fill targets → two voice.stt.transcribe children with distinct
+    // speakers under one batch span. Proves voice.stt.speaker flows from
+    // seg.speaker (not a hardcoded constant) and segment_count reflects N.
+    await buildExecution(stt, tone(0.2), true).execute();
+    const finished = exporter.getFinishedSpans();
+    const transcribes = finished.filter((s) => s.name === "voice.stt.transcribe");
+    const backfill = byName(finished)["voice.stt.backfill"];
+
+    expect(transcribes.length).toBe(2);
+    expect(backfill.attributes["voice.stt.segment_count"]).toBe(2);
+    const speakers = transcribes
+      .map((s) => s.attributes["voice.stt.speaker"])
+      .sort();
+    expect(speakers).toEqual(["agent", "user"]);
+    // both children parent under the single batch span
+    for (const t of transcribes) {
+      expect(t.parentSpanId).toBe(backfill.spanContext().spanId);
+    }
+    expect(stt.calls).toBe(2);
+  });
+
+  it("marks voice.stt.transcribe ERROR on provider failure but the run still completes", async () => {
+    const stt = new FakeSTT({ boom: true });
+    const result = await buildExecution(stt, tone(0.2)).execute();
+    expect(result).toBeTruthy(); // run completed despite the STT failure
+
+    const spans = byName(exporter.getFinishedSpans());
+    const t = spans["voice.stt.transcribe"];
+    expect(t.status.code).toBe(SpanStatusCode.ERROR);
+    expect(t.attributes["voice.stt.transcript_chars"]).toBeUndefined();
+    // The batch span itself is NOT errored — per-segment failures are swallowed
+    // inside it (best-effort), so a batch of otherwise-fine segments succeeds.
+    expect(spans["voice.stt.backfill"].status.code).not.toBe(
+      SpanStatusCode.ERROR,
+    );
+  });
+
+  it("emits no voice.stt.* spans when every segment already has a transcript", async () => {
+    const stt = new FakeSTT();
+    // Agent reply carries its own transcript → no segment is a back-fill target.
+    await buildExecution(stt, tone(0.2, "already have it")).execute();
+    const names = exporter.getFinishedSpans().map((s) => s.name);
+    expect(names).not.toContain("voice.stt.transcribe");
+    expect(names).not.toContain("voice.stt.backfill");
+    expect(stt.calls).toBe(0);
+  });
+});

--- a/javascript/src/voice/__tests__/voice-spans-stt.test.ts
+++ b/javascript/src/voice/__tests__/voice-spans-stt.test.ts
@@ -8,8 +8,8 @@
  * (`backfillSegmentTranscripts`) in `execute()`'s `finally`, over the recording
  * segments, OUTSIDE any turn span. Per the #776 decision this emits
  * `voice.stt.transcribe` (scope=run) nested under a `voice.stt.backfill` batch
- * span (the batch parent groups the otherwise-orphaned per-run spans and encodes
- * "per-run, not per-turn" in the trace shape).
+ * span (the batch parent groups the otherwise-orphaned per-run spans, carries
+ * the run-correlation attrs, and encodes "per-run, not per-turn" in the shape).
  *
  * Mic-free / offline: drives the REAL `ScenarioExecution.execute()` (the same
  * path `scenario.run()` takes) with a fake voice adapter, a fake STT provider,
@@ -31,18 +31,12 @@ const _ctxManager = new AsyncLocalStorageContextManager();
 _ctxManager.enable();
 context.setGlobalContextManager(_ctxManager);
 
-import {
-  AgentRole,
-  type AgentInput,
-  type AgentReturnTypes,
-  JudgeAgentAdapter,
-  UserSimulatorAgentAdapter,
-} from "../../domain";
+import { type AgentInput, JudgeAgentAdapter } from "../../domain";
 import { ScenarioExecution } from "../../execution/scenario-execution";
 import { agent, judge, user } from "../../script";
 import { AudioChunk } from "../audio-chunk";
-import { createAudioMessage } from "../messages";
 import type { STTProvider } from "../stt";
+import { AudioUserSimulator } from "./fixtures/audio-user-simulator";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
 
 const SR = 24000; // PCM16 mono 24kHz
@@ -57,25 +51,11 @@ function tone(seconds: number, transcript?: string): AudioChunk {
 /** In-process STT stub: returns a fixed text, or throws when `boom` is set. */
 class FakeSTT implements STTProvider {
   calls = 0;
-  constructor(private opts: { text?: string; boom?: boolean } = {}) {}
+  constructor(private opts: { text?: string; boom?: Error } = {}) {}
   async transcribe(_audio: AudioChunk): Promise<string> {
     this.calls++;
-    if (this.opts.boom) throw new Error("stt down");
+    if (this.opts.boom) throw this.opts.boom;
     return this.opts.text ?? "transcribed text";
-  }
-}
-
-/** User simulator that emits an AUDIO message so the agent records a user turn. */
-class AudioUserSimulator extends UserSimulatorAgentAdapter {
-  role = AgentRole.USER;
-  constructor(private userTranscript?: string) {
-    super();
-  }
-  async call(_input: AgentInput): Promise<AgentReturnTypes> {
-    return createAudioMessage(
-      tone(0.12, this.userTranscript),
-      "user",
-    ) as unknown as AgentReturnTypes;
   }
 }
 
@@ -93,23 +73,24 @@ class PassingJudge extends JudgeAgentAdapter {
   }
 }
 
+/**
+ * A voice run needs an AUDIO user turn (the framework fail-closes on a text-only
+ * user against a voice agent). The user chunk controls whether the USER segment
+ * is a back-fill target: a chunk WITH a transcript → the user segment carries it
+ * → NOT a target (default here); a transcript-LESS chunk → a target. The agent
+ * reply's transcript (or absence) controls the agent segment the same way.
+ */
 function buildExecution(
   stt: STTProvider,
   agentReply: AudioChunk,
-  transcriptlessUser = false,
+  userChunk: AudioChunk = tone(0.12, "I need help with my account"),
 ): ScenarioExecution {
-  // Default: the user audio carries a transcript, so ONLY the agent reply is a
-  // back-fill target. `transcriptlessUser` drops it so the user segment is a
-  // target too (used to prove voice.stt.speaker + segment_count scale).
-  const userTranscript = transcriptlessUser
-    ? undefined
-    : "I need help with my account";
   const adapter = new FakeVoiceAdapter({ responses: [agentReply] });
   return new ScenarioExecution(
     {
       name: "voice / stt back-fill spans",
       description: "#776 per-run STT back-fill spans",
-      agents: [adapter, new AudioUserSimulator(userTranscript), new PassingJudge()],
+      agents: [adapter, new AudioUserSimulator(userChunk), new PassingJudge()],
       voice: { stt },
     },
     [user(), agent(), judge()],
@@ -140,8 +121,7 @@ describe("voice.stt.* back-fill spans (#776)", () => {
   it("emits voice.stt.transcribe (scope=run) nested under voice.stt.backfill", async () => {
     const stt = new FakeSTT({ text: "the agent said this" });
     // Agent reply is AUDIO-ONLY (no transcript, no lastAgentTranscript) → its
-    // recording segment is a back-fill target; the user segment already carries
-    // its transcript so it is not.
+    // recording segment is a back-fill target; the text user makes no segment.
     await buildExecution(stt, tone(0.2)).execute();
     const spans = byName(exporter.getFinishedSpans());
 
@@ -160,22 +140,22 @@ describe("voice.stt.* back-fill spans (#776)", () => {
     expect(t.parentSpanId).toBe(
       spans["voice.stt.backfill"].spanContext().spanId,
     );
-    expect(
-      spans["voice.stt.backfill"].attributes["voice.stt.segment_count"],
-    ).toBe(1);
-    expect(spans["voice.stt.backfill"].attributes["voice.stt.scope"]).toBe(
-      "run",
-    );
+
+    // The batch span carries segment_count AND the run-correlation attrs, so the
+    // otherwise-orphan per-run trace is attributable to the run (#776 review).
+    const backfill = spans["voice.stt.backfill"];
+    expect(backfill.attributes["voice.stt.segment_count"]).toBe(1);
+    expect(backfill.attributes["voice.stt.scope"]).toBe("run");
+    expect(backfill.attributes["langwatch.origin"]).toBe("simulation");
+    expect(backfill.attributes["scenario.run_id"]).toBeTruthy();
     expect(stt.calls).toBe(1);
   });
 
   it("labels each segment's speaker and scales segment_count (user + agent targets)", async () => {
     const stt = new FakeSTT({ text: "text" });
-    // BOTH the user audio (no transcript) and the agent reply (no transcript)
-    // are back-fill targets → two voice.stt.transcribe children with distinct
-    // speakers under one batch span. Proves voice.stt.speaker flows from
-    // seg.speaker (not a hardcoded constant) and segment_count reflects N.
-    await buildExecution(stt, tone(0.2), true).execute();
+    // Transcript-LESS user chunk → BOTH the user and the agent segment are
+    // targets → two children with distinct speakers under one batch span.
+    await buildExecution(stt, tone(0.2), tone(0.12)).execute();
     const finished = exporter.getFinishedSpans();
     const transcribes = finished.filter((s) => s.name === "voice.stt.transcribe");
     const backfill = byName(finished)["voice.stt.backfill"];
@@ -193,8 +173,12 @@ describe("voice.stt.* back-fill spans (#776)", () => {
     expect(stt.calls).toBe(2);
   });
 
-  it("marks voice.stt.transcribe ERROR on provider failure but the run still completes", async () => {
-    const stt = new FakeSTT({ boom: true });
+  it("marks voice.stt.transcribe ERROR on provider failure but the run still completes, without leaking the raw provider message", async () => {
+    // A provider error whose message embeds a secret-shaped body (the exact
+    // OpenAI/ElevenLabs leak the sanitization guards against).
+    const stt = new FakeSTT({
+      boom: new Error("401 Unauthorized: invalid key sk-abc...wxyz body={...}"),
+    });
     const result = await buildExecution(stt, tone(0.2)).execute();
     expect(result).toBeTruthy(); // run completed despite the STT failure
 
@@ -207,6 +191,23 @@ describe("voice.stt.* back-fill spans (#776)", () => {
     expect(spans["voice.stt.backfill"].status.code).not.toBe(
       SpanStatusCode.ERROR,
     );
+    // SECURITY (#776 review): the raw provider message must NOT reach the
+    // exported span — the recorded exception is sanitized to a provider-agnostic
+    // string, so no response body / key fragment leaks into telemetry.
+    const recorded = JSON.stringify(t.events);
+    expect(recorded).not.toContain("sk-abc");
+    expect(recorded).not.toContain("401 Unauthorized");
+    expect(recorded).toContain("STT provider failed");
+  });
+
+  it("emits a span with no transcript_chars (OK, not ERROR) when STT returns empty text", async () => {
+    const stt = new FakeSTT({ text: "" }); // no-speech / silence result
+    await buildExecution(stt, tone(0.2)).execute();
+    const t = byName(exporter.getFinishedSpans())["voice.stt.transcribe"];
+    expect(t).toBeDefined();
+    expect(t.status.code).not.toBe(SpanStatusCode.ERROR);
+    expect(t.attributes["voice.stt.transcript_chars"]).toBeUndefined();
+    expect(t.attributes["voice.stt.audio_bytes"]).toBeGreaterThan(0);
   });
 
   it("emits no voice.stt.* spans when every segment already has a transcript", async () => {

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -313,11 +313,13 @@ class VoiceAgentAdapter(AgentAdapter):
             # ``voice.stt.transcribe`` — one span per per-turn STT provider call,
             # nesting under this turn's ``voice.turn`` span (#776). Python runs
             # STT per-turn (here); the TS mirror is a per-RUN back-fill batch
-            # (``voice.stt.backfill`` → ``voice.stt.transcribe``), so the same
-            # span name carries the same attributes at a language-appropriate
-            # position, disambiguated by ``voice.stt.scope``. A provider failure
-            # marks the span ERROR and propagates to the ``except`` below, which
-            # keeps the run alive (best-effort STT — behaviour unchanged).
+            # (``voice.stt.backfill`` → ``voice.stt.transcribe``). Shared
+            # attributes across BOTH languages: ``voice.stt.scope`` /
+            # ``.speaker`` / ``.audio_bytes`` / ``.transcript_chars``.
+            # ``voice.adapter.class`` is Python-ONLY here: the per-turn STT always
+            # transcribes THIS adapter's own agent output, whereas the TS per-run
+            # back-fill is adapter-agnostic over recorded segments. Disambiguate
+            # cross-language by ``voice.stt.scope`` (turn vs run).
             with voice_span(
                 "voice.stt.transcribe",
                 {
@@ -326,10 +328,27 @@ class VoiceAgentAdapter(AgentAdapter):
                     "voice.stt.speaker": "agent",
                     "voice.stt.audio_bytes": len(merged.data),
                 },
-            ) as _stt_span:
-                text = await transcribe(merged)
+            ) as stt_span:
+                try:
+                    text = await transcribe(merged)
+                except Exception as exc:
+                    # Sanitize BEFORE the span records it: provider SDK errors
+                    # (OpenAI/ElevenLabs) can embed the raw response body — and a
+                    # key fragment on a 401 — in the message, which
+                    # ``voice_span``'s ``record_exception`` would EXPORT to
+                    # telemetry. Log the detail locally at DEBUG (non-exported);
+                    # raise a minimal, provider-agnostic error (``from None`` so
+                    # the chained original is not formatted into the recorded
+                    # traceback) so the span still marks ERROR without leaking.
+                    # Mirrors ``ElevenLabsSTTProvider`` in ``voice/stt.py``.
+                    logger.debug(
+                        "voice: STT provider error detail", exc_info=True
+                    )
+                    raise RuntimeError(
+                        f"STT provider failed: {type(exc).__name__}"
+                    ) from None
                 if text:
-                    _stt_span.set_attribute("voice.stt.transcript_chars", len(text))
+                    stt_span.set_attribute("voice.stt.transcript_chars", len(text))
         except Exception:
             logger.warning(
                 "voice: agent-turn STT failed; the user simulator will see "

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -310,7 +310,26 @@ class VoiceAgentAdapter(AgentAdapter):
         if not merged.data or merged.transcript:
             return merged
         try:
-            text = await transcribe(merged)
+            # ``voice.stt.transcribe`` — one span per per-turn STT provider call,
+            # nesting under this turn's ``voice.turn`` span (#776). Python runs
+            # STT per-turn (here); the TS mirror is a per-RUN back-fill batch
+            # (``voice.stt.backfill`` → ``voice.stt.transcribe``), so the same
+            # span name carries the same attributes at a language-appropriate
+            # position, disambiguated by ``voice.stt.scope``. A provider failure
+            # marks the span ERROR and propagates to the ``except`` below, which
+            # keeps the run alive (best-effort STT — behaviour unchanged).
+            with voice_span(
+                "voice.stt.transcribe",
+                {
+                    "voice.adapter.class": type(self).__name__,
+                    "voice.stt.scope": "turn",
+                    "voice.stt.speaker": "agent",
+                    "voice.stt.audio_bytes": len(merged.data),
+                },
+            ) as _stt_span:
+                text = await transcribe(merged)
+                if text:
+                    _stt_span.set_attribute("voice.stt.transcript_chars", len(text))
         except Exception:
             logger.warning(
                 "voice: agent-turn STT failed; the user simulator will see "

--- a/python/tests/voice/test_voice_spans.py
+++ b/python/tests/voice/test_voice_spans.py
@@ -343,14 +343,51 @@ async def test_776_stt_no_span_when_transcript_already_present(restore_stt):
     assert fake.calls == 0
 
 
+def _exc_events_text(span) -> str:
+    """Concatenated text of every exception event recorded on a span."""
+    parts = []
+    for ev in getattr(span, "events", []) or []:
+        a = ev.attributes or {}
+        for key in ("exception.type", "exception.message", "exception.stacktrace"):
+            value = a.get(key)
+            if value:
+                parts.append(str(value))
+    return " ".join(parts)
+
+
 @pytest.mark.asyncio
 async def test_776_stt_failure_marks_error_but_turn_completes(restore_stt):
-    """#776: an STT provider failure marks the span ERROR yet the turn still completes (best-effort)."""
+    """#776: an STT provider failure marks the span ERROR yet the turn still completes (best-effort),
+    and the raw provider message is NOT leaked into the exported span (sanitized)."""
     exporter = _install_in_memory_provider()
-    set_stt_provider(_FakeSTT(boom=RuntimeError("stt down")))
+    # A provider error whose message embeds a secret-shaped body — the exact
+    # OpenAI/ElevenLabs leak the sanitization guards against.
+    set_stt_provider(
+        _FakeSTT(boom=RuntimeError("401 invalid key sk-abc...wxyz body={...}"))
+    )
     result = await _ScriptedAdapter([_NO_TX_CHUNK, "timeout"]).call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
     assert isinstance(result, dict) and result["role"] == "assistant"  # turn completed
     stt = _by_name(exporter.get_finished_spans())["voice.stt.transcribe"]
     assert stt.status.status_code == StatusCode.ERROR
     # no transcript_chars is recorded on the failure path
     assert "voice.stt.transcript_chars" not in attrs(stt)
+    # SECURITY (#776 review): the raw provider message must NOT reach the exported
+    # span — the recorded exception is sanitized to a provider-agnostic string.
+    recorded = _exc_events_text(stt)
+    assert "sk-abc" not in recorded
+    assert "401" not in recorded
+    assert "STT provider failed" in recorded
+
+
+@pytest.mark.asyncio
+async def test_776_stt_empty_text_span_ok_no_chars(restore_stt):
+    """#776: an empty STT result → span OK (not ERROR), no transcript_chars, transcript unset."""
+    exporter = _install_in_memory_provider()
+    set_stt_provider(_FakeSTT(text=""))
+    result = await _ScriptedAdapter([_NO_TX_CHUNK, "timeout"]).call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+    # audio-only message returned unchanged (no transcript part added)
+    assert isinstance(result, dict) and result["role"] == "assistant"
+    stt = _by_name(exporter.get_finished_spans())["voice.stt.transcribe"]
+    assert stt.status.status_code != StatusCode.ERROR
+    assert "voice.stt.transcript_chars" not in attrs(stt)
+    assert attrs(stt)["voice.stt.audio_bytes"] == 2400

--- a/python/tests/voice/test_voice_spans.py
+++ b/python/tests/voice/test_voice_spans.py
@@ -25,6 +25,7 @@ from opentelemetry.util._once import Once
 
 from scenario.voice import AdapterCapabilities, AudioChunk, VoiceAgentAdapter
 from scenario.voice.messages import create_audio_message
+from scenario.voice.stt import STTProvider, get_stt_provider, set_stt_provider
 
 from ._span_assert import attrs, ctx_id, int_attr, parent_id
 
@@ -276,3 +277,80 @@ async def test_a7_export_failure_never_breaks_the_turn(caplog):
         and "failed to export" in r.getMessage()
     ]
     assert warnings, "expected a scenario.voice WARNING for the swallowed span-end"
+
+
+# --- STT (#776) ---------------------------------------------------------------
+# Python transcribes per-turn inside call() (_ensure_transcript), so the
+# voice.stt.transcribe span nests under voice.turn. TS is per-run (a separate
+# test file) — see the #776 decision on the position asymmetry.
+
+_NO_TX_CHUNK = AudioChunk(data=b"\x00\x00" * 1200)  # 2400 bytes, NO transcript
+
+
+class _FakeSTT(STTProvider):
+    """In-process STT stub: returns a fixed text, or raises ``boom`` if set."""
+
+    def __init__(self, text: str = "transcribed", boom: BaseException | None = None):
+        self.text = text
+        self.boom = boom
+        self.calls = 0
+
+    async def transcribe(self, audio: AudioChunk) -> str:
+        self.calls += 1
+        if self.boom is not None:
+            raise self.boom
+        return self.text
+
+
+@pytest.fixture
+def restore_stt():
+    """Restore the global STT provider after a test swaps it."""
+    original = get_stt_provider()
+    yield
+    set_stt_provider(original)
+
+
+@pytest.mark.asyncio
+async def test_776_stt_span_nested_under_turn(restore_stt):
+    """#776: a transcript-less agent turn emits voice.stt.transcribe under voice.turn (scope=turn)."""
+    exporter = _install_in_memory_provider()
+    set_stt_provider(_FakeSTT(text="hello there"))
+    await _ScriptedAdapter([_NO_TX_CHUNK, "timeout"]).call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+    spans = _by_name(exporter.get_finished_spans())
+    assert "voice.stt.transcribe" in spans, list(spans)
+    stt = spans["voice.stt.transcribe"]
+    a = attrs(stt)
+    assert a["voice.stt.scope"] == "turn"
+    assert a["voice.stt.speaker"] == "agent"
+    assert a["voice.stt.audio_bytes"] == 2400
+    assert a["voice.stt.transcript_chars"] == len("hello there")
+    assert a["voice.adapter.class"] == "_ScriptedAdapter"
+    assert a["langwatch.span.type"] == "span"
+    # nests under the turn span (Python's per-turn position)
+    assert parent_id(stt) == ctx_id(spans["voice.turn"])
+
+
+@pytest.mark.asyncio
+async def test_776_stt_no_span_when_transcript_already_present(restore_stt):
+    """#776: a chunk that already carries a transcript emits NO span + makes NO provider call."""
+    exporter = _install_in_memory_provider()
+    fake = _FakeSTT()
+    set_stt_provider(fake)
+    # _CHUNK carries transcript="hi back" → _ensure_transcript short-circuits.
+    await _ScriptedAdapter([_CHUNK, "timeout"]).call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+    names = [s.name for s in exporter.get_finished_spans()]
+    assert "voice.stt.transcribe" not in names
+    assert fake.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_776_stt_failure_marks_error_but_turn_completes(restore_stt):
+    """#776: an STT provider failure marks the span ERROR yet the turn still completes (best-effort)."""
+    exporter = _install_in_memory_provider()
+    set_stt_provider(_FakeSTT(boom=RuntimeError("stt down")))
+    result = await _ScriptedAdapter([_NO_TX_CHUNK, "timeout"]).call(_audio_input())  # type: ignore[arg-type]  # duck-typed input stand-in for AgentInput
+    assert isinstance(result, dict) and result["role"] == "assistant"  # turn completed
+    stt = _by_name(exporter.get_finished_spans())["voice.stt.transcribe"]
+    assert stt.status.status_code == StatusCode.ERROR
+    # no transcript_chars is recorded on the failure path
+    assert "voice.stt.transcript_chars" not in attrs(stt)


### PR DESCRIPTION
> **Reviewer cockpit**
> - **Scariest thing** — STT is best-effort (a failure must NEVER fail the run). Two ways this diff could break that: (1) a provider exception now runs inside `voice_span`, whose `recordException` **exports** the message — OpenAI/ElevenLabs SDK errors embed the raw response body (+ a key fragment on a 401) → **telemetry leak** (found in review, **fixed**: sanitized at both sites); (2) a throw in `execute()`'s `finally` would **mask the scenario result** (the TS batch body is a `Promise.all` whose every element has its own try/catch → never rejects → `backfillSegmentTranscripts` stays non-throwing; the per-segment catch is now commented load-bearing).
> - **Start here** — `python/scenario/voice/adapter.py` `_ensure_transcript` and `javascript/src/execution/scenario-execution.ts` `transcribeSegment` / `backfillSegmentTranscripts`. They emit the *same* span at *different* trace depths on purpose (the #776 decision below).

## Why

Closes #776. #771 landed the base `voice.*` taxonomy but **deferred `voice.stt.transcribe`** because the STT seam is structurally asymmetric across the two SDKs and needed a position decision, not just code. This is PR6 of epic #770.

## What changed

- **`voice.stt.transcribe` = the atomic per-chunk STT span in BOTH languages** → *(alt: a distinct `voice.stt.*` name per language)* → same name + same attributes means one cross-language query works; the parent differs because each SDK calls STT from a structurally different place, encoded honestly in the trace **shape** + a `voice.stt.scope` attr.
- **Python: per-turn, nested under `voice.turn`** (`_ensure_transcript`, inside `call()`) → `voice.stt.scope="turn"`.
- **TS: per-run, under a NEW `voice.stt.backfill` batch parent** (`backfillSegmentTranscripts`, in `execute()`'s `finally`) → *(alt: bare spans)* → but `execute()` has **no run-root span** there, so bare spans would **orphan into N separate traces**; the batch span groups them and carries the run-correlation attrs (`scenario.run_id` / `langwatch.thread_id` / `langwatch.origin`) so the per-run trace is attributable to the run. `voice.stt.scope="run"`.
- **Pure instrumentation, no STT behaviour change** → the provider call, text handling, and the best-effort swallow (WARNING + audio-only chunk, run never fails) are unchanged; a provider failure additionally marks the span **ERROR** — with the message **sanitized** so no raw provider body/secret is exported.

**Decision (issue #776 asked to pick one):** taken **option 3** — keep `voice.stt.transcribe` atomic in both, give the TS per-run back-fill its own distinct parent. Rejected **option 1** (bare spans orphan) and **option 2** (restructure TS to per-turn — TS has *no* per-turn STT today; adding one is a real behaviour change with double-transcription risk).

## Taxonomy (new — please **lock** in review)

| Span | Langs | Parent | Key attributes |
|---|---|---|---|
| `voice.stt.transcribe` | py + ts | py: `voice.turn` · ts: `voice.stt.backfill` | `voice.stt.scope` (`turn`\|`run`), `.audio_bytes`, `.transcript_chars` (success), `.speaker`; **py-only** `voice.adapter.class` |
| `voice.stt.backfill` | ts only | root | `voice.stt.scope="run"`, `.segment_count`, `scenario.run_id`, `langwatch.thread_id`, `langwatch.origin` |

`langwatch.span.type="span"` on both (via the shared `voice_span`/`voiceSpan` guard from #771).

**Decided in review (not changed):** `voice.adapter.class` stays **py-only**. The TS back-fill is adapter-agnostic (it transcribes recorded segments, user + agent, from possibly multiple adapters; the user-segment case has no unambiguous adapter), so stamping the agent-under-test class would be wrong for user segments and inconsistent within TS. `voice.stt.scope` is the cross-language disambiguator.

## How it works

```
voice.stt.transcribe  (atomic per-chunk STT-provider span; shared name+attrs)
├── Python   scenario/voice/adapter.py :: _ensure_transcript
│            └── wraps `await transcribe(merged)` → child of the active voice.turn span
└── TS       execution/scenario-execution.ts :: backfillSegmentTranscripts
             └── voice.stt.backfill (per-run batch parent + run-correlation attrs)
                 └── transcribeSegment(seg) → one voice.stt.transcribe per target segment
```

## Human verification

Backend-only — no UI surface; visual proof exempt. <!-- no-ui-surface -->

1. Python server-side (independently re-verifiable): `curl -H "Authorization: Bearer $LANGWATCH_API_KEY" https://app.langwatch.ai/api/trace/53dbae6650a7b39d37d60d7390b05c1b` → the `voice.stt.transcribe` span nested under `voice.turn` with all attrs.
2. Falsifiability: `git stash` the two production hunks → `uv run pytest python/tests/voice/test_voice_spans.py -k 776` and `pnpm exec vitest run src/voice/__tests__/voice-spans-stt.test.ts` both fail (no `voice.stt.*` span); un-stash → both pass.
3. No-leak: the error tests assert the recorded span exception is the sanitized `STT provider failed: …`, never the raw `sk-…` / `401 …` fixture message.

## How I can prove I was successful

**1. Falsifiability RED→GREEN, both languages — `proven`.** New span-presence tests FAIL on the pre-instrumentation tree, PASS after:
```
# Python RED (pre-impl): voice.stt.transcribe absent
E   assert 'voice.stt.transcribe' in {'voice.audio.receive':…, 'voice.audio.send':…, 'voice.turn':…}
FAILED …::test_776_stt_span_nested_under_turn
2 failed, 1 passed, 12 deselected
# Python GREEN (now, incl. sanitization + empty-text tests added in review):
4 passed, 12 deselected in 0.03s

# TS RED (pre-impl): voice.stt.backfill absent
AssertionError: expected undefined to be defined  (spans["voice.stt.backfill"])
Tests  2 failed | 1 passed (3)
# TS GREEN (now, incl. multi-segment + empty-text + no-leak tests added in review):
Test Files  1 passed (1) · Tests  5 passed (5)
```
_(Note: the original RED capture shows the two span-presence tests failing; the multi-segment / empty-text / no-leak tests were **added during review** and post-date it — hence 3-test RED vs 5-test GREEN.)_

**2. Server-side ingestion via `GET /api/trace/<id>` (never `/search`) — Python `proven`; TS `claimed`.** A mic-free smoke drove the REAL `adapter.call()` with a fake in-process STT inside a `langwatch.trace()`, exporting through the real OTLP pipeline. Read back (HTTP 200), **independently re-verified by the review**:
```
GET .../api/trace/53dbae6650a7b39d37d60d7390b05c1b → 200   (project project_nWygNcPApt9bYgfYSk0wW)
stt-span-smoke-776 (root) → voice.turn(832c43e2) → { voice.audio.send, voice.audio.receive, voice.stt.transcribe }
voice.stt.transcribe.parent == voice.turn.span_id ✓
params: langwatch.span.type=span, voice.adapter.class=_ScriptedAdapter,
        voice.stt.scope=turn, voice.stt.speaker=agent, voice.stt.audio_bytes=2400, voice.stt.transcript_chars=49
```
TS ingestion is **`claimed`** (honest): TS *emission* is proven via InMemory (5 tests — asserting `voice.stt.backfill`, `voice.stt.segment_count`, `voice.stt.scope="run"`, AND the new `scenario.run_id` correlation attr); the export path is the identical `voiceSpan`→OTLP path #771 proved server-side and Python re-proved here. A TS server-side GET was attempted via the real `LangWatchExporter` (a real trace_id exported) but did not read back within the poll window this session (ingestion lag / throwaway-harness flush) — not blocking, Python is the representative cross-language ingestion proof.

**3. No regression — `proven`.**
```
Python:  python/tests/voice/{test_voice_spans, test_voice_spans_executor, test_voice_spans_elevenlabs}.py
         → 22 passed, 2 warnings in 0.48s
         pyright scenario/voice/adapter.py tests/voice/test_voice_spans.py → 0 errors, 0 warnings, 0 informations
TS:      voice-spans + voice-spans-stt + result-audio + hooks + vad-fallback + duration-fidelity
         → Test Files 6 passed (6) · Tests 42 passed (42)   (fixture change is safe for all consumers)
         tsc --noEmit → exit 0 ; eslint (changed files) → exit 0
```
**CI on HEAD `fab31af` (authoritative gate):** Python `test (3.12)` → **pass (6m13s)**, `python-complete` → pass. (JS `build`/`ci-checks` are draft-gated `skipping` per repo policy — the 42 local TS tests above are the JS evidence until ready.)

_(Local full `pytest tests/voice/` hits the known `scenario.run()` teardown-drain hang in `test_agent_wait_false.py` — zero STT refs, unrelated; e2e "errors" are missing-key collection skips. Both pre-exist this change.)_

## Review + fixes applied (7-reviewer `/review`, all findings resolved)

Design-soundness: **Option 3 correct, not a reinvention**; drift-reviewer: **no intent↔delivery drift**; test-reviewer: **tests solid**; proof-reviewer: **Python proof independently re-verified**. Fixes landed in `fab31af`:
- **[security] Fixed** — sanitize the STT provider exception before the span records it (no raw body/secret exported); py + ts + a no-leak assertion test each.
- **[design] Fixed** — `voice.stt.backfill` now carries run-correlation attrs (was an anonymous orphan trace).
- **[hygiene] Fixed** — reuse the canonical `AudioUserSimulator` fixture (extended to branch on the chunk transcript) instead of a same-named local redefinition.
- **[principles] Fixed** — extracted `transcribeSegment()`; clarified the py parity comment; renamed `_stt_span`.
- **[tests] Added** — empty-transcript coverage (both langs).

## Anything surprising?

- **Base = `issue770/voice-adapter-langwatch-spans`** (stacked on #777). **Retarget to `main` once #777 merges.**
- **Scope / follow-ups (filed, not deferred):** the **judge pre-pass** STT is a second, symmetric STT pass left uninstrumented → `voice.stt.transcribe` **undercounts** run STT → #785. Extract the duplicated `PassingJudge` test double → #786. Security audit of the other #770–774 `voiceSpan` sites for the same raw-provider-exception export vector (+ harden the 3 unhardened STT providers) → #787.
- **Reversibility:** if you prefer option 1, dial-back is dropping the `voice.stt.backfill` batch span (~10 lines).


