### PR TITLE
fix(voice): skip Twilio e2e fixtures on absent env, not fail

### DIFF
--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -166,12 +166,14 @@ jobs:
           TWILIO_PHONE_NUMBER_2: ${{ secrets.TWILIO_PHONE_NUMBER_2 }}
 
       - name: Run example-suite voice integration tests
-        # Reachability gate (issue #491). Without this, the demos this PR exists to
-        # un-skip can NEVER run: the step above collects three Twilio-gated tests
-        # (test_twilio_inbound/outbound/dtmf_ivr_e2e.py) whose fixtures pytest.FAIL —
-        # by design — when TWILIO_* env is absent, and those secrets are not configured
-        # on this repo. A failed step aborts the job, so every step below it is skipped.
-        # That is why voice-integration is 30/30 red and the isolated step has 0 runs.
+        # Reachability gate (issue #491), now belt-and-suspenders with #796. The step
+        # above collects three Twilio-gated tests (test_twilio_inbound/outbound/
+        # dtmf_ivr_e2e.py). Since #796 their fixtures SKIP when TWILIO_* env is absent
+        # (option b) instead of failing, so a missing-secret repo no longer aborts the
+        # job here — but this gate stays as defense-in-depth: any OTHER failure in the
+        # step above (an unrelated test, a live-provider blip) would still abort every
+        # step below it. Historically that abort — Twilio fixtures failing on absent
+        # env — is why voice-integration was 30/30 red with 0 runs of the isolated step.
         # Un-skipping the demos while leaving them unreachable would just trade
         # "@pytest.mark.skip" for "step never executes" — the same asserted-but-never-run
         # hole in a new costume.

--- a/python/tests/voice/conftest.py
+++ b/python/tests/voice/conftest.py
@@ -3,13 +3,14 @@ Shared test configuration and fail-fast preflight fixtures for the voice suite.
 
 Philosophy per TESTING.md ("E2E = happy paths via real examples, no mocks"):
 missing infrastructure is a test FAILURE with a clear message, not a silent
-skip. There are two narrow, deliberate exceptions: code that genuinely isn't
-shipped yet (transport stubs that still raise PendingTransportError), and the
-Twilio preflight fixtures below, which SKIP when TWILIO_* env is absent per
-the #796 decision (option b) — the on-demand voice-integration job must reach
-its later steps even when Twilio secrets aren't configured. A present-but-
-broken Twilio credential (env set but auth fails) still FAILS; skip-on-absence
-never masks a real failure.
+skip. A handful of fixtures deliberately skip instead: code not shipped yet
+(transport stubs raising PendingTransportError), optional/paid capability gates
+(ELEVENLABS_VOICE_ID, a provider-rejected GEMINI key), and — per the #796
+decision (option b) — the Twilio preflight fixtures below, which SKIP when
+TWILIO_* env is absent so the on-demand voice-integration job reaches its later
+steps even when Twilio secrets aren't configured. A present-but-broken Twilio
+credential (env set but auth fails) still FAILS; only genuine absence skips
+(a partial Twilio config — some keys set — is treated as absent).
 
 Preflight fixtures assert the required infrastructure is reachable before the
 test body runs. If anything is missing, the fixture fails with a one-line
@@ -91,10 +92,9 @@ def _require_twilio_env(keys: tuple[str, ...], auth_ok: Callable[[], bool]) -> N
 
     SKIP when any required var is ABSENT — a missing-secret run must not abort
     the CI job before later steps (the six target demos need no Twilio at all).
-    FAIL when env is present but the credentials don't authenticate — a
-    present-but-broken credential is a REAL failure, never a skip. This is the
-    one sanctioned exception to this file's fail-fast "missing infra is a
-    FAILURE" policy, and it is scoped to absence only.
+    A partial config (only some keys set) counts as absent and also skips.
+    FAIL when all keys are present but the credentials don't authenticate — a
+    present-but-broken credential is a REAL failure, not a skip.
     """
     missing = [k for k in keys if not os.getenv(k)]
     if missing:
@@ -105,9 +105,10 @@ def _require_twilio_env(keys: tuple[str, ...], auth_ok: Callable[[], bool]) -> N
         )
     if not auth_ok():
         pytest.fail(
-            "Twilio env is present but authentication failed. A present-but-"
-            "broken credential is a real failure, not a skip (#796): rotate "
-            "TWILIO_AUTH_TOKEN in python/.env (account creds are stale)."
+            "Twilio env is present but the credential check did not pass "
+            "(auth rejected, or the Twilio API was unreachable). A present-but-"
+            "broken credential is a real failure, not a skip (#796): verify "
+            "TWILIO_* in python/.env (rotate TWILIO_AUTH_TOKEN if creds are stale)."
         )
 
 
@@ -279,10 +280,10 @@ _twilio_auth_ok_cache: Optional[bool] = None
 def _twilio_auth_ok() -> bool:
     """Session-cached probe: does the Twilio auth token actually work?
 
-    Returns True if creds authenticate, False if 401. Skip (not fail) on 401
-    so a known-revoked token produces a clear 'rotate this var' message
-    instead of flooding the suite with noise. Missing env vars still FAIL
-    (fail-fast per TESTING.md) — this probe only runs once env is present.
+    Returns True if creds authenticate, False otherwise (a 401, or any error
+    reaching the Twilio API). Per the #796 decision the caller
+    (``_require_twilio_env``) treats a present-but-False result as a FAIL and a
+    fully-absent config as a SKIP; this probe only runs once env is present.
     """
     global _twilio_auth_ok_cache
     if _twilio_auth_ok_cache is not None:

--- a/python/tests/voice/conftest.py
+++ b/python/tests/voice/conftest.py
@@ -3,8 +3,13 @@ Shared test configuration and fail-fast preflight fixtures for the voice suite.
 
 Philosophy per TESTING.md ("E2E = happy paths via real examples, no mocks"):
 missing infrastructure is a test FAILURE with a clear message, not a silent
-skip. The only legitimate "skip" is for code that genuinely isn't shipped yet
-(transport stubs that still raise PendingTransportError).
+skip. There are two narrow, deliberate exceptions: code that genuinely isn't
+shipped yet (transport stubs that still raise PendingTransportError), and the
+Twilio preflight fixtures below, which SKIP when TWILIO_* env is absent per
+the #796 decision (option b) — the on-demand voice-integration job must reach
+its later steps even when Twilio secrets aren't configured. A present-but-
+broken Twilio credential (env set but auth fails) still FAILS; skip-on-absence
+never masks a real failure.
 
 Preflight fixtures assert the required infrastructure is reachable before the
 test body runs. If anything is missing, the fixture fails with a one-line
@@ -25,7 +30,7 @@ import socket
 import subprocess
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import pytest
 
@@ -69,6 +74,40 @@ def _require_env(*keys: str) -> None:
             f"Required env var(s) missing: {', '.join(missing)}. "
             "Set them in python/.env (see python/.env.example) — "
             "e2e tests fail on missing infrastructure, not skip."
+        )
+
+
+# Twilio keys required by both the outbound and inbound demos.
+_TWILIO_REQUIRED_KEYS = (
+    "TWILIO_ACCOUNT_SID",
+    "TWILIO_AUTH_TOKEN",
+    "TWILIO_PHONE_NUMBER",
+    "TWILIO_PHONE_NUMBER_2",
+)
+
+
+def _require_twilio_env(keys: tuple[str, ...], auth_ok: Callable[[], bool]) -> None:
+    """Gate a Twilio fixture per the #796 decision (option b).
+
+    SKIP when any required var is ABSENT — a missing-secret run must not abort
+    the CI job before later steps (the six target demos need no Twilio at all).
+    FAIL when env is present but the credentials don't authenticate — a
+    present-but-broken credential is a REAL failure, never a skip. This is the
+    one sanctioned exception to this file's fail-fast "missing infra is a
+    FAILURE" policy, and it is scoped to absence only.
+    """
+    missing = [k for k in keys if not os.getenv(k)]
+    if missing:
+        pytest.skip(
+            "Twilio env absent: " + ", ".join(missing) + ". Skipping "
+            "(skip-on-absent per #796 option b) — set these in python/.env "
+            "to run this test."
+        )
+    if not auth_ok():
+        pytest.fail(
+            "Twilio env is present but authentication failed. A present-but-"
+            "broken credential is a real failure, not a skip (#796): rotate "
+            "TWILIO_AUTH_TOKEN in python/.env (account creds are stale)."
         )
 
 
@@ -298,48 +337,22 @@ def _gemini_key_ok() -> bool:
 
 @pytest.fixture
 def requires_twilio_outbound():
-    """Fail unless Twilio outbound demo env is fully configured.
+    """Skip when Twilio env is ABSENT; FAIL when present-but-broken (#796 opt b).
 
     Outbound dials TWILIO_PHONE_NUMBER_2 by default — a second Twilio-owned
-    number whose own harness will answer. No human required.
-
-    If env is present but auth is rejected (401), skip with a clear 'rotate
-    TWILIO_AUTH_TOKEN' message. Missing env is still a FAIL.
+    number whose own harness answers. No human required.
     """
-    _require_env(
-        "TWILIO_ACCOUNT_SID",
-        "TWILIO_AUTH_TOKEN",
-        "TWILIO_PHONE_NUMBER",
-        "TWILIO_PHONE_NUMBER_2",
-    )
-    if not _twilio_auth_ok():
-        pytest.skip(
-            "Twilio auth token rejected (401). Rotate TWILIO_AUTH_TOKEN in "
-            "python/.env — account creds are stale."
-        )
+    _require_twilio_env(_TWILIO_REQUIRED_KEYS, _twilio_auth_ok)
 
 
 @pytest.fixture
 def requires_twilio_inbound():
-    """Fail unless Twilio inbound demo env is configured.
+    """Skip when Twilio env is ABSENT; FAIL when present-but-broken (#796 opt b).
 
     Inbound uses a second Twilio number (TWILIO_PHONE_NUMBER_2) to dial in
     to the primary (TWILIO_PHONE_NUMBER). No human required.
-
-    If env is present but auth is rejected (401), skip with a clear 'rotate
-    TWILIO_AUTH_TOKEN' message. Missing env is still a FAIL.
     """
-    _require_env(
-        "TWILIO_ACCOUNT_SID",
-        "TWILIO_AUTH_TOKEN",
-        "TWILIO_PHONE_NUMBER",
-        "TWILIO_PHONE_NUMBER_2",
-    )
-    if not _twilio_auth_ok():
-        pytest.skip(
-            "Twilio auth token rejected (401). Rotate TWILIO_AUTH_TOKEN in "
-            "python/.env — account creds are stale."
-        )
+    _require_twilio_env(_TWILIO_REQUIRED_KEYS, _twilio_auth_ok)
 
 
 @pytest.fixture

--- a/python/tests/voice/test_twilio_conftest_guard.py
+++ b/python/tests/voice/test_twilio_conftest_guard.py
@@ -51,20 +51,28 @@ def test_absent_env_skips_even_when_auth_would_pass(monkeypatch):
     assert kind == "skipped"
 
 
-def test_partial_env_skips_and_names_the_missing_keys(monkeypatch):
+def test_partial_env_skips_and_names_only_the_missing_keys(monkeypatch):
     """Only 2 of 4 keys set -> still a skip (any missing key triggers it),
-    and the skip message names the missing ones so the operator knows what
-    to configure."""
-    monkeypatch.delenv("TWILIO_ACCOUNT_SID", raising=False)
-    monkeypatch.delenv("TWILIO_AUTH_TOKEN", raising=False)
-    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+15550001111")
-    monkeypatch.setenv("TWILIO_PHONE_NUMBER_2", "+15550002222")
+    and the skip message names ONLY the missing keys (not the present ones) so
+    the operator knows exactly what to configure. Indexes the constant rather
+    than hardcoding key names so the test can't silently go stale if the
+    required-key set changes."""
+    absent = _TWILIO_REQUIRED_KEYS[:2]
+    present = _TWILIO_REQUIRED_KEYS[2:]
+    for key in absent:
+        monkeypatch.delenv(key, raising=False)
+    for key in present:
+        monkeypatch.setenv(key, "+15550001111")
 
     kind, message = _outcome(lambda: True)
     assert kind == "skipped"
     assert message is not None  # narrow for type-checkers; skip path always has a message
-    assert "TWILIO_ACCOUNT_SID" in message
-    assert "TWILIO_AUTH_TOKEN" in message
+    for key in absent:
+        assert key in message, f"skip message should name missing key {key}"
+    # ...and ONLY the missing keys: catches a `", ".join(missing)` -> `join(keys)`
+    # mutation that would name present keys too (containment alone would miss it).
+    for key in present:
+        assert key not in message, f"skip message should not name present key {key}"
 
 
 # ---------------------------------------------------------------- present -> fail/pass
@@ -88,3 +96,30 @@ def test_present_and_valid_passes_cleanly(monkeypatch):
 
     kind, _ = _outcome(lambda: True)
     assert kind == "passed"
+
+
+# ---------------------------------------------------------------- fixture wiring
+
+def test_twilio_fixtures_delegate_to_the_guard():
+    """The tests above pin the guard's logic; this pins that the *fixtures*
+    actually route through it. A fixture silently reverting to the old
+    fail-on-absent gate would reintroduce the #796 dispatch abort while every
+    test above stays green — only source inspection catches that. Mirrors the
+    `requires_transport_ready` probe precedent in conftest (inspect the source,
+    don't call the fixture — pytest forbids calling fixtures directly)."""
+    import inspect
+
+    from tests.voice import conftest
+
+    for fixture_name in ("requires_twilio_outbound", "requires_twilio_inbound"):
+        fixture = getattr(conftest, fixture_name)
+        # @pytest.fixture may wrap the function; unwrap to the real body.
+        func = getattr(fixture, "__wrapped__", fixture)
+        source = inspect.getsource(func)
+        assert "_require_twilio_env" in source, (
+            f"{fixture_name} no longer delegates to _require_twilio_env — the "
+            "#796 skip-on-absent gate may have regressed"
+        )
+        assert "_twilio_auth_ok" in source, (
+            f"{fixture_name} no longer passes the _twilio_auth_ok probe"
+        )

--- a/python/tests/voice/test_twilio_conftest_guard.py
+++ b/python/tests/voice/test_twilio_conftest_guard.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for the Twilio preflight-fixture gate decided in issue #796.
+
+Decision (option b): the Twilio fixtures must SKIP when TWILIO_* env is
+ABSENT — a missing-secret CI run has to reach its later steps instead of
+aborting — but FAIL when env is present-but-broken (credentials that don't
+authenticate). Skip only on absence; never mask a real failure.
+
+These tests drive `_require_twilio_env` directly rather than through the
+fixtures, with `monkeypatch` controlling env so the outcome is independent of
+this developer's real python/.env (which does have TWILIO_* configured).
+"""
+
+import pytest
+
+from tests.voice.conftest import _TWILIO_REQUIRED_KEYS, _require_twilio_env
+
+
+def _outcome(auth_ok):
+    """Call `_require_twilio_env` and classify the result as exactly one of
+    "passed" / "skipped" / "failed", plus the outcome message (None on pass).
+
+    A bare `pytest.raises(SomeExc)` would let a *wrong-type* outcome (e.g. a
+    Skipped escaping a block that expected Failed) leak past the context
+    manager and get reinterpreted by pytest's own runner as this test being
+    skipped rather than failed — quietly hiding a real mutation instead of
+    turning it red. Classifying explicitly and asserting on a plain string
+    means every wrong outcome surfaces as an ordinary AssertionError, which
+    pytest always reports as FAILED, never as skipped.
+    """
+    try:
+        result = _require_twilio_env(_TWILIO_REQUIRED_KEYS, auth_ok)
+    except pytest.skip.Exception as exc:
+        return "skipped", str(exc)
+    except pytest.fail.Exception as exc:
+        return "failed", str(exc)
+    assert result is None, "helper should return None on the success path"
+    return "passed", None
+
+
+# ---------------------------------------------------------------- absence -> skip
+
+def test_absent_env_skips_even_when_auth_would_pass(monkeypatch):
+    """All four keys missing -> skip. Absence must dominate the decision, so
+    auth_ok reporting True (it would never actually be called with no creds)
+    still results in a skip, not a pass."""
+    for key in _TWILIO_REQUIRED_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    kind, _ = _outcome(lambda: True)
+    assert kind == "skipped"
+
+
+def test_partial_env_skips_and_names_the_missing_keys(monkeypatch):
+    """Only 2 of 4 keys set -> still a skip (any missing key triggers it),
+    and the skip message names the missing ones so the operator knows what
+    to configure."""
+    monkeypatch.delenv("TWILIO_ACCOUNT_SID", raising=False)
+    monkeypatch.delenv("TWILIO_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+15550001111")
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER_2", "+15550002222")
+
+    kind, message = _outcome(lambda: True)
+    assert kind == "skipped"
+    assert message is not None  # narrow for type-checkers; skip path always has a message
+    assert "TWILIO_ACCOUNT_SID" in message
+    assert "TWILIO_AUTH_TOKEN" in message
+
+
+# ---------------------------------------------------------------- present -> fail/pass
+
+def test_present_but_broken_auth_fails_not_skips(monkeypatch):
+    """All four keys present but auth_ok() reports False -> FAIL, never a
+    skip. A present-but-broken credential is a real failure per #796, not
+    something to quietly skip past."""
+    for key in _TWILIO_REQUIRED_KEYS:
+        monkeypatch.setenv(key, "dummy-value")
+
+    kind, _ = _outcome(lambda: False)
+    assert kind == "failed"
+
+
+def test_present_and_valid_passes_cleanly(monkeypatch):
+    """All four keys present and auth_ok() reports True -> no skip, no
+    failure; the fixture lets the test proceed."""
+    for key in _TWILIO_REQUIRED_KEYS:
+        monkeypatch.setenv(key, "dummy-value")
+
+    kind, _ = _outcome(lambda: True)
+    assert kind == "passed"

--- a/python/tests/voice/test_twilio_conftest_guard.py
+++ b/python/tests/voice/test_twilio_conftest_guard.py
@@ -29,12 +29,15 @@ def _outcome(auth_ok):
     pytest always reports as FAILED, never as skipped.
     """
     try:
-        result = _require_twilio_env(_TWILIO_REQUIRED_KEYS, auth_ok)
+        _require_twilio_env(_TWILIO_REQUIRED_KEYS, auth_ok)
     except pytest.skip.Exception as exc:
         return "skipped", str(exc)
     except pytest.fail.Exception as exc:
         return "failed", str(exc)
-    assert result is None, "helper should return None on the success path"
+    # No exception -> the guard let the test proceed. The helper is
+    # procedure-like (it signals via pytest.skip/fail and always returns None),
+    # so we don't inspect its return value — inspecting it trips the
+    # "use of a procedure's return value" code-quality check.
     return "passed", None
 
 


### PR DESCRIPTION
**Low risk** — test-infra only (two voice e2e preflight fixtures + a hermetic regression test + doc/comment accuracy). No product code, no runtime surface. Start at `python/tests/voice/conftest.py::_require_twilio_env`.

## Why

`voice-integration.yml` could never produce a signal about the six multi-turn voice `@e2e` demos: the `pytest -m "integration and not voice_multiturn"` step collects three **Twilio-gated** e2e tests, and when `TWILIO_*` secrets are absent (they are not configured on this repo) those fixtures **failed** via `_require_env` — aborting the job **before** the isolated multi-turn step ran. This is the dispatch blocker on #796; per the decision there (option b), absent Twilio secrets should **skip**, not abort.

Refs #796 (Twilio dispatch-blocker slice). Full 6-demo triage — including which failures are owner design decisions — is in the issue: https://github.com/langwatch/scenario/issues/796#issuecomment-4957325515. This PR does **not** close #796.

## What changed

- **Twilio fixtures skip-on-*absent*, fail-on-*present-but-broken*** → *alternative:* add the 4 repo secrets (owner-only, needs the Twilio account) → skip keeps the fail-fast policy everywhere except the one missing-secret case that blocks dispatch; a present-but-broken credential still **fails** rather than skipping (the fixture path is logic-proven; the real `_twilio_auth_ok` 401→fail mapping is pre-existing and unchanged, and is not exercised by these hermetic tests — see the last bullet under "How I can prove").
- **Scoped to Twilio only** → *alternative:* also relax the ElevenLabs/Gemini fixtures → those secrets **are** configured in CI and don't block dispatch, so widening the carve-out would be unratified scope creep. Deliberately left as-is (the Gemini present-but-broken asymmetry is noted as a follow-up in the review verdict).
- **New hermetic regression test** `test_twilio_conftest_guard.py` → its `_outcome()` classifier asserts on a plain string instead of `pytest.raises(...)` → a `fail→skip` mutation would otherwise escape as `Skipped` and be **reinterpreted by pytest as a skipped test** (green), silently surviving; classifying explicitly makes every wrong-direction mutation a plain `AssertionError` → FAILED. A second test source-inspects the two fixtures so a silent revert to the old fail-on-absent gate is caught (the four logic tests can't see fixture wiring).
- **Doc/comment accuracy (review follow-ups)** → corrected stale docstrings this change introduced (`_twilio_auth_ok` still described skip-on-401; the "sanctioned exceptions" wording miscounted the EL/Gemini skips) and the now-false `voice-integration.yml` reachability-gate comment.

## Test plan

```
# green (5 tests, hermetic, no keys/network)
uv run pytest tests/voice/test_twilio_conftest_guard.py -q      # 5 passed
# type check
uv run pyright tests/voice/conftest.py tests/voice/test_twilio_conftest_guard.py   # 0 errors
```

## How I can prove I was successful

No playable artifact (test-infra change) — terminal transcript of the falsifiability + behavioral proof, run this session and CI-confirmed on HEAD `5e727d2`:

**Regression tests are load-bearing (mutation, all four assertions):**
```
# baseline: 5 passed

# absent-branch skip->fail (pre-#796 behavior):     2 skip tests go RED
# auth-branch fail->skip:                            1 fail test RED as AssertionError('skipped'=='failed')
#                                                     — reported FAILED, NOT reclassified as skipped
# join(missing)->join(keys):                         partial-env test RED (names present keys too)
# break a fixture's delegation:                      wiring test RED ("no longer delegates to _require_twilio_env")
```

**Behavioral — the real fixture, end to end (was FAIL before this PR):**
```
$ env TWILIO_ACCOUNT_SID= TWILIO_AUTH_TOKEN= TWILIO_PHONE_NUMBER= TWILIO_PHONE_NUMBER_2= \
    uv run pytest tests/voice/test_twilio_outbound_e2e.py -v
tests/voice/test_twilio_outbound_e2e.py::test_demo_twilio_outbound_e2e_success SKIPPED [100%]
1 skipped in 0.02s
```

**Scope of the proof (honest):** the skip-on-absent half is proven end-to-end on the real fixture. The present-but-broken→FAIL half is proven at the *logic* level (the fixture fails when `auth_ok` reports False); the real `_twilio_auth_ok` network-probe's 401→False mapping is pre-existing, unchanged, and not exercised here (TWILIO_* is absent in CI, so that branch can't run). CI `test (3.12)` green on `5e727d2`; pyright CI-clean over the whole tree.

## Anything surprising?

This unblocks the **dispatch** only. The six demos' own pass/fail status is a separate matter: `long_hold` and `emotional_escalation` root-cause to **design decisions** (not the timeout/turn-budget bumps earlier expected), and `accent_loop` / `multi_intent` / the two env-divergent demos are documented as owner decisions in the triage comment linked above. Nothing here changes those.

