### PR TITLE
test(voice): extract the duplicated PassingJudge test double to fixtures/

### DIFF
--- a/javascript/src/voice/__tests__/duration-fidelity.test.ts
+++ b/javascript/src/voice/__tests__/duration-fidelity.test.ts
@@ -33,7 +33,6 @@ import {
   AgentRole,
   type AgentInput,
   type AgentReturnTypes,
-  JudgeAgentAdapter,
   UserSimulatorAgentAdapter,
 } from "../../domain";
 import { agent, judge, user } from "../../script";
@@ -42,6 +41,7 @@ import { AudioChunk, PCM16_SAMPLE_RATE, PCM16_SAMPLE_WIDTH_BYTES } from "../audi
 import { createAudioMessage } from "../messages";
 import { VoiceRecordingRuntime } from "../recording.runtime";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+import { PassingJudge } from "./fixtures/passing-judge";
 
 /** WAV header is 44 bytes; the PCM payload follows. */
 const WAV_HEADER_BYTES = 44;
@@ -79,18 +79,6 @@ class AudioUserSimulator extends UserSimulatorAgentAdapter {
   }
 }
 
-class PassingJudge extends JudgeAgentAdapter {
-  criteria: string[] = ["Agent responds"];
-  async call(input: AgentInput) {
-    if (!input.judgmentRequest) return null;
-    return {
-      success: true,
-      reasoning: "voice turn completed",
-      metCriteria: [...this.criteria],
-      unmetCriteria: [],
-    };
-  }
-}
 
 /**
  * Build a voice run whose agent answers in MULTIPLE chunks so the merged

--- a/javascript/src/voice/__tests__/fixtures/passing-judge.ts
+++ b/javascript/src/voice/__tests__/fixtures/passing-judge.ts
@@ -1,0 +1,19 @@
+import {
+  type AgentInput,
+  type AgentReturnTypes,
+  JudgeAgentAdapter,
+} from "../../../domain";
+
+/** Fake judge that concludes the run successfully on the judge() step. */
+export class PassingJudge extends JudgeAgentAdapter {
+  criteria: string[] = ["Agent responds"];
+  async call(input: AgentInput): Promise<AgentReturnTypes> {
+    if (!input.judgmentRequest) return null;
+    return {
+      success: true,
+      reasoning: "voice turn completed",
+      metCriteria: [...this.criteria],
+      unmetCriteria: [],
+    };
+  }
+}

--- a/javascript/src/voice/__tests__/interrupt-truncation.test.ts
+++ b/javascript/src/voice/__tests__/interrupt-truncation.test.ts
@@ -24,7 +24,6 @@ import {
   AgentRole,
   type AgentInput,
   type AgentReturnTypes,
-  JudgeAgentAdapter,
   UserSimulatorAgentAdapter,
 } from "../../domain";
 import { ScenarioExecution } from "../../execution/scenario-execution";
@@ -36,6 +35,7 @@ import { AdapterCapabilities } from "../capabilities";
 import { createAudioMessage } from "../messages";
 import type { AudioSegment, VoiceEvent } from "../recording.types";
 import { markTruncatedAgentSegments } from "../segment-utils";
+import { PassingJudge } from "./fixtures/passing-judge";
 
 /** A non-silent PCM16 tone (mono, 24kHz) carrying a transcript. */
 function tone(durationSeconds: number, transcript: string): AudioChunk {
@@ -174,13 +174,6 @@ class AudioUserSim extends UserSimulatorAgentAdapter {
   }
 }
 
-class PassingJudge extends JudgeAgentAdapter {
-  criteria = ["ok"];
-  async call(input: AgentInput) {
-    if (!input.judgmentRequest) return null;
-    return { success: true, reasoning: "done", metCriteria: ["ok"], unmetCriteria: [] };
-  }
-}
 
 /** Voice agent that produces a LONG reply (many chunks) so a barge-in lands within it. */
 class VerboseVoiceAdapter extends VoiceAgentAdapter {

--- a/javascript/src/voice/__tests__/proceed-interrupt.test.ts
+++ b/javascript/src/voice/__tests__/proceed-interrupt.test.ts
@@ -53,7 +53,6 @@ import {
   AgentRole,
   type AgentInput,
   type AgentReturnTypes,
-  JudgeAgentAdapter,
   UserSimulatorAgentAdapter,
 } from "../../domain";
 import { ScenarioExecution } from "../../execution/scenario-execution";
@@ -62,6 +61,7 @@ import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
 import { createAudioMessage, extractTranscript } from "../messages";
+import { PassingJudge } from "./fixtures/passing-judge";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -151,26 +151,11 @@ class VoiceUserSim extends UserSimulatorAgentAdapter {
   }
 }
 
-/**
- * Judge that only resolves on an explicit judgment request (never in proceed).
- *
- * NOTE: No artificial delay here. The inline barge-in fires BEFORE _step runs
- * JUDGE, so JUDGE timing no longer affects the interrupt window. The prior
- * design needed a 100 ms JUDGE delay to model the race; the new inline design
- * does not depend on JUDGE latency at all.
- */
-class PassingJudge extends JudgeAgentAdapter {
-  criteria = ["ok"];
-  async call(input: AgentInput) {
-    if (!input.judgmentRequest) return null;
-    return {
-      success: true,
-      reasoning: "done",
-      metCriteria: ["ok"],
-      unmetCriteria: [],
-    };
-  }
-}
+// The scenarios below use PassingJudge (fixtures/passing-judge) with no
+// artificial delay: the inline barge-in fires BEFORE _step runs JUDGE, so
+// JUDGE timing no longer affects the interrupt window. The prior design
+// needed a 100 ms JUDGE delay to model the race; the new inline design does
+// not depend on JUDGE latency at all.
 
 // ---------------------------------------------------------------------------
 // Test

--- a/javascript/src/voice/__tests__/result-audio.test.ts
+++ b/javascript/src/voice/__tests__/result-audio.test.ts
@@ -32,7 +32,6 @@ import {
   AgentRole,
   type AgentInput,
   type AgentReturnTypes,
-  JudgeAgentAdapter,
   UserSimulatorAgentAdapter,
 } from "../../domain";
 import { agent, judge, user } from "../../script";
@@ -41,6 +40,7 @@ import { AudioChunk } from "../audio-chunk";
 import { createAudioMessage } from "../messages";
 import { VoiceRecordingRuntime } from "../recording.runtime";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
+import { PassingJudge } from "./fixtures/passing-judge";
 
 /** A short non-silent PCM16 chunk (mono, 24kHz) carrying a transcript. */
 function tone(durationSeconds: number, transcript: string): AudioChunk {
@@ -67,19 +67,6 @@ class AudioUserSimulator extends UserSimulatorAgentAdapter {
   }
 }
 
-/** Fake judge that concludes the run successfully on the judge() step. */
-class PassingJudge extends JudgeAgentAdapter {
-  criteria: string[] = ["Agent responds"];
-  async call(input: AgentInput) {
-    if (!input.judgmentRequest) return null;
-    return {
-      success: true,
-      reasoning: "voice turn completed",
-      metCriteria: [...this.criteria],
-      unmetCriteria: [],
-    };
-  }
-}
 
 function buildVoiceExecution(): {
   execution: ScenarioExecution;


### PR DESCRIPTION
## Ticket

Closes #786. Follow-up from the #783 review: `PassingJudge` (a fake judge that concludes a run successfully on the `judge()` step) was copied across several voice suites. `javascript/src/voice/__tests__/fixtures/` is already the home for shared voice test doubles (`FakeVoiceAdapter`, `AudioUserSimulator`).

## Change

- New `fixtures/passing-judge.ts` exporting a single `PassingJudge`.
- Removed the local copies from `duration-fidelity`, `interrupt-truncation`, `proceed-interrupt`, and `result-audio` and imported the shared one (also dropped the now-unused `JudgeAgentAdapter` import from each).

The four copies had drifted into two variants (`["Agent responds"]` / "voice turn completed" vs `["ok"]` / "done"). No suite asserts on the judge's `criteria`, `reasoning`, or `metCriteria` (only `result.success === true`), so consolidating to one canonical version is behavior-preserving. `proceed-interrupt`'s judge-timing rationale comment is kept, relocated to the usage site.

Note: `voice-spans-stt.test.ts` (named in the issue) has no `PassingJudge` copy on `main`, so nothing to change there.

## Evidence

- `npx vitest run` on the four suites: **22 passed**.
- `pnpm typecheck` clean.
- The new fixture lints clean. (Pre-existing `import/order` errors in these test files are unrelated to this change and are not gated by CI: `lint:all` skips the root package and `lint:lib` excludes `*.test.ts` / `__tests__/**`.)

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.