### PR TITLE
feat(voice): instrument Twilio adapter with LangWatch spans

### DIFF
--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -21,6 +21,7 @@
  *   exception.
  */
 
+import { context } from "@opentelemetry/api";
 import type { Span } from "@opentelemetry/api";
 import type { VoiceAgentAdapter } from "./adapter";
 import { PendingTransportError } from "./adapters/pending-transport-error";
@@ -334,7 +335,19 @@ export async function defaultVoiceCall(
       "voice.adapter.class": adapter.constructor.name,
       "voice.turn.index": turnIndex,
     },
-    (span) => runVoiceTurn(adapter, input, span),
+    async (span) => {
+      // Publish the live turn context so background-receive-loop adapters
+      // (Pipecat/Twilio) can parent their detached-callback recv spans under
+      // THIS turn (#774). context.active() here is the voice.turn span (voiceSpan
+      // ran us inside its context.with). Cleared in finally so a callback firing
+      // between turns finds `undefined` and skips its span.
+      adapter._voiceTurnContext = context.active();
+      try {
+        return await runVoiceTurn(adapter, input, span);
+      } finally {
+        adapter._voiceTurnContext = undefined;
+      }
+    },
   );
 }
 

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -13,6 +13,8 @@
  * OpenAI Realtime, Gemini Live, ElevenLabs).
  */
 
+import type { Context } from "@opentelemetry/api";
+
 import { defaultVoiceCall } from "./adapter.runtime";
 import { AudioChunk } from "./audio-chunk";
 import { AdapterCapabilities, UnsupportedCapabilityError } from "./capabilities";
@@ -145,6 +147,16 @@ export abstract class VoiceAgentAdapter extends AgentAdapter {
    * by {@link scenario.interrupt} when `afterWords: N` is set.
    */
   streamingTranscript?: string;
+
+  /**
+   * Live OTel context of the CURRENT `voice.turn`, published by
+   * {@link defaultVoiceCall} for background-receive-loop adapters
+   * (Pipecat/Twilio) to parent their detached-callback recv spans under the
+   * turn (#774 — the reusable pattern Twilio PR5 inherits). `undefined` between
+   * turns, so a callback firing outside a turn skips its span rather than
+   * parenting under a closed turn. Internal (underscore) — not a public API.
+   */
+  _voiceTurnContext?: Context;
 
   /**
    * Transmit DTMF tones to the telephony peer. Adapters that advertise

--- a/javascript/src/voice/adapters/__tests__/pipecat-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/pipecat-spans.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Pipecat-specific voice-span tests (#770 / #774, PR4). TypeScript mirror of
+ * `python/tests/voice/test_voice_spans_pipecat.py`.
+ *
+ * Drives the REAL `PipecatAgentAdapter` (base `defaultVoiceCall`/drain + the
+ * background `onMessage` receive callback) against a fake WebSocket, asserting:
+ *  - P1 — a Pipecat turn emits the #771 base spans with class = Pipecat, and the
+ *    connect span carries the Pipecat transport attrs.
+ *  - P2 — the background receive callback emits a `voice.audio.receive` span
+ *    parented to the turn (not detached/closed). Core AC: proves the
+ *    context-capture pattern Twilio (#770 PR5) reuses.
+ *  - P3 — a receive timeout marks `voice.audio.receive` ERROR.
+ *  - P-regression — no orphaned/leaked span from the background callback on
+ *    disconnect.
+ *
+ * Mic-free: an InMemorySpanExporter captures spans from the real production
+ * code; only the vendor WebSocket is faked.
+ */
+import { Buffer } from "node:buffer";
+
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Register a context manager ONCE so context.with propagates across awaits (the
+// receive-loop parenting under test depends on it). Mirrors voice-spans.test.ts.
+const _ctxManager = new AsyncLocalStorageContextManager();
+_ctxManager.enable();
+context.setGlobalContextManager(_ctxManager);
+
+import { type AgentInput } from "../../../domain/agents";
+import {
+  startVoiceAdapters,
+  stopVoiceAdapters,
+} from "../../adapter.runtime";
+import { AudioChunk } from "../../audio-chunk";
+import { createAudioMessage } from "../../messages";
+import { type VoiceExecutorState } from "../../voice-executor-state";
+import { PipecatAgentAdapter, type PipecatWebSocketLike } from "../pipecat";
+import { pcm16ToMulaw } from "../twilio-shared";
+
+/** Fake ws.WebSocket: captures outbound, pushes inbound via emit(). */
+class FakeWebSocket implements PipecatWebSocketLike {
+  readonly sent: string[] = [];
+  private listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  send(data: string | Uint8Array): void {
+    this.sent.push(
+      typeof data === "string" ? data : Buffer.from(data).toString("utf8"),
+    );
+  }
+  close(): void {
+    this.emit("close", undefined);
+  }
+  on(event: "message", listener: (data: unknown) => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "close", listener: () => void): this;
+  on(event: "open", listener: () => void): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string, listener: (...args: any[]) => void): this {
+    (this.listeners[event] ??= []).push(listener);
+    return this;
+  }
+  once(event: "open", listener: () => void): this;
+  once(event: "error", listener: (err: Error) => void): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string, listener: (...args: any[]) => void): this {
+    const wrapped = (...args: unknown[]): void => {
+      this.off(event, wrapped);
+      listener(...args);
+    };
+    return this.on(event as "open", wrapped as () => void);
+  }
+  removeAllListeners(event?: string): this {
+    if (event) this.listeners[event] = [];
+    else this.listeners = {};
+    return this;
+  }
+  emit(event: string, arg: unknown): void {
+    for (const l of [...(this.listeners[event] ?? [])]) l(arg);
+  }
+  private off(event: string, listener: (...args: unknown[]) => void): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    const idx = arr.indexOf(listener);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+}
+
+const SR = 24000;
+
+function tone(seconds: number): AudioChunk {
+  const data = new Uint8Array(Math.round(seconds * SR) * 2);
+  for (let i = 0; i < data.length; i++) data[i] = (i % 250) + 1;
+  return new AudioChunk({ data });
+}
+
+/** One coalesced inbound chunk: ~100 ms of µ-law (>= 800 bytes) as a media frame. */
+function inboundMediaFrame(streamSid: string): string {
+  const pcm8k = new Uint8Array(1600); // 800 samples @ 8 kHz PCM16 → 800 µ-law bytes
+  const view = new DataView(pcm8k.buffer);
+  for (let i = 0; i < 800; i++) view.setInt16(i * 2, 3000, true);
+  const mulaw = pcm16ToMulaw(pcm8k);
+  return JSON.stringify({
+    event: "media",
+    streamSid,
+    media: { payload: Buffer.from(mulaw).toString("base64") },
+  });
+}
+
+function audioInput(incoming?: AudioChunk): AgentInput {
+  const newMessages = incoming ? [createAudioMessage(incoming, "user")] : [];
+  return { newMessages } as unknown as AgentInput;
+}
+
+function byName(spans: ReadableSpan[]): Record<string, ReadableSpan> {
+  return Object.fromEntries(spans.map((s) => [s.name, s]));
+}
+
+function receives(spans: ReadableSpan[]): ReadableSpan[] {
+  return spans.filter((s) => s.name === "voice.audio.receive");
+}
+
+function makeAdapter(socketRef: { ws?: FakeWebSocket }): PipecatAgentAdapter {
+  return new PipecatAgentAdapter({
+    url: "ws://bot/ws",
+    streamSid: "MZtest",
+    callSid: "CAtest",
+    realTimePacing: false,
+    webSocketFactory: () => {
+      const ws = new FakeWebSocket();
+      socketRef.ws = ws;
+      queueMicrotask(() => ws.emit("open", undefined));
+      return ws;
+    },
+  });
+}
+
+describe("Pipecat voice.* span instrumentation (#774)", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+  afterEach(async () => {
+    await provider.shutdown();
+    trace.disable();
+  });
+
+  // P1 — base spans + class
+  it("emits the base spans for a Pipecat turn with class = Pipecat", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    ref.ws!.emit("message", inboundMediaFrame("MZtest")); // buffered agent chunk
+    await adapter.call(audioInput(tone(0.05)));
+    await adapter.disconnect();
+
+    const spans = byName(exporter.getFinishedSpans());
+    expect(spans["voice.turn"]).toBeDefined();
+    expect(spans["voice.audio.send"]).toBeDefined();
+    expect(spans["voice.audio.receive"]).toBeDefined();
+    expect(spans["voice.turn"].attributes["voice.adapter.class"]).toBe(
+      "PipecatAgentAdapter",
+    );
+  });
+
+  // P1 — connect span carries transport attrs (driven through the real executor seam)
+  it("stamps voice.pipecat.transport onto the connect span", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    await startVoiceAdapters([adapter], {} as unknown as VoiceExecutorState);
+    await stopVoiceAdapters([adapter]);
+
+    const connect = byName(exporter.getFinishedSpans())["voice.adapter.connect"];
+    expect(connect.attributes["voice.adapter.class"]).toBe("PipecatAgentAdapter");
+    expect(connect.attributes["voice.pipecat.transport"]).toBe("websocket");
+    expect(connect.attributes["voice.pipecat.transport_format"]).toBe("mulaw/8000");
+  });
+
+  // P2 (core) — background callback emits a receive span parented to the turn
+  it("parents the background-callback voice.audio.receive span under the turn", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    // Start the turn: call() publishes _voiceTurnContext SYNCHRONOUSLY before its
+    // first await. Deliver the agent chunk now → the onMessage callback decodes
+    // it under a LIVE turn.
+    const call = adapter.call(audioInput(tone(0.05)));
+    ref.ws!.emit("message", inboundMediaFrame("MZtest"));
+    await call;
+    await adapter.disconnect();
+
+    const spans = exporter.getFinishedSpans();
+    const turn = byName(spans)["voice.turn"];
+    const bg = receives(spans).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    expect(bg.length).toBeGreaterThanOrEqual(1);
+    // Core AC: parented directly under the turn, not a detached/root span.
+    expect(bg[0].parentSpanId).toBe(turn.spanContext().spanId);
+    expect(bg[0].attributes["voice.audio.bytes"]).toBeGreaterThan(0);
+  });
+
+  // P2 flood-guard — one background span per turn, invariant to chunk count
+  it("emits at most one background span per turn (invariant to chunk count)", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    const call = adapter.call(audioInput(tone(0.05)));
+    for (let i = 0; i < 3; i++) ref.ws!.emit("message", inboundMediaFrame("MZtest"));
+    await call;
+    await adapter.disconnect();
+
+    const bg = receives(exporter.getFinishedSpans()).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    expect(bg).toHaveLength(1);
+  });
+
+  // Documents the turn-liveness gate limit (review F3): a turn drained from
+  // pre-buffered audio (delivered before the turn context was published) gets no
+  // background marker; the base receive span still covers it.
+  it("emits no background span for a turn drained from pre-buffered audio", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTailSilence: number }).responseTailSilence = 0.05;
+    await adapter.connect();
+    ref.ws!.emit("message", inboundMediaFrame("MZtest")); // enqueued BEFORE call()
+    await adapter.call(audioInput(tone(0.05))); // drains the pre-buffered chunk
+    await adapter.disconnect();
+
+    const spans = exporter.getFinishedSpans();
+    const bg = receives(spans).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    const base = receives(spans).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] !== "background_loop",
+    );
+    expect(base.length).toBeGreaterThanOrEqual(1);
+    expect(bg).toHaveLength(0);
+  });
+
+  // P-regression — a callback firing between turns emits no background span
+  it("emits no background span for a frame delivered outside a turn", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    await adapter.connect();
+    ref.ws!.emit("message", inboundMediaFrame("MZtest")); // no turn active
+    await adapter.disconnect();
+
+    const bg = receives(exporter.getFinishedSpans()).filter(
+      (s) => s.attributes["voice.pipecat.recv.source"] === "background_loop",
+    );
+    expect(bg).toHaveLength(0);
+  });
+
+  // P3 — receive timeout marks the span ERROR
+  it("marks voice.audio.receive ERROR on a receive timeout", async () => {
+    const ref: { ws?: FakeWebSocket } = {};
+    const adapter = makeAdapter(ref);
+    (adapter as unknown as { responseTimeout: number }).responseTimeout = 0.05;
+    await adapter.connect();
+    // Feed no inbound → the first receiveAudio times out.
+    await expect(adapter.call(audioInput(tone(0.05)))).rejects.toThrow();
+    await adapter.disconnect();
+
+    const recv = receives(exporter.getFinishedSpans())[0];
+    expect(recv.status.code).toBe(SpanStatusCode.ERROR);
+    expect(recv.attributes["voice.audio.terminated_reason"]).toBe(
+      "first_chunk_timeout",
+    );
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/twilio-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-spans.test.ts
@@ -44,6 +44,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import WebSocket from "ws";
 
 // Register a context manager ONCE so context.with propagates across awaits —
 // mirrors voice-spans.test.ts (this file's module graph is isolated per
@@ -455,6 +456,117 @@ describe("voice.twilio.* span instrumentation (#775)", () => {
       const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
       expect(disconnect.attributes["voice.twilio.rest_restore_failed"]).toBe(true);
     });
+
+    it("resets webhook_invocations / webhook_rejected across a reconnect on the same instance (MUST-FIX #788 review: rejectedCount previously leaked)", async () => {
+      const authToken = "the-shared-secret";
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest, validateSignature: true, authToken, httpPort: 0 });
+      tracked.push(adapter);
+
+      // Session 1: one unsigned POST -> rejected.
+      await startVoiceAdapters([adapter], bareVoiceState());
+      const form = new URLSearchParams({ From: "+14155551234" });
+      const r1 = await fetch(`${adapter.localBaseUrl}/twilio/voice`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+      });
+      await r1.text();
+      expect(r1.status).toBe(403);
+      await stopVoiceAdapters([adapter]);
+
+      const disconnect1 = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect1.attributes["voice.twilio.webhook_invocations"]).toBe(1);
+      expect(disconnect1.attributes["voice.twilio.webhook_rejected"]).toBe(1);
+
+      // Session 2: reconnect the SAME instance, make ZERO webhook calls. Prior
+      // to the fix, `rejectedCount` (the webhook_rejected source) was never
+      // reset in connect()/disconnect() — unlike every other Tier-2b counter
+      // — so this session's disconnect span still reported the stale 1 from
+      // session 1.
+      //
+      // disconnect() nulls the injected REST stub as part of its normal full
+      // teardown (unrelated to this fix), so connect() would otherwise build
+      // a REAL TwilioRESTHelper hitting the live API on the reconnect. Patch
+      // the prototype for the duration of session 2 so it stays hermetic too
+      // — mirroring what constructing a second stubbed adapter would give it.
+      const originalResolve = TwilioRESTHelper.prototype.resolvePhoneNumberSid;
+      TwilioRESTHelper.prototype.resolvePhoneNumberSid = async () => PHONE_NUMBER_SID;
+      try {
+        await startVoiceAdapters([adapter], bareVoiceState());
+        await stopVoiceAdapters([adapter]);
+      } finally {
+        TwilioRESTHelper.prototype.resolvePhoneNumberSid = originalResolve;
+      }
+
+      const disconnectSpans = exporter
+        .getFinishedSpans()
+        .filter((s) => s.name === "voice.adapter.disconnect");
+      expect(disconnectSpans).toHaveLength(2);
+      const disconnect2 = disconnectSpans[1]!;
+      expect(disconnect2.attributes["voice.twilio.webhook_invocations"]).toBe(0);
+      expect(disconnect2.attributes["voice.twilio.webhook_rejected"]).toBe(0);
+    });
+
+    it(
+      "stream_ended_reason reflects the ACTUAL close (not a pre-teardown snapshot) when the call " +
+        "is still live at disconnect() time (MUST-FIX #788 review, regression)",
+      async () => {
+        // Every other T3 test above pre-drives its socket double to a
+        // natural stop/close/error completion BEFORE calling disconnect() —
+        // which dodges this exact race (reviewer-reproduced empirically).
+        // This test instead keeps a REAL WebSocket connection open with real
+        // media flowing and NO terminal frame, then runs the REAL
+        // stopVoiceAdapters teardown while the call is genuinely still live
+        // — so the server-shutdown inside disconnect() (`webhookServer.stop()`,
+        // which closes every open `wss` client) is what forces the closure
+        // the span must observe. A fake `MediaStreamWebSocket` double can't
+        // discriminate this: `stop()` only closes REAL `wss` clients, so a
+        // fake socket fed via `_driveStreamSession` is never affected
+        // regardless of stamp ordering. Only a REAL `ws` client makes the
+        // shutdown-await the thing that closes the stream — exactly the
+        // mechanism the bug is about.
+        //
+        // FALSIFIER: on the pre-fix code (the counter stamp BEFORE
+        // `webhookServer.stop()`), this fails —
+        // stream_ended_reason=="none" — because the media loop hasn't
+        // reacted to the shutdown yet when the span is stamped. Fixed code
+        // stamps AFTER stop() and passes.
+        const { rest } = stubRest(PHONE_NUMBER_SID);
+        const adapter = makeAdapter({ rest, httpPort: 0 });
+        tracked.push(adapter);
+        await startVoiceAdapters([adapter], bareVoiceState());
+
+        const wsUrl = `${adapter.localBaseUrl.replace(/^http:/, "ws:")}/twilio/stream`;
+        const client = await new Promise<WebSocket>((resolve, reject) => {
+          const c = new WebSocket(wsUrl);
+          c.once("open", () => resolve(c));
+          c.once("error", reject);
+        });
+        client.send(startFrame());
+        await vi.waitFor(() => expect(adapter._streamSidForTest).toBe(STREAM_SID));
+
+        // Three individually-flushing media frames — NO stop frame. The
+        // stream is still LIVE when teardown begins below.
+        for (let i = 0; i < 3; i++) {
+          client.send(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
+        }
+        // Poll for the REAL server-side loop to actually decode+enqueue what
+        // was sent over the wire (real TCP, not an in-process queue) —
+        // avoids a flaky blind sleep.
+        await vi.waitFor(() => expect(adapter._framesReceivedForTest).toBe(3));
+
+        // The REAL teardown, invoked while the socket is STILL open — nobody
+        // sent a stop frame or closed the connection. disconnect()'s own
+        // server-shutdown is what forces the close.
+        await stopVoiceAdapters([adapter]);
+        client.close();
+
+        const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+        expect(disconnect.attributes["voice.twilio.frames_received"]).toBe(3);
+        expect(disconnect.attributes["voice.twilio.stream_ended_reason"]).not.toBe("none");
+      },
+    );
   });
 
   // --- T4 / T5 (dial OK) -----------------------------------------------------

--- a/javascript/src/voice/adapters/__tests__/twilio-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-spans.test.ts
@@ -1,0 +1,774 @@
+/**
+ * Twilio-specific voice-span attributes (#770 / #771 taxonomy, #775 scope).
+ * TypeScript mirror of `python/tests/voice/test_voice_spans_twilio.py`.
+ *
+ * Drives the REAL `TwilioAgentAdapter` (REST stubbed via constructor DI,
+ * media transport driven through the real `TwilioWebhookServer` loop over a
+ * scripted/controllable socket double) through `startVoiceAdapters`/
+ * `stopVoiceAdapters` and through `placeCall()`/`waitForCall()` directly,
+ * asserting the Twilio contributions this PR adds:
+ *
+ * - T1: base spans (voice.turn / voice.audio.send / voice.audio.receive) are
+ *   NOT hollow for Twilio. REGRESSION GUARD — already GREEN before any #775
+ *   instrumentation lands (Twilio's call() is inherited, not overridden).
+ * - T2: voice.adapter.connect carries Twilio connect-time config attrs.
+ * - T3: voice.adapter.disconnect carries call-lifetime counters (frames,
+ *   DTMF, stream-ended reason, REST-restore-failed, webhook invocation/
+ *   rejection counts).
+ * - T4/T5: a NEW voice.adapter.dial span wraps placeCall() / waitForCall() —
+ *   the REST dial + the stream-connected wait.
+ * - T6: dial ERROR on a stream-connect timeout (the marquee "I placed the
+ *   call but no media ever streamed" failure).
+ * - T7: dial ERROR on a REST failure records the ORIGINAL exception.
+ * - T8: SKIPPED — see the comment block above the T10 section. The JS OTel
+ *   SDK already guards `Span.end()` against a throwing processor (proven in
+ *   `voice-spans.test.ts`'s own A7 comment), so a "boom processor at the
+ *   dial site" test would be vacuous in TS — it can't fail even against an
+ *   adapter with NO dial span at all. Python's T8 is the meaningful test for
+ *   this AC.
+ * - T9: py<->ts parity — see the comment block near the bottom.
+ * - T10: span count is invariant to media-frame count (flood guard).
+ *
+ * Design doc: sc#775 "Twilio voice-adapter LangWatch spans: design + ACs".
+ * Harness patterns copied (not cross-imported — matching this suite's
+ * existing per-file `stubRest`/socket-double convention) from
+ * `twilio.test.ts` / `twilio-server.test.ts` (`stubRest`) and
+ * `twilio-silent-stop-drain.test.ts` (`scriptedSocket` / `controllableSocket`
+ * / `driveTwilioProduction`).
+ */
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Register a context manager ONCE so context.with propagates across awaits —
+// mirrors voice-spans.test.ts (this file's module graph is isolated per
+// vitest worker, so each span-test file registers its own).
+const _ctxManager = new AsyncLocalStorageContextManager();
+_ctxManager.enable();
+context.setGlobalContextManager(_ctxManager);
+
+import {
+  driveCall,
+  driveTwilioProduction,
+  makeAgentInput,
+} from "../../__tests__/helpers/drive-production";
+import { startVoiceAdapters, stopVoiceAdapters } from "../../adapter.runtime";
+import { AudioChunk } from "../../audio-chunk";
+import type { VoiceExecutorState } from "../../voice-executor-state";
+import { TwilioAgentAdapter } from "../twilio";
+import type { MediaStreamWebSocket } from "../twilio-server";
+import { buildMediaFrame, TwilioRESTHelper } from "../twilio-shared";
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+const STREAM_SID = "MZ775";
+const CALL_SID = "CA775";
+const PHONE_NUMBER_SID = "PN" + "0".repeat(32);
+
+function startFrame(streamSid = STREAM_SID, callSid = CALL_SID): string {
+  return JSON.stringify({ event: "start", start: { streamSid, callSid } });
+}
+
+function stopFrame(): string {
+  return JSON.stringify({ event: "stop" });
+}
+
+function dtmfFrame(digit: string, streamSid = STREAM_SID): string {
+  return JSON.stringify({ event: "dtmf", streamSid, dtmf: { digit } });
+}
+
+/** A minimal VoiceExecutorState — only what startVoiceAdapters/VAD-fallback
+ * registration touches (nothing, for span-only tests). Mirrors the
+ * `makeVoiceState()` pattern in el-audioqueue-turn-boundary.test.ts, trimmed
+ * to the empty case since these tests don't exercise recording/VAD. */
+function bareVoiceState(): VoiceExecutorState {
+  return {} as unknown as VoiceExecutorState;
+}
+
+/**
+ * A `MediaStreamWebSocket` double whose `receiveText()` serves `frames` in
+ * order, then either resolves `null` (socket close) or rejects with
+ * `closeWith` (transport error) — the three termination shapes
+ * `stream_ended_reason` distinguishes (stop / close / error).
+ */
+function scriptedSocket(
+  frames: string[],
+  opts?: { closeWith?: Error },
+): MediaStreamWebSocket {
+  let idx = 0;
+  return {
+    send() {
+      // Outbound is irrelevant to these tests.
+    },
+    receiveText() {
+      if (idx < frames.length) return Promise.resolve(frames[idx++]!);
+      if (opts?.closeWith) return Promise.reject(opts.closeWith);
+      return Promise.resolve(null); // socket closed
+    },
+    close() {
+      // No-op for the double.
+    },
+  };
+}
+
+/**
+ * A `MediaStreamWebSocket` double the test can feed mid-flight — needed
+ * where the media loop must stay LIVE while the test drives a concurrent
+ * `call()` (T1). Copied from `twilio-silent-stop-drain.test.ts`.
+ */
+function controllableSocket(): MediaStreamWebSocket & {
+  push(item: string | null | Error): void;
+} {
+  const queued: Array<string | null | Error> = [];
+  const waiters: Array<{
+    resolve: (v: string | null) => void;
+    reject: (e: Error) => void;
+  }> = [];
+  return {
+    send() {
+      // Outbound is irrelevant to these tests.
+    },
+    close() {
+      // No-op for the double.
+    },
+    push(item: string | null | Error): void {
+      const waiter = waiters.shift();
+      if (waiter) {
+        if (item instanceof Error) waiter.reject(item);
+        else waiter.resolve(item);
+        return;
+      }
+      queued.push(item);
+    },
+    receiveText(): Promise<string | null> {
+      if (queued.length > 0) {
+        const item = queued.shift()!;
+        if (item instanceof Error) return Promise.reject(item);
+        return Promise.resolve(item);
+      }
+      return new Promise((resolve, reject) => {
+        waiters.push({ resolve, reject });
+      });
+    },
+  };
+}
+
+/** REST double: a real TwilioRESTHelper with network methods replaced.
+ * `writeCalls` records every writeVoiceUrl mutation in order (set, restore,
+ * ...) — needed by the rest_restore_failed tests. Local copy of the
+ * `stubRest` pattern in twilio.test.ts / twilio-server.test.ts, extended
+ * with the call log twilio.test.ts doesn't need. */
+function stubRest(sid: string): {
+  rest: TwilioRESTHelper;
+  writeCalls: Array<[string, string]>;
+} {
+  const rest = new TwilioRESTHelper("ACtest", "secret");
+  const writeCalls: Array<[string, string]> = [];
+  rest.resolvePhoneNumberSid = async () => sid;
+  rest.readVoiceUrl = async () => "https://old-webhook.example.com/previous";
+  rest.writeVoiceUrl = async (phoneNumberSid, voiceUrl) => {
+    writeCalls.push([phoneNumberSid, voiceUrl]);
+  };
+  rest.placeCall = async () => "CA" + "1".repeat(32);
+  rest.sendDtmfOnCall = async () => undefined;
+  return { rest, writeCalls };
+}
+
+function makeAdapter(opts?: {
+  rest?: TwilioRESTHelper;
+  validateSignature?: boolean;
+  authToken?: string;
+  httpPort?: number;
+}): TwilioAgentAdapter {
+  return new TwilioAgentAdapter({
+    accountSid: "ACtest",
+    authToken: opts?.authToken ?? "secret",
+    phoneNumber: "+14155551234",
+    publicBaseUrl: "https://example.test",
+    validateSignature: opts?.validateSignature ?? false,
+    httpPort: opts?.httpPort ?? 0,
+    rest: opts?.rest ?? stubRest(PHONE_NUMBER_SID).rest,
+  });
+}
+
+/** HMAC-SHA1(authToken, url + sortedParamsConcat), base64 — mirrors the
+ * `signFixture` helper in twilio.test.ts's `verifyTwilioSignature` suite. */
+async function signFixture(args: {
+  authToken: string;
+  url: string;
+  params: Record<string, string>;
+}): Promise<string> {
+  const { createHmac } = await import("node:crypto");
+  const sortedKeys = Object.keys(args.params).sort();
+  let data = args.url;
+  for (const key of sortedKeys) data += key + args.params[key];
+  return createHmac("sha1", args.authToken).update(data).digest("base64");
+}
+
+function byName(
+  spans: ReturnType<InMemorySpanExporter["getFinishedSpans"]>,
+): Record<string, (typeof spans)[number]> {
+  return Object.fromEntries(spans.map((s) => [s.name, s]));
+}
+
+/** Every voice.audio.receive span (base drain + background-loop marker share
+ * the same NAME, disambiguated only by voice.twilio.recv.source). */
+function receives(
+  spans: ReturnType<InMemorySpanExporter["getFinishedSpans"]>,
+): ReturnType<InMemorySpanExporter["getFinishedSpans"]> {
+  return spans.filter((s) => s.name === "voice.audio.receive");
+}
+
+describe("voice.twilio.* span instrumentation (#775)", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  const tracked: TwilioAgentAdapter[] = [];
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+  afterEach(async () => {
+    while (tracked.length > 0) {
+      try {
+        await tracked.pop()!.disconnect();
+      } catch {
+        // Best-effort teardown.
+      }
+    }
+    await provider.shutdown();
+    trace.disable();
+  });
+
+  // --- T1 (regression) -----------------------------------------------------
+
+  it("T1 REGRESSION (already GREEN): a real turn over Twilio emits voice.turn > {send, receive}, voice.adapter.class == TwilioAgentAdapter", async () => {
+    const adapter = makeAdapter();
+    tracked.push(adapter);
+    adapter.responseTailSilence = 0.05; // keep the test fast
+    await adapter.connect();
+    const socket = controllableSocket();
+    const loop = adapter._driveStreamSession(socket);
+    socket.push(startFrame());
+    await vi.waitFor(() => expect(adapter._streamSidForTest).toBe(STREAM_SID));
+
+    // One real agent-audio media frame >= the 800-byte batch threshold, so it
+    // flushes into the inbound queue immediately — deterministic, no sleep-race.
+    socket.push(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
+    await sleep(50); // let the loop task drain the pushed frame
+
+    await driveCall(
+      adapter,
+      makeAgentInput(new AudioChunk({ data: new Uint8Array(2400) })),
+    );
+
+    socket.push(stopFrame());
+    await loop;
+
+    const spans = byName(exporter.getFinishedSpans());
+    const turn = spans["voice.turn"];
+    expect(turn.attributes["voice.adapter.class"]).toBe("TwilioAgentAdapter");
+    expect(spans["voice.audio.send"].parentSpanId).toBe(turn.spanContext().spanId);
+    expect(spans["voice.audio.receive"].parentSpanId).toBe(turn.spanContext().spanId);
+  });
+
+  // --- T2 (connect attrs) ---------------------------------------------------
+
+  describe("T2 — connect attrs", () => {
+    it(
+      "voice.adapter.connect carries phone_number_sid / validate_signature / webhook_port " +
+        "(NOT direction — FLAGGED: connect() is direction-agnostic, mode stays 'idle' " +
+        "until placeCall()/waitForCall() picks one AFTER this span has already closed; " +
+        "direction is tested on voice.adapter.dial instead — T4/T5 below)",
+      async () => {
+        const { rest } = stubRest(PHONE_NUMBER_SID);
+        const adapter = makeAdapter({ rest, validateSignature: true, httpPort: 0 });
+        tracked.push(adapter);
+
+        await startVoiceAdapters([adapter], bareVoiceState());
+        const connect = byName(exporter.getFinishedSpans())["voice.adapter.connect"];
+        expect(connect.attributes["voice.adapter.class"]).toBe("TwilioAgentAdapter");
+        expect(connect.attributes["voice.twilio.phone_number_sid"]).toBe(
+          PHONE_NUMBER_SID,
+        );
+        expect(connect.attributes["voice.twilio.validate_signature"]).toBe(true);
+        expect(connect.attributes["voice.twilio.webhook_port"]).toBe(0);
+      },
+    );
+  });
+
+  // --- T3 (disconnect counters) ---------------------------------------------
+
+  describe("T3 — disconnect counters", () => {
+    it("carries frames_received / dtmf_received / stream_ended_reason=='stop' from a deterministic N=3/M=2 script", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await startVoiceAdapters([adapter], bareVoiceState());
+
+      const frames = [
+        startFrame(),
+        buildMediaFrame(STREAM_SID, new Uint8Array(160).fill(0x7f)),
+        buildMediaFrame(STREAM_SID, new Uint8Array(160).fill(0x7f)),
+        buildMediaFrame(STREAM_SID, new Uint8Array(160).fill(0x7f)),
+        dtmfFrame("1"),
+        dtmfFrame("5"),
+        stopFrame(),
+      ];
+      await driveTwilioProduction(adapter, scriptedSocket(frames));
+      await stopVoiceAdapters([adapter]);
+
+      const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect.attributes["voice.twilio.frames_received"]).toBe(3);
+      expect(disconnect.attributes["voice.twilio.dtmf_received"]).toBe(2);
+      expect(disconnect.attributes["voice.twilio.stream_ended_reason"]).toBe("stop");
+    });
+
+    it("records stream_ended_reason=='close' on a socket close with no stop frame", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await startVoiceAdapters([adapter], bareVoiceState());
+
+      await driveTwilioProduction(adapter, scriptedSocket([startFrame()]));
+      await stopVoiceAdapters([adapter]);
+
+      const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect.attributes["voice.twilio.stream_ended_reason"]).toBe("close");
+    });
+
+    it("records stream_ended_reason=='error' on a non-disconnect transport error", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await startVoiceAdapters([adapter], bareVoiceState());
+
+      await expect(
+        driveTwilioProduction(
+          adapter,
+          scriptedSocket([startFrame()], {
+            closeWith: new Error("boom: transport failure"),
+          }),
+        ),
+      ).rejects.toThrow("boom: transport failure");
+      await stopVoiceAdapters([adapter]);
+
+      const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect.attributes["voice.twilio.stream_ended_reason"]).toBe("error");
+    });
+
+    it("records stream_ended_reason=='none' when no media session ever ran", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await startVoiceAdapters([adapter], bareVoiceState());
+      await stopVoiceAdapters([adapter]);
+
+      const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect.attributes["voice.twilio.stream_ended_reason"]).toBe("none");
+    });
+
+    it("carries webhook_invocations==2 / webhook_rejected==1 from one unsigned + one validly-signed POST", async () => {
+      const authToken = "the-shared-secret";
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest, validateSignature: true, authToken, httpPort: 0 });
+      tracked.push(adapter);
+      await startVoiceAdapters([adapter], bareVoiceState());
+
+      // 1. Unsigned -> rejected (403).
+      const form = new URLSearchParams({ From: "+14155551234" });
+      const r1 = await fetch(`${adapter.localBaseUrl}/twilio/voice`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+      });
+      await r1.text();
+      expect(r1.status).toBe(403);
+
+      // 2. Validly signed (against publicBaseUrl, which the server uses for
+      // signature reconstruction) -> accepted (200).
+      const params = { From: "+14155551234" };
+      const signature = await signFixture({
+        authToken,
+        url: `${adapter.publicBaseUrl}/twilio/voice`,
+        params,
+      });
+      const r2 = await fetch(`${adapter.localBaseUrl}/twilio/voice`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "X-Twilio-Signature": signature,
+        },
+        body: new URLSearchParams(params).toString(),
+      });
+      await r2.text();
+      expect(r2.status).toBe(200);
+
+      await stopVoiceAdapters([adapter]);
+
+      const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect.attributes["voice.twilio.webhook_invocations"]).toBe(2);
+      expect(disconnect.attributes["voice.twilio.webhook_rejected"]).toBe(1);
+    });
+
+    it("reports rest_restore_failed==false on a clean answer-mode restore", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await startVoiceAdapters([adapter], bareVoiceState());
+      adapter._signalStreamConnected();
+      await adapter.waitForCall();
+
+      await stopVoiceAdapters([adapter]);
+
+      const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect.attributes["voice.twilio.rest_restore_failed"]).toBe(false);
+    });
+
+    it("reports rest_restore_failed==true when the REST restore call throws (swallowed, run continues)", async () => {
+      const { rest, writeCalls } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await startVoiceAdapters([adapter], bareVoiceState());
+      adapter._signalStreamConnected();
+      await adapter.waitForCall();
+
+      const originalWrite = rest.writeVoiceUrl.bind(rest);
+      rest.writeVoiceUrl = async (sid, url) => {
+        await originalWrite(sid, url);
+        if (writeCalls.length === 2) {
+          // The restore call, not the initial set.
+          throw new Error("simulated Twilio REST outage");
+        }
+      };
+
+      await stopVoiceAdapters([adapter]); // must not throw despite the injected failure
+
+      const disconnect = byName(exporter.getFinishedSpans())["voice.adapter.disconnect"];
+      expect(disconnect.attributes["voice.twilio.rest_restore_failed"]).toBe(true);
+    });
+  });
+
+  // --- T4 / T5 (dial OK) -----------------------------------------------------
+
+  describe("T4 / T5 — dial OK", () => {
+    it("T4: placeCall emits ONE voice.adapter.dial span, OK, outbound, call_sid set, latency present, no timeout outcome", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await adapter.connect();
+      adapter._signalStreamConnected(); // pre-fire: stream "already" connected
+      await adapter.placeCall({ to: "+14155557777" });
+
+      const dialSpans = exporter
+        .getFinishedSpans()
+        .filter((s) => s.name === "voice.adapter.dial");
+      expect(dialSpans).toHaveLength(1);
+      const dial = dialSpans[0]!;
+      expect(dial.status.code).not.toBe(SpanStatusCode.ERROR);
+      expect(dial.attributes["voice.adapter.class"]).toBe("TwilioAgentAdapter");
+      expect(dial.attributes["voice.twilio.direction"]).toBe("outbound");
+      expect(dial.attributes["voice.twilio.call_sid"]).toBe("CA" + "1".repeat(32));
+      expect(dial.attributes["voice.twilio.stream_connect_latency_ms"]).toBeTypeOf(
+        "number",
+      );
+      expect(dial.attributes["voice.twilio.dial_outcome"]).not.toBe(
+        "stream_connect_timeout",
+      );
+      // PII note (flagged in the final report): asserted redaction-tolerantly —
+      // passes whether the eventual impl stores the raw E.164 or a
+      // redactE164-style last-4 form.
+      expect(String(dial.attributes["voice.twilio.to"])).toMatch(/7777$/);
+      expect(String(dial.attributes["voice.twilio.from"])).toMatch(/1234$/);
+    });
+
+    it("T5: waitForCall emits voice.adapter.dial, direction=='inbound'", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await adapter.connect();
+      adapter._signalStreamConnected();
+      await adapter.waitForCall();
+
+      const dial = byName(exporter.getFinishedSpans())["voice.adapter.dial"];
+      expect(dial, "expected a voice.adapter.dial span").toBeDefined();
+      expect(dial.status.code).not.toBe(SpanStatusCode.ERROR);
+      expect(dial.attributes["voice.twilio.direction"]).toBe("inbound");
+    });
+  });
+
+  // --- T6 (dial ERROR, marquee: stream_connect_timeout) ----------------------
+
+  it("T6 MARQUEE: a stream-connect timeout marks voice.adapter.dial ERROR with dial_outcome=='stream_connect_timeout'", async () => {
+    const { rest } = stubRest(PHONE_NUMBER_SID);
+    const adapter = makeAdapter({ rest });
+    tracked.push(adapter);
+    await adapter.connect();
+    // Do NOT signal stream-connected — placeCall must time out.
+    await expect(
+      adapter.placeCall({ to: "+14155557777", timeoutMs: 50 }),
+    ).rejects.toThrow(/timed out/);
+
+    const dial = byName(exporter.getFinishedSpans())["voice.adapter.dial"];
+    expect(dial, "expected a voice.adapter.dial span").toBeDefined();
+    expect(dial.status.code).toBe(SpanStatusCode.ERROR);
+    expect(dial.attributes["voice.twilio.dial_outcome"]).toBe("stream_connect_timeout");
+  });
+
+  // --- T7 (dial ERROR, REST failure — original exception) ---------------------
+
+  it("T7: a REST failure inside placeCall marks voice.adapter.dial ERROR and records the ORIGINAL exception", async () => {
+    const { rest } = stubRest(PHONE_NUMBER_SID);
+    rest.placeCall = async () => {
+      throw new Error("Twilio REST: rate limited");
+    };
+    const adapter = makeAdapter({ rest });
+    tracked.push(adapter);
+    await adapter.connect();
+
+    await expect(adapter.placeCall({ to: "+14155557777" })).rejects.toThrow(
+      "Twilio REST: rate limited",
+    );
+
+    const dial = byName(exporter.getFinishedSpans())["voice.adapter.dial"];
+    expect(dial, "expected a voice.adapter.dial span").toBeDefined();
+    expect(dial.status.code).toBe(SpanStatusCode.ERROR);
+    const exceptionEvents = dial.events.filter((e) => e.name === "exception");
+    expect(exceptionEvents.length).toBeGreaterThan(0);
+    const last = exceptionEvents.at(-1)!;
+    expect(last.attributes?.["exception.type"]).toBe("Error");
+    expect(String(last.attributes?.["exception.message"])).toContain("rate limited");
+  });
+
+  // T8 (never-break safety) is intentionally NOT mirrored here — see the
+  // module docstring above. The JS OTel SDK's Span.end() already guards a
+  // throwing SpanProcessor.onEnd internally (voice-spans.test.ts's own A7
+  // comment: "Span.end() already guards processor.onEnd internally, so the
+  // run is safe via the SDK here"), so a "boom processor at voice.adapter.dial"
+  // test would pass identically whether or not voice.adapter.dial exists at
+  // all — it cannot discriminate RED from GREEN and would be a hollow test.
+  // Python's T8 is where this guard is genuinely exercised (raw `span.end()`
+  // is UNGUARDED there). Flagged in the final report rather than shipped as a
+  // vacuous "pass".
+
+  // --- T9 (py<->ts parity) -----------------------------------------------------
+  //
+  // Not independently testable inside one language's suite. Parity is
+  // enforced by this file AND python/tests/voice/test_voice_spans_twilio.py
+  // hard-coding the IDENTICAL span name ("voice.adapter.dial") and
+  // attribute-key strings: "voice.twilio.direction",
+  // "voice.twilio.phone_number_sid", "voice.twilio.validate_signature",
+  // "voice.twilio.webhook_port", "voice.twilio.frames_received",
+  // "voice.twilio.dtmf_received", "voice.twilio.stream_ended_reason",
+  // "voice.twilio.rest_restore_failed", "voice.twilio.webhook_invocations",
+  // "voice.twilio.webhook_rejected", "voice.twilio.to", "voice.twilio.from",
+  // "voice.twilio.call_sid", "voice.twilio.stream_connect_latency_ms",
+  // "voice.twilio.dial_outcome". A renamed key in either language's
+  // implementation fails THAT language's own suite — that divergence IS the
+  // falsifier.
+
+  // --- T10 (no per-frame spans / flood guard) -----------------------------------
+
+  describe("T10 — flood guard", () => {
+    it("span count from a connect->media-loop->disconnect cycle is invariant to media-frame count", async () => {
+      // NOTE (honesty flag, not oversold as RED): with only the two lifecycle
+      // spans in play, this already holds true pre-#775 (2 spans regardless
+      // of N) — on its own it does not discriminate RED/GREEN for this PR.
+      // It is a forward flood-guard protecting the T3 counter implementation
+      // from regressing into a per-frame-span design.
+      async function run(nFrames: number): Promise<number> {
+        await provider.shutdown();
+        trace.disable();
+        exporter = new InMemorySpanExporter();
+        provider = new NodeTracerProvider({
+          spanProcessors: [new SimpleSpanProcessor(exporter)],
+        });
+        trace.setGlobalTracerProvider(provider);
+
+        const { rest } = stubRest(PHONE_NUMBER_SID);
+        const adapter = makeAdapter({ rest });
+        tracked.push(adapter);
+        await startVoiceAdapters([adapter], bareVoiceState());
+        const frames = [
+          startFrame(),
+          ...Array.from({ length: nFrames }, () =>
+            buildMediaFrame(STREAM_SID, new Uint8Array(160).fill(0x7f)),
+          ),
+          stopFrame(),
+        ];
+        await driveTwilioProduction(adapter, scriptedSocket(frames));
+        await stopVoiceAdapters([adapter]);
+        return exporter
+          .getFinishedSpans()
+          .filter((s) => s.name.startsWith("voice.")).length;
+      }
+
+      const few = await run(3);
+      const many = await run(30);
+      expect(few).toBe(many);
+      expect(few).toBe(2);
+    });
+  });
+
+  // --- T11 (Tier 3 — background-loop delivery markers, #781/#774 base) ---------
+  //
+  // #781 rebased Twilio onto #774's reusable primitive: base `defaultVoiceCall`
+  // publishes the live `voice.turn` OTel context onto `adapter._voiceTurnContext`
+  // (cleared in a `finally`); a background-receive-loop adapter parents a
+  // detached-task delivery marker span under it via
+  // `voiceReceiveSpanUnder(parent, attrs, fn)`. Mirrors `pipecat-spans.test.ts`'s
+  // P2 suite one-to-one, swapping `voice.pipecat.recv.source` ->
+  // `voice.twilio.recv.source`. Unlike Pipecat-TS (a synchronous ws `message`
+  // callback), Twilio's `mediaStreamLoop` is a genuine async loop — the same
+  // queue/task shape as Python — so the ordering trick below (not Pipecat-TS's
+  // "emit synchronously mid-call") is what applies here.
+  //
+  // Ordering trick (mirrors the Python T11 suite): `defaultVoiceCall` publishes
+  // `_voiceTurnContext` SYNCHRONOUSLY, before its first genuine await (the
+  // frame-pacing `sleep` inside `sendAudio`, or — for a no-incoming turn — the
+  // first `receiveAudio` wait inside the drain). The background loop task is
+  // already parked on `receiveText()` and can only resume once `call()` actually
+  // yields, so a frame pushed into the `controllableSocket()` queue immediately
+  // before `await driveCall(...)` is decoded by the loop AFTER the turn context
+  // is live (T11a/T11b). Pushing the frame earlier, with an intervening
+  // `await sleep(...)` BEFORE `call()` ever starts (T11c/T11d), instead lets the
+  // loop decode+enqueue it with NO turn live — the complementary case.
+  describe("T11 — Tier 3 background-loop delivery markers", () => {
+    it("T11a (Tier-3 core, mirrors Pipecat P2): background media loop emits voice.audio.receive parented to the live turn", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      adapter.responseTailSilence = 0.05; // keep the test fast
+      await adapter.connect();
+      const socket = controllableSocket();
+      const loop = adapter._driveStreamSession(socket);
+      socket.push(startFrame());
+      await vi.waitFor(() => expect(adapter._streamSidForTest).toBe(STREAM_SID));
+
+      // Push ONE agent-audio frame, THEN IMMEDIATELY start the turn — see the
+      // ordering-trick note above.
+      socket.push(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
+      await driveCall(
+        adapter,
+        makeAgentInput(new AudioChunk({ data: new Uint8Array(2400) })),
+      );
+
+      socket.push(stopFrame());
+      await loop;
+
+      const spans = exporter.getFinishedSpans();
+      const turn = byName(spans)["voice.turn"];
+      const bg = receives(spans).filter(
+        (s) => s.attributes["voice.twilio.recv.source"] === "background_loop",
+      );
+      expect(bg.length).toBeGreaterThanOrEqual(1);
+      // Core assertion: parented directly under the turn, NOT a detached/closed
+      // span (the loop's frozen scheduling-time context).
+      expect(bg[0].parentSpanId).toBe(turn.spanContext().spanId);
+      expect(bg[0].attributes["voice.audio.bytes"]).toBeGreaterThan(0);
+    });
+
+    it("T11b (Tier-3 flood-guard, mirrors Pipecat P2): three deliveries within one live turn emit exactly ONE background span", async () => {
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      adapter.responseTailSilence = 0.05;
+      await adapter.connect();
+      const socket = controllableSocket();
+      const loop = adapter._driveStreamSession(socket);
+      socket.push(startFrame());
+      await vi.waitFor(() => expect(adapter._streamSidForTest).toBe(STREAM_SID));
+
+      for (let i = 0; i < 3; i++) {
+        // three 800-byte (individually-flushing) frames, one turn
+        socket.push(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
+      }
+      await driveCall(
+        adapter,
+        makeAgentInput(new AudioChunk({ data: new Uint8Array(2400) })),
+      );
+
+      socket.push(stopFrame());
+      await loop;
+
+      const bg = receives(exporter.getFinishedSpans()).filter(
+        (s) => s.attributes["voice.twilio.recv.source"] === "background_loop",
+      );
+      expect(bg).toHaveLength(1);
+    });
+
+    it("T11c (turn-liveness gate boundary, mirrors Pipecat's review-F2/F3 test): a pre-buffered turn has a base receive span but no background marker", async () => {
+      // FLAG (mirrors the T1/T10 honesty pattern from the earlier report): this
+      // assertion holds both BEFORE and AFTER a correct Tier-3 implementation —
+      // nothing here exercises the marker's presence, only its correct absence.
+      // It is a forward regression guard against an over-eager implementation
+      // that ignores the turn-liveness gate, not a RED discriminator for
+      // Tier-3's initial existence. T11a/T11b are the RED discriminators for
+      // that (confirmed empirically — see the RED run below).
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      adapter.responseTailSilence = 0.05;
+      await adapter.connect();
+      const socket = controllableSocket();
+      const loop = adapter._driveStreamSession(socket);
+      socket.push(startFrame());
+      await vi.waitFor(() => expect(adapter._streamSidForTest).toBe(STREAM_SID));
+
+      socket.push(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
+      await sleep(50); // let the loop decode+enqueue with NO turn live
+
+      await driveCall(
+        adapter,
+        makeAgentInput(new AudioChunk({ data: new Uint8Array(2400) })),
+      ); // drains the pre-buffered chunk
+
+      socket.push(stopFrame());
+      await loop;
+
+      const spans = exporter.getFinishedSpans();
+      const base = receives(spans).filter(
+        (s) => s.attributes["voice.twilio.recv.source"] !== "background_loop",
+      );
+      const bg = receives(spans).filter(
+        (s) => s.attributes["voice.twilio.recv.source"] === "background_loop",
+      );
+      expect(base.length).toBeGreaterThanOrEqual(1);
+      expect(bg).toHaveLength(0);
+    });
+
+    it("T11d (regression, mirrors Pipecat's P-regression test): a frame delivered with no active turn emits no background span", async () => {
+      // FLAG (same caveat as T11c): GREEN both before and after a correct
+      // implementation — a forward guard, not a RED discriminator.
+      const { rest } = stubRest(PHONE_NUMBER_SID);
+      const adapter = makeAdapter({ rest });
+      tracked.push(adapter);
+      await adapter.connect();
+      const socket = controllableSocket();
+      const loop = adapter._driveStreamSession(socket);
+      socket.push(startFrame());
+      await vi.waitFor(() => expect(adapter._streamSidForTest).toBe(STREAM_SID));
+
+      // No call() in flight -> _voiceTurnContext is undefined -> the loop
+      // buffers the decoded chunk but must emit no span.
+      socket.push(buildMediaFrame(STREAM_SID, new Uint8Array(800).fill(0x7f)));
+      await sleep(50); // let the background loop process the frame
+
+      socket.push(stopFrame());
+      await loop;
+
+      const bg = receives(exporter.getFinishedSpans()).filter(
+        (s) => s.attributes["voice.twilio.recv.source"] === "background_loop",
+      );
+      expect(bg).toHaveLength(0);
+    });
+  });
+});

--- a/javascript/src/voice/adapters/pipecat.ts
+++ b/javascript/src/voice/adapters/pipecat.ts
@@ -22,10 +22,14 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import type { Context } from "@opentelemetry/api";
+
 import { AgentRole } from "../../domain/agents";
+import { Logger } from "../../utils/logger";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
+import { currentSpan, setSpanAttributes, voiceReceiveSpanUnder } from "../telemetry";
 import { sleep } from "../utils";
 import { PendingTransportError } from "./pending-transport-error";
 import {
@@ -188,6 +192,14 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
    * subtle risk of one advancing while the other lags.
    */
   private interruptPhase: "idle" | "interrupted" = "idle";
+  /**
+   * The turn context we last emitted a background `voice.audio.receive` span
+   * for — so {@link flushBufferedMulaw} spans only the FIRST wire delivery of
+   * each turn (one span/turn, no per-chunk flood). Reset implicitly: the next
+   * turn publishes a distinct `_voiceTurnContext` (#774).
+   */
+  private bgSpanTurnContext?: Context;
+  private readonly logger = new Logger("PipecatAgentAdapter");
 
   constructor(init: PipecatAgentAdapterInit = {}) {
     super();
@@ -284,6 +296,15 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
         },
       }),
     );
+
+    // Stamp Pipecat transport attrs onto the active `voice.adapter.connect` span
+    // (opened by `startVoiceAdapters`). Base spans are name-owned; the adapter
+    // contributes attributes, never a parallel span name — mirror ElevenLabs'
+    // `voice.elevenlabs.agent_id` seam (`adapters/elevenlabs.ts`).
+    setSpanAttributes(currentSpan(), {
+      "voice.pipecat.transport": this.transport,
+      "voice.pipecat.transport_format": this.transportFormat,
+    });
   }
 
   /** Whether the Media Streams WebSocket is open (Gap #11). */
@@ -481,8 +502,48 @@ export class PipecatAgentAdapter extends VoiceAgentAdapter {
     }
     this.mulawChunks = [];
     this.mulawChunksByteLength = 0;
-    const pcm = mulaw8kToPcm16At24k(mulaw);
-    const chunk = new AudioChunk({ data: pcm });
+    // On the FIRST wire delivery of a turn (base call() published its context on
+    // the adapter), wrap the decode+deliver in a voice.audio.receive span
+    // parented to THAT turn (#774) — so this background ws-callback's receive
+    // work is attributed to the turn instead of the callback's detached/root
+    // context. A producer-side delivery marker (carries the delivered byte
+    // count); the consumer-side wait + timeout/ERROR (P3) live on the base
+    // receive span that wraps receiveAudio, disambiguated by
+    // voice.pipecat.recv.source. Emitted at most once per turn (matching the
+    // base's one-receive-span-per-turn granularity + the epic's no-per-tick-flood
+    // rule). Between turns _voiceTurnContext is undefined and we decode without a
+    // span, so no detached span leaks from a callback firing outside a turn.
+    let chunk: AudioChunk;
+    try {
+      const parent = this._voiceTurnContext;
+      if (parent !== undefined && parent !== this.bgSpanTurnContext) {
+        this.bgSpanTurnContext = parent;
+        chunk = voiceReceiveSpanUnder(
+          parent,
+          {
+            "voice.adapter.class": this.constructor.name,
+            "voice.pipecat.recv.source": "background_loop",
+          },
+          (span) => {
+            const pcm = mulaw8kToPcm16At24k(mulaw);
+            span.setAttribute("voice.audio.bytes", pcm.length);
+            return new AudioChunk({ data: pcm });
+          },
+        );
+      } else {
+        chunk = new AudioChunk({ data: mulaw8kToPcm16At24k(mulaw) });
+      }
+    } catch (err) {
+      // Parity with Python `_recv_loop`'s `except Exception`: a decode/span
+      // failure in this SYNCHRONOUS ws 'message' callback must not propagate —
+      // an uncaught throw here would crash the handler / drop the socket. Log and
+      // drop this one batch; keep receiving.
+      this.logger.warn(
+        "Pipecat: failed to decode/deliver an inbound audio batch; dropping it",
+        err,
+      );
+      return;
+    }
     const waiter = this.inbox.waiter;
     if (waiter) {
       this.inbox.waiter = null;

--- a/javascript/src/voice/adapters/twilio-server.ts
+++ b/javascript/src/voice/adapters/twilio-server.ts
@@ -20,9 +20,11 @@ import { Buffer } from "node:buffer";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
 
+import type { Context } from "@opentelemetry/api";
 import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
 
 import { AudioChunk } from "../audio-chunk";
+import { voiceReceiveSpanUnder } from "../telemetry";
 
 import type { TwilioAgentAdapter } from "./twilio";
 import { twilioLogger } from "./twilio-logger";
@@ -172,6 +174,13 @@ export class TwilioWebhookServer {
     url: URL,
   ): Promise<void> {
     const adapter = this._adapter;
+    // Webhook visibility counter (#775 disconnect T3): the media-stream WS
+    // loop has no direct span (frozen-ctx + flood hazard), so a
+    // misconfigured/rejected webhook shows up as a `voice.adapter.dial`
+    // stream_connect_timeout with no obvious cause. This counter — stamped
+    // onto `voice.adapter.disconnect` — closes that gap without a
+    // per-request span.
+    adapter._recordWebhookInvocation();
     let body: string;
     try {
       body = await readBody(req, MAX_BODY_BYTES);
@@ -282,18 +291,57 @@ export class TwilioWebhookServer {
     const buffered: number[] = [];
     const flushThresholdBytes = (BATCH_MS / TWILIO_FRAME_MS) * 160; // 100ms = 800 bytes µ-law
 
+    // Tier-3 (#775): the turn-ctx object we last emitted a background-loop
+    // `voice.audio.receive` delivery marker for — so the marker fires ONCE
+    // per live turn (mirrors Pipecat's `bgSpanTurnContext`, the #774/#781
+    // primitive). Fresh per `mediaStreamLoop()` invocation, i.e. per
+    // connected call/session — matches `buffered` above.
+    let lastBgSpanTurnContext: Context | undefined;
+
     const flush = (): void => {
       if (buffered.length === 0) return;
       const mulaw = new Uint8Array(buffered);
       buffered.length = 0;
       const pcm = mulaw8kToPcm16_24k(mulaw);
-      adapter._enqueueInbound(new AudioChunk({ data: pcm }));
+      // At the FIRST wire delivery under a LIVE turn, wrap the enqueue in a
+      // `voice.audio.receive` background-loop delivery marker parented to
+      // that turn (#774/#781 primitive) — mirrors Pipecat's
+      // `flushBufferedMulaw`. Between turns (`_voiceTurnContext` undefined)
+      // or for later deliveries within the SAME turn (identity-check), no
+      // span is emitted: only the first wire delivery per turn is spanned
+      // (flood guard), and a fully pre-buffered turn (audio queued before
+      // any turn went live) is drained by the base `voice.audio.receive`
+      // span with no background marker at all.
+      //
+      // Coverage limit (by design, mirrors Pipecat): `voice.audio.bytes` is
+      // the DELIVERED coalesced-batch size, which may fold in a sub-100ms
+      // µ-law tail carried over from the prior turn.
+      const parent = adapter._voiceTurnContext;
+      if (parent === undefined || parent === lastBgSpanTurnContext) {
+        adapter._enqueueInbound(new AudioChunk({ data: pcm }));
+        return;
+      }
+      lastBgSpanTurnContext = parent;
+      voiceReceiveSpanUnder(
+        parent,
+        {
+          "voice.adapter.class": adapter.constructor.name,
+          "voice.twilio.recv.source": "background_loop",
+          "voice.audio.bytes": pcm.length,
+        },
+        () => {
+          adapter._enqueueInbound(new AudioChunk({ data: pcm }));
+        },
+      );
     };
 
     try {
       while (true) {
         const text = await ws.receiveText();
-        if (text == null) return; // socket closed
+        if (text == null) {
+          adapter._setStreamEndedReason("close");
+          return; // socket closed
+        }
         const frame = parseMediaStreamFrame(text);
         if (!frame) continue;
 
@@ -302,9 +350,11 @@ export class TwilioWebhookServer {
           if (frame.callSid) adapter._setCallSid(frame.callSid);
           adapter._signalStreamConnected();
         } else if (frame.event === "media" && frame.payloadMulaw) {
+          adapter._recordFrameReceived();
           for (const byte of frame.payloadMulaw) buffered.push(byte);
           if (buffered.length >= flushThresholdBytes) flush();
         } else if (frame.event === "dtmf" && frame.dtmfDigit) {
+          adapter._recordDtmfReceived();
           twilioLogger.debug("received DTMF", { digit: frame.dtmfDigit });
           if (adapter.onDtmf) {
             try {
@@ -319,9 +369,16 @@ export class TwilioWebhookServer {
           }
         } else if (frame.event === "stop") {
           flush();
+          adapter._setStreamEndedReason("stop");
           return;
         }
       }
+    } catch (err) {
+      // Any transport error that is not a clean socket close (`text == null`
+      // above) propagates to `runStreamSession`'s caller unchanged — tag the
+      // outcome before re-throwing.
+      adapter._setStreamEndedReason("error");
+      throw err;
     } finally {
       // Terminal sentinel (#695; mirrors the #648 / #646 fix). Whether the loop
       // exits on a "stop" frame, a socket close (`receiveText` resolves null),

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -22,6 +22,7 @@ import { AgentRole } from "../../domain/agents";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
+import { currentSpan, setSpanAttributes, voiceSpan } from "../telemetry";
 import { sleep } from "../utils";
 
 import { TwilioWebhookServer, type MediaStreamWebSocket } from "./twilio-server";
@@ -32,10 +33,17 @@ import {
   buildMediaFrame,
   iterMulawFrames,
   pcm16_24kToMulaw8k,
+  redactE164,
   validateE164,
 } from "./twilio-shared";
 
 export type TwilioAdapterMode = "idle" | "answer" | "call";
+
+/** How the media-stream session most recently ended. "none" until a session
+ * has ever run (the disconnect-counters T3 enum, #775). Set by
+ * {@link TwilioWebhookServer.mediaStreamLoop} at each of its three
+ * termination paths. */
+export type TwilioStreamEndedReason = "stop" | "close" | "error" | "none";
 
 const PLACE_CALL_A_LEG_SAY_TEXT =
   "Thank you for calling. " +
@@ -121,6 +129,16 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   // and at media-stream-loop entry (per-call scope — a second session on the
   // same connected adapter must not inherit the previous session's flag).
   private _streamEnded = false;
+  // Call-lifetime counters stamped onto `voice.adapter.disconnect` from inside
+  // disconnect() (#775 Tier 2b — mirrors ElevenLabs' pump-counter seam).
+  // Accumulated by the media loop (twilio-server.ts) and the `/twilio/voice`
+  // webhook handler; reset on connect()/disconnect() like `_streamEnded`
+  // above. `webhook_rejected` reuses the pre-existing `rejectedCount` field
+  // (below) rather than duplicating it.
+  private _framesReceived = 0;
+  private _dtmfReceived = 0;
+  private _streamEndedReason: TwilioStreamEndedReason = "none";
+  private _webhookInvocations = 0;
 
   constructor(options: TwilioAgentAdapterOptions) {
     super();
@@ -158,10 +176,29 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
       this._rest = new TwilioRESTHelper(this.accountSid, this.authToken, this.fetchImpl);
     }
     this._phoneNumberSid = await this._rest.resolvePhoneNumberSid(this.phoneNumber);
+
+    // Stamp Twilio-specific attrs onto the active `voice.adapter.connect` span
+    // (opened by `startVoiceAdapters`). Base spans are name-owned; the adapter
+    // contributes attributes, never a parallel span name — mirror ElevenLabs'
+    // `voice.elevenlabs.agent_id` seam (`adapters/elevenlabs.ts`).
+    // NOTE: no `voice.twilio.direction` here — connect() is direction-agnostic
+    // (`_mode` stays "idle" until placeCall()/waitForCall(), after this span
+    // has already closed); direction is stamped on the NEW
+    // `voice.adapter.dial` span instead (see placeCall/waitForCall).
+    setSpanAttributes(currentSpan(), {
+      "voice.twilio.phone_number_sid": this._phoneNumberSid,
+      "voice.twilio.validate_signature": this.validateSignature,
+      "voice.twilio.webhook_port": this.httpPort,
+    });
+
     this._mode = "idle";
     this._streamConnected = makeDeferred<void>();
     this._inboundQueue.reset();
     this._streamEnded = false;
+    this._framesReceived = 0;
+    this._dtmfReceived = 0;
+    this._streamEndedReason = "none";
+    this._webhookInvocations = 0;
 
     this._webhookServer = new TwilioWebhookServer(this);
     await this._webhookServer.start();
@@ -176,12 +213,17 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   async disconnect(): Promise<void> {
     if (!this._connected) return;
 
-    // Restore prior voice_url (answer mode only).
+    // Restore prior voice_url (answer mode only). `restRestoreFailed` tracks
+    // whether either restore below threw — previously fully swallowed; now
+    // surfaced onto the disconnect span (#775 Tier 2b) so a Twilio REST
+    // outage during teardown is no longer invisible. The swallow behavior
+    // itself (a failed restore must never block disconnect()) is unchanged.
+    let restRestoreFailed = false;
     if (this._mode === "answer" && this._phoneNumberSid && this._rest) {
       try {
         await this._rest.writeVoiceUrl(this._phoneNumberSid, this._priorVoiceUrl ?? "");
       } catch {
-        // Best-effort.
+        restRestoreFailed = true;
       }
     }
     if (this._mode === "call" && this._calleePhoneNumberSid && this._rest) {
@@ -191,9 +233,21 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
           this._priorCalleeVoiceUrl ?? "",
         );
       } catch {
-        // Best-effort.
+        restRestoreFailed = true;
       }
     }
+
+    // Stamp call-lifetime counters onto the active `voice.adapter.disconnect`
+    // span (opened by `stopVoiceAdapters`) — mirrors ElevenLabs' pump-counter
+    // stamp (`adapters/elevenlabs.ts`).
+    setSpanAttributes(currentSpan(), {
+      "voice.twilio.frames_received": this._framesReceived,
+      "voice.twilio.dtmf_received": this._dtmfReceived,
+      "voice.twilio.stream_ended_reason": this._streamEndedReason,
+      "voice.twilio.webhook_invocations": this._webhookInvocations,
+      "voice.twilio.webhook_rejected": this.rejectedCount,
+      "voice.twilio.rest_restore_failed": restRestoreFailed,
+    });
 
     if (this._webhookServer) {
       await this._webhookServer.stop();
@@ -212,6 +266,10 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     this._streamConnected = makeDeferred<void>();
     this._inboundQueue.reset();
     this._streamEnded = false;
+    this._framesReceived = 0;
+    this._dtmfReceived = 0;
+    this._streamEndedReason = "none";
+    this._webhookInvocations = 0;
   }
 
   // ------------------------------------------------------------------ direction
@@ -233,29 +291,61 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     const attachStreamToSelf = args.attachStreamToSelf ?? true;
     const timeoutMs = args.timeoutMs ?? 120_000;
 
-    if (attachStreamToSelf) {
-      this._calleePhoneNumberSid = await rest.resolvePhoneNumberSid(args.to);
-      this._priorCalleeVoiceUrl =
-        (await rest.readVoiceUrl(this._calleePhoneNumberSid)) ?? undefined;
-      const webhookUrl = `${publicBaseUrl.replace(/\/$/, "")}/twilio/voice`;
-      await rest.writeVoiceUrl(this._calleePhoneNumberSid, webhookUrl);
-    }
+    // NEW `voice.adapter.dial` span (#775 Tier 2a): self-instrumented, since
+    // no executor span is active by the time placeCall()/waitForCall() run
+    // (the `voice.adapter.connect` span already closed). Wraps the REST dial
+    // + the stream-connected wait — the "I placed the call but no media ever
+    // streamed" failure surface.
+    await voiceSpan(
+      "voice.adapter.dial",
+      {
+        "voice.adapter.class": this.constructor.name,
+        "voice.twilio.direction": "outbound",
+        "voice.twilio.to": redactE164(args.to),
+        "voice.twilio.from": redactE164(this.phoneNumber),
+      },
+      async (span) => {
+        if (attachStreamToSelf) {
+          this._calleePhoneNumberSid = await rest.resolvePhoneNumberSid(args.to);
+          this._priorCalleeVoiceUrl =
+            (await rest.readVoiceUrl(this._calleePhoneNumberSid)) ?? undefined;
+          const webhookUrl = `${publicBaseUrl.replace(/\/$/, "")}/twilio/voice`;
+          await rest.writeVoiceUrl(this._calleePhoneNumberSid, webhookUrl);
+        }
 
-    const inlineALegTwiml =
-      `<?xml version="1.0" encoding="UTF-8"?>` +
-      `<Response>` +
-      `<Say voice="Polly.Joanna">${PLACE_CALL_A_LEG_SAY_TEXT}</Say>` +
-      `<Pause length="120"/>` +
-      `</Response>`;
-    this._callSid = await rest.placeCall({
-      to: args.to,
-      from: this.phoneNumber,
-      twiml: inlineALegTwiml,
-    });
+        const inlineALegTwiml =
+          `<?xml version="1.0" encoding="UTF-8"?>` +
+          `<Response>` +
+          `<Say voice="Polly.Joanna">${PLACE_CALL_A_LEG_SAY_TEXT}</Say>` +
+          `<Pause length="120"/>` +
+          `</Response>`;
+        this._callSid = await rest.placeCall({
+          to: args.to,
+          from: this.phoneNumber,
+          twiml: inlineALegTwiml,
+        });
+        setSpanAttributes(span, { "voice.twilio.call_sid": this._callSid });
 
-    if (attachStreamToSelf) {
-      await this._streamConnected.promiseWithTimeout(timeoutMs);
-    }
+        if (attachStreamToSelf) {
+          const dialWaitStarted = performance.now(); // monotonic
+          try {
+            await this._streamConnected.promiseWithTimeout(timeoutMs);
+          } catch (err) {
+            // The media stream never connected — the marquee "I placed the
+            // call but no media ever streamed" failure. Tag the outcome
+            // BEFORE re-throwing; the re-thrown error still marks the span
+            // ERROR (voiceSpan's own exception handling).
+            span.setAttribute("voice.twilio.dial_outcome", "stream_connect_timeout");
+            throw err;
+          }
+          setSpanAttributes(span, {
+            "voice.twilio.stream_connect_latency_ms": Math.round(
+              performance.now() - dialWaitStarted,
+            ),
+          });
+        }
+      },
+    );
   }
 
   async waitForCall(timeoutMs = 120_000): Promise<void> {
@@ -268,11 +358,40 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     }
     this._enterMode("answer");
 
-    this._priorVoiceUrl =
-      (await rest.readVoiceUrl(phoneNumberSid)) ?? undefined;
-    const webhookUrl = `${publicBaseUrl.replace(/\/$/, "")}/twilio/voice`;
-    await rest.writeVoiceUrl(phoneNumberSid, webhookUrl);
-    await this._streamConnected.promiseWithTimeout(timeoutMs);
+    // NEW `voice.adapter.dial` span (#775 Tier 2a) — see placeCall()'s
+    // comment for the rationale (self-instrumented, no executor span active
+    // here).
+    await voiceSpan(
+      "voice.adapter.dial",
+      {
+        "voice.adapter.class": this.constructor.name,
+        "voice.twilio.direction": "inbound",
+        "voice.twilio.to": redactE164(this.phoneNumber),
+      },
+      async (span) => {
+        this._priorVoiceUrl =
+          (await rest.readVoiceUrl(phoneNumberSid)) ?? undefined;
+        const webhookUrl = `${publicBaseUrl.replace(/\/$/, "")}/twilio/voice`;
+        await rest.writeVoiceUrl(phoneNumberSid, webhookUrl);
+
+        const dialWaitStarted = performance.now(); // monotonic
+        try {
+          await this._streamConnected.promiseWithTimeout(timeoutMs);
+        } catch (err) {
+          // Nobody dialed in — tag the outcome BEFORE re-throwing; the
+          // re-thrown error still marks the span ERROR (voiceSpan's own
+          // exception handling).
+          span.setAttribute("voice.twilio.dial_outcome", "stream_connect_timeout");
+          throw err;
+        }
+        setSpanAttributes(span, {
+          "voice.twilio.call_sid": this._callSid,
+          "voice.twilio.stream_connect_latency_ms": Math.round(
+            performance.now() - dialWaitStarted,
+          ),
+        });
+      },
+    );
   }
 
   private _enterMode(mode: TwilioAdapterMode): void {
@@ -456,6 +575,22 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   }
   /** @internal */ get _modeForServer(): TwilioAdapterMode {
     return this._mode;
+  }
+  /** @internal Disconnect-counter (#775 Tier 2b): one `media` frame received. */
+  _recordFrameReceived(): void {
+    this._framesReceived += 1;
+  }
+  /** @internal Disconnect-counter (#775 Tier 2b): one `dtmf` frame received. */
+  _recordDtmfReceived(): void {
+    this._dtmfReceived += 1;
+  }
+  /** @internal Disconnect-counter (#775 Tier 2b): how the media session ended. */
+  _setStreamEndedReason(reason: TwilioStreamEndedReason): void {
+    this._streamEndedReason = reason;
+  }
+  /** @internal Disconnect-counter (#775 Tier 2b): one `/twilio/voice` POST. */
+  _recordWebhookInvocation(): void {
+    this._webhookInvocations += 1;
   }
 
   // ------------------------------------------------------------------ assertions

--- a/javascript/src/voice/adapters/twilio.ts
+++ b/javascript/src/voice/adapters/twilio.ts
@@ -199,6 +199,10 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     this._dtmfReceived = 0;
     this._streamEndedReason = "none";
     this._webhookInvocations = 0;
+    // MUST-FIX (#775 review): reset alongside the other Tier-2b counters so a
+    // reconnect on the same instance doesn't leak the previous session's
+    // rejected count (see the matching reset in disconnect()).
+    this.rejectedCount = 0;
 
     this._webhookServer = new TwilioWebhookServer(this);
     await this._webhookServer.start();
@@ -237,9 +241,27 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
       }
     }
 
+    // Tear the server down FIRST. This is what ACTUALLY closes a still-live
+    // media stream (`stop()` closes every open `wss` client), which is what
+    // lets `mediaStreamLoop`'s catch/terminal branches (twilio-server.ts)
+    // make their FINAL writes to `_framesReceived` / `_streamEndedReason` /
+    // etc. The counter stamp below MUST run after this await, not before —
+    // stamping first (the #775 review-caught bug) reads the pre-teardown
+    // snapshot and reports `stream_ended_reason=="none"` / undercounted
+    // frames for a call that was still live when disconnect() was invoked,
+    // even though the call did in fact end (via this very shutdown) moments
+    // later.
+    if (this._webhookServer) {
+      await this._webhookServer.stop();
+    }
+
     // Stamp call-lifetime counters onto the active `voice.adapter.disconnect`
     // span (opened by `stopVoiceAdapters`) — mirrors ElevenLabs' pump-counter
-    // stamp (`adapters/elevenlabs.ts`).
+    // stamp (`adapters/elevenlabs.ts`). Sampled AFTER the shutdown-await above
+    // (not before) so a still-live call's FINAL counts/reason are captured,
+    // not a mid-call snapshot. The disconnect span stays the active span
+    // across the await (AsyncLocalStorage context survives awaits), so
+    // `currentSpan()` here still targets it.
     setSpanAttributes(currentSpan(), {
       "voice.twilio.frames_received": this._framesReceived,
       "voice.twilio.dtmf_received": this._dtmfReceived,
@@ -249,9 +271,6 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
       "voice.twilio.rest_restore_failed": restRestoreFailed,
     });
 
-    if (this._webhookServer) {
-      await this._webhookServer.stop();
-    }
     this._connected = false;
     this._webhookServer = null;
     this._rest = null;
@@ -270,6 +289,11 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
     this._dtmfReceived = 0;
     this._streamEndedReason = "none";
     this._webhookInvocations = 0;
+    // MUST-FIX (#775 review): every other Tier-2b counter resets on both
+    // connect() and disconnect() — this pre-existing field didn't, so a
+    // reconnect on the same instance leaked the previous session's rejected
+    // count into the new session's disconnect span.
+    this.rejectedCount = 0;
   }
 
   // ------------------------------------------------------------------ direction
@@ -333,9 +357,14 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
           } catch (err) {
             // The media stream never connected — the marquee "I placed the
             // call but no media ever streamed" failure. Tag the outcome
-            // BEFORE re-throwing; the re-thrown error still marks the span
-            // ERROR (voiceSpan's own exception handling).
-            span.setAttribute("voice.twilio.dial_outcome", "stream_connect_timeout");
+            // BEFORE re-throwing ONLY when it's genuinely the timeout
+            // (matches Python's `except asyncio.TimeoutError` scoping — a
+            // non-timeout rejection of the deferred must not be mislabeled).
+            // The re-thrown error still marks the span ERROR either way
+            // (voiceSpan's own exception handling).
+            if (err instanceof DeferredTimeoutError) {
+              span.setAttribute("voice.twilio.dial_outcome", "stream_connect_timeout");
+            }
             throw err;
           }
           setSpanAttributes(span, {
@@ -378,10 +407,14 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
         try {
           await this._streamConnected.promiseWithTimeout(timeoutMs);
         } catch (err) {
-          // Nobody dialed in — tag the outcome BEFORE re-throwing; the
-          // re-thrown error still marks the span ERROR (voiceSpan's own
+          // Nobody dialed in — tag the outcome BEFORE re-throwing ONLY when
+          // it's genuinely the timeout (matches Python's
+          // `except asyncio.TimeoutError` scoping). The re-thrown error
+          // still marks the span ERROR either way (voiceSpan's own
           // exception handling).
-          span.setAttribute("voice.twilio.dial_outcome", "stream_connect_timeout");
+          if (err instanceof DeferredTimeoutError) {
+            span.setAttribute("voice.twilio.dial_outcome", "stream_connect_timeout");
+          }
           throw err;
         }
         setSpanAttributes(span, {
@@ -570,6 +603,12 @@ export class TwilioAgentAdapter extends VoiceAgentAdapter {
   get _streamSidForTest(): string | undefined {
     return this._streamSid;
   }
+  /** @internal Test-only view of the disconnect-counter (#775 review): lets a
+   * test poll for a REAL wire delivery to have landed before proceeding,
+   * instead of a blind sleep. */
+  get _framesReceivedForTest(): number {
+    return this._framesReceived;
+  }
   /** @internal */ _onWebhookRejected(): void {
     this.rejectedCount += 1;
   }
@@ -621,6 +660,22 @@ interface Deferred<T> {
   promiseWithTimeout(timeoutMs: number): Promise<T>;
 }
 
+/**
+ * Thrown by {@link Deferred.promiseWithTimeout} specifically when the
+ * timeout elapses — a distinct type (not a plain `Error`) so callers
+ * (placeCall/waitForCall's `dial_outcome` tagging) can precisely distinguish
+ * "the wait timed out" from any OTHER rejection of the underlying deferred
+ * (e.g. a future `.reject(...)` caller), matching Python's
+ * `except asyncio.TimeoutError` scoping (#775 review fix — the original code
+ * tagged ANY rejection as a timeout).
+ */
+class DeferredTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`TwilioAgentAdapter: timed out after ${timeoutMs}ms`);
+    this.name = "DeferredTimeoutError";
+  }
+}
+
 function makeDeferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -639,7 +694,7 @@ function makeDeferred<T>(): Deferred<T> {
           promise,
           new Promise<T>((_, rej) => {
             timer = setTimeout(
-              () => rej(new Error(`TwilioAgentAdapter: timed out after ${timeoutMs}ms`)),
+              () => rej(new DeferredTimeoutError(timeoutMs)),
               timeoutMs,
             );
           }),

--- a/javascript/src/voice/telemetry.ts
+++ b/javascript/src/voice/telemetry.ts
@@ -19,6 +19,7 @@ import {
   context,
   trace,
   SpanStatusCode,
+  type Context,
   type Span,
 } from "@opentelemetry/api";
 import { Logger } from "../utils/logger";
@@ -67,20 +68,65 @@ export async function voiceSpan<T>(
     span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
     throw err;
   } finally {
-    try {
-      span.end();
-    } catch (exportErr) {
-      logger.warn(
-        `voice: span '${name}' failed to export; dropping it (run continues)`,
-        exportErr,
-      );
-    }
+    endGuarded(span, name);
+  }
+}
+
+/**
+ * End a span, swallowing a processor/exporter failure (a bad `SpanProcessor.onEnd`
+ * throws from `end()`, which would otherwise propagate into the audio path). The
+ * single guarded-end shared by {@link voiceSpan} and {@link voiceReceiveSpanUnder}
+ * so a fix to the guard can't be applied to one and missed on the other.
+ */
+function endGuarded(span: Span, name: string): void {
+  try {
+    span.end();
+  } catch (exportErr) {
+    logger.warn(
+      `voice: span '${name}' failed to export; dropping it (run continues)`,
+      exportErr,
+    );
   }
 }
 
 /** The currently-active span, for adapters stamping attributes onto a span they did not open. */
 export function currentSpan(): Span | undefined {
   return trace.getSpan(context.active());
+}
+
+/**
+ * Run `fn` inside a guarded `voice.audio.receive` span pinned under an EXPLICIT
+ * parent context, synchronously.
+ *
+ * The seam for background-receive-loop adapters (Pipecat/Twilio) whose real
+ * receive runs in a NON-async ws callback: they parent this span under the live
+ * `voice.turn` context the base `call()` published on the adapter, not the
+ * callback's detached/root context (#774). Synchronous; the span becomes the
+ * active span for the body (via `context.with`, matching Python's
+ * `voice_span(parent=)`) so a nested span added later parents correctly in both
+ * runtimes. `end()` is guarded exactly like `voiceSpan` (shared {@link endGuarded}).
+ */
+export function voiceReceiveSpanUnder<T>(
+  parent: Context,
+  attributes: Record<string, unknown>,
+  fn: (span: Span) => T,
+): T {
+  const span = trace
+    .getTracer(TRACER_NAME)
+    .startSpan("voice.audio.receive", undefined, parent);
+  span.setAttribute("langwatch.span.type", "span");
+  applyAttributes(span, attributes);
+  try {
+    const result = context.with(trace.setSpan(parent, span), () => fn(span));
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+  } catch (err) {
+    span.recordException(err as Error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+    throw err;
+  } finally {
+    endGuarded(span, "voice.audio.receive");
+  }
 }
 
 /** Set non-nullish attributes on `span` if it is recording. Never throws. */

--- a/python/scenario/voice/_telemetry.py
+++ b/python/scenario/voice/_telemetry.py
@@ -51,24 +51,32 @@ def _tracer():
 
 @contextlib.contextmanager
 def voice_span(
-    name: str, attributes: Optional[Dict[str, Any]] = None
+    name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+    *,
+    parent: Optional[context.Context] = None,
 ) -> Iterator[Span]:
     """Open a guarded ``scenario.voice`` span.
 
     - Sets ``langwatch.span.type=span`` plus any non-``None`` ``attributes``.
     - Becomes the current span so nested ``voice_span``/framework spans parent
-      under it automatically (ambient OTel context — no parent is passed).
+      under it automatically (ambient OTel context when ``parent`` is ``None``).
+    - ``parent`` pins the span under an EXPLICIT OTel context instead of the
+      ambient one — the seam a background-receive-loop adapter (Pipecat, Twilio)
+      uses to parent detached-task recv spans under the live ``voice.turn`` the
+      base ``call()`` published, rather than the loop's frozen connect-time
+      context (#774). ``None`` preserves the original ambient-nesting behaviour.
     - A body exception is recorded, sets the span ERROR, and is **re-raised**
       (a transport error must surface).
     - ``span.end()`` is wrapped: a processor/exporter failure is swallowed and
       logged WARNING, never propagated into the audio path.
     """
-    span = _tracer().start_span(name)
+    span = _tracer().start_span(name, context=parent)
     span.set_attribute("langwatch.span.type", "span")
     for key, value in (attributes or {}).items():
         if value is not None:
             span.set_attribute(key, value)
-    token = context.attach(trace.set_span_in_context(span))
+    token = context.attach(trace.set_span_in_context(span, parent))
     try:
         yield span
     except BaseException as exc:  # noqa: BLE001 - mark + re-raise, never swallow the body

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -16,11 +16,15 @@ each adapter needing its own bookkeeping.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import logging
 import time
 from abc import abstractmethod
-from typing import Any, Callable, ClassVar, List, Optional
+from typing import Any, Callable, ClassVar, Iterator, List, Optional
+
+from opentelemetry import context as otel_context
+from opentelemetry.context import Context
 
 logger = logging.getLogger("scenario.voice")
 
@@ -113,6 +117,13 @@ class VoiceAgentAdapter(AgentAdapter):
     # Hard cap on a single agent turn's audio. Prevents runaway loops if a
     # transport never signals end-of-stream. 30s = a long sentence.
     response_max_duration: float = 30.0
+
+    # Live OTel context of the CURRENT ``voice.turn``, published by ``call()``
+    # for background-receive-loop adapters (Pipecat/Twilio) to parent their
+    # detached-task recv spans under the turn (#774). ``None`` between turns.
+    # Class-level default so it exists even for a subclass that skips
+    # ``super().__init__()`` (mirrors the ``_agent_speaking`` safety-net).
+    _voice_turn_context: Optional[Context] = None
 
     def __init__(self) -> None:
         # Per-instance event used by the interruption path to wait until
@@ -215,6 +226,24 @@ class VoiceAgentAdapter(AgentAdapter):
             ),
         )
 
+    @contextlib.contextmanager
+    def _voice_turn_context_scope(self) -> Iterator[None]:
+        """Publish the live ``voice.turn`` OTel context for background-loop adapters.
+
+        Pipecat/Twilio run their real receive in a background task/callback whose
+        OTel context was frozen at ``connect()`` (a now-closed span). They read
+        :attr:`_voice_turn_context` to parent those detached recv spans under the
+        CURRENT ``voice.turn`` (#774 — the reusable pattern Twilio PR5 inherits).
+        Entered INSIDE the ``voice.turn`` span so ``get_current()`` captures it;
+        cleared on exit so a late background frame BETWEEN turns finds ``None`` and
+        skips its span rather than parenting under a closed turn.
+        """
+        self._voice_turn_context = otel_context.get_current()
+        try:
+            yield
+        finally:
+            self._voice_turn_context = None
+
     async def call(self, input: AgentInput) -> AgentReturnTypes:
         """
         Default implementation: extract audio from the latest user message,
@@ -263,7 +292,7 @@ class VoiceAgentAdapter(AgentAdapter):
                 "voice.adapter.class": type(self).__name__,
                 "voice.turn.index": turn_index,
             },
-        ) as _turn_span:
+        ) as _turn_span, self._voice_turn_context_scope():
             _turn_started = time.monotonic()
             # Clear the speaking-event for this turn — set in _drain on first chunk.
             self._agent_speaking_event.clear()

--- a/python/scenario/voice/adapters/_twilio_server.py
+++ b/python/scenario/voice/adapters/_twilio_server.py
@@ -27,9 +27,12 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import suppress
-from typing import Any, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
+
+from opentelemetry.context import Context
 
 from ..audio_chunk import AudioChunk
+from .._telemetry import voice_span
 from ._twilio_shared import (
     _redact_e164,
     mulaw8k_to_pcm16_24k,
@@ -145,6 +148,14 @@ class TwilioWebhookServer:
             """
             from urllib.parse import parse_qs
 
+            # Webhook visibility counters (#775 Tier 3 note / disconnect T3):
+            # the media-stream WS loop has no direct span (frozen-ctx + flood
+            # hazard), so a misconfigured/rejected webhook shows up as a
+            # ``voice.adapter.dial`` stream_connect_timeout with no obvious
+            # cause. These counters — stamped onto ``voice.adapter.disconnect``
+            # — close that gap without a per-request span.
+            adapter._webhook_invocations += 1
+
             body = (await request.body()).decode("utf-8", errors="replace")
             fields = parse_qs(body)
             from_number = (fields.get("From") or [""])[0]
@@ -158,6 +169,7 @@ class TwilioWebhookServer:
                         "TwilioAgentAdapter: rejecting voice webhook — "
                         "missing or invalid X-Twilio-Signature"
                     )
+                    adapter._webhook_rejected += 1
                     return Response(content="forbidden", status_code=403)
 
             if adapter.allowed_callers is not None and from_number not in adapter.allowed_callers:
@@ -165,6 +177,7 @@ class TwilioWebhookServer:
                     "TwilioAgentAdapter: rejecting call from %s (not in allowed_callers)",
                     _redact_e164(from_number),
                 )
+                adapter._webhook_rejected += 1
                 return Response(
                     content="<Response><Reject/></Response>",
                     media_type="application/xml",
@@ -263,6 +276,51 @@ class TwilioWebhookServer:
         buffered_mulaw = bytearray()
         BATCH_MS = 100
 
+        # Tier-3 (#775): the turn-ctx object we last emitted a background-loop
+        # ``voice.audio.receive`` delivery marker for — so the marker fires
+        # ONCE per live turn (mirrors Pipecat's ``_bg_span_turn_context``, the
+        # #774/#781 primitive). Fresh per ``media_stream_loop()`` invocation,
+        # i.e. per connected call/session — matches ``buffered_mulaw`` above.
+        last_bg_turn_ctx: Optional[Context] = None
+
+        async def _enqueue(pcm: bytes) -> None:
+            """Enqueue decoded audio; at the FIRST wire delivery under a LIVE
+            turn, wrap the enqueue in a ``voice.audio.receive`` background-loop
+            delivery marker parented to that turn (#774/#781 primitive) —
+            mirrors Pipecat's ``_deliver``. Between turns
+            (``_voice_turn_context is None``) or for later deliveries within
+            the SAME turn (identity-check), no span is emitted: only the first
+            wire delivery per turn is spanned (flood guard), and a fully
+            pre-buffered turn (audio queued before any turn went live) is
+            drained by the base ``voice.audio.receive`` span with no
+            background marker at all.
+
+            Coverage limit (by design, mirrors Pipecat): ``voice.audio.bytes``
+            is the DELIVERED coalesced-batch size, which may fold in a
+            sub-100ms µ-law tail carried over from the prior turn.
+            """
+            nonlocal last_bg_turn_ctx
+            assert adapter._inbound_queue is not None
+            parent = adapter._voice_turn_context
+            if parent is None or parent is last_bg_turn_ctx:
+                await adapter._inbound_queue.put(AudioChunk(data=pcm))
+                return
+            last_bg_turn_ctx = parent
+            with voice_span(
+                "voice.audio.receive",
+                {
+                    "voice.adapter.class": type(adapter).__name__,
+                    "voice.twilio.recv.source": "background_loop",
+                    "voice.audio.bytes": len(pcm),
+                },
+                parent=parent,
+            ):
+                await adapter._inbound_queue.put(AudioChunk(data=pcm))
+
+        # Deferred import, matching this module's ``run_stream_session``
+        # pattern of keeping fastapi out of import-time dependencies.
+        from fastapi import WebSocketDisconnect
+
         try:
             while True:
                 msg = await ws.receive_text()
@@ -277,6 +335,7 @@ class TwilioWebhookServer:
                     adapter._stream_connected.set()
 
                 elif frame.event == "media" and frame.payload_mulaw:
+                    adapter._frames_received += 1
                     buffered_mulaw.extend(frame.payload_mulaw)
                     # 20ms per frame → flush every ~5 frames. Queue may be
                     # None if disconnect() raced ahead of the final frames;
@@ -287,9 +346,10 @@ class TwilioWebhookServer:
                     ):
                         pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await adapter._inbound_queue.put(AudioChunk(data=pcm))
+                        await _enqueue(pcm)
 
                 elif frame.event == "dtmf" and frame.dtmf_digit:
+                    adapter._dtmf_received += 1
                     logger.debug("TwilioAgentAdapter: received DTMF %s", frame.dtmf_digit)
                     if adapter.on_dtmf is not None:
                         try:
@@ -308,8 +368,22 @@ class TwilioWebhookServer:
                     if buffered_mulaw and adapter._inbound_queue is not None:
                         pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await adapter._inbound_queue.put(AudioChunk(data=pcm))
+                        await _enqueue(pcm)
+                    adapter._stream_ended_reason = "stop"
                     return
+        except WebSocketDisconnect:
+            # Socket closed mid-stream. ``run_stream_session`` swallows this
+            # type specifically (see its docstring) — tag the outcome BEFORE
+            # re-raising so that swallow's caller-visible behavior is
+            # unchanged.
+            adapter._stream_ended_reason = "close"
+            raise
+        except Exception:
+            # Any OTHER transport error (not a clean disconnect) propagates to
+            # ``run_stream_session``'s caller unchanged — tag the outcome
+            # before re-raising.
+            adapter._stream_ended_reason = "error"
+            raise
         finally:
             # Terminal sentinel (#695; mirrors the #648 / #646 fix). Whether the
             # loop exits on a "stop" frame, a socket close (``receive_text``

--- a/python/scenario/voice/adapters/pipecat.py
+++ b/python/scenario/voice/adapters/pipecat.py
@@ -24,9 +24,12 @@ import logging
 import uuid
 from typing import Any, ClassVar, Literal, Optional
 
+from opentelemetry.context import Context
+
 from ..adapter import AgentStreamEndedError, VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
 from ..capabilities import AdapterCapabilities
+from .._telemetry import voice_span
 from ._twilio_shared import (
     TWILIO_FRAME_MS,
     build_clear_frame,
@@ -128,6 +131,11 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
         # Set True when _recv_loop terminates (crash or clean close). Lets
         # recv_audio fail fast on a drained queue without re-reading it (#498).
         self._recv_loop_done: bool = False
+        # The turn context we last emitted a background ``voice.audio.receive``
+        # span for — so ``_deliver`` spans only the FIRST wire delivery of each
+        # turn (one span/turn, no per-100ms-chunk flood). Reset implicitly: the
+        # next turn publishes a distinct ``_voice_turn_context`` object (#774).
+        self._bg_span_turn_context: Optional[Context] = None
         # Serialises concurrent send_audio() calls — without it two paced
         # senders would interleave 20-ms mulaw frames on the wire and the
         # bot would receive corrupted audio. Used for the interruption case
@@ -188,6 +196,21 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
                     },
                 }
             )
+        )
+
+        # Stamp Pipecat transport attrs onto the active ``voice.adapter.connect``
+        # span (opened by the executor connect loop). Base spans are name-owned;
+        # the adapter contributes attributes, never a parallel span name — mirror
+        # ElevenLabs' ``voice.elevenlabs.agent_id`` seam (``adapters/elevenlabs.py``).
+        from opentelemetry import trace as _otel_trace
+        from .._telemetry import set_span_attributes
+
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {
+                "voice.pipecat.transport": self.transport,
+                "voice.pipecat.transport_format": self.transport_format,
+            },
         )
 
         self._recv_task = asyncio.create_task(self._recv_loop())
@@ -313,9 +336,8 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
                     # as raw µ-law payload if we see one.
                     buffered_mulaw.extend(raw)
                     if len(buffered_mulaw) >= (BATCH_MS * 8):
-                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        self._deliver(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await queue.put(AudioChunk(data=pcm))
                     continue
 
                 frame = parse_media_stream_frame(raw)
@@ -324,14 +346,12 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
                 if frame.event == "media" and frame.payload_mulaw:
                     buffered_mulaw.extend(frame.payload_mulaw)
                     if len(buffered_mulaw) >= (BATCH_MS * 8):
-                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        self._deliver(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await queue.put(AudioChunk(data=pcm))
                 elif frame.event == "stop":
                     if buffered_mulaw:
-                        pcm = mulaw8k_to_pcm16_24k(bytes(buffered_mulaw))
+                        self._deliver(bytes(buffered_mulaw))
                         buffered_mulaw.clear()
-                        await queue.put(AudioChunk(data=pcm))
                     return
         except asyncio.CancelledError:
             raise
@@ -352,6 +372,62 @@ class PipecatAgentAdapter(VoiceAgentAdapter):
             # two lines, so a waiter can't observe a half-set terminal state.)
             self._recv_loop_done = True
             queue.put_nowait(_RECV_LOOP_DONE)
+
+    def _deliver(self, mulaw: bytes) -> None:
+        """Decode a coalesced µ-law batch to PCM16/24k and enqueue it.
+
+        On the FIRST wire delivery of a turn — the base ``call()`` published its
+        OTel context via :attr:`VoiceAgentAdapter._voice_turn_context` — wrap the
+        decode+enqueue in a ``voice.audio.receive`` span parented to THAT turn
+        (#774), so the background ``_recv_loop`` task's receive work is attributed
+        to the turn instead of the task's frozen connect-time context (a
+        now-closed span).
+
+        This is a producer-side **delivery marker** (it carries the delivered
+        byte count); the consumer-side wait and the timeout/ERROR semantics (P3)
+        live on the base ``voice.audio.receive`` span that wraps ``recv_audio``.
+        The span is disambiguated from that base span by
+        ``voice.pipecat.recv.source=background_loop``.
+
+        Emitted at most ONCE per turn (only the first delivery under a given turn
+        context) — matching the base's one-receive-span-per-turn granularity and
+        the epic's no-per-tick-flood rule (the EL pump H1), so a multi-second turn
+        of 100 ms chunks is not exploded into dozens of sibling spans. Between
+        turns the context is ``None`` and we enqueue WITHOUT a span, so no
+        detached/closed-parent span can leak from the background task. The body is
+        synchronous (``put_nowait`` on the unbounded queue), so a ``disconnect()``
+        cancel can never land mid-span.
+
+        Coverage limits (by design — this is a marker, not exhaustive accounting):
+        - ``voice.audio.bytes`` is the DELIVERED coalesced-chunk size, which may
+          fold in a sub-100 ms µ-law tail carried over from the prior turn (the
+          recv-loop coalesces to 800-byte batches across the turn boundary — a
+          pre-existing property the base drain chunks share; not corrected here
+          because flushing a partial batch at the boundary would drop that audio).
+        - A turn whose agent audio was ALREADY buffered before ``call()`` published
+          the turn context (an opening greeting delivered during ``connect``) is
+          drained from the queue without a fresh wire delivery, so it gets no
+          background marker — the base ``voice.audio.receive`` span still covers
+          its consumption. The marker records in-turn wire deliveries, not every
+          turn that consumes audio (the deterministic turn-liveness gate).
+        """
+        assert self._inbound_queue is not None
+        parent = self._voice_turn_context
+        if parent is None or parent is self._bg_span_turn_context:
+            self._inbound_queue.put_nowait(AudioChunk(data=mulaw8k_to_pcm16_24k(mulaw)))
+            return
+        self._bg_span_turn_context = parent
+        with voice_span(
+            "voice.audio.receive",
+            {
+                "voice.adapter.class": type(self).__name__,
+                "voice.pipecat.recv.source": "background_loop",
+            },
+            parent=parent,
+        ) as span:
+            pcm = mulaw8k_to_pcm16_24k(mulaw)
+            span.set_attribute("voice.audio.bytes", len(pcm))
+            self._inbound_queue.put_nowait(AudioChunk(data=pcm))
 
     # ------------------------------------------------------------------ assertions
 

--- a/python/scenario/voice/adapters/twilio.py
+++ b/python/scenario/voice/adapters/twilio.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from contextlib import suppress
 from typing import Any, Callable, ClassVar, Literal, Optional
 
@@ -28,10 +29,16 @@ from typing import Any, Callable, ClassVar, Literal, Optional
 # first-use keeps the API small.
 TwilioAdapterMode = Literal["idle", "answer", "call"]
 
+#: How the media-stream session most recently ended. "none" until a session has
+#: ever run (the disconnect-counters T3 enum, #775). Set by the media loop
+#: (`_twilio_server.py`) at each of its three termination paths.
+TwilioStreamEndedReason = Literal["stop", "close", "error", "none"]
+
 from ...types import AgentRole
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
 from ..capabilities import AdapterCapabilities
+from .._telemetry import voice_span
 from ._twilio_shared import (
     TWILIO_FRAME_MS,
     TwilioRESTHelper,
@@ -165,6 +172,17 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         # inherit the previous session's flag).
         self._stream_ended: bool = False
 
+        # Call-lifetime counters stamped onto ``voice.adapter.disconnect`` from
+        # inside disconnect() (#775 Tier 2b — mirrors ElevenLabs' pump-counter
+        # seam). Accumulated by the media loop (`_twilio_server.py`) and the
+        # `/twilio/voice` webhook handler; reset on connect()/disconnect() like
+        # `_stream_ended` above.
+        self._frames_received: int = 0
+        self._dtmf_received: int = 0
+        self._stream_ended_reason: TwilioStreamEndedReason = "none"
+        self._webhook_invocations: int = 0
+        self._webhook_rejected: int = 0
+
 
     # ------------------------------------------------------------------ repr
 
@@ -206,10 +224,35 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         self._rest = TwilioRESTHelper(self.account_sid, self.auth_token)
         self._phone_number_sid = self._rest.resolve_phone_number_sid(self.phone_number)
 
+        # Stamp Twilio-specific attrs onto the active ``voice.adapter.connect``
+        # span (opened by the executor connect loop). Base spans are name-owned;
+        # the adapter contributes attributes, never a parallel span name — mirror
+        # ElevenLabs' ``voice.elevenlabs.agent_id`` seam (``adapters/elevenlabs.py``).
+        # NOTE: no ``voice.twilio.direction`` here — connect() is direction-
+        # agnostic (``_mode`` stays "idle" until place_call()/wait_for_call(),
+        # after this span has already closed); direction is stamped on the NEW
+        # ``voice.adapter.dial`` span instead (see place_call/wait_for_call).
+        from opentelemetry import trace as _otel_trace
+        from .._telemetry import set_span_attributes
+
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {
+                "voice.twilio.phone_number_sid": self._phone_number_sid,
+                "voice.twilio.validate_signature": self.validate_signature,
+                "voice.twilio.webhook_port": self.http_port,
+            },
+        )
+
         self._stream_connected = asyncio.Event()
         self._inbound_queue = asyncio.Queue()
         self._server_shutdown = asyncio.Event()
         self._stream_ended = False
+        self._frames_received = 0
+        self._dtmf_received = 0
+        self._stream_ended_reason = "none"
+        self._webhook_invocations = 0
+        self._webhook_rejected = 0
         self._mode = "idle"
 
         # Webhook server is its own unit — see _twilio_server.py. The
@@ -231,8 +274,14 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
             return
 
         # 1. Restore webhook first so Twilio doesn't keep hitting a dead URL.
+        # ``rest_restore_failed`` tracks whether either restore below raised —
+        # previously fully swallowed via ``suppress(Exception)``; now surfaced
+        # onto the disconnect span (#775 Tier 2b) so a Twilio REST outage during
+        # teardown is no longer invisible. The swallow behavior itself (a failed
+        # restore must never block disconnect()) is unchanged.
+        rest_restore_failed = False
         if self._mode == "answer" and self._phone_number_sid is not None:
-            with suppress(Exception):
+            try:
                 prior = self._prior_voice_url or ""
                 self._rest.write_voice_url(self._phone_number_sid, prior)
                 logger.debug(
@@ -240,10 +289,12 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
                     prior,
                     self._phone_number_sid,
                 )
+            except Exception:
+                rest_restore_failed = True
         # place_call() rewrites the CALLEE's voice_url to attach Media
         # Streams to B-leg. Restore that too.
         if self._mode == "call" and self._callee_phone_number_sid is not None:
-            with suppress(Exception):
+            try:
                 prior_b = self._prior_callee_voice_url or ""
                 self._rest.write_voice_url(self._callee_phone_number_sid, prior_b)
                 logger.debug(
@@ -251,6 +302,26 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
                     prior_b,
                     self._callee_phone_number_sid,
                 )
+            except Exception:
+                rest_restore_failed = True
+
+        # Stamp call-lifetime counters onto the active ``voice.adapter.disconnect``
+        # span (opened by the executor disconnect loop) — mirrors ElevenLabs'
+        # pump-counter stamp (``adapters/elevenlabs.py``).
+        from opentelemetry import trace as _otel_trace
+        from .._telemetry import set_span_attributes
+
+        set_span_attributes(
+            _otel_trace.get_current_span(),
+            {
+                "voice.twilio.frames_received": self._frames_received,
+                "voice.twilio.dtmf_received": self._dtmf_received,
+                "voice.twilio.stream_ended_reason": self._stream_ended_reason,
+                "voice.twilio.webhook_invocations": self._webhook_invocations,
+                "voice.twilio.webhook_rejected": self._webhook_rejected,
+                "voice.twilio.rest_restore_failed": rest_restore_failed,
+            },
+        )
 
         # 2. Signal server to shut down, then wait for the task.
         if self._server_shutdown is not None:
@@ -274,6 +345,11 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         self._stream_ws = None
         self._inbound_queue = None
         self._stream_ended = False
+        self._frames_received = 0
+        self._dtmf_received = 0
+        self._stream_ended_reason = "none"
+        self._webhook_invocations = 0
+        self._webhook_rejected = 0
 
     # ------------------------------------------------------------------ direction
 
@@ -338,55 +414,91 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         assert self._rest is not None
         assert self._stream_connected is not None
 
-        if attach_stream_to_self:
-            # Resolve B-leg's number SID and snapshot+rewrite its voice_url so
-            # B's leg attaches its Media Stream to our harness webhook. We own
-            # this number (same Twilio account); disconnect() will restore.
-            self._callee_phone_number_sid = self._rest.resolve_phone_number_sid(to)
-            self._prior_callee_voice_url = self._rest.read_voice_url(
-                self._callee_phone_number_sid
+        # NEW ``voice.adapter.dial`` span (#775 Tier 2a): self-instrumented,
+        # since no executor span is active by the time place_call()/
+        # wait_for_call() run (the ``voice.adapter.connect`` span already
+        # closed). Wraps the REST dial + the ``_stream_connected`` wait — the
+        # "I placed the call but no media ever streamed" failure surface.
+        from .._telemetry import set_span_attributes
+
+        with voice_span(
+            "voice.adapter.dial",
+            {
+                "voice.adapter.class": type(self).__name__,
+                "voice.twilio.direction": "outbound",
+                "voice.twilio.to": _redact_e164(to),
+                "voice.twilio.from": _redact_e164(self.phone_number),
+            },
+        ) as _dial:
+            if attach_stream_to_self:
+                # Resolve B-leg's number SID and snapshot+rewrite its voice_url so
+                # B's leg attaches its Media Stream to our harness webhook. We own
+                # this number (same Twilio account); disconnect() will restore.
+                self._callee_phone_number_sid = self._rest.resolve_phone_number_sid(to)
+                self._prior_callee_voice_url = self._rest.read_voice_url(
+                    self._callee_phone_number_sid
+                )
+                webhook_url = self.public_base_url.rstrip("/") + "/twilio/voice"
+                self._rest.write_voice_url(self._callee_phone_number_sid, webhook_url)
+                logger.info(
+                    "TwilioAgentAdapter: rewrote callee %s voice_url to %s",
+                    _redact_e164(to),
+                    webhook_url,
+                )
+
+            # A-leg TwiML: play a short deterministic <Say> line, then hold
+            # the bridge open. Twilio runs this on the originator side while
+            # B's webhook attaches the Media Stream.
+            #
+            # The <Say> gives the recording a known-good utterance to
+            # transcribe. A bare <Pause> alone produces 120s of line silence
+            # that Whisper has been observed to hallucinate as non-English
+            # text (issue #465 in this PR). The Say is a one-time anchor at
+            # call setup; the Media Stream carries the real bidirectional
+            # conversation that follows.
+            inline_a_leg_twiml = (
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                "<Response>"
+                f'<Say voice="Polly.Joanna">{PLACE_CALL_A_LEG_SAY_TEXT}</Say>'
+                '<Pause length="120"/>'
+                "</Response>"
             )
-            webhook_url = self.public_base_url.rstrip("/") + "/twilio/voice"
-            self._rest.write_voice_url(self._callee_phone_number_sid, webhook_url)
+            self._call_sid = self._rest.place_call(
+                to=to, from_=self.phone_number, twiml=inline_a_leg_twiml
+            )
             logger.info(
-                "TwilioAgentAdapter: rewrote callee %s voice_url to %s",
+                "TwilioAgentAdapter: placed call %s from %s to %s",
+                self._call_sid,
+                _redact_e164(self.phone_number),
                 _redact_e164(to),
-                webhook_url,
             )
+            set_span_attributes(_dial, {"voice.twilio.call_sid": self._call_sid})
 
-        # A-leg TwiML: play a short deterministic <Say> line, then hold
-        # the bridge open. Twilio runs this on the originator side while
-        # B's webhook attaches the Media Stream.
-        #
-        # The <Say> gives the recording a known-good utterance to
-        # transcribe. A bare <Pause> alone produces 120s of line silence
-        # that Whisper has been observed to hallucinate as non-English
-        # text (issue #465 in this PR). The Say is a one-time anchor at
-        # call setup; the Media Stream carries the real bidirectional
-        # conversation that follows.
-        inline_a_leg_twiml = (
-            '<?xml version="1.0" encoding="UTF-8"?>'
-            "<Response>"
-            f'<Say voice="Polly.Joanna">{PLACE_CALL_A_LEG_SAY_TEXT}</Say>'
-            '<Pause length="120"/>'
-            "</Response>"
-        )
-        self._call_sid = self._rest.place_call(
-            to=to, from_=self.phone_number, twiml=inline_a_leg_twiml
-        )
-        logger.info(
-            "TwilioAgentAdapter: placed call %s from %s to %s",
-            self._call_sid,
-            _redact_e164(self.phone_number),
-            _redact_e164(to),
-        )
-
-        if attach_stream_to_self:
-            # Wait for OUR webhook to fire — only meaningful when we rewrote
-            # the callee's voice_url to point at us. In originator-only mode
-            # (attach_stream_to_self=False), there's no stream coming to us;
-            # the callee has its own harness which owns the stream.
-            await asyncio.wait_for(self._stream_connected.wait(), timeout=timeout)
+            if attach_stream_to_self:
+                # Wait for OUR webhook to fire — only meaningful when we rewrote
+                # the callee's voice_url to point at us. In originator-only mode
+                # (attach_stream_to_self=False), there's no stream coming to us;
+                # the callee has its own harness which owns the stream.
+                _dial_wait_started = time.monotonic()
+                try:
+                    await asyncio.wait_for(self._stream_connected.wait(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    # The media stream never connected — the marquee "I placed
+                    # the call but no media ever streamed" failure. Tag the
+                    # outcome BEFORE re-raising; the raised TimeoutError still
+                    # marks the span ERROR (voice_span's own exception handling).
+                    _dial.set_attribute(
+                        "voice.twilio.dial_outcome", "stream_connect_timeout"
+                    )
+                    raise
+                set_span_attributes(
+                    _dial,
+                    {
+                        "voice.twilio.stream_connect_latency_ms": round(
+                            (time.monotonic() - _dial_wait_started) * 1000
+                        ),
+                    },
+                )
 
     async def wait_for_call(self, timeout: float = 120.0) -> None:
         """
@@ -420,14 +532,46 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         assert self._phone_number_sid is not None
         assert self._stream_connected is not None
 
-        # Snapshot the prior webhook so we can restore it on disconnect, then
-        # point the number at our server. Only answer mode does this.
-        self._prior_voice_url = self._rest.read_voice_url(self._phone_number_sid)
-        webhook_url = self.public_base_url.rstrip("/") + "/twilio/voice"
-        self._rest.write_voice_url(self._phone_number_sid, webhook_url)
-        logger.info("TwilioAgentAdapter: webhook set to %s", webhook_url)
+        # NEW ``voice.adapter.dial`` span (#775 Tier 2a) — see place_call()'s
+        # comment for the rationale (self-instrumented, no executor span active
+        # here).
+        from .._telemetry import set_span_attributes
 
-        await asyncio.wait_for(self._stream_connected.wait(), timeout=timeout)
+        with voice_span(
+            "voice.adapter.dial",
+            {
+                "voice.adapter.class": type(self).__name__,
+                "voice.twilio.direction": "inbound",
+                "voice.twilio.to": _redact_e164(self.phone_number),
+            },
+        ) as _dial:
+            # Snapshot the prior webhook so we can restore it on disconnect, then
+            # point the number at our server. Only answer mode does this.
+            self._prior_voice_url = self._rest.read_voice_url(self._phone_number_sid)
+            webhook_url = self.public_base_url.rstrip("/") + "/twilio/voice"
+            self._rest.write_voice_url(self._phone_number_sid, webhook_url)
+            logger.info("TwilioAgentAdapter: webhook set to %s", webhook_url)
+
+            _dial_wait_started = time.monotonic()
+            try:
+                await asyncio.wait_for(self._stream_connected.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                # Nobody dialed in — tag the outcome BEFORE re-raising; the
+                # raised TimeoutError still marks the span ERROR (voice_span's
+                # own exception handling).
+                _dial.set_attribute(
+                    "voice.twilio.dial_outcome", "stream_connect_timeout"
+                )
+                raise
+            set_span_attributes(
+                _dial,
+                {
+                    "voice.twilio.call_sid": self._call_sid,
+                    "voice.twilio.stream_connect_latency_ms": round(
+                        (time.monotonic() - _dial_wait_started) * 1000
+                    ),
+                },
+            )
 
     def _enter_mode(self, mode: TwilioAdapterMode) -> None:
         """Transition idle → mode, or raise if already in a different mode.

--- a/python/scenario/voice/adapters/twilio.py
+++ b/python/scenario/voice/adapters/twilio.py
@@ -34,11 +34,13 @@ TwilioAdapterMode = Literal["idle", "answer", "call"]
 #: (`_twilio_server.py`) at each of its three termination paths.
 TwilioStreamEndedReason = Literal["stop", "close", "error", "none"]
 
+from opentelemetry import trace as _otel_trace
+
 from ...types import AgentRole
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
 from ..capabilities import AdapterCapabilities
-from .._telemetry import voice_span
+from .._telemetry import set_span_attributes, voice_span
 from ._twilio_shared import (
     TWILIO_FRAME_MS,
     TwilioRESTHelper,
@@ -232,9 +234,6 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         # agnostic (``_mode`` stays "idle" until place_call()/wait_for_call(),
         # after this span has already closed); direction is stamped on the NEW
         # ``voice.adapter.dial`` span instead (see place_call/wait_for_call).
-        from opentelemetry import trace as _otel_trace
-        from .._telemetry import set_span_attributes
-
         set_span_attributes(
             _otel_trace.get_current_span(),
             {
@@ -305,12 +304,31 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
             except Exception:
                 rest_restore_failed = True
 
+        # 2. Signal server to shut down, then wait for the task. This is what
+        # ACTUALLY closes a still-live media stream (uvicorn's graceful
+        # shutdown tears down the open WS), which is what lets the media
+        # loop's ``finally``/except-handlers (``_twilio_server.py``) make
+        # their FINAL writes to ``_frames_received`` / ``_stream_ended_reason``
+        # / etc. The counter stamp below MUST run after this await, not
+        # before — stamping first (the #775 review-caught bug) reads the
+        # pre-teardown snapshot and reports ``stream_ended_reason=="none"`` /
+        # undercounted frames for a call that was still live when disconnect()
+        # was invoked, even though the call did in fact end (via this very
+        # shutdown) moments later.
+        if self._server_shutdown is not None:
+            self._server_shutdown.set()
+        if self._server_task is not None:
+            with suppress(Exception):
+                await asyncio.wait_for(self._server_task, timeout=3.0)
+
         # Stamp call-lifetime counters onto the active ``voice.adapter.disconnect``
         # span (opened by the executor disconnect loop) — mirrors ElevenLabs'
-        # pump-counter stamp (``adapters/elevenlabs.py``).
-        from opentelemetry import trace as _otel_trace
-        from .._telemetry import set_span_attributes
-
+        # pump-counter stamp (``adapters/elevenlabs.py``). Sampled AFTER the
+        # shutdown-await above (not before) so a still-live call's FINAL
+        # counts/reason are captured, not a mid-call snapshot. The disconnect
+        # span stays the current span across the await (contextvars survive
+        # awaits within the same task), so ``get_current_span()`` here still
+        # targets it.
         set_span_attributes(
             _otel_trace.get_current_span(),
             {
@@ -322,13 +340,6 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
                 "voice.twilio.rest_restore_failed": rest_restore_failed,
             },
         )
-
-        # 2. Signal server to shut down, then wait for the task.
-        if self._server_shutdown is not None:
-            self._server_shutdown.set()
-        if self._server_task is not None:
-            with suppress(Exception):
-                await asyncio.wait_for(self._server_task, timeout=3.0)
 
         # 3. Reset state.
         self._rest = None
@@ -419,8 +430,6 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         # wait_for_call() run (the ``voice.adapter.connect`` span already
         # closed). Wraps the REST dial + the ``_stream_connected`` wait — the
         # "I placed the call but no media ever streamed" failure surface.
-        from .._telemetry import set_span_attributes
-
         with voice_span(
             "voice.adapter.dial",
             {
@@ -535,8 +544,6 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         # NEW ``voice.adapter.dial`` span (#775 Tier 2a) — see place_call()'s
         # comment for the rationale (self-instrumented, no executor span active
         # here).
-        from .._telemetry import set_span_attributes
-
         with voice_span(
             "voice.adapter.dial",
             {

--- a/python/tests/voice/test_voice_spans_pipecat.py
+++ b/python/tests/voice/test_voice_spans_pipecat.py
@@ -1,0 +1,359 @@
+"""Pipecat-specific voice-span tests (#770 / #774, PR4).
+
+Drives the REAL ``PipecatAgentAdapter`` (base ``call()``/drain + the background
+``_recv_loop`` task) with a faked ``websockets`` connection, asserting:
+
+- **P1** — a Pipecat turn emits the #771 base spans with
+  ``voice.adapter.class`` = Pipecat, and the connect span carries the
+  Pipecat transport attributes.
+- **P2** — the background receive loop emits a ``voice.audio.receive`` span
+  parented to the turn (not a detached/closed span). This is the core AC: it
+  proves the context-capture pattern that Twilio (#770 PR5) reuses.
+- **P3** — a receive timeout marks ``voice.audio.receive`` ERROR.
+- **P-regression** — no orphaned/leaked span from the background task on
+  disconnect.
+
+Mic-free: an ``InMemorySpanExporter`` captures spans from the real production
+code; only the vendor WebSocket is faked. Mirrors the OTel-reset discipline of
+``test_voice_spans.py`` (reset the provider AND the set-once guard each test).
+"""
+
+import asyncio
+import base64
+import json
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+from opentelemetry.util._once import Once
+
+from scenario.voice import AudioChunk, PipecatAgentAdapter
+from scenario.voice.messages import create_audio_message
+
+from ._span_assert import attrs, ctx_id, int_attr, parent_id
+
+
+@pytest.fixture(autouse=True)
+def reset_otel():
+    def _reset() -> None:
+        trace._TRACER_PROVIDER = None
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _install_in_memory_provider() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+def _by_name(spans):
+    return {s.name: s for s in spans}
+
+
+def _receives(spans):
+    """Every ``voice.audio.receive`` span (base + background are same-named)."""
+    return [s for s in spans if s.name == "voice.audio.receive"]
+
+
+_SENTINEL_CLOSE = object()
+
+
+class _FakeWebSocket:
+    """Stand-in for the websockets client connection (see test_pipecat_adapter)."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._inbox: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def send(self, text: str) -> None:
+        self.sent.append(text)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        item = await self._inbox.get()
+        if item is _SENTINEL_CLOSE:
+            raise StopAsyncIteration
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+        await self._inbox.put(_SENTINEL_CLOSE)
+
+    def feed(self, frame: str) -> None:
+        self._inbox.put_nowait(frame)
+
+    def end_stream(self) -> None:
+        self._inbox.put_nowait(_SENTINEL_CLOSE)
+
+
+def _media_frame(stream_sid: str, mulaw: bytes) -> str:
+    return json.dumps(
+        {
+            "event": "media",
+            "streamSid": stream_sid,
+            "media": {"payload": base64.b64encode(mulaw).decode()},
+        }
+    )
+
+
+# 100 ms of µ-law silence (800 bytes) = the adapter's coalescing batch → one chunk.
+_ONE_CHUNK_MULAW = b"\x7f" * 800
+
+# Arbitrary stream SID for the synthetic media frames — the recv loop's parser
+# ignores it, so any value works (and it avoids an Optional[str] narrowing on the
+# adapter's own stream_sid, which pyright can't prove non-None post-connect).
+_STREAM_SID = "MZtest"
+
+
+def _audio_input():
+    msg = create_audio_message(AudioChunk(data=b"\x00\x00" * 1200), role="user")
+
+    class _State:
+        current_turn = 0
+
+    class _FakeInput:
+        new_messages = [msg]
+        scenario_state = _State()
+
+    return _FakeInput()
+
+
+async def _connect(monkeypatch, adapter):
+    fake = _FakeWebSocket()
+
+    async def _fake_connect(url, **_):
+        return fake
+
+    monkeypatch.setattr("websockets.connect", _fake_connect)
+    await adapter.connect()
+    return fake
+
+
+# --- P1 -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p1_turn_emits_base_spans_with_pipecat_class(monkeypatch):
+    """P1: a Pipecat turn inherits the #771 base spans, class = Pipecat."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05  # end the drain fast after one chunk
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        merged = AudioChunk(data=b"\x00\x00" * 10, transcript="hi")  # short-circuit STT
+        adapter._ensure_transcript = _AsyncReturn(merged)  # type: ignore[method-assign]
+        await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    spans = _by_name(exporter.get_finished_spans())
+    assert {"voice.turn", "voice.audio.send", "voice.audio.receive"} <= set(spans)
+    assert attrs(spans["voice.turn"])["voice.adapter.class"] == "PipecatAgentAdapter"
+
+
+@pytest.mark.asyncio
+async def test_p1_connect_span_carries_pipecat_transport_attrs(monkeypatch):
+    """P1: the adapter stamps its transport onto the base voice.adapter.connect span.
+
+    Driven through the executor connect loop (which owns the connect span), the
+    same seam ElevenLabs uses for voice.elevenlabs.agent_id.
+    """
+    from scenario.scenario_executor import ScenarioExecutor
+
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    fake = _FakeWebSocket()
+
+    async def _fake_connect(url, **_):
+        return fake
+
+    monkeypatch.setattr("websockets.connect", _fake_connect)
+    executor = ScenarioExecutor(
+        name="pipecat-span-test", description="test", agents=[adapter], script=[]
+    )
+    try:
+        await executor._voice_connect_all()
+    finally:
+        fake.end_stream()
+        await executor._voice_disconnect_all()
+
+    connect = _by_name(exporter.get_finished_spans())["voice.adapter.connect"]
+    assert attrs(connect)["voice.adapter.class"] == "PipecatAgentAdapter"
+    assert attrs(connect)["voice.pipecat.transport"] == "websocket"
+    assert attrs(connect)["voice.pipecat.transport_format"] == "mulaw/8000"
+
+
+# --- P2 (core) ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p2_background_receive_span_parented_to_turn(monkeypatch):
+    """P2 (core AC): the background ``_recv_loop`` emits a ``voice.audio.receive``
+    span parented DIRECTLY to the turn — proving the context-capture pattern
+    (the loop task's own OTel context was frozen at connect, a closed span)."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        # Feed one agent chunk BEFORE call(). call() publishes the turn context
+        # SYNCHRONOUSLY (before its first await), so the background loop — which
+        # runs during call()'s awaits — decodes this frame under a LIVE turn.
+        fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        adapter._ensure_transcript = _AsyncReturn(  # type: ignore[method-assign]
+            AudioChunk(data=b"\x00\x00" * 10, transcript="hi")
+        )
+        await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    spans = exporter.get_finished_spans()
+    turn = _by_name(spans)["voice.turn"]
+    bg = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert bg, "expected a background-loop voice.audio.receive span"
+    # The core assertion: parented directly under the turn, NOT a detached/closed
+    # span (the loop's frozen connect-time context).
+    assert parent_id(bg[0]) == ctx_id(turn)
+    assert int_attr(bg[0], "voice.audio.bytes") > 0
+
+
+@pytest.mark.asyncio
+async def test_p2_one_background_span_per_turn_not_per_chunk(monkeypatch):
+    """P2 flood-guard: several wire deliveries in ONE turn emit exactly ONE
+    background span — matching the base's one-receive-span-per-turn granularity
+    and the epic's no-per-tick-flood rule (the EL pump H1)."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        for _ in range(3):  # three 100 ms chunks, one turn
+            fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        adapter._ensure_transcript = _AsyncReturn(  # type: ignore[method-assign]
+            AudioChunk(data=b"\x00\x00" * 10, transcript="hi")
+        )
+        await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    bg = [
+        s
+        for s in _receives(exporter.get_finished_spans())
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert len(bg) == 1, f"expected one background span per turn, got {len(bg)}"
+
+
+@pytest.mark.asyncio
+async def test_prebuffered_turn_has_base_span_but_no_background_marker(monkeypatch):
+    """Documents the turn-liveness gate limit (review F2): agent audio delivered
+    and enqueued BEFORE call() publishes the turn context (e.g. a greeting during
+    connect) is drained from the queue without a fresh wire delivery, so it gets
+    NO background marker — the base voice.audio.receive span still covers it."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_tail_silence = 0.05
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+        await asyncio.sleep(0.05)  # _recv_loop decodes+enqueues with NO turn live
+        adapter._ensure_transcript = _AsyncReturn(  # type: ignore[method-assign]
+            AudioChunk(data=b"\x00\x00" * 10, transcript="hi")
+        )
+        await adapter.call(_audio_input())  # type: ignore[arg-type]  # drains the pre-buffered chunk
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    spans = exporter.get_finished_spans()
+    base = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.pipecat.recv.source") != "background_loop"
+    ]
+    bg = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert base, "base drain receive span should still be present"
+    assert bg == [], "a pre-buffered turn emits no background marker (by design)"
+
+
+@pytest.mark.asyncio
+async def test_pregression_no_background_span_between_turns(monkeypatch):
+    """P-regression: a chunk decoded with NO active turn emits NO background span.
+
+    The turn-liveness gate keeps the background task from leaking a
+    detached/closed-parent span (e.g. a late frame after the turn closed, or a
+    pre-turn greeting frame). Also covers the disconnect teardown path.
+    """
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    fake = await _connect(monkeypatch, adapter)
+    # No call() in flight → _voice_turn_context is None → _recv_loop buffers the
+    # decoded chunk but emits no span.
+    fake.feed(_media_frame(_STREAM_SID, _ONE_CHUNK_MULAW))
+    await asyncio.sleep(0.05)  # let the background loop process the frame
+    await adapter.disconnect()
+
+    bg = [
+        s
+        for s in _receives(exporter.get_finished_spans())
+        if attrs(s).get("voice.pipecat.recv.source") == "background_loop"
+    ]
+    assert bg == [], "no background receive span should be emitted between turns"
+
+
+# --- P3 -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p3_receive_timeout_marks_receive_span_error(monkeypatch):
+    """P3: a first-chunk receive timeout (no audio fed) marks voice.audio.receive ERROR."""
+    exporter = _install_in_memory_provider()
+    adapter = PipecatAgentAdapter(url="ws://bot/ws")
+    adapter.response_timeout = 0.05  # fail the first-chunk wait fast (feed nothing)
+    fake = await _connect(monkeypatch, adapter)
+    try:
+        with pytest.raises(Exception):
+            await adapter.call(_audio_input())  # type: ignore[arg-type]
+    finally:
+        fake.end_stream()
+        await adapter.disconnect()
+
+    recv = _by_name(exporter.get_finished_spans())["voice.audio.receive"]
+    assert recv.status.status_code == StatusCode.ERROR
+    assert attrs(recv)["voice.audio.terminated_reason"] == "first_chunk_timeout"
+
+
+class _AsyncReturn:
+    """A tiny awaitable-returning stand-in for _ensure_transcript (avoids real STT)."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __call__(self, _merged):
+        return self._value

--- a/python/tests/voice/test_voice_spans_twilio.py
+++ b/python/tests/voice/test_voice_spans_twilio.py
@@ -1,0 +1,945 @@
+"""Twilio-specific voice-span attributes (#770 / #771 taxonomy, #775 scope).
+
+Drives the REAL ``TwilioAgentAdapter`` (REST mocked, media transport driven
+through the real ``TwilioWebhookServer`` loop over a scripted/controllable WS
+double) through the executor connect/disconnect loops and through
+``place_call()``/``wait_for_call()`` directly, asserting the Twilio
+contributions this PR adds:
+
+- T1: base spans (voice.turn / voice.audio.send / voice.audio.receive) are
+  NOT hollow for Twilio. REGRESSION GUARD — already GREEN before any #775
+  instrumentation lands (Twilio does not override ``call()``).
+- T2: ``voice.adapter.connect`` carries Twilio connect-time config attrs.
+- T3: ``voice.adapter.disconnect`` carries call-lifetime counters (frames,
+  DTMF, stream-ended reason, REST-restore-failed, webhook invocation/
+  rejection counts).
+- T4/T5: a NEW ``voice.adapter.dial`` span wraps ``place_call()`` /
+  ``wait_for_call()`` — the REST dial + the ``_stream_connected`` wait.
+- T6: dial ERROR on a stream-connect timeout (the marquee "I placed the call
+  but no media ever streamed" failure) — ``dial_outcome=="stream_connect_timeout"``.
+- T7: dial ERROR on a REST failure records the ORIGINAL exception.
+- T8: a misbehaving SpanProcessor at the dial site never breaks ``place_call()``.
+- T9: py<->ts parity — see the comment block near the bottom; not
+  independently testable inside one language's suite.
+- T10: span count is invariant to media-frame count (flood guard).
+
+Design doc: sc#775 "Twilio voice-adapter LangWatch spans: design + ACs".
+Harness patterns copied (not cross-imported, matching
+``test_voice_spans_elevenlabs.py``'s local ``_FakeWs`` convention) from
+``test_twilio_adapter.py`` (``FakeREST`` / ``_install_fake_rest``) and
+``test_twilio_silent_stop_drain.py`` (``_ScriptedWS`` / ``_ControllableWS`` /
+``drive_twilio_production``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Optional
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+from opentelemetry.util._once import Once
+
+from scenario.scenario_executor import ScenarioExecutor
+from scenario.voice import AudioChunk, TwilioAgentAdapter
+from scenario.voice.adapters._twilio_shared import build_media_frame
+from scenario.voice.testing.wrapper_harness import (
+    drive_call,
+    drive_twilio_production,
+    make_agent_input,
+    make_connected_twilio_adapter,
+)
+
+from ._span_assert import attrs, ctx_id, int_attr, parent_id
+
+
+# --------------------------------------------------------------------------- otel infra
+
+
+@pytest.fixture(autouse=True)
+def reset_otel():
+    def _reset() -> None:
+        trace._TRACER_PROVIDER = None
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _install_in_memory_provider() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+def _by_name(spans):
+    return {s.name: s for s in spans}
+
+
+def _receives(spans):
+    """Every ``voice.audio.receive`` span (base drain + background-loop marker
+    share the same NAME, disambiguated only by ``voice.twilio.recv.source``)."""
+    return [s for s in spans if s.name == "voice.audio.receive"]
+
+
+def _exec(adapter: TwilioAgentAdapter) -> ScenarioExecutor:
+    return ScenarioExecutor(
+        name="twilio-voice-span-test", description="test", agents=[adapter], script=[]
+    )
+
+
+# --------------------------------------------------------------------------- Twilio REST double
+#
+# Local copy of the FakeREST / _install_fake_rest pattern from
+# test_twilio_adapter.py. Span-test files in this suite duplicate their
+# vendor doubles rather than cross-import another test module —
+# test_voice_spans_elevenlabs.py does the same with its own local _FakeWs.
+
+
+class FakeREST:
+    """In-memory stand-in for TwilioRESTHelper, recording every mutation."""
+
+    def __init__(self, account_sid: str = "", auth_token: str = "") -> None:
+        self.account_sid = account_sid
+        self.auth_token = auth_token
+        self.write_calls: list[tuple[str, str]] = []
+        self.place_call_kwargs: list[dict[str, Any]] = []
+        self._prior_voice_url = "https://old-webhook.example.com/previous"
+
+    def resolve_phone_number_sid(self, number: str) -> str:
+        return "PN" + "0" * 32
+
+    def read_voice_url(self, sid: str) -> str:
+        return self._prior_voice_url
+
+    def write_voice_url(self, sid: str, url: str) -> None:
+        self.write_calls.append((sid, url))
+
+    def place_call(self, *, to: str, from_: str, twiml: str) -> str:
+        # Mirrors the real TwilioRESTHelper.place_call signature.
+        self.place_call_kwargs.append({"to": to, "from_": from_, "twiml": twiml})
+        return "CA" + "1" * 32
+
+    def send_dtmf_on_call(self, call_sid: str, tones: str) -> None:
+        pass
+
+
+def _install_fake_rest(monkeypatch: Any) -> list[FakeREST]:
+    """Patch the REST helper and suppress the uvicorn server task. Returns the
+    list that collects every FakeREST instance constructed."""
+    rest_instances: list[FakeREST] = []
+
+    def _factory(account_sid: str, auth_token: str) -> FakeREST:
+        r = FakeREST(account_sid, auth_token)
+        rest_instances.append(r)
+        return r
+
+    monkeypatch.setattr("scenario.voice.adapters.twilio.TwilioRESTHelper", _factory)
+
+    async def _fake_run_server(self: Any) -> None:
+        return
+
+    monkeypatch.setattr(TwilioAgentAdapter, "_run_server", _fake_run_server)
+    return rest_instances
+
+
+def _make_adapter(**overrides: Any) -> TwilioAgentAdapter:
+    kwargs: dict[str, Any] = dict(
+        account_sid="AC" + "0" * 32,
+        auth_token="secret",
+        phone_number="+14155551234",
+        public_base_url="https://example.trycloudflare.com",
+        validate_signature=False,
+    )
+    kwargs.update(overrides)
+    return TwilioAgentAdapter(**kwargs)
+
+
+# --------------------------------------------------------------------------- media-loop frame builders
+
+STREAM_SID = "MZ775"
+CALL_SID = "CA775"
+
+
+def _start_frame(stream_sid: str = STREAM_SID, call_sid: str = CALL_SID) -> str:
+    return json.dumps(
+        {"event": "start", "start": {"streamSid": stream_sid, "callSid": call_sid}}
+    )
+
+
+def _stop_frame() -> str:
+    return json.dumps({"event": "stop"})
+
+
+def _dtmf_frame(digit: str, stream_sid: str = STREAM_SID) -> str:
+    return json.dumps(
+        {"event": "dtmf", "streamSid": stream_sid, "dtmf": {"digit": digit}}
+    )
+
+
+class _ScriptedWS:
+    """Compact starlette-WebSocket double: serves ``frames`` in order, then
+    raises ``close_with`` (or, absent that, errors on exhaustion). Trimmed
+    local copy of the pattern in ``test_twilio_silent_stop_drain.py``."""
+
+    def __init__(
+        self, frames: list[str], *, close_with: Optional[BaseException] = None
+    ) -> None:
+        self._frames = list(frames)
+        self._idx = 0
+        self._close_with = close_with
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        return None
+
+    async def receive_text(self) -> str:
+        if self._idx < len(self._frames):
+            msg = self._frames[self._idx]
+            self._idx += 1
+            return msg
+        if self._close_with is not None:
+            raise self._close_with
+        raise AssertionError(  # pragma: no cover
+            "scripted WS exhausted without a terminal frame"
+        )
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+
+class _ControllableWS:
+    """WS double the test can feed mid-flight: ``receive_text()`` blocks until
+    ``push()`` supplies a frame. Needed where the media loop must stay LIVE
+    while the test drives a concurrent ``call()`` (T1) — the scripted double
+    above always finishes first."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[Any]" = asyncio.Queue()
+        self.sent: list[str] = []
+
+    def push(self, item: Any) -> None:
+        self._queue.put_nowait(item)
+
+    async def accept(self) -> None:
+        return None
+
+    async def receive_text(self) -> str:
+        item = await self._queue.get()
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+
+# --- T1 (regression) -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t1_regression_call_emits_turn_send_receive_with_twilio_class():
+    """T1 (REGRESSION — already GREEN before any #775 instrumentation lands):
+    TwilioAgentAdapter does not override ``call()`` (twilio.py inherits
+    adapter.py:202), so a turn driven over a real (mocked-transport) media
+    stream already emits ``voice.turn`` with child ``voice.audio.send`` +
+    ``voice.audio.receive``, ``voice.adapter.class=='TwilioAgentAdapter'``,
+    and correct parent nesting. Pinned here so a future refactor can't
+    silently hollow this out for Twilio specifically.
+    """
+    exporter = _install_in_memory_provider()
+    adapter = make_connected_twilio_adapter()
+    adapter.response_tail_silence = 0.05  # keep the test fast
+    ws = _ControllableWS()
+    loop_task = asyncio.create_task(drive_twilio_production(adapter, ws))
+    ws.push(_start_frame())
+    assert adapter._stream_connected is not None
+    await asyncio.wait_for(adapter._stream_connected.wait(), timeout=2.0)
+
+    # One real agent-audio media frame >= the 800-byte batch threshold, so it
+    # flushes into the inbound queue immediately — deterministic, no sleep-race.
+    ws.push(build_media_frame(STREAM_SID, bytes([0x7F]) * 800))
+    await asyncio.sleep(0.05)  # let the loop task drain the pushed frame
+
+    user_audio = AudioChunk(data=b"\x00\x00" * 1200)
+    await drive_call(adapter, make_agent_input(user_audio))
+
+    ws.push(_stop_frame())
+    await asyncio.wait_for(loop_task, timeout=2.0)
+
+    spans = _by_name(exporter.get_finished_spans())
+    turn = spans["voice.turn"]
+    assert attrs(turn)["voice.adapter.class"] == "TwilioAgentAdapter"
+    assert parent_id(spans["voice.audio.send"]) == ctx_id(turn)
+    assert parent_id(spans["voice.audio.receive"]) == ctx_id(turn)
+
+
+# --- T2 (connect attrs) ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t2_connect_span_carries_twilio_phone_and_config_attrs(monkeypatch):
+    """T2: after connect(), voice.adapter.connect carries the Twilio config
+    attrs that ARE knowable at connect() time: phone_number_sid (resolved via
+    REST), validate_signature + webhook_port (construction-time config).
+
+    FLAGGED, not silently resolved: the design doc's Tier-1 bullet also lists
+    ``voice.twilio.direction`` as a connect()-span attribute, but connect() is
+    direction-agnostic — ``_mode`` stays "idle" until place_call()/
+    wait_for_call() is invoked, and that choice happens AFTER this span has
+    already closed (the design doc's own dial-span analysis: "you cannot
+    stamp attributes onto a closed span"). The constructor has no direction
+    param either. So ``voice.twilio.direction`` cannot be a real
+    voice.adapter.connect attribute; it is tested on voice.adapter.dial
+    instead (see T4/T5 below), where it IS architecturally knowable. Encoding
+    it here would pin an impossible contract rather than catch a real gap —
+    see the final report for this flag.
+    """
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0, validate_signature=True)
+    executor = _exec(adapter)
+
+    await executor._voice_connect_all()
+    try:
+        connect = _by_name(exporter.get_finished_spans())["voice.adapter.connect"]
+        assert attrs(connect)["voice.adapter.class"] == "TwilioAgentAdapter"
+        assert attrs(connect)["voice.twilio.phone_number_sid"] == "PN" + "0" * 32
+        assert attrs(connect)["voice.twilio.validate_signature"] is True
+        assert attrs(connect)["voice.twilio.webhook_port"] == 0
+    finally:
+        await executor._voice_disconnect_all()
+
+
+# --- T3 (disconnect counters) ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_carries_frame_and_dtmf_counters_and_stop_reason(
+    monkeypatch,
+):
+    """T3: after a call with N=3 media frames + M=2 DTMF ending in a "stop"
+    frame, voice.adapter.disconnect carries frames_received==3,
+    dtmf_received==2, stream_ended_reason=="stop". The fake WS serves a fixed
+    deterministic script (not real timing), so the counts are exact and
+    non-flaky."""
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+
+    frames = [
+        _start_frame(),
+        build_media_frame(STREAM_SID, bytes([0x7F]) * 160),
+        build_media_frame(STREAM_SID, bytes([0x7F]) * 160),
+        build_media_frame(STREAM_SID, bytes([0x7F]) * 160),
+        _dtmf_frame("1"),
+        _dtmf_frame("5"),
+        _stop_frame(),
+    ]
+    await drive_twilio_production(adapter, _ScriptedWS(frames))
+    await executor._voice_disconnect_all()
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert int_attr(disconnect, "voice.twilio.frames_received") == 3
+    assert int_attr(disconnect, "voice.twilio.dtmf_received") == 2
+    assert attrs(disconnect)["voice.twilio.stream_ended_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_stream_ended_reason_is_close_on_socket_disconnect(
+    monkeypatch,
+):
+    """T3 (enum member): a socket close with no "stop" frame records
+    reason=='close'."""
+    from starlette.websockets import WebSocketDisconnect
+
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+
+    ws = _ScriptedWS([_start_frame()], close_with=WebSocketDisconnect(code=1000))
+    await drive_twilio_production(adapter, ws)  # swallowed inside run_stream_session
+    await executor._voice_disconnect_all()
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert attrs(disconnect)["voice.twilio.stream_ended_reason"] == "close"
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_stream_ended_reason_is_error_on_transport_exception(
+    monkeypatch,
+):
+    """T3 (enum member): a non-disconnect transport error records
+    reason=='error'."""
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+
+    ws = _ScriptedWS(
+        [_start_frame()], close_with=RuntimeError("boom: transport failure")
+    )
+    with pytest.raises(RuntimeError, match="boom: transport failure"):
+        await drive_twilio_production(adapter, ws)
+    await executor._voice_disconnect_all()
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert attrs(disconnect)["voice.twilio.stream_ended_reason"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_stream_ended_reason_is_none_when_no_call_ran(
+    monkeypatch,
+):
+    """T3 (enum member): connect() + disconnect() with no media session at all
+    records reason=='none' — the media loop never engaged."""
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+    await executor._voice_disconnect_all()
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert attrs(disconnect)["voice.twilio.stream_ended_reason"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_carries_webhook_invocation_and_rejection_counts(
+    monkeypatch,
+):
+    """T3 (webhook visibility delta): one unsigned (403, rejected) + one
+    validly-signed (200, accepted) POST to /twilio/voice -> disconnect
+    carries webhook_invocations==2, webhook_rejected==1. This is what makes a
+    misconfigured-webhook stream_connect_timeout diagnosable without a direct
+    webhook span (design doc's D-hazard note)."""
+    from fastapi.testclient import TestClient
+    from twilio.request_validator import RequestValidator
+
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    auth_token = "the-shared-secret"
+    adapter = _make_adapter(
+        http_port=0, validate_signature=True, auth_token=auth_token
+    )
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+
+    assert adapter.public_base_url is not None
+    app = adapter._build_app()
+    client = TestClient(app, base_url=adapter.public_base_url)
+
+    r1 = client.post("/twilio/voice", data={"From": "+14155551234"})
+    assert r1.status_code == 403  # unsigned -> rejected
+
+    url = adapter.public_base_url.rstrip("/") + "/twilio/voice"
+    params = {"From": "+14155551234"}
+    signature = RequestValidator(auth_token).compute_signature(url, params)
+    r2 = client.post(
+        "/twilio/voice", data=params, headers={"X-Twilio-Signature": signature}
+    )
+    assert r2.status_code == 200  # validly signed -> accepted
+
+    await executor._voice_disconnect_all()
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert int_attr(disconnect, "voice.twilio.webhook_invocations") == 2
+    assert int_attr(disconnect, "voice.twilio.webhook_rejected") == 1
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_rest_restore_failed_is_false_on_clean_restore(
+    monkeypatch,
+):
+    """T3: a normal answer-mode restore on disconnect reports
+    rest_restore_failed==False."""
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+    assert adapter._stream_connected is not None
+    adapter._stream_connected.set()
+    await adapter.wait_for_call(timeout=1.0)
+
+    await executor._voice_disconnect_all()
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert attrs(disconnect)["voice.twilio.rest_restore_failed"] is False
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_rest_restore_failed_is_true_when_rest_restore_raises(
+    monkeypatch,
+):
+    """T3: when the REST voice_url restore raises (a Twilio outage),
+    disconnect() still completes (the existing ``suppress(Exception)``
+    swallow), but now reports rest_restore_failed==True so the swallowed
+    failure is no longer invisible."""
+    exporter = _install_in_memory_provider()
+    rest_instances = _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+    assert adapter._stream_connected is not None
+    adapter._stream_connected.set()
+    await adapter.wait_for_call(timeout=1.0)
+
+    rest = rest_instances[0]
+    original_write = rest.write_voice_url
+
+    def _flaky_write(sid: str, url: str) -> None:
+        original_write(sid, url)
+        if len(rest.write_calls) == 2:  # the restore call, not the initial set
+            raise RuntimeError("simulated Twilio REST outage")
+
+    rest.write_voice_url = _flaky_write  # type: ignore[method-assign]
+
+    await executor._voice_disconnect_all()  # must not raise despite the injected failure
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert attrs(disconnect)["voice.twilio.rest_restore_failed"] is True
+
+
+# --- T4 / T5 (dial OK) -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t4_dial_span_ok_outbound_place_call(monkeypatch):
+    """T4: placeCall() over a mocked REST + a pre-fired stream-connect signal
+    emits ONE voice.adapter.dial span, OK, direction=='outbound', call_sid
+    set, stream_connect_latency_ms present, and does NOT carry
+    dial_outcome=='stream_connect_timeout' (negative discriminator)."""
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    await adapter.connect()
+    try:
+        assert adapter._stream_connected is not None
+        adapter._stream_connected.set()  # pre-fire: stream "already" connected
+        await adapter.place_call(to="+14155557777")
+
+        dial_spans = [
+            s for s in exporter.get_finished_spans() if s.name == "voice.adapter.dial"
+        ]
+        assert len(dial_spans) == 1
+        dial = dial_spans[0]
+        assert dial.status.status_code != StatusCode.ERROR
+        assert attrs(dial)["voice.adapter.class"] == "TwilioAgentAdapter"
+        assert attrs(dial)["voice.twilio.direction"] == "outbound"
+        assert attrs(dial)["voice.twilio.call_sid"] == "CA" + "1" * 32
+        assert "voice.twilio.stream_connect_latency_ms" in attrs(dial)
+        assert attrs(dial).get("voice.twilio.dial_outcome") != "stream_connect_timeout"
+        # PII note (flagged in the final report): asserted redaction-tolerantly —
+        # passes whether the eventual impl stores the raw E.164 or a
+        # _redact_e164-style last-4 form.
+        assert attrs(dial)["voice.twilio.to"].endswith("7777")
+        assert attrs(dial)["voice.twilio.from"].endswith("1234")
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_t5_dial_span_ok_inbound_wait_for_call(monkeypatch):
+    """T5: waitForCall() emits voice.adapter.dial, direction=='inbound'."""
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    await adapter.connect()
+    try:
+        assert adapter._stream_connected is not None
+        adapter._stream_connected.set()
+        await adapter.wait_for_call(timeout=1.0)
+
+        dial = _by_name(exporter.get_finished_spans())["voice.adapter.dial"]
+        assert dial.status.status_code != StatusCode.ERROR
+        assert attrs(dial)["voice.twilio.direction"] == "inbound"
+    finally:
+        await adapter.disconnect()
+
+
+# --- T6 (dial ERROR, marquee: stream_connect_timeout) ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_t6_dial_span_error_on_stream_connect_timeout(monkeypatch):
+    """T6 (MARQUEE): the media stream never connects (Twilio's Media Streams
+    WS never opens back to us — e.g. a misconfigured/rejected webhook). The
+    EXISTING asyncio.TimeoutError still raises (regression-safe); NEW:
+    voice.adapter.dial is ERROR with
+    voice.twilio.dial_outcome=='stream_connect_timeout'. This is the
+    "I placed the call but no media ever streamed" story the epic exists for.
+    """
+    exporter = _install_in_memory_provider()
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    await adapter.connect()
+    try:
+        # Do NOT set _stream_connected — place_call must time out.
+        with pytest.raises(asyncio.TimeoutError):
+            await adapter.place_call(to="+14155557777", timeout=0.05)
+
+        dial = _by_name(exporter.get_finished_spans())["voice.adapter.dial"]
+        assert dial.status.status_code == StatusCode.ERROR
+        assert attrs(dial)["voice.twilio.dial_outcome"] == "stream_connect_timeout"
+    finally:
+        await adapter.disconnect()
+
+
+# --- T7 (dial ERROR, REST failure — original exception) --------------------------
+
+
+@pytest.mark.asyncio
+async def test_t7_dial_span_error_on_rest_failure_records_original_exception(
+    monkeypatch,
+):
+    """T7: a REST failure inside placeCall() marks voice.adapter.dial ERROR
+    and records the ORIGINAL exception (not a re-wrapped one) — both via the
+    span status description (``type(exc).__name__``, the ``voice_span``
+    convention) and the recorded exception event's exception.type /
+    exception.message."""
+    exporter = _install_in_memory_provider()
+    rest_instances = _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    await adapter.connect()
+    try:
+        def _boom(*, to: str, from_: str, twiml: str) -> str:
+            raise RuntimeError("Twilio REST: rate limited")
+
+        rest_instances[0].place_call = _boom  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="rate limited"):
+            await adapter.place_call(to="+14155557777")
+
+        dial = _by_name(exporter.get_finished_spans())["voice.adapter.dial"]
+        assert dial.status.status_code == StatusCode.ERROR
+        assert dial.status.description == "RuntimeError"
+        exception_events = [e for e in dial.events if e.name == "exception"]
+        assert exception_events, "expected span.record_exception on the dial span"
+        assert exception_events[-1].attributes is not None
+        assert exception_events[-1].attributes["exception.type"] == "RuntimeError"
+        assert "rate limited" in str(exception_events[-1].attributes["exception.message"])
+    finally:
+        await adapter.disconnect()
+
+
+# --- T8 (never-break safety) ------------------------------------------------------
+
+
+class _BoomProcessor(SimpleSpanProcessor):
+    def on_end(self, span):  # noqa: D401 - a misbehaving processor
+        if span.name == "voice.adapter.dial":
+            raise RuntimeError("simulated span-export failure")
+
+
+@pytest.mark.asyncio
+async def test_t8_dial_span_export_failure_never_breaks_a_successful_place_call(
+    monkeypatch, caplog
+):
+    """T8: a SpanProcessor.on_end that throws at the dial site is swallowed
+    (WARNING logged via the scenario.voice logger), the run continues, and
+    placeCall still returns its real (successful) result. Mirrors the
+    existing A7 guard test (test_voice_spans.py) applied to the new dial
+    site."""
+    provider = TracerProvider()
+    provider.add_span_processor(_BoomProcessor(InMemorySpanExporter()))
+    trace.set_tracer_provider(provider)
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    await adapter.connect()
+    try:
+        assert adapter._stream_connected is not None
+        adapter._stream_connected.set()
+        with caplog.at_level(logging.WARNING, logger="scenario.voice"):
+            await adapter.place_call(to="+14155557777")  # must not raise
+        assert adapter._mode == "call"  # the real result still landed
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and r.name == "scenario.voice"
+            and "failed to export" in r.getMessage()
+        ]
+        assert warnings, "expected a scenario.voice WARNING for the swallowed span-end"
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_t8_dial_span_export_failure_does_not_mask_a_real_timeout(monkeypatch):
+    """T8 (error-path twin): the same misbehaving processor must not swallow
+    or replace a REAL failure — a genuine stream-connect timeout still raises
+    asyncio.TimeoutError, unchanged, despite the boom processor at the dial
+    site."""
+    provider = TracerProvider()
+    provider.add_span_processor(_BoomProcessor(InMemorySpanExporter()))
+    trace.set_tracer_provider(provider)
+    _install_fake_rest(monkeypatch)
+    adapter = _make_adapter(http_port=0)
+    await adapter.connect()
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await adapter.place_call(to="+14155557777", timeout=0.05)
+    finally:
+        await adapter.disconnect()
+
+
+# --- T9 (py<->ts parity) -----------------------------------------------------------
+#
+# Not independently testable inside one language's suite. Parity is enforced
+# by this file AND javascript/src/voice/adapters/__tests__/twilio-spans.test.ts
+# hard-coding the IDENTICAL span name ("voice.adapter.dial") and attribute-key
+# strings: "voice.twilio.direction", "voice.twilio.phone_number_sid",
+# "voice.twilio.validate_signature", "voice.twilio.webhook_port",
+# "voice.twilio.frames_received", "voice.twilio.dtmf_received",
+# "voice.twilio.stream_ended_reason", "voice.twilio.rest_restore_failed",
+# "voice.twilio.webhook_invocations", "voice.twilio.webhook_rejected",
+# "voice.twilio.to", "voice.twilio.from", "voice.twilio.call_sid",
+# "voice.twilio.stream_connect_latency_ms", "voice.twilio.dial_outcome". A
+# renamed key in either language's implementation fails THAT language's own
+# suite — that divergence IS the falsifier.
+
+
+# --- T10 (no per-frame spans / flood guard) -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t10_voice_span_count_invariant_to_frame_count(monkeypatch):
+    """T10: a connect -> media-loop -> disconnect cycle emits NO per-frame
+    spans — the voice.* span count from the cycle does not scale with the
+    number of media frames driven through it.
+
+    NOTE (honesty flag, not oversold as RED): with only the two lifecycle
+    spans in play, this already holds true pre-#775 (2 spans regardless of
+    N) — on its own it does not discriminate RED/GREEN for this PR. It is a
+    forward flood-guard protecting the T3 counter implementation from
+    regressing into a per-frame-span design (mirrors
+    test_voice_spans_elevenlabs.py's H1 pump-tick invariant)."""
+    _install_fake_rest(monkeypatch)
+
+    async def _run(n_frames: int) -> int:
+        trace._TRACER_PROVIDER = None
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+        exporter = _install_in_memory_provider()
+        adapter = _make_adapter(http_port=0)
+        executor = _exec(adapter)
+        await executor._voice_connect_all()
+        frames = (
+            [_start_frame()]
+            + [
+                build_media_frame(STREAM_SID, bytes([0x7F]) * 160)
+                for _ in range(n_frames)
+            ]
+            + [_stop_frame()]
+        )
+        await drive_twilio_production(adapter, _ScriptedWS(frames))
+        await executor._voice_disconnect_all()
+        return len(
+            [s for s in exporter.get_finished_spans() if s.name.startswith("voice.")]
+        )
+
+    few = await _run(3)
+    many = await _run(30)
+    assert few == many == 2
+
+
+# --- T11 (Tier 3 — background-loop delivery markers, #781/#774 base) -------------
+#
+# #781 rebased Twilio onto #774's reusable primitive: base ``call()`` publishes the
+# live ``voice.turn`` OTel context onto ``self._voice_turn_context`` (cleared in a
+# ``finally``); a background-receive-loop adapter parents a detached-task delivery
+# marker span under it via ``voice_span(name, attrs, parent=ctx)``. Mirrors
+# ``test_voice_spans_pipecat.py``'s P2 suite one-to-one, swapping
+# ``voice.pipecat.recv.source`` -> ``voice.twilio.recv.source`` and Pipecat's
+# always-running ``_recv_task``/synchronous-callback-free loop for Twilio's
+# ``media_stream_loop`` background task driven here via ``_ControllableWS`` +
+# ``drive_twilio_production`` (the same real-production-wrapper seam T1 uses).
+#
+# Ordering trick (identical to the Pipecat suite, see its P2 docstring): ``call()``
+# publishes ``_voice_turn_context`` SYNCHRONOUSLY, before its first genuine
+# ``await`` (the frame-pacing ``asyncio.sleep`` inside ``send_audio``, or — for
+# a no-incoming turn — the first ``recv_audio`` wait inside the drain). The
+# background loop task is already parked on ``receive_text()`` and can only
+# resume once ``call()`` actually yields, so a frame pushed into the
+# ``_ControllableWS`` queue immediately before ``await drive_call(...)`` is
+# decoded by the loop AFTER the turn context is live (T11a/T11b). Pushing the
+# frame earlier, with an intervening ``await asyncio.sleep(...)`` BEFORE
+# ``call()`` ever starts (T11c/T11d), instead lets the loop decode+enqueue it
+# with NO turn live — the complementary case.
+
+
+@pytest.mark.asyncio
+async def test_t11a_background_receive_span_parented_to_turn():
+    """T11a (Tier-3 core, mirrors Pipecat P2): the background
+    ``media_stream_loop`` task emits a ``voice.audio.receive`` span parented
+    DIRECTLY to the live ``voice.turn`` — proving Twilio reuses the #774
+    context-capture primitive (the loop task's own ambient OTel context is
+    whatever was active when the task was scheduled, NOT the turn — a
+    detached/closed-parent span without this). RED: the marker does not exist
+    on the pre-Tier-3 adapter."""
+    exporter = _install_in_memory_provider()
+    adapter = make_connected_twilio_adapter()
+    adapter.response_tail_silence = 0.05  # keep the test fast
+    ws = _ControllableWS()
+    loop_task = asyncio.create_task(drive_twilio_production(adapter, ws))
+    ws.push(_start_frame())
+    assert adapter._stream_connected is not None
+    await asyncio.wait_for(adapter._stream_connected.wait(), timeout=2.0)
+
+    # Push ONE agent-audio frame, THEN IMMEDIATELY start the turn — see the
+    # ordering-trick note above.
+    ws.push(build_media_frame(STREAM_SID, bytes([0x7F]) * 800))
+    user_audio = AudioChunk(data=b"\x00\x00" * 1200)
+    await drive_call(adapter, make_agent_input(user_audio))
+
+    ws.push(_stop_frame())
+    await asyncio.wait_for(loop_task, timeout=2.0)
+
+    spans = exporter.get_finished_spans()
+    turn = _by_name(spans)["voice.turn"]
+    bg = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.twilio.recv.source") == "background_loop"
+    ]
+    assert bg, "expected a background-loop voice.audio.receive span"
+    # The core assertion: parented directly under the turn, NOT a
+    # detached/closed span (the loop's frozen scheduling-time context).
+    assert parent_id(bg[0]) == ctx_id(turn)
+    assert int_attr(bg[0], "voice.audio.bytes") > 0
+
+
+@pytest.mark.asyncio
+async def test_t11b_one_background_span_per_turn_not_per_frame():
+    """T11b (Tier-3 flood-guard, mirrors Pipecat P2): three separate wire
+    deliveries within ONE live turn emit exactly ONE background-loop marker
+    span — matching the base's one-receive-span-per-turn granularity and the
+    epic's no-per-tick-flood rule (the EL pump H1 / Pipecat P2 precedent).
+    RED: today there is no background marker at all (0, not 1)."""
+    exporter = _install_in_memory_provider()
+    adapter = make_connected_twilio_adapter()
+    adapter.response_tail_silence = 0.05
+    ws = _ControllableWS()
+    loop_task = asyncio.create_task(drive_twilio_production(adapter, ws))
+    ws.push(_start_frame())
+    assert adapter._stream_connected is not None
+    await asyncio.wait_for(adapter._stream_connected.wait(), timeout=2.0)
+
+    for _ in range(3):  # three 800-byte (individually-flushing) frames, one turn
+        ws.push(build_media_frame(STREAM_SID, bytes([0x7F]) * 800))
+    user_audio = AudioChunk(data=b"\x00\x00" * 1200)
+    await drive_call(adapter, make_agent_input(user_audio))
+
+    ws.push(_stop_frame())
+    await asyncio.wait_for(loop_task, timeout=2.0)
+
+    bg = [
+        s
+        for s in _receives(exporter.get_finished_spans())
+        if attrs(s).get("voice.twilio.recv.source") == "background_loop"
+    ]
+    assert len(bg) == 1, f"expected one background span per turn, got {len(bg)}"
+
+
+@pytest.mark.asyncio
+async def test_t11c_prebuffered_turn_has_base_span_but_no_background_marker():
+    """T11c (turn-liveness gate boundary, mirrors Pipecat's review-F2 test):
+    agent audio delivered and enqueued BEFORE any call() has published a live
+    turn context (e.g. audio buffered during connect, before the first turn)
+    is later drained by the base drain WITHOUT a fresh wire delivery under
+    that turn, so it carries NO background_loop marker — the base
+    ``voice.audio.receive`` span still covers its consumption.
+
+    FLAG (mirrors T1/T10's honesty pattern in the earlier report): this
+    assertion holds both BEFORE and AFTER a correct Tier-3 implementation —
+    nothing here exercises the marker's presence, only its correct absence.
+    It is a forward regression guard against an over-eager implementation
+    that ignores the turn-liveness gate (spans every delivery unconditionally),
+    not a RED discriminator for Tier-3's initial existence. T11a/T11b are the
+    RED discriminators for that.
+    """
+    exporter = _install_in_memory_provider()
+    adapter = make_connected_twilio_adapter()
+    adapter.response_tail_silence = 0.05
+    ws = _ControllableWS()
+    loop_task = asyncio.create_task(drive_twilio_production(adapter, ws))
+    ws.push(_start_frame())
+    assert adapter._stream_connected is not None
+    await asyncio.wait_for(adapter._stream_connected.wait(), timeout=2.0)
+
+    ws.push(build_media_frame(STREAM_SID, bytes([0x7F]) * 800))
+    await asyncio.sleep(0.05)  # let the loop decode+enqueue with NO turn live
+
+    user_audio = AudioChunk(data=b"\x00\x00" * 1200)
+    await drive_call(
+        adapter, make_agent_input(user_audio)
+    )  # drains the pre-buffered chunk
+
+    ws.push(_stop_frame())
+    await asyncio.wait_for(loop_task, timeout=2.0)
+
+    spans = exporter.get_finished_spans()
+    base = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.twilio.recv.source") != "background_loop"
+    ]
+    bg = [
+        s
+        for s in _receives(spans)
+        if attrs(s).get("voice.twilio.recv.source") == "background_loop"
+    ]
+    assert base, "base drain receive span should still be present"
+    assert bg == [], "a pre-buffered turn emits no background marker (by design)"
+
+
+@pytest.mark.asyncio
+async def test_t11d_regression_no_background_span_between_turns():
+    """T11d (regression, mirrors Pipecat's P-regression test): a frame decoded
+    with NO active turn (no call() ever ran) emits NO background span — the
+    turn-liveness gate keeps the background media loop from leaking a
+    detached/closed-parent span (e.g. a late frame after the turn closed, or
+    a pre-turn greeting frame). Also covers the disconnect teardown path.
+
+    FLAG (same caveat as T11c): GREEN both before and after a correct
+    implementation — a forward guard against an implementation that spans
+    unconditionally, not a RED discriminator for Tier-3's initial existence.
+    """
+    exporter = _install_in_memory_provider()
+    adapter = make_connected_twilio_adapter()
+    ws = _ControllableWS()
+    loop_task = asyncio.create_task(drive_twilio_production(adapter, ws))
+    ws.push(_start_frame())
+    assert adapter._stream_connected is not None
+    await asyncio.wait_for(adapter._stream_connected.wait(), timeout=2.0)
+
+    # No call() in flight -> _voice_turn_context is None -> the loop buffers
+    # the decoded chunk but must emit no span.
+    ws.push(build_media_frame(STREAM_SID, bytes([0x7F]) * 800))
+    await asyncio.sleep(0.05)  # let the background loop process the frame
+
+    ws.push(_stop_frame())
+    await asyncio.wait_for(loop_task, timeout=2.0)
+
+    bg = [
+        s
+        for s in _receives(exporter.get_finished_spans())
+        if attrs(s).get("voice.twilio.recv.source") == "background_loop"
+    ]
+    assert bg == [], "no background receive span should be emitted between turns"

--- a/python/tests/voice/test_voice_spans_twilio.py
+++ b/python/tests/voice/test_voice_spans_twilio.py
@@ -54,6 +54,7 @@ from scenario.voice.adapters._twilio_shared import build_media_frame
 from scenario.voice.testing.wrapper_harness import (
     drive_call,
     drive_twilio_production,
+    free_port,
     make_agent_input,
     make_connected_twilio_adapter,
 )
@@ -151,6 +152,25 @@ def _install_fake_rest(monkeypatch: Any) -> list[FakeREST]:
         return
 
     monkeypatch.setattr(TwilioAgentAdapter, "_run_server", _fake_run_server)
+    return rest_instances
+
+
+def _install_fake_rest_real_server(monkeypatch: Any) -> list[FakeREST]:
+    """Like :func:`_install_fake_rest`, but leaves ``_run_server`` INTACT so a
+    REAL uvicorn server binds and a REAL WebSocket connection can be closed by
+    disconnect()'s own server-shutdown path — needed by the disconnect-ordering
+    regression test below (PR #788 review), which specifically exercises the
+    REAL ``_server_task`` teardown (the mechanism that actually closes a
+    still-live socket), not the faked no-op every other test in this file
+    uses."""
+    rest_instances: list[FakeREST] = []
+
+    def _factory(account_sid: str, auth_token: str) -> FakeREST:
+        r = FakeREST(account_sid, auth_token)
+        rest_instances.append(r)
+        return r
+
+    monkeypatch.setattr("scenario.voice.adapters.twilio.TwilioRESTHelper", _factory)
     return rest_instances
 
 
@@ -515,6 +535,72 @@ async def test_t3_disconnect_rest_restore_failed_is_true_when_rest_restore_raise
 
     disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
     assert attrs(disconnect)["voice.twilio.rest_restore_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_t3_disconnect_reflects_the_actual_stream_close_not_a_pre_teardown_snapshot(
+    monkeypatch,
+):
+    """T3 (regression — PR #788 review, reproduced empirically): the
+    disconnect() counter / stream_ended_reason stamp must sample state AFTER
+    the transport has ACTUALLY torn down, not before.
+
+    Every other T3 test above pre-drives its socket double to a natural
+    stop/close/error completion BEFORE calling disconnect() — which dodges
+    this exact race, since ``_stream_ended_reason`` is already final by the
+    time disconnect() runs. This test instead keeps a REAL WebSocket
+    connection open with real media flowing and NO terminal frame, then runs
+    the REAL executor teardown while the call is genuinely still live — so
+    the server-shutdown inside disconnect() (``_server_shutdown.set()`` +
+    ``await asyncio.wait_for(self._server_task, ...)``) is what forces the
+    closure the span must observe. A queue-fed double (``_ControllableWS`` /
+    the faked no-op ``_run_server``) can't discriminate this: nothing ties
+    disconnect()'s shutdown signal to a fake socket's queue, so the loop would
+    never terminate regardless of stamp ordering. Only a REAL uvicorn server +
+    REAL client socket makes the shutdown-await the thing that closes the
+    stream — which is exactly the mechanism the bug is about.
+
+    FALSIFIER: on the pre-fix code (the counter stamp BEFORE the
+    ``_server_task`` shutdown-await), this fails —
+    ``stream_ended_reason=="none"`` and ``frames_received`` undercounted,
+    because the media loop hasn't reacted to the shutdown yet when the span is
+    stamped. Fixed code stamps AFTER the await and passes.
+    """
+    exporter = _install_in_memory_provider()
+    _install_fake_rest_real_server(monkeypatch)
+    adapter = _make_adapter(http_port=free_port())
+    executor = _exec(adapter)
+    await executor._voice_connect_all()
+
+    import websockets
+
+    ws_url = f"ws://127.0.0.1:{adapter.http_port}/twilio/stream"
+    async with websockets.connect(ws_url) as client:
+        await client.send(_start_frame())
+        assert adapter._stream_connected is not None
+        await asyncio.wait_for(adapter._stream_connected.wait(), timeout=5.0)
+
+        # Three individually-flushing media frames — NO stop frame. The
+        # stream is still LIVE when teardown begins below.
+        for _ in range(3):
+            await client.send(build_media_frame(STREAM_SID, bytes([0x7F]) * 800))
+        # Poll for the REAL server-side loop to actually decode+enqueue what
+        # was sent over the wire (real TCP, not an in-process queue) — avoids
+        # a flaky blind sleep.
+        for _ in range(200):
+            if adapter._frames_received >= 3:
+                break
+            await asyncio.sleep(0.01)
+        assert adapter._frames_received == 3  # sanity: frames genuinely landed
+
+        # The REAL teardown, invoked while the socket is STILL open — nobody
+        # sent a stop frame or closed the connection. disconnect()'s own
+        # server-shutdown is what forces the close.
+        await executor._voice_disconnect_all()
+
+    disconnect = _by_name(exporter.get_finished_spans())["voice.adapter.disconnect"]
+    assert int_attr(disconnect, "voice.twilio.frames_received") == 3
+    assert attrs(disconnect)["voice.twilio.stream_ended_reason"] != "none"
 
 
 # --- T4 / T5 (dial OK) -----------------------------------------------------------


### PR DESCRIPTION
> **Reviewer cockpit**
> - **⚠ Base is `issue774/pipecat-langwatch-spans` (#781 Pipecat), NOT `issue770` as the issue implies.** #781 landed the background-loop turn-context primitive (`_voice_turn_context` / `_voiceTurnContext`) that this PR's Tier 3 **reuses** rather than duplicates. This is a **3-deep draft stack** `#777 (EL) ← #781 (Pipecat) ← #775 (Twilio)`. **Retarget to `main` after BOTH #777 and #781 merge.** If you'd rather I re-base on `issue770` and defer Tier 3, say the word.
> - **Scariest thing:** the media-stream loop's termination handling changed from a bare `try/finally` to `try/except WebSocketDisconnect/except Exception/finally` (to label `stream_ended_reason`). If that re-raise were dropped, a mid-call socket close would stop propagating and `run_stream_session`'s swallow contract would silently change. It is **tag-then-`raise`** (behavior preserved) — verified, but it's the one control-flow edit.
> - **Start here:** `python/scenario/voice/adapters/_twilio_server.py` `media_stream_loop` (the `except`/`finally` + the `_enqueue` closure) — the highest-leverage spot; the TS mirror is `twilio-server.ts` `mediaStreamLoop`.
> - **New taxonomy to LOCK:** `voice.adapter.dial` is a **new base-owned span name** (only Twilio populates it today), following #780's `voice.adapter.interrupt` precedent. Flagged for your call on the name.

## Why

Closes #775. A developer debugging a failed Twilio (`REST + webhook + media-stream`) voice `scenario.run()` currently can't **see the failure in the trace** — most of all the marquee Twilio failure: *the call was placed but no media ever streamed*. This instruments the adapter with `voice.*` spans mirroring the #771/ElevenLabs taxonomy, so that failure (and the transport lifecycle) shows up in LangWatch.

## What changed

- **`voice.adapter.dial` new span (Tier 2)** → *alternative:* fold call-establishment into `voice.adapter.connect` attributes → **rejected because it's architecturally impossible**: `place_call`/`wait_for_call` run *after* the executor's `connect` span has already closed (Twilio splits server-setup from call-placement), so there is no open span to attribute onto. A separate span is forced; the name follows the `voice.adapter.<verb>` + #780 precedent. On the `_stream_connected` wait timeout it goes **ERROR** with `voice.twilio.dial_outcome=stream_connect_timeout` — the "no media streamed" story.
- **Tier 3 reuses #781's primitive** → *alternative:* the issue's "capture context at spawn" → **rejected** (spawn ctx = the *closed* connect span; the exact mis-parent #781's devils-advocate pass corrected). The media loop emits ONE `voice.audio.receive` (`voice.twilio.recv.source=background_loop`) per turn, parented to the live `voice.turn` via `_voice_turn_context`.
- **Vendor data = attributes on base spans, never a `voice.twilio.*` span NAME** (taxonomy rule): connect attrs + disconnect counters (frames / dtmf / `stream_ended_reason` / webhook invocations+rejections / `rest_restore_failed`).
- **PII: `voice.twilio.to`/`.from` redacted** via the existing `_redact_e164`/`redactE164` → *alternative:* raw E.164 → rejected (spans export to an external SaaS; codebase already redacts phone numbers in logs).

## How it works

```
Twilio turn flow (base #771/#781 spans, inherited — Twilio does NOT override call())
  voice.turn
    voice.audio.send            (base send-site)
    voice.audio.receive         (base drain, consumer-side)
    voice.audio.receive  ⟵ NEW  (Tier 3: source=background_loop, media-loop delivery marker, parented to voice.turn)
Executor lifecycle
  voice.adapter.connect  + voice.twilio.phone_number_sid/.validate_signature/.webhook_port   (Tier 1)
  voice.adapter.disconnect + voice.twilio.frames_received/.dtmf_received/.stream_ended_reason/.webhook_*/.rest_restore_failed  (Tier 2b)
Call establishment (user-invoked, outside executor lifecycle)
  voice.adapter.dial     ⟵ NEW  (Tier 2a: REST dial + stream-connect wait; ERROR+dial_outcome on timeout)
```
Files: `twilio.py`/`twilio.ts` (connect attrs, dial span, disconnect counters), `_twilio_server.py`/`twilio-server.ts` (media-loop counters, `stream_ended_reason`, webhook counters, Tier-3 marker). Wrap-only — no transport control flow changed except the tag-then-reraise noted above.

## Human verification

Backend-only — no UI surface; visual proof exempt. <!-- no-ui-surface -->
To verify by hand: run the span test suites in `## Test plan` below, and check the server-side trace landings quoted in `## How I can prove I was successful`.

## Test plan

- `python/tests/voice/test_voice_spans_twilio.py` — 20 tests (T1–T11d). `uv run pytest tests/voice/test_voice_spans_twilio.py -q` → **20 passed**.
- `javascript/src/voice/adapters/__tests__/twilio-spans.test.ts` — 18 tests. `npx vitest run …twilio-spans.test.ts` → **18 passed** (1 skip = ts-T8, documented vacuous — JS OTel guards `Span.end()` internally).
- No regression: py `test_twilio_*` + `test_voice_spans_*` → **111 passed**; ts `adapters/__tests__/` → **215 passed / 1 skipped**.

## How I can prove I was successful

**[PROVEN] Falsifiability RED→GREEN (same tree, `git stash` the production files):**
```
WITHOUT impl:  py 15 failed, 5 passed   |  ts 14 failed | 4 passed (18)
WITH impl:     py 21 passed             |  ts 20 passed (1 skipped)   ← incl. the 2 review-fix regression tests
```

**[PROVEN] Production-value correctness of the disconnect teardown (review-caught, see below)** — a REAL uvicorn + `websockets` client test drives a still-live media stream, then invokes the REAL `_voice_disconnect_all()`/`stopVoiceAdapters` teardown, and asserts `voice.twilio.stream_ended_reason != "none"` + `frames_received == 3`. Verified RED on the pre-reorder code (`stream_ended_reason=="none"`), GREEN after — the queue-fed doubles can't discriminate this race, which is why the first round missed it.

**[PROVEN] Server-side landing (ingestion of the attr schema)** — mic-free harness emits the span surface via the real `voice_span` helper under `langwatch.setup()`; `GET /api/trace/93c97f12321430c0b6db77da0c761f7b` (per-trace, not search) returns them ingested. Scope: this proves the **new names/attr KEYS ingest** (attr VALUES here are representative, not adapter-produced — production values are proven by the hermetic tests above):
```
6 spans: voice.adapter.connect · voice.adapter.dial · voice.turn · voice.audio.receive · voice.adapter.disconnect · <root>
voice.adapter.dial   params.voice.twilio = {direction:outbound, to:***7777, from:***1234, call_sid:CA…, stream_connect_latency_ms:128}
voice.audio.receive  params.voice.twilio.recv.source=background_loop  bytes=4796  parent_id=def6b0435ce9a855 == voice.turn.span_id ✓
```
Base spans + `background_loop` were already proven server-side by #781. `to`/`from` land **redacted**.

**[PROVEN] Typecheck/lint:** `pyright` (standard) 0 errors/0 warnings on both changed py files; `tsc --noEmit` exit 0; `eslint` exit 0 on both changed ts files (zero-delta).

**[CLAIMED, scoped] No live phone call.** Proof is hermetic (tests drive the REAL adapter methods with a mocked Twilio REST client + a mocked stream signal) + the server-side landing above. A real inbound/outbound PSTN call was not placed (no Twilio number provisioned in this env); the hermetic + ingestion proof is the floor for a span-only change with no other user-observable surface than the trace.

_Evidence is headless terminal/JSON output embedded verbatim above (no rendered PNG in this environment); the trace is live and re-fetchable at the id above._

## Anything surprising?

- **Base/stack** (see cockpit) — on #781, 3-deep, retarget after #777+#781.
- **`voice.adapter.dial` is new taxonomy** — please LOCK the name in review (or say fold-differently).
- **Out of scope (deliberate, tracked):** no direct span on the media-loop/webhook handler (frozen-ctx + flood; their signal is the disconnect counters + the dial-timeout ERROR); `voice.adapter.interrupt` deferred to #780 (Twilio inherits it once that lands); `send_dtmf` span (low value); the py-vs-ts `is_connected()` override asymmetry (py doesn't override it — a pre-existing parity gap, not a span concern) — worth a follow-up issue.

