### PR TITLE
docs(voice): drop references to a docs/proposals tree that never landed (#613)

### DIFF
--- a/python/scenario/voice/adapters/twilio.py
+++ b/python/scenario/voice/adapters/twilio.py
@@ -13,8 +13,6 @@ One adapter class serves both directions a Twilio number can participate in:
 FastAPI webhook + Media Streams WS server, open a public URL (user-supplied
 or via ``CloudflareTunnel``). After ``connect()``, call either
 ``place_call()`` or ``wait_for_call()``.
-
-See source §5.3 and docs/proposals/issue-350-ralph-real-transports.md.
 """
 
 from __future__ import annotations

--- a/python/tests/voice/test_feature_file_contract.py
+++ b/python/tests/voice/test_feature_file_contract.py
@@ -3,8 +3,8 @@ Structural guard for specs/voice-agents.feature — the behavioral contract.
 
 Parses the feature file with the same Gherkin parser pytest-bdd uses and
 asserts it is well-formed. Catches regressions where a scenario gets
-dropped, a tag gets misspelled, or an AC is deleted without updating the
-prove-it report.
+dropped, a tag gets misspelled, or the tag split drifts from the counts
+this module pins.
 
 This is the minimum-viable half of "BDD wiring." Full pytest-bdd binding
 (one executable test per Scenario) is tracked as follow-up; local
@@ -102,7 +102,7 @@ def test_every_scenario_is_tagged_unit_integration_or_e2e(parsed_feature):
     )
 
 
-def test_tag_split_matches_prove_it_report(parsed_feature):
+def test_tag_split_matches_the_pinned_counts(parsed_feature):
     """
     The post-#561/#604 tag split is 79 @unit / 13 @integration / 35 @e2e.
     The end-to-end examples and pain-pattern scenarios are @e2e (happy paths

--- a/specs/voice-docs-surface.feature
+++ b/specs/voice-docs-surface.feature
@@ -140,11 +140,10 @@ Feature: User-facing docs surface for the voice-agent adapter system
     And the legacy Multimodal -> Voice Agents group is removed from the sidebar config
 
   @integration
-  Scenario: The voice docs cross-link to the proposal and the behavioral contract
+  Scenario: The voice docs cross-link to the behavioral contract
     Given the Voice Agents docs section is published
     When a reader opens Getting Started or Choosing an Adapter
-    Then the page links to docs/proposals/issue-350-voice-agents-source.md for design context
-    And the page links to specs/voice-agents.feature for the 99-scenario behavioral contract
+    Then the page links to specs/voice-agents.feature for the 99-scenario behavioral contract
 
   # ============================================================
   # Group: Legacy gpt-4o-audio-preview voice surface retirement


### PR DESCRIPTION
## Ticket

Closes #613. `docs/proposals/` is absent from `origin/main` **and from all history** (`git log --all -- 'docs/proposals/*'` is empty), so every pointer at it sends a reader hunting for a file that was never committed.

## Premise correction

The ticket lists **three** live path references. Only **two** survive on `main`: the third, in `test_feature_file_contract.py`, was already cleaned up by #610/#612 as the ticket anticipated. What remains there is the *wording* and the function name, which the ticket also flags.

The ticket is marked "investigation pending", so here is the current state, verified rather than assumed:

| Location | Reference | State |
| --- | --- | --- |
| `python/scenario/voice/adapters/twilio.py:17` | `docs/proposals/issue-350-ralph-real-transports.md` | live, removed here |
| `specs/voice-docs-surface.feature:146` | `docs/proposals/issue-350-voice-agents-source.md` | live, removed here |
| `python/tests/voice/test_feature_file_contract.py` | path ref | **already gone** (#610/#612) |
| same file | `prove-it report` wording + function name | live, fixed here |

## Change

Three files, net -3 lines.

**`twilio.py`** loses `See source §5.3 and docs/proposals/issue-350-ralph-real-transports.md.` Both halves are unresolvable (the `§5.3` is the sibling pattern tracked in #595), and the paragraphs above it already describe the connect/place_call/wait_for_call flow it pointed at, so nothing is lost.

**`voice-docs-surface.feature`** required the published docs to link the proposal "for design context". I checked: **nothing under `docs/` links it, and nothing can**, so the scenario asserted a requirement that was impossible to satisfy. It now covers only the cross-link that does exist (`specs/voice-agents.feature`), and the scenario title drops "the proposal" to match. Safe because the feature has **no pytest-bdd binding** (nothing in the repo references `voice-docs-surface`), so this changes no test.

**`test_feature_file_contract.py`** is the one worth a look. Its docstring claimed it catches "an AC deleted without updating the prove-it report", and `test_tag_split_matches_prove_it_report` was named after it. **The report never existed, and the test never read one**: it asserts the tag split against counts pinned in its own body. The name pointed a `grep` at a phantom and described behaviour the code does not implement. Both now say what the module actually does (`test_tag_split_matches_the_pinned_counts`).

## Evidence

| Check | Result |
| --- | --- |
| No dangling refs remain | `git grep 'docs/proposals\|issue-350-\|prove-it report'` returns nothing |
| Rename is safe | old function name referenced nowhere in the repo |
| Contract test still runs | **5 passed**, including the renamed `test_tag_split_matches_the_pinned_counts` |
| Twilio + contract suites | **76 passed, 2 skipped** |
| Adapter still imports | `import twilio` OK, docstring intact at 14 lines, no `proposals` mention |
| Spec still valid Gherkin | parses OK, 18 scenarios, edited one renamed as intended |

**Not verified:** the full `pytest tests/voice/` sweep times out locally on tests that reach the network. I ran every suite that touches the changed files instead; CI is the check that matters.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.