### PR TITLE
fix(voice/#829): bring recv_audio's keepalive hard-ceiling to Python (JS parity)

### DIFF
--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -47,7 +47,7 @@ import base64
 import json
 import logging
 from collections import deque
-from typing import Any, ClassVar, Deque, Literal, Optional
+from typing import Any, ClassVar, Deque, Final, Literal, Optional
 
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
@@ -69,6 +69,16 @@ CONVAI_URL_TEMPLATE = "wss://api.elevenlabs.io/v1/convai/conversation?agent_id={
 #: non-mic stream. The default commit mode is therefore ``"text"``; the silence
 #: tail survives as an opt-in for callers who want the pure server-VAD audio path.
 SILENCE_TAIL_BYTES = 16000
+
+#: Absolute wall-clock ceiling (seconds) for a single :meth:`recv_audio` call
+#: that keepalive pings do NOT reset. The idle deadline is re-armed on every
+#: inbound frame, pings included (#649), so a slow-but-pinging server is not
+#: aborted mid-think — but EL ConvAI pings *indefinitely* on a turn it will
+#: never answer with audio (e.g. after it ends/transfers its turn), which would
+#: otherwise wedge the whole multi-turn run (issue #829; the absolute backstop
+#: explicitly deferred in #493). 45s is generous enough for a genuinely slow
+#: agent to respond, but finite so a non-responding turn times out cleanly.
+KEEPALIVE_HARD_CEILING_S: Final[float] = 45.0
 
 #: How :meth:`ElevenLabsAgentAdapter.send_audio` signals end-of-turn to EL ConvAI.
 #:
@@ -592,22 +602,35 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         Design decision (issue #493 — intentional, not an oversight): because
         a received ping is treated as proof of liveness, a hosted agent that
         keeps pinging but never sends audio (e.g. a wedged tool/RAG call) will
-        make this method wait **indefinitely**. There is deliberately **no
-        total-duration ceiling** here — a legitimate 30s+ silent-but-pinging
-        stretch must not abort the turn, which a cumulative budget would do.
+        make this method wait past ``timeout``. A legitimate 30s+
+        silent-but-pinging stretch must not abort the turn, which a cumulative
+        budget would do — so pings keep re-arming the idle deadline below.
+        But EL ConvAI can also ping *indefinitely* on a turn it will never
+        answer with audio (e.g. after it ends/transfers its turn), which would
+        otherwise wedge the whole multi-turn run forever. To bound that case
+        without punishing a merely slow agent, :data:`KEEPALIVE_HARD_CEILING_S`
+        sets an absolute wall-clock ceiling, computed ONCE per call and NOT
+        reset by pings (issue #829; the backstop explicitly deferred in #493).
         The caller's ``response_max_duration`` is checked *between*
         ``recv_audio`` calls and does **not** bound a single in-progress recv.
-        (An absolute caller-side backstop for the wedged-agent case is tracked
-        as a separate follow-up; it is intentionally not implemented here.)
         """
         import websockets  # for the ConnectionClosed terminal (issue #648)
 
         if self._ws is None:
             raise RuntimeError("ElevenLabsAgentAdapter: not connected")
 
-        deadline = asyncio.get_running_loop().time() + timeout
+        start = asyncio.get_running_loop().time()
+        deadline = start + timeout
+        # Absolute wall-clock ceiling that keepalive pings do NOT reset (#829 /
+        # the deferred #493 backstop). EL ConvAI pings indefinitely on a turn it
+        # will never answer with audio (e.g. after it ends or transfers its
+        # turn); with only the ping-resettable idle ``deadline`` this loop would
+        # wedge forever. The ceiling bounds that pings-but-no-audio case. At
+        # least ``timeout`` so it never pre-empts the idle deadline.
+        hard_deadline = start + max(timeout, KEEPALIVE_HARD_CEILING_S)
         while True:
-            remaining = deadline - asyncio.get_running_loop().time()
+            now = asyncio.get_running_loop().time()
+            remaining = min(deadline, hard_deadline) - now
             if remaining <= 0:
                 raise asyncio.TimeoutError("ElevenLabsAgentAdapter: recv_audio timed out")
 

--- a/python/tests/voice/test_elevenlabs_recv_keepalive.py
+++ b/python/tests/voice/test_elevenlabs_recv_keepalive.py
@@ -41,6 +41,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from scenario.voice import AudioChunk, ElevenLabsAgentAdapter
+from scenario.voice.adapters import elevenlabs as elevenlabs_module
 
 
 # Timing budget. Each ping gap is comfortably under TIMEOUT (so a
@@ -155,3 +156,158 @@ async def test_recv_audio_still_times_out_on_truly_dead_socket():
         await adapter.connect()
         with pytest.raises(asyncio.TimeoutError):
             await adapter.recv_audio(timeout=TIMEOUT)
+
+
+# --------------------------------------------------------------------------- #
+# Issue #829 — absolute hard-ceiling backstop on top of the keepalive-aware   #
+# sliding idle deadline above.                                                #
+# --------------------------------------------------------------------------- #
+#
+# #493 (tested above) made ``recv_audio`` tolerate a silent-but-pinging
+# stretch by resetting the idle deadline on every received frame, pings
+# included — but that fix deliberately left recv_audio willing to wait
+# *forever* as long as pings kept arriving (see the "Design decision" note in
+# the ``recv_audio`` docstring at the time). EL ConvAI ping indefinitely on a
+# turn it will never answer with audio (e.g. after it ends/transfers its
+# turn), so that unbounded wait would wedge a multi-turn run forever.
+#
+# The #829 fix adds ``KEEPALIVE_HARD_CEILING_S``: an absolute wall-clock
+# ceiling, computed ONCE per ``recv_audio`` call and NOT reset by pings. These
+# tests monkeypatch the module constant down to a small value so they run in
+# well under a second, mirroring how ``TIMEOUT``/``PING_GAP`` are scaled down
+# above for the #493 tests.
+
+# Scaled-down timings for the hard-ceiling tests. HARD_CEILING must be >=
+# IDLE_TIMEOUT (recv_audio's own ``timeout`` argument) so
+# ``max(timeout, KEEPALIVE_HARD_CEILING_S)`` actually selects the ceiling —
+# otherwise these tests would degenerate into re-testing the idle deadline.
+IDLE_TIMEOUT = 0.10   # recv_audio's own per-call idle-wait budget
+# NOT named PING_GAP: that name is already bound at module level (0.08, above)
+# for the #493 tests. A same-named module-level assignment here would REBIND
+# that global for the rest of the module's lifetime — the #493 test functions
+# read PING_GAP at call time (after the whole module has finished importing),
+# so they'd silently pick up this smaller value instead of their own.
+CEILING_PING_GAP = 0.03  # delay before each ping frame; < IDLE_TIMEOUT so pings keep re-arming it
+HARD_CEILING = 0.25   # scaled-down stand-in for KEEPALIVE_HARD_CEILING_S (real value: 45s)
+
+assert CEILING_PING_GAP < IDLE_TIMEOUT, (
+    f"timing invariant broken: CEILING_PING_GAP={CEILING_PING_GAP} must be < "
+    f"IDLE_TIMEOUT={IDLE_TIMEOUT} so the idle deadline never trips on its own"
+)
+assert HARD_CEILING >= IDLE_TIMEOUT, (
+    f"timing invariant broken: HARD_CEILING={HARD_CEILING} must be >= IDLE_TIMEOUT="
+    f"{IDLE_TIMEOUT} so max(timeout, HARD_CEILING) actually selects the ceiling"
+)
+
+
+def _make_endless_pinging_ws() -> AsyncMock:
+    """A mock WS whose ``recv()`` yields an unbounded stream of pings, each
+    preceded by a :data:`CEILING_PING_GAP` sleep, and NEVER an audio frame —
+    modelling a turn EL ConvAI will never answer with audio."""
+    call_index = 0
+
+    async def fake_recv():
+        nonlocal call_index
+        await asyncio.sleep(CEILING_PING_GAP)
+        event_id = call_index
+        call_index += 1
+        return json.dumps(
+            {"type": "ping", "ping_event": {"event_id": event_id, "ping_ms": 5}}
+        )
+
+    mock_ws = AsyncMock()
+    mock_ws.recv = fake_recv
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+    return mock_ws
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_recv_audio_hard_ceiling_fires_despite_endless_pings(monkeypatch):
+    """Issue #829: steady pings alone must NOT let recv_audio wait forever.
+
+    Each ping gap (``CEILING_PING_GAP``) is comfortably under ``IDLE_TIMEOUT``,
+    so the keepalive-aware sliding idle deadline (#493) is re-armed every time and
+    would, on its own, let this run indefinitely. But the pings never stop and
+    audio never arrives — the total pinging stretch is unbounded, and greatly
+    exceeds the (scaled-down) ``KEEPALIVE_HARD_CEILING_S``. The absolute
+    hard-ceiling backstop must fire and raise ``asyncio.TimeoutError`` instead
+    of hanging.
+
+    ``@pytest.mark.timeout(5)`` is a safety net, not the behavior under test:
+    if the hard ceiling regresses back to "wait forever on pings", this test
+    fails fast instead of hanging the suite.
+    """
+    monkeypatch.setattr(elevenlabs_module, "KEEPALIVE_HARD_CEILING_S", HARD_CEILING)
+
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    mock_ws = _make_endless_pinging_ws()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+
+
+@pytest.mark.asyncio
+async def test_recv_audio_succeeds_when_slow_agent_responds_before_hard_ceiling(monkeypatch):
+    """Issue #829 guard: the hard ceiling must not punish a genuinely slow —
+    but eventually responding — agent.
+
+    A few pings arrive (each gap < ``IDLE_TIMEOUT``, so the sliding idle
+    deadline tolerates them per #493) and THEN audio arrives, all well before
+    the (scaled-down) ``KEEPALIVE_HARD_CEILING_S`` elapses. ``recv_audio``
+    must still return the audio normally — the ceiling bounds a
+    pings-but-no-audio stretch, not a merely slow one.
+
+    Monkeypatches the same scaled-down ``HARD_CEILING`` as the fires-despite-
+    endless-pings test above: against the real 45s default this scenario
+    would trivially pass regardless of whether the ceiling logic is correct,
+    so exercising the actual (scaled) boundary is what makes this test
+    meaningful.
+    """
+    monkeypatch.setattr(elevenlabs_module, "KEEPALIVE_HARD_CEILING_S", HARD_CEILING)
+
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    pcm_payload = b"\x56\x78" * 8  # 16 bytes of dummy PCM16
+    b64_audio = base64.b64encode(pcm_payload).decode()
+
+    # 3 pings (0.09s of pinging) then audio, ~0.14s total — comfortably under
+    # both IDLE_TIMEOUT-per-gap (0.10s) and HARD_CEILING (0.25s).
+    frames: list[tuple[float, str]] = [
+        (
+            CEILING_PING_GAP,
+            json.dumps({"type": "ping", "ping_event": {"event_id": i, "ping_ms": 5}}),
+        )
+        for i in range(3)
+    ]
+    frames.append(
+        (CEILING_PING_GAP, json.dumps({"type": "audio", "audio_event": {"audio_base_64": b64_audio}}))
+    )
+    assert sum(delay for delay, _ in frames) < HARD_CEILING, (
+        "timing invariant broken: total frame delay must stay under HARD_CEILING "
+        "so this test actually proves the slow-but-responding path, not the ceiling"
+    )
+
+    call_index = 0
+
+    async def fake_recv():
+        nonlocal call_index
+        delay, msg = frames[call_index]
+        call_index += 1
+        await asyncio.sleep(delay)
+        return msg
+
+    mock_ws = AsyncMock()
+    mock_ws.recv = fake_recv
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        result = await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+
+    assert isinstance(result, AudioChunk)
+    assert result.data == pcm_payload


### PR DESCRIPTION
## Summary

Fixes #829. The Python `ElevenLabsAgentAdapter.recv_audio` was missing the absolute wall-clock hard-ceiling that the JS adapter already has (from #707).

- EL ConvAI can ping (keepalive) indefinitely on a turn it will never answer with audio (e.g. after it ends/transfers its turn).
- `recv_audio`'s idle deadline re-arms on **every** inbound frame, pings included (per #493/#649) — correct behavior for a legitimately slow-but-pinging agent, but it means a pings-but-no-audio stretch would wedge the receive **forever**, since there was no absolute ceiling (the backstop #493 deliberately deferred).
- Adds `KEEPALIVE_HARD_CEILING_S = 45.0`: an absolute wall-clock ceiling computed **once** per `recv_audio` call (`start + max(timeout, KEEPALIVE_HARD_CEILING_S)`), never reset by pings. The loop now waits against `min(deadline, hard_deadline)` and raises `asyncio.TimeoutError` when that's exceeded.
- Brings Python to parity with the JS adapter, which already has this exact mechanism (`KEEPALIVE_HARD_CEILING_S`, same value, same `max(timeout, ceiling)` sizing) from #707/AC-705.

Reimplemented fresh against current `main` per the issue's guidance — the only prior copy of this fix lived on an abandoned, unmerged, month-stale branch (`origin/fix/705-python-parity-wip`, 229 files diverged) that was not rebased/cherry-picked from.

## Changes

- `python/scenario/voice/adapters/elevenlabs.py`:
  - New module constant `KEEPALIVE_HARD_CEILING_S = 45.0` with docstring rationale mirroring the JS side.
  - `recv_audio`: compute `hard_deadline` once before the loop; wait against `min(deadline, hard_deadline)`; updated method docstring to describe the new ceiling (previously said "no total-duration ceiling... intentionally not implemented here" — now describes the #829 fix).
- `python/tests/voice/test_elevenlabs_recv_keepalive.py`:
  - New test `test_recv_audio_hard_ceiling_fires_despite_endless_pings`: steady pings (each gap under the idle timeout) for a stretch longer than a scaled-down, monkeypatched `KEEPALIVE_HARD_CEILING_S`, with audio never arriving → `recv_audio` raises `TimeoutError` instead of hanging.
  - New test `test_recv_audio_succeeds_when_slow_agent_responds_before_hard_ceiling`: a few pings then audio, all before the (scaled-down) ceiling → still succeeds normally, proving the ceiling isn't too aggressive.
  - Both mock `websockets.connect` (no real network) with small scaled-down timings; full file runs in ~1s.

Verified the JS adapter (`javascript/src/voice/adapters/elevenlabs.ts`) already has the equivalent fix from #707 (`KEEPALIVE_HARD_CEILING_S`, `AC-705` test) — no changes needed there, confirmed no regression by running its test suite.

## Test plan

- [x] New unit tests pass (`uv run pytest tests/voice/test_elevenlabs_recv_keepalive.py -v`) — 4 passed in ~1.2s
- [x] Confirmed RED without the fix: reverting the production change makes the new tests fail (`AttributeError` on the now-missing constant), and a standalone repro script confirms `recv_audio` genuinely hangs past a 2s guard against endless pings on pre-fix code
- [x] Full Python voice unit suite green: `uv run pytest tests/voice/ -m "not integration"` — 544 passed, 35 deselected (e2e, needs live creds)
- [x] `pyright` and `ruff check` clean on the changed file
- [x] JS adapter test suite green: `npx vitest run src/voice/adapters/__tests__/elevenlabs.test.ts` — 54 passed, including AC-705 (hard-ceiling) and AC-KA5 (idle-deadline) tests
- [ ] Not validated against a live hosted ElevenLabs ConvAI agent (no `ELEVENLABS_API_KEY`/`ELEVENLABS_AGENT_ID` in this environment) — the env-gated e2e tests self-skip without those keys, per the issue's guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)