### PR TITLE
fix(python): derive scenario.__version__ from package metadata

### DIFF
--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -107,6 +107,7 @@ from .config import ScenarioConfig
 
 # Tracing public API
 from ._tracing import setup_scenario_tracing, scenario_only, with_custom_scopes
+from ._tracing.sdk_metadata import SCENARIO_SDK_VERSION as _SCENARIO_SDK_VERSION
 from ._tracing.live import RealtimeLangWatchSession as realtime_langwatch_session
 
 # Then import modules with dependencies
@@ -260,4 +261,14 @@ __all__ = [
     "DEFAULT_GOAT_TECHNIQUES",
     "JudgeAgent",
 ]
-__version__ = "0.1.0"
+#: The installed ``langwatch-scenario`` version, read from package metadata.
+#:
+#: Aliases the constant the tracing layer already resolves via
+#: ``importlib.metadata``, so the version has one source of truth: the
+#: ``version`` in ``pyproject.toml`` that release-please bumps. A literal here
+#: would drift, because nothing keeps it in step with a release: this constant
+#: sat at ``"0.1.0"`` from the first release through 0.7.31.
+#:
+#: Falls back to ``"unknown"`` when package metadata is unavailable, matching
+#: ``scenario.sdk.version`` on trace spans.
+__version__ = _SCENARIO_SDK_VERSION

--- a/python/tests/test_package_version.py
+++ b/python/tests/test_package_version.py
@@ -1,0 +1,52 @@
+"""Unit tests for the public ``scenario.__version__`` constant.
+
+``__version__`` sat at ``"0.1.0"`` from the first release through 0.7.31,
+because nothing bumps it: release-please updates ``pyproject.toml``, the
+changelog and the manifest, and the config declares no ``extra-files``.
+
+These tests pin it to package metadata, the same source
+``scenario.sdk.version`` already reads, so it cannot silently drift again.
+"""
+
+from __future__ import annotations
+
+import os
+from importlib.metadata import version as pkg_version
+
+os.environ.setdefault("SCENARIO_HEADLESS", "true")
+
+import scenario
+from scenario._tracing.sdk_metadata import SCENARIO_SDK_NAME, SCENARIO_SDK_VERSION
+
+
+def test_version_matches_installed_package_metadata():
+    assert scenario.__version__ == pkg_version(SCENARIO_SDK_NAME)
+
+
+def test_version_matches_the_version_stamped_on_traces():
+    # A run's trace and the importing code must never disagree about which
+    # SDK version produced it.
+    assert scenario.__version__ == SCENARIO_SDK_VERSION
+
+
+def test_version_is_not_a_hardcoded_literal():
+    # Guards the actual regression: a literal reintroduced here would pass the
+    # assertions above only until the next release bumps pyproject.toml.
+    import ast
+    import pathlib
+
+    source = pathlib.Path(scenario.__file__).read_text()
+    tree = ast.parse(source)
+
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
+        ):
+            continue
+        assert not isinstance(node.value, ast.Constant), (
+            "__version__ must derive from package metadata, not a literal: "
+            "a literal drifts on the next release (see issue #744's AC, and "
+            "the 0.1.0 vs 0.7.31 drift this test was added for)"
+        )

--- a/python/tests/test_package_version.py
+++ b/python/tests/test_package_version.py
@@ -10,7 +10,9 @@ These tests pin it to package metadata, the same source
 
 from __future__ import annotations
 
+import ast
 import os
+import pathlib
 from importlib.metadata import version as pkg_version
 
 os.environ.setdefault("SCENARIO_HEADLESS", "true")
@@ -29,23 +31,38 @@ def test_version_matches_the_version_stamped_on_traces():
     assert scenario.__version__ == SCENARIO_SDK_VERSION
 
 
+def _version_assignments(module) -> list[ast.expr | None]:
+    """Every value assigned to a module-level ``__version__``.
+
+    Covers plain (``__version__ = x``) and annotated (``__version__: str = x``)
+    assignments. Missing the annotated form would let the exact regression this
+    module guards against walk back in under a type hint.
+    """
+    assert module.__file__ is not None, f"{module.__name__} has no __file__ to read"
+    tree = ast.parse(pathlib.Path(module.__file__).read_text())
+
+    values: list[ast.expr | None] = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if any(
+                isinstance(t, ast.Name) and t.id == "__version__"
+                for t in node.targets
+            ):
+                values.append(node.value)
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == "__version__":
+                values.append(node.value)
+    return values
+
+
 def test_version_is_not_a_hardcoded_literal():
     # Guards the actual regression: a literal reintroduced here would pass the
     # assertions above only until the next release bumps pyproject.toml.
-    import ast
-    import pathlib
+    values = _version_assignments(scenario)
+    assert values, "no module-level __version__ assignment found in scenario/__init__.py"
 
-    source = pathlib.Path(scenario.__file__).read_text()
-    tree = ast.parse(source)
-
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        if not any(
-            isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
-        ):
-            continue
-        assert not isinstance(node.value, ast.Constant), (
+    for value in values:
+        assert not isinstance(value, ast.Constant), (
             "__version__ must derive from package metadata, not a literal: "
             "a literal drifts on the next release (see issue #744's AC, and "
             "the 0.1.0 vs 0.7.31 drift this test was added for)"


### PR DESCRIPTION
## Context

Handling the CodeRabbit comment on the release PR #658, which flagged that `scenario.__version__` is `"0.1.0"` while the package ships `0.7.32`.

**The drift is real** (`__version__ = "0.1.0"` at `python/scenario/__init__.py:263` vs `0.7.31` on main), **but the suggested fix was to set the literal to the current version, and that is what caused the bug.** Nothing bumps this constant: release-please updates `pyproject.toml`, the changelog and the manifest, and `.release-please-config.json` declares no `extra-files`. That is why a literal survived 76 releases untouched. Setting it to `0.7.32` reads correctly today and is wrong again the moment 0.7.33 ships.

This PR is opened **against `main` rather than pushed to #658**, because #658 is a release-please branch that gets regenerated on every run (a manual commit there would be clobbered), and a release PR should carry release metadata only.

## Change

`__version__` now aliases the constant the tracing layer already resolves through `importlib.metadata`, so the version has a single source of truth: the `version` in `pyproject.toml`.

The repo already settled this exact question for the same value on the tracing side. `_tracing/sdk_metadata.py` reads package metadata "rather than a hardcoded literal", and issue #744's AC is explicit: *"Version is NOT hardcoded — read from package metadata."* `__version__` was simply never brought in line. A side effect worth having: the public constant and the `scenario.sdk.version` trace attribute can no longer disagree about which SDK produced a run.

No new import cost or cycle: `__init__.py` already imports `_tracing` at line 102.

## Evidence

Verified against the real installed distribution:

```
scenario.__version__ : 0.7.31      (was "0.1.0")
pyproject/metadata   : 0.7.31
MATCH                : True
scenario.sdk.version : 0.7.31
consistent w/ traces : True
```

| Check | Result |
| --- | --- |
| New tests | **3 passed** (`tests/test_package_version.py`) |
| Sibling suite | **3 passed** (`tests/test_sdk_version_attributes.py`) |
| Import smoke (cycle check) | clean, `__version__ = 0.7.31` |

**Mutation-tested, and this is the part that makes the case.** Rather than only asserting the tests pass, I ran them against both alternatives:

| `__init__.py` state | Result |
| --- | --- |
| `"0.1.0"` (main today) | **3 failed** — catches the reported bug |
| `"0.7.31"` (the suggested fix) | **1 failed, 2 passed** — the value assertions pass *today*; the literal guard is the one that fails |
| `_SCENARIO_SDK_VERSION` (this PR) | **3 passed** |

That middle row is the whole argument: a hardcoded value is indistinguishable from correct until the next release. So the third test asserts the AST node for `__version__` is not a constant, which is what actually prevents the regression from returning.

**Not verified:** the full `pytest tests/` sweep timed out locally on tests that reach the network; I did not chase it, since this change touches only a module constant and the import smoke plus both version suites are green. CI is the check that matters here.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.