### PR TITLE
chore: repoint the python recordings gitignore policy at python/outputs/ (#624)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,47 +195,56 @@ docs/docs/public/reference/python/**/*
 .claude/settings.local.json
 .worktrees
 
-# Voice demo recordings — most are regenerated per local run, NOT
-# committed. But the subset listed below is checked in as PR
-# evidence: each demo's `full.wav`, `manifest.json`, and per-turn
-# `segments/` directory are the canonical "prove it" artifacts for
-# reviewers. See python/recordings/README.md.
-python/recordings/*
-!python/recordings/README.md
-!python/recordings/elevenlabs_hosted/
-!python/recordings/elevenlabs_branded/
-!python/recordings/elevenlabs_interruption/
-!python/recordings/twilio_inbound/
-!python/recordings/twilio_outbound/
-!python/recordings/gemini_live/
-!python/recordings/gemini_live_interruption/
+# Python voice demo outputs (recordings + manifests). Most are regenerated
+# per local run, NOT committed. But the subset listed below is checked in as
+# PR evidence: each demo's `full.wav`, `manifest.json`, and for the core
+# provider demos the per-turn `segments/` directory are the canonical
+# "prove it" artifacts for reviewers. See python/outputs/README.md (parent
+# index) and python/outputs/recordings/README.md (audio policy).
+#
+# Shape: outputs/ is the artifact parent (room for traces/, logs/,
+# screenshots/ later). recordings/ is the audio subdir, and only it is
+# whitelisted today; new artifact siblings will get their own block when added.
+python/outputs/*
+!python/outputs/README.md
+!python/outputs/recordings/
+python/outputs/recordings/*
+!python/outputs/recordings/README.md
+# Core provider demos: commit full.wav + manifest.json + per-turn segments/.
+!python/outputs/recordings/elevenlabs_hosted/
+!python/outputs/recordings/elevenlabs_branded/
+!python/outputs/recordings/elevenlabs_interruption/
+!python/outputs/recordings/twilio_inbound/
+!python/outputs/recordings/twilio_outbound/
+!python/outputs/recordings/gemini_live/
+!python/outputs/recordings/gemini_live_interruption/
 # Additional demos — commit only full.wav + manifest.json (skip segments/
 # to avoid hundreds of tiny per-turn wavs in the tree).
-!python/recordings/openai_realtime_agent/
-python/recordings/openai_realtime_agent/segments/
-!python/recordings/pipecat_scenario/
-python/recordings/pipecat_scenario/segments/
-!python/recordings/pipecat_ws/
-python/recordings/pipecat_ws/segments/
-!python/recordings/basic_greeting/
-python/recordings/basic_greeting/segments/
-!python/recordings/voice_text_parity/
-python/recordings/voice_text_parity/segments/
-!python/recordings/recording_playback/
-python/recordings/recording_playback/segments/
-!python/recordings/interruption_recovery/
-python/recordings/interruption_recovery/segments/
-!python/recordings/random_interruptions/
-python/recordings/random_interruptions/segments/
-!python/recordings/angry_customer/
-python/recordings/angry_customer/segments/
-!python/recordings/background_handoff/
-python/recordings/background_handoff/segments/
-!python/recordings/stt_swap/
-python/recordings/stt_swap/segments/
+!python/outputs/recordings/openai_realtime_agent/
+python/outputs/recordings/openai_realtime_agent/segments/
+!python/outputs/recordings/pipecat_scenario/
+python/outputs/recordings/pipecat_scenario/segments/
+!python/outputs/recordings/pipecat_ws/
+python/outputs/recordings/pipecat_ws/segments/
+!python/outputs/recordings/basic_greeting/
+python/outputs/recordings/basic_greeting/segments/
+!python/outputs/recordings/voice_text_parity/
+python/outputs/recordings/voice_text_parity/segments/
+!python/outputs/recordings/recording_playback/
+python/outputs/recordings/recording_playback/segments/
+!python/outputs/recordings/interruption_recovery/
+python/outputs/recordings/interruption_recovery/segments/
+!python/outputs/recordings/random_interruptions/
+python/outputs/recordings/random_interruptions/segments/
+!python/outputs/recordings/angry_customer/
+python/outputs/recordings/angry_customer/segments/
+!python/outputs/recordings/background_handoff/
+python/outputs/recordings/background_handoff/segments/
+!python/outputs/recordings/stt_swap/
+python/outputs/recordings/stt_swap/segments/
 
 # TypeScript voice demo outputs (recordings + manifests) — same policy as
-# python/recordings/ above. Regenerated per local run by the @e2e demo tests
+# python/outputs/recordings/ above. Regenerated per local run by the @e2e demo tests
 # under javascript/examples/vitest/tests/voice/; the committed subset below
 # is the canonical "prove it" audio evidence. See
 # javascript/examples/vitest/outputs/README.md (parent index) and


### PR DESCRIPTION
## Ticket

Closes #624. The recordings `.gitignore` block still governs `python/recordings/`, the path #586 emptied when it moved the demos to `python/outputs/recordings/`. **Nothing is tracked under the old path any more (0 files), so all 38 lines of the block match nothing**, and the real artifact directory (68 tracked files) is governed by no rule at all.

## Change

One file, `.gitignore`. Repoint the block and adopt the same `outputs/` parent shape the **TypeScript block directly below it already uses**, so `python/outputs/` is treated like `javascript/examples/vitest/outputs/` and future artifact siblings (`traces/`, `logs/`) are ignored by default rather than by omission. Also fixes the two dead cross-references to `python/recordings/README.md`.

**One correction to the ticket, worth a reviewer's eye.** It warns that "the exception allowlist is stale relative to the actual committed inventory, so this is NOT a blind path-swap". That is no longer true: the block has been kept current since filing. I derived the allowlist from the tracked tree rather than trusting either list, and they match exactly:

| | Demos |
| --- | --- |
| Track `segments/` (7) | `elevenlabs_hosted`, `elevenlabs_branded`, `elevenlabs_interruption`, `gemini_live`, `gemini_live_interruption`, `twilio_inbound`, `twilio_outbound` |
| Track only `full.wav` + `manifest.json` (11) | `openai_realtime_agent`, `pipecat_scenario`, `pipecat_ws`, `basic_greeting`, `voice_text_parity`, `recording_playback`, `interruption_recovery`, `random_interruptions`, `angry_customer`, `background_handoff`, `stt_swap` |

Those are precisely the existing core / additional exception groups. So the allowlist is carried over unchanged and only the path moved, which is what makes this reviewable.

## Evidence

Simulated a demo run dropping artifacts, then diffed `git status` between the two `.gitignore` versions:

**On `origin/main` today, the tree is dirtied:**
```
?? python/outputs/recordings/angry_customer/segments/
?? python/outputs/recordings/background_handoff/segments/
?? python/outputs/recordings/basic_greeting/segments/
?? python/outputs/recordings/brand_new_demo/
?? python/outputs/recordings/stt_swap/segments/
?? python/outputs/traces/
```

**With this change, identical simulation, clean:**
```
(nothing)
```

Three invariants checked mechanically:

| Invariant | Result |
| --- | --- |
| No **tracked** file becomes ignored (would break a later `git add`) | all **69** tracked files under `python/outputs/` remain un-ignored |
| Regenerated / new artifacts **are** ignored | additional-demo `segments/`, a brand-new demo's `full.wav`, and `python/outputs/traces/` all ignored |
| Core-demo `segments/` stay **committable** | `elevenlabs_*`, `gemini_live`, `twilio_*` segments plus both READMEs un-ignored |

**Scope caveat, stated plainly:** the ticket also lists the tracked `full.wav` / `manifest.json` showing as ` M` after a run. `.gitignore` cannot fix that, since it only affects untracked files; a tracked file always reports modifications. This PR removes the `??` noise and the dead path. The ` M` churn is inherent to committing regenerated evidence and needs a separate decision (leave it, or stop tracking the volatile ones).

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.