### PR TITLE
fix(judge): protect unbounded judge transcript for non-litellm agents

### DIFF
--- a/python/examples/test_judge_transcript_size_protection_e2e.py
+++ b/python/examples/test_judge_transcript_size_protection_e2e.py
@@ -60,13 +60,17 @@ class NonLitellmSalesAgent(scenario.AgentAdapter):
                 f"row_{i}_{j}=value_{j}" for j in range(100)
             )
             messages.append({"role": "tool", "tool_call_id": call_id, "content": f"[{row}]"})
+        # Deliberately generic -- NEEDLE_FACT must not be restated here. If it
+        # were, the judge could pass by reading this summary alone (e.g. via
+        # a cheap expand_transcript on just the last message), without ever
+        # searching the buried tool result, which would defeat the point of
+        # this test: proving the judge can dig a fact out of a large,
+        # non-litellm tool-call history rather than relying on it being
+        # conveniently restated in the final assistant turn.
         messages.append(
             {
                 "role": "assistant",
-                "content": (
-                    "I checked 27 sales records. Order ORD-88421 was refunded "
-                    "for $204.50."
-                ),
+                "content": "I checked 27 sales records.",
             }
         )
         return messages

--- a/python/examples/test_judge_transcript_size_protection_e2e.py
+++ b/python/examples/test_judge_transcript_size_protection_e2e.py
@@ -1,0 +1,101 @@
+"""
+End-to-end example: a non-litellm agent adapter with a large tool-call
+transcript, judged by a real JudgeAgent.
+
+Reproduces the exact shape of issue #836: an AgentAdapter that never routes
+its own tool calls through litellm (so JudgeSpanCollector never sees them)
+returns many large tool-call/tool-result messages in one turn. Before the
+fix, this content flowed into the judge prompt completely unbounded and the
+judge's size-management system (gated only on litellm spans) never
+activated.
+
+This test buries a single fact deep inside 27 large tool-call results and
+asks the judge to verify it -- proving the judge can still find and use
+that fact via the transcript's own discovery tools (expand_transcript /
+grep_transcript) instead of the content silently exceeding the judge
+model's effective attention ("lost in the middle").
+"""
+
+import json
+
+import pytest
+
+import scenario
+from scenario.types import AgentInput, AgentReturnTypes
+
+scenario.configure(default_model="openai/gpt-4.1-mini")
+
+NEEDLE_QUERY_INDEX = 13
+NEEDLE_FACT = "order_id=ORD-88421 status=REFUNDED refund_amount=204.50"
+
+
+class NonLitellmSalesAgent(scenario.AgentAdapter):
+    """Simulates an agent that talks to its own backend directly (e.g. a
+    proprietary REST/SSE API) and never calls litellm itself for tool
+    execution -- so none of its tool calls ever become an OpenTelemetry
+    span. Returns 27 large tool-call/tool-result message pairs in one turn,
+    matching the reporter's real repro shape (issue #836)."""
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        messages = []
+        for i in range(27):
+            call_id = f"call_{i}"
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "run_sql",
+                                "arguments": json.dumps({"query": f"SELECT * FROM sales_{i}"}),
+                            },
+                        }
+                    ],
+                }
+            )
+            row = NEEDLE_FACT if i == NEEDLE_QUERY_INDEX else ",".join(
+                f"row_{i}_{j}=value_{j}" for j in range(100)
+            )
+            messages.append({"role": "tool", "tool_call_id": call_id, "content": f"[{row}]"})
+        messages.append(
+            {
+                "role": "assistant",
+                "content": (
+                    "I checked 27 sales records. Order ORD-88421 was refunded "
+                    "for $204.50."
+                ),
+            }
+        )
+        return messages
+
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio
+async def test_judge_finds_needle_in_large_non_litellm_transcript():
+    """A judge criterion that depends on a fact buried inside a large,
+    non-litellm tool-call transcript must still be verifiable -- proving
+    #836's transcript-size protection activates for agents that never
+    produce spans."""
+    result = await scenario.run(
+        name="non-litellm large transcript judge",
+        description="User asks the agent to check on the status of order ORD-88421.",
+        agents=[
+            NonLitellmSalesAgent(),
+            scenario.UserSimulatorAgent(),
+            scenario.JudgeAgent(
+                criteria=[
+                    "Agent's tool call results confirm order ORD-88421 was refunded for $204.50",
+                ],
+            ),
+        ],
+        script=[
+            scenario.user("Can you check the status of order ORD-88421?"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+
+    assert result.success is True, result.reasoning

--- a/python/scenario/_judge/__init__.py
+++ b/python/scenario/_judge/__init__.py
@@ -13,6 +13,7 @@ from .judge_span_digest_formatter import (
 )
 from .judge_utils import JudgeUtils
 from .trace_tools import expand_trace, grep_trace
+from .transcript_tools import expand_transcript, grep_transcript
 
 __all__ = [
     "DEFAULT_TOKEN_THRESHOLD",
@@ -20,6 +21,8 @@ __all__ = [
     "JudgeUtils",
     "estimate_tokens",
     "expand_trace",
+    "expand_transcript",
     "grep_trace",
+    "grep_transcript",
     "judge_span_digest_formatter",
 ]

--- a/python/scenario/_judge/judge_utils.py
+++ b/python/scenario/_judge/judge_utils.py
@@ -177,8 +177,69 @@ def _render_tool_call(call: Any) -> Optional[str]:
     return f"{name}({rendered_args})"
 
 
+def _render_message_line(msg: Any, id_to_name: Dict[str, str]) -> str:
+    """
+    Renders a single message as one transcript line. Shared by
+    ``build_transcript_from_messages`` (the full transcript) and the
+    transcript discovery tools (``expand_transcript``/``grep_transcript``),
+    which need the exact same per-message rendering to index into.
+    """
+    role = msg.get("role", "unknown")
+    content = msg.get("content", "")
+    truncated_content = _truncate_base64_media(content)
+
+    tool_calls = msg.get("tool_calls")
+    if isinstance(tool_calls, list) and tool_calls:
+        # Assistant turn with tool calls. Render one [tool_call: ...]
+        # segment per call, in emission order, alongside any text content.
+        # When content is None/empty (the common pure-tool-call shape),
+        # omit the bare `null`/`""` so the line never reads `assistant: null`.
+        rendered_calls = [
+            f"[tool_call: {rendered}]"
+            for call in tool_calls
+            if (rendered := _render_tool_call(call)) is not None
+        ]
+        segments: List[str] = []
+        if content not in (None, ""):
+            segments.append(json.dumps(truncated_content))
+        segments.extend(rendered_calls)
+        return f"{role}: {' '.join(segments)}"
+
+    if role == "tool":
+        # Tool result. Resolve the originating function name from the
+        # id->name map built in the first pass.
+        tool_call_id = msg.get("tool_call_id")
+        name = (
+            id_to_name.get(tool_call_id) if isinstance(tool_call_id, str) else None
+        ) or "unknown"
+        return f"tool ({name}): {json.dumps(truncated_content)}"
+
+    return f"{role}: {json.dumps(truncated_content)}"
+
+
 class JudgeUtils:
     """Utilities for the Judge agent."""
+
+    @staticmethod
+    def render_transcript_lines(
+        messages: List[ChatCompletionMessageParam],
+    ) -> List[str]:
+        """
+        Renders each message to its own transcript line, in order.
+
+        This is the same rendering ``build_transcript_from_messages`` joins
+        into a single string, exposed separately so callers (e.g. the
+        transcript discovery tools) can index individual messages by
+        position without re-implementing the rendering rules.
+
+        Args:
+            messages: Array of ChatCompletionMessageParam from conversation
+
+        Returns:
+            One rendered line per message, same order as ``messages``.
+        """
+        id_to_name = _build_tool_call_id_to_name(messages)
+        return [_render_message_line(msg, id_to_name) for msg in messages]
 
     @staticmethod
     def build_transcript_from_messages(
@@ -199,43 +260,4 @@ class JudgeUtils:
         Returns:
             Plain text transcript with one message per line
         """
-        id_to_name = _build_tool_call_id_to_name(messages)
-
-        lines = []
-        for msg in messages:
-            role = msg.get("role", "unknown")
-            content = msg.get("content", "")
-            truncated_content = _truncate_base64_media(content)
-
-            tool_calls = msg.get("tool_calls")
-            if isinstance(tool_calls, list) and tool_calls:
-                # Assistant turn with tool calls. Render one [tool_call: ...]
-                # segment per call, in emission order, alongside any text content.
-                # When content is None/empty (the common pure-tool-call shape),
-                # omit the bare `null`/`""` so the line never reads `assistant: null`.
-                rendered_calls = [
-                    f"[tool_call: {rendered}]"
-                    for call in tool_calls
-                    if (rendered := _render_tool_call(call)) is not None
-                ]
-                segments: List[str] = []
-                if content not in (None, ""):
-                    segments.append(json.dumps(truncated_content))
-                segments.extend(rendered_calls)
-                lines.append(f"{role}: {' '.join(segments)}")
-                continue
-
-            if role == "tool":
-                # Tool result. Resolve the originating function name from the
-                # id->name map built in the first pass.
-                tool_call_id = msg.get("tool_call_id")
-                name = (
-                    id_to_name.get(tool_call_id)
-                    if isinstance(tool_call_id, str)
-                    else None
-                ) or "unknown"
-                lines.append(f"tool ({name}): {json.dumps(truncated_content)}")
-                continue
-
-            lines.append(f"{role}: {json.dumps(truncated_content)}")
-        return "\n".join(lines)
+        return "\n".join(JudgeUtils.render_transcript_lines(messages))

--- a/python/scenario/_judge/judge_utils.py
+++ b/python/scenario/_judge/judge_utils.py
@@ -177,7 +177,9 @@ def _render_tool_call(call: Any) -> Optional[str]:
     return f"{name}({rendered_args})"
 
 
-def _render_message_line(msg: Any, id_to_name: Dict[str, str]) -> str:
+def _render_message_line(
+    msg: ChatCompletionMessageParam, id_to_name: Dict[str, str]
+) -> str:
     """
     Renders a single message as one transcript line. Shared by
     ``build_transcript_from_messages`` (the full transcript) and the

--- a/python/scenario/_judge/transcript_tools.py
+++ b/python/scenario/_judge/transcript_tools.py
@@ -17,7 +17,7 @@ keyed on the transcript's own estimated token count rather than on spans.
 
 import re
 from dataclasses import dataclass
-from typing import Any, List, Sequence
+from typing import Any, Final, List, Sequence
 
 from openai.types.chat import ChatCompletionMessageParam
 
@@ -26,13 +26,13 @@ from .judge_utils import JudgeUtils
 
 # Budget constants (mirrors trace_tools.py's budgets so discovery results
 # stay comparably sized regardless of which discovery path produced them).
-TOOL_RESULT_TOKEN_BUDGET = 4096
+TOOL_RESULT_TOKEN_BUDGET: Final[int] = 4096
 """Maximum estimated tokens for a single tool result."""
 
-TOOL_RESULT_CHAR_BUDGET = TOOL_RESULT_TOKEN_BUDGET * 4
+TOOL_RESULT_CHAR_BUDGET: Final[int] = TOOL_RESULT_TOKEN_BUDGET * 4
 """Maximum characters for a single tool result (~4000 tokens * 4 chars)."""
 
-MAX_GREP_MATCHES = 20
+MAX_GREP_MATCHES: Final[int] = 20
 """Maximum number of grep matches returned."""
 
 
@@ -41,7 +41,7 @@ class _IndexedMessage:
     """A message paired with its rendered transcript line and 0-based index."""
 
     index: int
-    message: Any
+    message: ChatCompletionMessageParam
     line: str
 
 

--- a/python/scenario/_judge/transcript_tools.py
+++ b/python/scenario/_judge/transcript_tools.py
@@ -143,9 +143,23 @@ def expand_transcript(
     if len(indices) == 0:
         return "Error: provide at least one message index."
 
+    # Defensive: the tool schema declares `indices` as integers, but not
+    # every litellm-routed provider enforces function-call argument types as
+    # strictly as OpenAI does. A non-integer entry (e.g. a stringified "2")
+    # must not crash the discovery loop -- coerce what's coercible and drop
+    # the rest instead of raising (sorting a mixed-type set below would
+    # otherwise TypeError).
+    parsed_indices: List[int] = []
+    malformed: List[Any] = []
+    for raw in indices:
+        try:
+            parsed_indices.append(int(raw))
+        except (TypeError, ValueError):
+            malformed.append(raw)
+
     valid_range = range(len(indexed))
-    selected = [entry for entry in indexed if entry.index in indices]
-    invalid = sorted(set(indices) - set(valid_range))
+    selected = [entry for entry in indexed if entry.index in parsed_indices]
+    out_of_range = sorted(set(parsed_indices) - set(valid_range))
 
     if not selected:
         return (
@@ -156,8 +170,10 @@ def expand_transcript(
     lines: List[str] = []
     for entry in selected:
         lines.append(f"[{entry.index}] {entry.line}")
-    if invalid:
-        lines.append(f"\n[Ignored out-of-range indices: {invalid}]")
+    if out_of_range:
+        lines.append(f"\n[Ignored out-of-range indices: {out_of_range}]")
+    if malformed:
+        lines.append(f"\n[Ignored non-integer indices: {malformed}]")
 
     return _truncate_to_char_budget("\n".join(lines).rstrip())
 

--- a/python/scenario/_judge/transcript_tools.py
+++ b/python/scenario/_judge/transcript_tools.py
@@ -74,6 +74,31 @@ def _truncate_to_char_budget(text: str) -> str:
     )
 
 
+def _skeleton_line(entry: _IndexedMessage) -> str:
+    """Renders one message's structure-only skeleton line: index, role,
+    tool-call name(s) if any, and estimated size — but not its content."""
+    msg = entry.message
+    role = msg.get("role", "unknown") if isinstance(msg, dict) else "unknown"
+    tokens = estimate_tokens(entry.line)
+
+    note = ""
+    tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
+    if isinstance(tool_calls, list) and tool_calls:
+        names = [
+            call.get("function", {}).get("name", "unknown")
+            for call in tool_calls
+            if isinstance(call, dict)
+        ]
+        note = f" [tool_calls: {', '.join(names)}]"
+    elif role == "tool":
+        # Reuse the same "tool (name): ..." prefix the full line already
+        # carries instead of re-deriving the id->name mapping here.
+        prefix = entry.line.split(":", 1)[0]
+        note = f" [{prefix}]"
+
+    return f"[{entry.index}] {role}{note} (~{tokens} tokens)"
+
+
 def build_transcript_skeleton(
     messages: Sequence[ChatCompletionMessageParam],
 ) -> str:
@@ -84,40 +109,62 @@ def build_transcript_skeleton(
     mirroring format_structure_only()'s relationship to expand_trace/grep_trace
     for spans.
 
+    Bounded to ~TOOL_RESULT_TOKEN_BUDGET tokens even though each line is
+    tiny: a transcript of thousands of short messages (e.g. a
+    streaming/high-frequency tool-call agent) can still produce a skeleton
+    that blows past the threshold it exists to enforce. When that happens,
+    a head+tail window is kept — the start frames the scenario, the end is
+    what the judge is actually deciding on — and the elided middle is still
+    reachable via expand_transcript/grep_transcript.
+
     Args:
         messages: The conversation messages.
 
     Returns:
-        Plain text skeleton, one line per message.
+        Plain text skeleton, one line per message (or a head+tail window).
     """
     indexed = _index_messages(messages)
     if not indexed:
         return "No messages recorded."
 
-    lines: List[str] = [f"Messages: {len(indexed)}", ""]
-    for entry in indexed:
-        msg = entry.message
-        role = msg.get("role", "unknown") if isinstance(msg, dict) else "unknown"
-        tokens = estimate_tokens(entry.line)
+    entry_lines = [_skeleton_line(entry) for entry in indexed]
+    header = f"Messages: {len(indexed)}"
+    full_body = "\n".join(entry_lines)
 
-        note = ""
-        tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
-        if isinstance(tool_calls, list) and tool_calls:
-            names = [
-                call.get("function", {}).get("name", "unknown")
-                for call in tool_calls
-                if isinstance(call, dict)
-            ]
-            note = f" [tool_calls: {', '.join(names)}]"
-        elif role == "tool":
-            # Reuse the same "tool (name): ..." prefix the full line already
-            # carries instead of re-deriving the id->name mapping here.
-            prefix = entry.line.split(":", 1)[0]
-            note = f" [{prefix}]"
+    if estimate_tokens(full_body) <= TOOL_RESULT_TOKEN_BUDGET:
+        return f"{header}\n\n{full_body}"
 
-        lines.append(f"[{entry.index}] {role}{note} (~{tokens} tokens)")
+    half_budget = TOOL_RESULT_TOKEN_BUDGET // 2
+    head: List[str] = []
+    head_tokens = 0
+    for line in entry_lines:
+        line_tokens = estimate_tokens(line)
+        if head and head_tokens + line_tokens > half_budget:
+            break
+        head.append(line)
+        head_tokens += line_tokens
 
-    return "\n".join(lines)
+    tail: List[str] = []
+    tail_tokens = 0
+    for line in reversed(entry_lines[len(head):]):
+        line_tokens = estimate_tokens(line)
+        if tail and tail_tokens + line_tokens > half_budget:
+            break
+        tail.append(line)
+        tail_tokens += line_tokens
+    tail.reverse()
+
+    omitted = len(entry_lines) - len(head) - len(tail)
+    middle = (
+        [
+            f"... [{omitted} messages omitted — use grep_transcript(pattern) "
+            "or expand_transcript(indices) to reach them] ..."
+        ]
+        if omitted > 0
+        else []
+    )
+    body = "\n".join(head + middle + tail)
+    return f"{header}\n\n{body}"
 
 
 def expand_transcript(
@@ -157,9 +204,10 @@ def expand_transcript(
         except (TypeError, ValueError):
             malformed.append(raw)
 
+    parsed_index_set = set(parsed_indices)
     valid_range = range(len(indexed))
-    selected = [entry for entry in indexed if entry.index in parsed_indices]
-    out_of_range = sorted(set(parsed_indices) - set(valid_range))
+    selected = [entry for entry in indexed if entry.index in parsed_index_set]
+    out_of_range = sorted(parsed_index_set - set(valid_range))
 
     if not selected:
         return (

--- a/python/scenario/_judge/transcript_tools.py
+++ b/python/scenario/_judge/transcript_tools.py
@@ -1,0 +1,217 @@
+"""
+Tools for progressive transcript discovery: expand_transcript and grep_transcript.
+
+Mirrors ``trace_tools.py``'s ``expand_trace``/``grep_trace``, but operates on
+the raw conversation messages instead of OpenTelemetry spans.
+
+Why this exists: ``JudgeSpanCollector`` only ever contains spans created by
+``autotrack_litellm_calls`` — completions made through litellm in the
+harness's own process. An ``AgentAdapter`` that talks to its own backend
+directly (REST/SSE/gRPC/etc., not via litellm) produces tool-call messages
+that never become spans, so the span-based size-management system (structure
+-only digest + expand_trace/grep_trace) is blind to that content, while the
+message transcript built from ``input.messages`` carries it unbounded. This
+module gives the transcript itself the same bounded-discovery treatment,
+keyed on the transcript's own estimated token count rather than on spans.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any, List, Sequence
+
+from openai.types.chat import ChatCompletionMessageParam
+
+from .estimate_tokens import estimate_tokens
+from .judge_utils import JudgeUtils
+
+# Budget constants (mirrors trace_tools.py's budgets so discovery results
+# stay comparably sized regardless of which discovery path produced them).
+TOOL_RESULT_TOKEN_BUDGET = 4096
+"""Maximum estimated tokens for a single tool result."""
+
+TOOL_RESULT_CHAR_BUDGET = TOOL_RESULT_TOKEN_BUDGET * 4
+"""Maximum characters for a single tool result (~4000 tokens * 4 chars)."""
+
+MAX_GREP_MATCHES = 20
+"""Maximum number of grep matches returned."""
+
+
+@dataclass
+class _IndexedMessage:
+    """A message paired with its rendered transcript line and 0-based index."""
+
+    index: int
+    message: Any
+    line: str
+
+
+def _index_messages(
+    messages: Sequence[ChatCompletionMessageParam],
+) -> List[_IndexedMessage]:
+    """Renders every message and pairs it with its position, preserving order.
+
+    Order is the conversation's own order (the same order the full transcript
+    renders in) — unlike spans, messages have no independent start-time to
+    re-sort by, so position IS the identity discovery tools reference.
+    """
+    lines = JudgeUtils.render_transcript_lines(list(messages))
+    return [
+        _IndexedMessage(index=i, message=msg, line=line)
+        for i, (msg, line) in enumerate(zip(messages, lines))
+    ]
+
+
+def _truncate_to_char_budget(text: str) -> str:
+    """Truncates text to fit within the tool result character budget."""
+    if len(text) <= TOOL_RESULT_CHAR_BUDGET:
+        return text
+    truncated = text[:TOOL_RESULT_CHAR_BUDGET]
+    return (
+        truncated
+        + "\n\n[TRUNCATED] Output exceeded ~4000 token budget. "
+        "Use grep_transcript(pattern) to search for specific content, "
+        "or expand_transcript with fewer indices."
+    )
+
+
+def build_transcript_skeleton(
+    messages: Sequence[ChatCompletionMessageParam],
+) -> str:
+    """
+    Builds a structure-only view of the transcript: one line per message
+    showing its index, role, tool-call name(s) if any, and estimated size —
+    but not its content. Paired with expand_transcript/grep_transcript,
+    mirroring format_structure_only()'s relationship to expand_trace/grep_trace
+    for spans.
+
+    Args:
+        messages: The conversation messages.
+
+    Returns:
+        Plain text skeleton, one line per message.
+    """
+    indexed = _index_messages(messages)
+    if not indexed:
+        return "No messages recorded."
+
+    lines: List[str] = [f"Messages: {len(indexed)}", ""]
+    for entry in indexed:
+        msg = entry.message
+        role = msg.get("role", "unknown") if isinstance(msg, dict) else "unknown"
+        tokens = estimate_tokens(entry.line)
+
+        note = ""
+        tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
+        if isinstance(tool_calls, list) and tool_calls:
+            names = [
+                call.get("function", {}).get("name", "unknown")
+                for call in tool_calls
+                if isinstance(call, dict)
+            ]
+            note = f" [tool_calls: {', '.join(names)}]"
+        elif role == "tool":
+            # Reuse the same "tool (name): ..." prefix the full line already
+            # carries instead of re-deriving the id->name mapping here.
+            prefix = entry.line.split(":", 1)[0]
+            note = f" [{prefix}]"
+
+        lines.append(f"[{entry.index}] {role}{note} (~{tokens} tokens)")
+
+    return "\n".join(lines)
+
+
+def expand_transcript(
+    messages: Sequence[ChatCompletionMessageParam],
+    indices: List[int],
+) -> str:
+    """
+    Expands one or more messages from the transcript, returning their full
+    rendered content.
+
+    Args:
+        messages: The full array of conversation messages.
+        indices: 0-based message indices to expand (as shown in the skeleton).
+
+    Returns:
+        Formatted string with full message content, truncated to ~4096 tokens.
+    """
+    indexed = _index_messages(messages)
+
+    if len(indexed) == 0:
+        return "No messages recorded."
+
+    if len(indices) == 0:
+        return "Error: provide at least one message index."
+
+    valid_range = range(len(indexed))
+    selected = [entry for entry in indexed if entry.index in indices]
+    invalid = sorted(set(indices) - set(valid_range))
+
+    if not selected:
+        return (
+            f"Error: no messages matched the given indices. "
+            f"Valid range: 0-{len(indexed) - 1}."
+        )
+
+    lines: List[str] = []
+    for entry in selected:
+        lines.append(f"[{entry.index}] {entry.line}")
+    if invalid:
+        lines.append(f"\n[Ignored out-of-range indices: {invalid}]")
+
+    return _truncate_to_char_budget("\n".join(lines).rstrip())
+
+
+def grep_transcript(
+    messages: Sequence[ChatCompletionMessageParam], pattern: str
+) -> str:
+    """
+    Searches across all rendered message lines for a pattern.
+
+    Args:
+        messages: The full array of conversation messages.
+        pattern: Case-insensitive search pattern.
+
+    Returns:
+        Formatted string with matches, limited to 20 results and ~4000 tokens.
+    """
+    indexed = _index_messages(messages)
+
+    if len(indexed) == 0:
+        return "No messages recorded."
+
+    escaped_pattern = re.escape(pattern)
+    regex = re.compile(escaped_pattern, re.IGNORECASE)
+
+    matches = [entry for entry in indexed if regex.search(entry.line)]
+
+    if not matches:
+        roles = list(
+            dict.fromkeys(
+                m.get("role", "unknown") if isinstance(m, dict) else "unknown"
+                for m in messages
+            )
+        )
+        return f'No matches found for "{pattern}". Roles present: {", ".join(roles)}'
+
+    total_matches = len(matches)
+    limited = matches[:MAX_GREP_MATCHES]
+
+    lines: List[str] = []
+    for entry in limited:
+        role = (
+            entry.message.get("role", "unknown")
+            if isinstance(entry.message, dict)
+            else "unknown"
+        )
+        lines.append(f"--- [{entry.index}] {role} ---")
+        lines.append(f"  {entry.line}")
+        lines.append("")
+
+    if total_matches > MAX_GREP_MATCHES:
+        lines.append(
+            f"[{total_matches - MAX_GREP_MATCHES} more matches omitted. "
+            "Refine your search pattern for more specific results.]"
+        )
+
+    return _truncate_to_char_budget("\n".join(lines).rstrip())

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -15,6 +15,7 @@ from typing import Any, List, Optional, Sequence, cast
 import litellm
 from litellm import Choices
 from litellm.files.main import ModelResponse
+from openai.types.chat import ChatCompletionMessageParam
 
 from scenario.cache import scenario_cache
 from scenario.agent_adapter import AgentAdapter
@@ -856,7 +857,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         tools: List[dict],
         tool_choice: Any,
         spans: Sequence[Any],
-        working_messages: Sequence[Any],
+        working_messages: Sequence[ChatCompletionMessageParam],
         effective_criteria: List[str],
         input_messages: Sequence[Any],
     ) -> AgentReturnTypes:
@@ -1018,7 +1019,10 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         )
 
     def _execute_discovery_tool(
-        self, tool_call: Any, spans: Sequence[Any], working_messages: Sequence[Any]
+        self,
+        tool_call: Any,
+        spans: Sequence[Any],
+        working_messages: Sequence[ChatCompletionMessageParam],
     ) -> str:
         """
         Executes an expand_trace, grep_trace, expand_transcript, or

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -24,6 +24,11 @@ from ._error_messages import agent_not_configured_error_message
 from ._judge import JudgeUtils, judge_span_digest_formatter
 from ._judge.estimate_tokens import estimate_tokens, DEFAULT_TOKEN_THRESHOLD
 from ._judge.trace_tools import expand_trace, grep_trace
+from ._judge.transcript_tools import (
+    build_transcript_skeleton,
+    expand_transcript,
+    grep_transcript,
+)
 from ._tracing import judge_span_collector, JudgeSpanCollector
 from .types import AgentInput, AgentReturnTypes, AgentRole, ScenarioResult
 from .voice._transcribe import transcribe_segments
@@ -33,7 +38,9 @@ from .voice.modality_resolver import ModalityTier, resolve_modality
 logger = logging.getLogger("scenario")
 
 
-_DISCOVERY_TOOL_NAMES = frozenset({"expand_trace", "grep_trace"})
+_DISCOVERY_TOOL_NAMES = frozenset(
+    {"expand_trace", "grep_trace", "expand_transcript", "grep_transcript"}
+)
 
 
 def _stringify_tool_output(output: Any) -> str:
@@ -491,7 +498,26 @@ class JudgeAgent(AgentAdapter):
                 )
         transcript = JudgeUtils.build_transcript_from_messages(working_messages)
         spans = self._span_collector.get_spans_for_thread(input.thread_id)
-        digest, is_large_trace = self._build_trace_digest(spans)
+        digest, is_large_span_trace = self._build_trace_digest(spans)
+
+        # The transcript is built from input.messages regardless of whether
+        # the agent under test routed its calls through litellm, so it can be
+        # arbitrarily large even when `spans` (litellm-only) stays small and
+        # `is_large_span_trace` never trips (issue #836). Gate the transcript
+        # itself on its own estimated size, independent of the span digest,
+        # so an agent whose tool calls never became spans still gets bounded
+        # transcript rendering + discovery tools instead of an unbounded
+        # block silently flowing into the judge prompt.
+        is_large_transcript = estimate_tokens(transcript) > self._token_threshold
+        is_large_trace = is_large_span_trace or is_large_transcript
+
+        if is_large_transcript:
+            transcript_for_prompt = (
+                build_transcript_skeleton(working_messages)
+                + "\n\nUse expand_transcript(indices) to see full message content or grep_transcript(pattern) to search across messages. Reference messages by the index shown in brackets."
+            )
+        else:
+            transcript_for_prompt = transcript
 
         logger.debug(f"OpenTelemetry traces built: {digest[:200]}...")
 
@@ -508,7 +534,7 @@ class JudgeAgent(AgentAdapter):
 
         content_for_judge = f"""
 <transcript>
-{transcript}
+{transcript_for_prompt}
 </transcript>
 <opentelemetry_traces>
 {digest}
@@ -627,8 +653,10 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             },
         ]
 
-        if is_large_trace:
+        if is_large_span_trace:
             tools = self._build_progressive_discovery_tools() + tools
+        if is_large_transcript:
+            tools = self._build_transcript_discovery_tools() + tools
 
         enforce_judgment = input.judgment_request is not None
         has_criteria = len(effective_criteria) > 0
@@ -653,6 +681,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 tools=tools,
                 tool_choice=tool_choice,
                 spans=spans,
+                working_messages=working_messages,
                 effective_criteria=effective_criteria,
                 input_messages=input.messages,
             )
@@ -763,6 +792,63 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             },
         ]
 
+    def _build_transcript_discovery_tools(self) -> List[dict]:
+        """
+        Builds the expand_transcript and grep_transcript tool definitions for
+        litellm. Parallel to ``_build_progressive_discovery_tools``, but for
+        message-transcript discovery instead of span discovery (see
+        ``transcript_tools.py`` for why the two need to be independent).
+
+        Returns:
+            List of tool definition dicts for litellm function calling.
+        """
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "expand_transcript",
+                    "description": (
+                        "Expand one or more messages to see their full content. "
+                        "Use the message index shown in brackets in the transcript "
+                        "skeleton."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "indices": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "description": "0-based message indices to expand",
+                            },
+                        },
+                        "required": ["indices"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "grep_transcript",
+                    "description": (
+                        "Search across all message content for a pattern "
+                        "(case-insensitive). Returns matching messages with context."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "pattern": {
+                                "type": "string",
+                                "description": "Search pattern (case-insensitive)",
+                            },
+                        },
+                        "required": ["pattern"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+        ]
+
     def _run_discovery_loop(
         self,
         *,
@@ -770,25 +856,29 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         tools: List[dict],
         tool_choice: Any,
         spans: Sequence[Any],
+        working_messages: Sequence[Any],
         effective_criteria: List[str],
         input_messages: Sequence[Any],
     ) -> AgentReturnTypes:
         """
         Runs the multi-step discovery loop for large traces.
 
-        The judge can call expand_trace/grep_trace tools multiple times before
-        reaching a terminal tool (finish_test/continue_test) or hitting the
-        max discovery steps limit.
+        The judge can call expand_trace/grep_trace (spans) and/or
+        expand_transcript/grep_transcript (messages) tools multiple times
+        before reaching a terminal tool (finish_test/continue_test) or
+        hitting the max discovery steps limit.
 
         On intermediate steps, tool_choice is "required" so the judge can freely
-        pick expand_trace/grep_trace. On the final step, the original tool_choice
+        pick a discovery tool. On the final step, the original tool_choice
         (which may force finish_test) is applied.
 
         Args:
             messages: The conversation messages so far.
             tools: The tool definitions.
             tool_choice: The tool choice constraint for the final step.
-            spans: The spans for executing expand/grep tools.
+            spans: The spans for executing expand_trace/grep_trace.
+            working_messages: The conversation messages for executing
+                expand_transcript/grep_transcript.
             effective_criteria: The criteria to judge against.
 
         Returns:
@@ -855,7 +945,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             })
 
             for tc in message.tool_calls:
-                tool_result = self._execute_discovery_tool(tc, spans)
+                tool_result = self._execute_discovery_tool(tc, spans, working_messages)
                 messages.append({
                     "role": "tool",
                     "tool_call_id": tc.id,
@@ -927,13 +1017,18 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             forced_response, effective_criteria, rewritten_messages, input_messages=input_messages
         )
 
-    def _execute_discovery_tool(self, tool_call: Any, spans: Sequence[Any]) -> str:
+    def _execute_discovery_tool(
+        self, tool_call: Any, spans: Sequence[Any], working_messages: Sequence[Any]
+    ) -> str:
         """
-        Executes an expand_trace or grep_trace tool call.
+        Executes an expand_trace, grep_trace, expand_transcript, or
+        grep_transcript tool call.
 
         Args:
             tool_call: The tool call from the LLM response.
-            spans: The spans to operate on.
+            spans: The spans to operate on for expand_trace/grep_trace.
+            working_messages: The conversation messages to operate on for
+                expand_transcript/grep_transcript.
 
         Returns:
             The tool result string.
@@ -950,6 +1045,13 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             )
         elif tool_call.function.name == "grep_trace":
             return grep_trace(spans, args.get("pattern", ""))
+        elif tool_call.function.name == "expand_transcript":
+            return expand_transcript(
+                working_messages,
+                indices=args.get("indices", []),
+            )
+        elif tool_call.function.name == "grep_transcript":
+            return grep_transcript(working_messages, args.get("pattern", ""))
         else:
             return f"Unknown tool: {tool_call.function.name}"
 

--- a/python/tests/test_judge_transcript_size_protection.py
+++ b/python/tests/test_judge_transcript_size_protection.py
@@ -23,7 +23,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scenario import JudgeAgent
-from scenario._judge.transcript_tools import expand_transcript
+from scenario._judge.estimate_tokens import DEFAULT_TOKEN_THRESHOLD, estimate_tokens
+from scenario._judge.transcript_tools import build_transcript_skeleton, expand_transcript
 from scenario._tracing.judge_span_collector import JudgeSpanCollector
 from scenario.cache import context_scenario
 from scenario.config import ScenarioConfig
@@ -312,3 +313,40 @@ class TestExpandTranscriptMalformedIndices:
         )
         assert "[1] assistant" in result
         assert "Ignored non-integer indices" in result
+
+
+class TestSkeletonItselfIsBounded:
+    """The skeleton exists to keep the judge prompt bounded, so it must
+    bound itself: a transcript with thousands of tiny messages (e.g. a
+    streaming/high-frequency tool-call agent) has a tiny per-message cost
+    but can still produce a skeleton that blows past the same threshold
+    that triggered structure-only rendering in the first place.
+    """
+
+    def test_many_tiny_messages_still_produce_a_bounded_skeleton(self) -> None:
+        messages = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(5000)
+        ]
+        skeleton = build_transcript_skeleton(cast(Any, messages))
+        assert estimate_tokens(skeleton) <= DEFAULT_TOKEN_THRESHOLD
+
+    def test_bounded_skeleton_keeps_head_and_tail(self) -> None:
+        messages = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(5000)
+        ]
+        skeleton = build_transcript_skeleton(cast(Any, messages))
+        assert "[0] user" in skeleton
+        assert "[4999] assistant" in skeleton
+        assert "omitted" in skeleton
+
+    def test_small_message_count_is_unaffected(self) -> None:
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        skeleton = build_transcript_skeleton(cast(Any, messages))
+        assert "omitted" not in skeleton
+        assert "[0] user" in skeleton
+        assert "[1] assistant" in skeleton

--- a/python/tests/test_judge_transcript_size_protection.py
+++ b/python/tests/test_judge_transcript_size_protection.py
@@ -17,10 +17,11 @@ agent adapter.
 """
 
 import json
-from typing import Any, cast
+from typing import Any, Dict, Generator, List, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from openai.types.chat import ChatCompletionMessageParam
 
 from scenario import JudgeAgent
 from scenario._judge.estimate_tokens import DEFAULT_TOKEN_THRESHOLD, estimate_tokens
@@ -35,18 +36,18 @@ from scenario.config import ScenarioConfig
 from scenario.types import AgentInput
 
 
-def create_mock_collector(spans: list) -> JudgeSpanCollector:
+def create_mock_collector(spans: List[Any]) -> JudgeSpanCollector:
     collector = MagicMock(spec=JudgeSpanCollector)
     collector.get_spans_for_thread.return_value = spans
     return collector
 
 
-def create_large_non_litellm_transcript() -> list:
+def create_large_non_litellm_transcript() -> List[ChatCompletionMessageParam]:
     """Simulates a non-litellm agent: 27 tool calls with large SQL-like
     result payloads, mirroring the reporter's real repro. None of this
     ever became a span, since the agent doesn't route through litellm.
     """
-    messages: list = [
+    messages: List[ChatCompletionMessageParam] = [
         {"role": "user", "content": "Please pull the Q3 sales report."},
     ]
     for i in range(27):
@@ -80,7 +81,7 @@ def create_large_non_litellm_transcript() -> list:
     return messages
 
 
-def create_base_input(messages: list) -> AgentInput:
+def create_base_input(messages: List[ChatCompletionMessageParam]) -> AgentInput:
     mock_scenario_state = MagicMock()
     mock_scenario_state.description = "Test scenario"
     mock_scenario_state.current_turn = 1
@@ -95,7 +96,7 @@ def create_base_input(messages: list) -> AgentInput:
     )
 
 
-def mock_litellm_response(tool_name: str, args: dict):
+def mock_litellm_response(tool_name: str, args: Dict[str, Any]) -> MagicMock:
     response = MagicMock()
     response.choices = [MagicMock()]
     tool_call = MagicMock()
@@ -107,7 +108,8 @@ def mock_litellm_response(tool_name: str, args: dict):
 
 
 @pytest.fixture(autouse=True)
-def setup_config():
+def setup_config() -> Generator[None, None, None]:
+    previous_default_config = ScenarioConfig.default_config
     ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
     mock_executor = MagicMock()
     mock_executor.config = MagicMock()
@@ -115,7 +117,7 @@ def setup_config():
     token = context_scenario.set(mock_executor)
     yield
     context_scenario.reset(token)
-    ScenarioConfig.default_config = None
+    ScenarioConfig.default_config = previous_default_config
 
 
 class TestNonLitellmAgentGetsTranscriptProtection:
@@ -225,7 +227,7 @@ class TestNonLitellmAgentGetsTranscriptProtection:
         """A normal, small transcript should render in full with no
         discovery tools -- unchanged behavior for the common case.
         """
-        messages = [
+        messages: List[ChatCompletionMessageParam] = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there!"},
         ]
@@ -303,7 +305,7 @@ class TestExpandTranscriptMalformedIndices:
         # Should not raise TypeError from sorting a mixed-type set. Args are
         # deliberately malformed (as if a lax provider ignored the schema),
         # hence the cast past expand_transcript's List[int] signature.
-        result = expand_transcript(cast(Any, messages), indices=cast(Any, ["1", 5]))
+        result = expand_transcript(cast(List[ChatCompletionMessageParam], messages), indices=cast(Any, ["1", 5]))
         assert "[1] assistant" in result
         assert "Ignored out-of-range indices: [5]" in result
 
@@ -313,7 +315,7 @@ class TestExpandTranscriptMalformedIndices:
             {"role": "assistant", "content": "hello"},
         ]
         result = expand_transcript(
-            cast(Any, messages), indices=cast(Any, [None, {}, "1"])
+            cast(List[ChatCompletionMessageParam], messages), indices=cast(Any, [None, {}, "1"])
         )
         assert "[1] assistant" in result
         assert "Ignored non-integer indices" in result
@@ -332,7 +334,7 @@ class TestSkeletonItselfIsBounded:
             {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
             for i in range(5000)
         ]
-        skeleton = build_transcript_skeleton(cast(Any, messages))
+        skeleton = build_transcript_skeleton(cast(List[ChatCompletionMessageParam], messages))
         assert estimate_tokens(skeleton) <= DEFAULT_TOKEN_THRESHOLD
 
     def test_bounded_skeleton_keeps_head_and_tail(self) -> None:
@@ -340,7 +342,7 @@ class TestSkeletonItselfIsBounded:
             {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
             for i in range(5000)
         ]
-        skeleton = build_transcript_skeleton(cast(Any, messages))
+        skeleton = build_transcript_skeleton(cast(List[ChatCompletionMessageParam], messages))
         assert "[0] user" in skeleton
         assert "[4999] assistant" in skeleton
         assert "omitted" in skeleton
@@ -350,7 +352,7 @@ class TestSkeletonItselfIsBounded:
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "hello"},
         ]
-        skeleton = build_transcript_skeleton(cast(Any, messages))
+        skeleton = build_transcript_skeleton(cast(List[ChatCompletionMessageParam], messages))
         assert "omitted" not in skeleton
         assert "[0] user" in skeleton
         assert "[1] assistant" in skeleton
@@ -363,25 +365,25 @@ class TestTranscriptToolsEmptyAndErrorPaths:
     """
 
     def test_skeleton_on_empty_messages(self) -> None:
-        assert build_transcript_skeleton(cast(Any, [])) == "No messages recorded."
+        assert build_transcript_skeleton(cast(List[ChatCompletionMessageParam], [])) == "No messages recorded."
 
     def test_expand_on_empty_messages(self) -> None:
-        result = expand_transcript(cast(Any, []), indices=[0])
+        result = expand_transcript(cast(List[ChatCompletionMessageParam], []), indices=[0])
         assert result == "No messages recorded."
 
     def test_expand_with_no_indices_requested(self) -> None:
         messages = [{"role": "user", "content": "hi"}]
-        result = expand_transcript(cast(Any, messages), indices=[])
+        result = expand_transcript(cast(List[ChatCompletionMessageParam], messages), indices=[])
         assert result == "Error: provide at least one message index."
 
     def test_expand_with_only_out_of_range_indices(self) -> None:
         messages = [{"role": "user", "content": "hi"}]
-        result = expand_transcript(cast(Any, messages), indices=[7, 8])
+        result = expand_transcript(cast(List[ChatCompletionMessageParam], messages), indices=[7, 8])
         assert "Error: no messages matched the given indices" in result
         assert "Valid range: 0-0" in result
 
     def test_grep_on_empty_messages(self) -> None:
-        result = grep_transcript(cast(Any, []), "x")
+        result = grep_transcript(cast(List[ChatCompletionMessageParam], []), "x")
         assert result == "No messages recorded."
 
     def test_grep_with_no_matches_lists_roles(self) -> None:
@@ -389,7 +391,7 @@ class TestTranscriptToolsEmptyAndErrorPaths:
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "hi there"},
         ]
-        result = grep_transcript(cast(Any, messages), "nonexistent_pattern_xyz")
+        result = grep_transcript(cast(List[ChatCompletionMessageParam], messages), "nonexistent_pattern_xyz")
         assert "No matches found" in result
         assert "user" in result
         assert "assistant" in result
@@ -399,13 +401,13 @@ class TestTranscriptToolsEmptyAndErrorPaths:
         messages = [
             {"role": "user", "content": f"needle occurrence {i}"} for i in range(25)
         ]
-        result = grep_transcript(cast(Any, messages), "needle")
+        result = grep_transcript(cast(List[ChatCompletionMessageParam], messages), "needle")
         assert "5 more matches omitted" in result
 
     def test_expand_truncates_oversized_result(self) -> None:
         # A single message far larger than the ~16KB tool-result char budget.
         messages = [{"role": "user", "content": "x" * 20000}]
-        result = expand_transcript(cast(Any, messages), indices=[0])
+        result = expand_transcript(cast(List[ChatCompletionMessageParam], messages), indices=[0])
         assert "[TRUNCATED]" in result
         assert "grep_transcript(pattern)" in result
 

--- a/python/tests/test_judge_transcript_size_protection.py
+++ b/python/tests/test_judge_transcript_size_protection.py
@@ -1,0 +1,281 @@
+"""Regression tests for issue #836.
+
+JudgeAgent's trace-size protection (structure-only digest + expand_trace/
+grep_trace discovery) was gated entirely on `spans`, which only ever
+contains spans from `autotrack_litellm_calls`. An AgentAdapter that talks to
+its own backend directly (REST/SSE/gRPC/etc., not via litellm) produces
+tool-call messages that never become spans, so `is_large_trace` never
+tripped for such agents and the raw `transcript` block — built from
+`input.messages` with no cap of any kind other than base64 stripping — was
+sent to the judge unbounded. Large transcripts could then silently get
+"lost in the middle" for a small/cheap judge model, producing a confident
+but wrong verdict instead of an error.
+
+These tests build a large *transcript* (many tool-call/tool-result
+messages) while keeping `spans` empty, simulating exactly that non-litellm
+agent adapter.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scenario import JudgeAgent
+from scenario._tracing.judge_span_collector import JudgeSpanCollector
+from scenario.cache import context_scenario
+from scenario.config import ScenarioConfig
+from scenario.types import AgentInput
+
+
+def create_mock_collector(spans: list) -> JudgeSpanCollector:
+    collector = MagicMock(spec=JudgeSpanCollector)
+    collector.get_spans_for_thread.return_value = spans
+    return collector
+
+
+def create_large_non_litellm_transcript() -> list:
+    """Simulates a non-litellm agent: 27 tool calls with large SQL-like
+    result payloads, mirroring the reporter's real repro. None of this
+    ever became a span, since the agent doesn't route through litellm.
+    """
+    messages: list = [
+        {"role": "user", "content": "Please pull the Q3 sales report."},
+    ]
+    for i in range(27):
+        call_id = f"call_{i}"
+        messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "run_sql",
+                            "arguments": json.dumps({"query": f"SELECT * FROM sales_{i}"}),
+                        },
+                    }
+                ],
+            }
+        )
+        # ~2500 chars per result, 27 of them -> well over the 32KB
+        # (8192 tokens * 4 chars) transcript threshold.
+        big_row = ",".join(f"row_{i}_{j}=value_{j}" for j in range(100))
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call_id,
+                "content": f"[{big_row}]",
+            }
+        )
+    return messages
+
+
+def create_base_input(messages: list) -> AgentInput:
+    mock_scenario_state = MagicMock()
+    mock_scenario_state.description = "Test scenario"
+    mock_scenario_state.current_turn = 1
+    mock_scenario_state.config.max_turns = 10
+
+    return AgentInput(
+        thread_id="test-thread",
+        messages=messages,
+        new_messages=[],
+        judgment_request=None,
+        scenario_state=mock_scenario_state,
+    )
+
+
+def mock_litellm_response(tool_name: str, args: dict):
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    tool_call = MagicMock()
+    tool_call.function.name = tool_name
+    tool_call.function.arguments = json.dumps(args)
+    response.choices[0].message.tool_calls = [tool_call]
+    response.choices[0].message.content = None
+    return response
+
+
+@pytest.fixture(autouse=True)
+def setup_config():
+    ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
+    mock_executor = MagicMock()
+    mock_executor.config = MagicMock()
+    mock_executor.config.cache_key = None
+    token = context_scenario.set(mock_executor)
+    yield
+    context_scenario.reset(token)
+    ScenarioConfig.default_config = None
+
+
+class TestNonLitellmAgentGetsTranscriptProtection:
+    """The core #836 repro: empty spans, huge transcript."""
+
+    @pytest.mark.asyncio
+    async def test_large_transcript_with_no_spans_still_triggers_discovery(self) -> None:
+        """Before the fix: spans=[] kept is_large_trace False forever, so no
+        expand/grep tools were ever offered and the raw transcript went out
+        unbounded. After the fix: transcript size alone must be able to
+        trigger structure-only rendering + discovery tools.
+        """
+        messages = create_large_non_litellm_transcript()
+        collector = create_mock_collector([])  # no spans: not a litellm agent
+        judge = JudgeAgent(criteria=["Agent verified the sales data"], span_collector=collector)
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            return_value=mock_litellm_response("continue_test", {}),
+        ) as mock_completion:
+            await judge.call(create_base_input(messages))
+
+            call_kwargs = mock_completion.call_args.kwargs
+            tool_names = [t["function"]["name"] for t in call_kwargs["tools"]]
+            assert "expand_transcript" in tool_names
+            assert "grep_transcript" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_large_transcript_is_not_sent_unbounded(self) -> None:
+        """The full 60-row-per-call SQL payloads must NOT appear verbatim in
+        the prompt sent to the judge once the transcript is large — that's
+        exactly the unbounded flow the issue describes.
+        """
+        messages = create_large_non_litellm_transcript()
+        collector = create_mock_collector([])
+        judge = JudgeAgent(criteria=["Agent verified the sales data"], span_collector=collector)
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            return_value=mock_litellm_response("continue_test", {}),
+        ) as mock_completion:
+            await judge.call(create_base_input(messages))
+
+            call_kwargs = mock_completion.call_args.kwargs
+            user_msg = call_kwargs["messages"][1]["content"]
+            # A marker only present inside one of the large SQL rows.
+            assert "row_13_30=value_30" not in user_msg
+            # But the structure-only skeleton should still mention the tool.
+            assert "run_sql" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_expand_transcript_recovers_full_content(self) -> None:
+        """The judge can still reach the full content via expand_transcript,
+        so nothing is permanently lost -- it's just no longer force-fed
+        unbounded on every call.
+        """
+        messages = create_large_non_litellm_transcript()
+        collector = create_mock_collector([])
+        judge = JudgeAgent(criteria=["Agent verified the sales data"], span_collector=collector)
+
+        expand_response = MagicMock()
+        expand_response.choices = [MagicMock()]
+        expand_tool_call = MagicMock()
+        expand_tool_call.id = "call_x"
+        expand_tool_call.function.name = "expand_transcript"
+        # Index 2 is the first "tool" result message (index 0 = user,
+        # index 1 = assistant tool_call, index 2 = tool result).
+        expand_tool_call.function.arguments = json.dumps({"indices": [2]})
+        expand_response.choices[0].message.tool_calls = [expand_tool_call]
+        expand_response.choices[0].message.content = None
+        expand_response.choices[0].message.role = "assistant"
+
+        finish_response = mock_litellm_response(
+            "finish_test",
+            {
+                "criteria": {"agent_verified_the_sales_data": "true"},
+                "reasoning": "Verified via expanded tool result",
+                "verdict": "success",
+            },
+        )
+
+        call_count = 0
+        captured_tool_message = {}
+
+        def mock_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return expand_response
+            # Capture what the discovery tool actually returned.
+            for m in kwargs["messages"]:
+                if m.get("tool_call_id") == "call_x":
+                    captured_tool_message["content"] = m["content"]
+            return finish_response
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            side_effect=mock_completion,
+        ):
+            await judge.call(create_base_input(messages))
+
+            assert call_count == 2
+            assert "row_0_" in captured_tool_message["content"]
+
+    @pytest.mark.asyncio
+    async def test_small_transcript_unaffected(self) -> None:
+        """A normal, small transcript should render in full with no
+        discovery tools -- unchanged behavior for the common case.
+        """
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        collector = create_mock_collector([])
+        judge = JudgeAgent(criteria=["Agent greets the user"], span_collector=collector)
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            return_value=mock_litellm_response("continue_test", {}),
+        ) as mock_completion:
+            await judge.call(create_base_input(messages))
+
+            call_kwargs = mock_completion.call_args.kwargs
+            tool_names = [t["function"]["name"] for t in call_kwargs["tools"]]
+            assert "expand_transcript" not in tool_names
+            assert "grep_transcript" not in tool_names
+            user_msg = call_kwargs["messages"][1]["content"]
+            assert "Hi there!" in user_msg
+
+
+class TestGrepTranscriptTool:
+    @pytest.mark.asyncio
+    async def test_grep_transcript_finds_matching_message(self) -> None:
+        messages = create_large_non_litellm_transcript()
+        collector = create_mock_collector([])
+        judge = JudgeAgent(criteria=["Agent verified the sales data"], span_collector=collector)
+
+        grep_response = MagicMock()
+        grep_response.choices = [MagicMock()]
+        grep_tool_call = MagicMock()
+        grep_tool_call.id = "call_g"
+        grep_tool_call.function.name = "grep_transcript"
+        grep_tool_call.function.arguments = json.dumps({"pattern": "sales_13"})
+        grep_response.choices[0].message.tool_calls = [grep_tool_call]
+        grep_response.choices[0].message.content = None
+        grep_response.choices[0].message.role = "assistant"
+
+        continue_response = mock_litellm_response("continue_test", {})
+
+        call_count = 0
+        captured = {}
+
+        def mock_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return grep_response
+            for m in kwargs["messages"]:
+                if m.get("tool_call_id") == "call_g":
+                    captured["content"] = m["content"]
+            return continue_response
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            side_effect=mock_completion,
+        ):
+            await judge.call(create_base_input(messages))
+
+            assert call_count == 2
+            assert "sales_13" in captured["content"]

--- a/python/tests/test_judge_transcript_size_protection.py
+++ b/python/tests/test_judge_transcript_size_protection.py
@@ -17,11 +17,13 @@ agent adapter.
 """
 
 import json
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from scenario import JudgeAgent
+from scenario._judge.transcript_tools import expand_transcript
 from scenario._tracing.judge_span_collector import JudgeSpanCollector
 from scenario.cache import context_scenario
 from scenario.config import ScenarioConfig
@@ -279,3 +281,34 @@ class TestGrepTranscriptTool:
 
             assert call_count == 2
             assert "sales_13" in captured["content"]
+
+
+class TestExpandTranscriptMalformedIndices:
+    """expand_transcript is reachable from an LLM tool call, so a
+    misbehaving/lax provider (not every litellm-routed model enforces
+    function-call argument types as strictly as OpenAI) sending non-integer
+    array entries must not crash the discovery loop.
+    """
+
+    def test_non_integer_indices_do_not_raise(self) -> None:
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        # Should not raise TypeError from sorting a mixed-type set. Args are
+        # deliberately malformed (as if a lax provider ignored the schema),
+        # hence the cast past expand_transcript's List[int] signature.
+        result = expand_transcript(cast(Any, messages), indices=cast(Any, ["1", 5]))
+        assert "[1] assistant" in result
+        assert "Ignored out-of-range indices: [5]" in result
+
+    def test_unparseable_indices_are_reported_not_raised(self) -> None:
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = expand_transcript(
+            cast(Any, messages), indices=cast(Any, [None, {}, "1"])
+        )
+        assert "[1] assistant" in result
+        assert "Ignored non-integer indices" in result

--- a/python/tests/test_judge_transcript_size_protection.py
+++ b/python/tests/test_judge_transcript_size_protection.py
@@ -24,7 +24,11 @@ import pytest
 
 from scenario import JudgeAgent
 from scenario._judge.estimate_tokens import DEFAULT_TOKEN_THRESHOLD, estimate_tokens
-from scenario._judge.transcript_tools import build_transcript_skeleton, expand_transcript
+from scenario._judge.transcript_tools import (
+    build_transcript_skeleton,
+    expand_transcript,
+    grep_transcript,
+)
 from scenario._tracing.judge_span_collector import JudgeSpanCollector
 from scenario.cache import context_scenario
 from scenario.config import ScenarioConfig
@@ -350,3 +354,147 @@ class TestSkeletonItselfIsBounded:
         assert "omitted" not in skeleton
         assert "[0] user" in skeleton
         assert "[1] assistant" in skeleton
+
+
+class TestTranscriptToolsEmptyAndErrorPaths:
+    """Direct unit coverage for the discovery tools' guard clauses --
+    empty-transcript short-circuits, empty/out-of-range index requests,
+    and the no-match/too-many-match grep branches.
+    """
+
+    def test_skeleton_on_empty_messages(self) -> None:
+        assert build_transcript_skeleton(cast(Any, [])) == "No messages recorded."
+
+    def test_expand_on_empty_messages(self) -> None:
+        result = expand_transcript(cast(Any, []), indices=[0])
+        assert result == "No messages recorded."
+
+    def test_expand_with_no_indices_requested(self) -> None:
+        messages = [{"role": "user", "content": "hi"}]
+        result = expand_transcript(cast(Any, messages), indices=[])
+        assert result == "Error: provide at least one message index."
+
+    def test_expand_with_only_out_of_range_indices(self) -> None:
+        messages = [{"role": "user", "content": "hi"}]
+        result = expand_transcript(cast(Any, messages), indices=[7, 8])
+        assert "Error: no messages matched the given indices" in result
+        assert "Valid range: 0-0" in result
+
+    def test_grep_on_empty_messages(self) -> None:
+        result = grep_transcript(cast(Any, []), "x")
+        assert result == "No messages recorded."
+
+    def test_grep_with_no_matches_lists_roles(self) -> None:
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = grep_transcript(cast(Any, messages), "nonexistent_pattern_xyz")
+        assert "No matches found" in result
+        assert "user" in result
+        assert "assistant" in result
+
+    def test_grep_truncates_past_max_matches(self) -> None:
+        # 25 matching messages, MAX_GREP_MATCHES caps display at 20.
+        messages = [
+            {"role": "user", "content": f"needle occurrence {i}"} for i in range(25)
+        ]
+        result = grep_transcript(cast(Any, messages), "needle")
+        assert "5 more matches omitted" in result
+
+    def test_expand_truncates_oversized_result(self) -> None:
+        # A single message far larger than the ~16KB tool-result char budget.
+        messages = [{"role": "user", "content": "x" * 20000}]
+        result = expand_transcript(cast(Any, messages), indices=[0])
+        assert "[TRUNCATED]" in result
+        assert "grep_transcript(pattern)" in result
+
+
+class TestExecuteDiscoveryToolDispatchEdgeCases:
+    """JudgeAgent._execute_discovery_tool dispatches expand_transcript/
+    grep_transcript alongside the pre-existing expand_trace/grep_trace and
+    unknown-tool fallback. These exercise that dispatcher's guard branches
+    through the real discovery loop rather than calling it directly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_call_arguments_do_not_crash_the_loop(self) -> None:
+        messages = create_large_non_litellm_transcript()
+        collector = create_mock_collector([])
+        judge = JudgeAgent(criteria=["Agent verified the sales data"], span_collector=collector)
+
+        bad_args_response = MagicMock()
+        bad_args_response.choices = [MagicMock()]
+        bad_tool_call = MagicMock()
+        bad_tool_call.id = "call_bad"
+        bad_tool_call.function.name = "expand_transcript"
+        bad_tool_call.function.arguments = "{not valid json"
+        bad_args_response.choices[0].message.tool_calls = [bad_tool_call]
+        bad_args_response.choices[0].message.content = None
+        bad_args_response.choices[0].message.role = "assistant"
+
+        continue_response = mock_litellm_response("continue_test", {})
+
+        call_count = 0
+        captured = {}
+
+        def mock_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return bad_args_response
+            for m in kwargs["messages"]:
+                if m.get("tool_call_id") == "call_bad":
+                    captured["content"] = m["content"]
+            return continue_response
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            side_effect=mock_completion,
+        ):
+            result = await judge.call(create_base_input(messages))
+
+            assert call_count == 2
+            assert "could not parse arguments" in captured["content"]
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_tool_name_reports_unknown_tool(self) -> None:
+        messages = create_large_non_litellm_transcript()
+        collector = create_mock_collector([])
+        judge = JudgeAgent(criteria=["Agent verified the sales data"], span_collector=collector)
+
+        hallucinated_response = MagicMock()
+        hallucinated_response.choices = [MagicMock()]
+        hallucinated_tool_call = MagicMock()
+        hallucinated_tool_call.id = "call_hallucinated"
+        hallucinated_tool_call.function.name = "search_the_web"
+        hallucinated_tool_call.function.arguments = "{}"
+        hallucinated_response.choices[0].message.tool_calls = [hallucinated_tool_call]
+        hallucinated_response.choices[0].message.content = None
+        hallucinated_response.choices[0].message.role = "assistant"
+
+        continue_response = mock_litellm_response("continue_test", {})
+
+        call_count = 0
+        captured = {}
+
+        def mock_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return hallucinated_response
+            for m in kwargs["messages"]:
+                if m.get("tool_call_id") == "call_hallucinated":
+                    captured["content"] = m["content"]
+            return continue_response
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            side_effect=mock_completion,
+        ):
+            result = await judge.call(create_base_input(messages))
+
+            assert call_count == 2
+            assert captured["content"] == "Unknown tool: search_the_web"
+            assert result == []


### PR DESCRIPTION
Fixes #836

## Problem

`JudgeAgent`'s trace-size protection (structure-only digest + `expand_trace`/`grep_trace` discovery loop) is gated entirely on `is_large_trace`, which is computed **only** from spans collected by `JudgeSpanCollector` — i.e. spans produced by `autotrack_litellm_calls`. Any `AgentAdapter` that talks to its own backend directly (REST/SSE/gRPC/etc.) and never routes calls through `litellm` produces tool-call messages that never become spans.

For such agents, `spans` stays empty/small forever, so `is_large_trace` never trips — while the actual `transcript` block (built from `input.messages` via `JudgeUtils.build_transcript_from_messages`) has **no size cap of any kind** beyond stripping base64 media. Large tool-call content (SQL result sets, long documents, etc.) flows into the judge prompt completely unbounded.

The reporter hit this with a proprietary agent whose 27 tool calls (with large SQL result payloads) never became spans; the judge (`gpt-4o-mini`) silently dropped/ignored large portions of the unbounded transcript ("lost in the middle") and returned a confident but wrong `faithfulness: 0.0` verdict claiming "no tool calls were made" — a false negative with no error signal at all.

## Fix

- `is_large_trace` is now `is_large_span_trace OR is_large_transcript`, where `is_large_transcript` is computed from the actual transcript's own estimated token count — independent of spans.
- When the transcript itself is large, it's rendered as a structure-only **skeleton** (one line per message: index, role, tool-call name(s), estimated size — no content), the same pattern already used for large span digests.
- Two new discovery tools, `expand_transcript(indices)` and `grep_transcript(pattern)`, mirror `expand_trace`/`grep_trace` but operate on message position instead of span ID, so the judge can still reach full content on demand instead of it being force-fed (or silently dropped) on every call.
- `JudgeUtils.build_transcript_from_messages` is refactored to expose `render_transcript_lines`, a per-message renderer shared by the full transcript builder and the new discovery tools, so `expand_transcript` shows byte-identical content to what the full transcript would have shown.
- Small transcripts (the common case) are completely unaffected — same full inline rendering as before.

## Testing

- New `tests/test_judge_transcript_size_protection.py` reproduces the exact bug: empty `spans` (simulating a non-litellm agent) + a large transcript (27 tool calls with large payloads, mirroring the reporter's repro). Verified this test **fails against unmodified `main`** (4/5 cases) and passes after the fix.
- Full existing judge test suite (`test_judge_agent*.py`, `test_judge_discovery_*.py`, `test_judge_utilities.py`, `test_judge_force_verdict_hardening.py`) passes unchanged — the span-based path is untouched.
- Full `pytest tests/` run: 1139 passed (the only failures are pre-existing e2e tests requiring live API keys, unrelated to this change).
- `pyright` clean on all touched files.

## Test plan
- [x] Reproduced the bug with a failing test against `main`
- [x] Fix makes the new test pass
- [x] Existing judge/discovery test suite passes unchanged
- [x] Full python test suite passes (excluding pre-existing env-gated e2e failures)
- [x] `pyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)