### PR TITLE
fix(javascript): make published dist loadable by plain Node (ESM + CJS)

### DIFF
--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -68,6 +68,14 @@ jobs:
         run: pnpm build:all
         working-directory: javascript
 
+      # Loads both built entrypoints with plain Node (no bundler resolution).
+      # Catches publish-breaking output bugs the vitest suite cannot see:
+      # extensionless deep imports that only bundlers resolve, and CJS-shim
+      # import.meta crashes — both shipped in releases up to 0.5.4.
+      - name: Smoke-load dist (ESM + CJS)
+        run: pnpm smoke:dist
+        working-directory: javascript
+
       - name: Lint
         run: pnpm lint:all
         working-directory: javascript

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -15,6 +15,7 @@
     "clean": "rm -rf dist *.tgz",
     "build": "tsup",
     "buildpack": "pnpm run build && pnpm pack",
+    "smoke:dist": "node -e \"require('./dist/index.js'); console.log('CJS dist loads OK')\" && node -e \"import('./dist/index.mjs').then(() => console.log('ESM dist loads OK'), (e) => { console.error(e); process.exit(1); })\"",
     "watch": "pnpm run build -- --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -64,12 +64,16 @@ import { openai } from "@ai-sdk/openai";
 // constructs the base client directly. (STT/TTS keep using the root wrapper.)
 // EXPLICIT-FILE imports: a directory/package import of `.../conversation` resolves
 // to its `index.js` barrel, which fails under our ESM (`moduleResolution: bundler`)
-// build — import the concrete files instead.
-import { AudioInterface } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/AudioInterface";
-import { Conversation } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/Conversation";
+// build — import the concrete files instead. The runtime (non-type) imports also
+// need the explicit `.js` extension: @elevenlabs/elevenlabs-js ships no exports
+// map, so Node resolves these deep paths as literal files. Extensionless they
+// only resolve under bundler semantics (vitest/tsx/webpack) and crash plain
+// `node` consumers of the published dist/index.mjs with ERR_MODULE_NOT_FOUND.
+import { AudioInterface } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/AudioInterface.js";
+import { Conversation } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/Conversation.js";
 import type { ConversationClient } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/interfaces/ConversationClient";
 import type { WebSocketFactory } from "@elevenlabs/elevenlabs-js/api/resources/conversationalAi/conversation/interfaces/WebSocketInterface";
-import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js/Client";
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js/Client.js";
 import type { LanguageModel } from "ai";
 
 import { AgentRole } from "../../domain/agents";

--- a/javascript/src/voice/effects/noise.ts
+++ b/javascript/src/voice/effects/noise.ts
@@ -10,7 +10,14 @@ import { fileURLToPath } from "node:url";
 
 import { EffectFn, int16ToPcm16, linearResample, pcm16ToInt16, rate } from "./common";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
+// Dual-format module location: in the ESM build `import.meta.url` is real; in
+// the CJS build tsup rewrites `import.meta` to an empty object (its shim), so
+// `fileURLToPath(undefined)` would throw at require() time and take the whole
+// package down with it. `__dirname` exists exactly in that build, so prefer it.
+const HERE =
+  typeof __dirname !== "undefined"
+    ? __dirname
+    : dirname(fileURLToPath(import.meta.url));
 
 /**
  * Candidate locations for the bundled noise assets, in priority order. The


### PR DESCRIPTION
## What

Makes the published `@langwatch/scenario` npm package actually loadable by plain Node, in both module systems, and adds a CI gate so this class of bug cannot ship again.

While smoke-testing the just-published 0.5.4 tarball with raw `node` (no bundler), both entrypoints failed at load:

- **ESM** (`import '@langwatch/scenario'`): `ERR_MODULE_NOT_FOUND` on `@elevenlabs/elevenlabs-js/.../AudioInterface`. The ElevenLabs adapter deep-imports three files from a package that ships no `exports` map, so Node resolves the specifiers as literal file paths. Extensionless, they only resolve under bundler semantics (vitest/tsx/webpack), which is why the test suite never saw it.
- **CJS** (`require('@langwatch/scenario')`): `ERR_INVALID_ARG_TYPE` from `fileURLToPath(undefined)`. `noise.ts` computed `fileURLToPath(import.meta.url)` at module top level, and tsup's CJS build stubs `import.meta` to `{}`.

Both bugs are pre-existing: 0.5.3 fails identically, so 0.5.4 made nothing worse. Every current consumer evidently runs through a bundler-resolution runtime.

## Fix

- Add the explicit `.js` extension to the three runtime deep imports in `elevenlabs.ts` (type-only imports are erased and need no change).
- Resolve the noise-assets base dir from `__dirname` when it exists (the CJS build) and fall back to `import.meta.url` (the ESM build). Asset candidate paths are unchanged in both layouts.
- New `smoke:dist` script loads `dist/index.js` with `require` and `dist/index.mjs` with dynamic `import` using plain Node, and runs in `javascript-ci` right after the build step.

## Verification

- `pnpm build && npm pack`, installed the tarball into a clean project: `import` and `require` both load cleanly (they both failed before the fix).
- `pnpm smoke:dist` passes locally and fails when either bug is reintroduced.
- Effects + ElevenLabs vitest suites: 84 passed. `lint:lib` and `typecheck` clean.
