### PR TITLE
fix(voice): stop pipecat bot process cleanly

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,20 +8,15 @@
 # that branch protection requires.
 name: python-ci
 
-# All OpenAI-compatible traffic (judge LLMs, TTS, STT) rides the LangWatch
-# AI Gateway: OPENAI_API_KEY holds a LangWatch virtual key, and these base
-# URLs point every client family (openai SDK, litellm, ai-sdk) at it.
-env:
-  CI: true
-  OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
-  OPENAI_API_BASE: https://gateway.langwatch.ai/v1
-
 on:
   push:
     branches:
       - main
   pull_request:
   workflow_dispatch:
+
+env:
+  CI: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -100,9 +95,8 @@ jobs:
         run: uv run pyright .
         working-directory: python
 
-      # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
+      # Examples — skipped for Dependabot PRs since they don't have access to repo secrets
       - name: Test (Examples)
-        if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         # Examples hit real LLMs over the network; they can legitimately take
         # well over the 60s per-test timeout that pytest.ini sets for the unit
         # suite. Override to 300s here so slow-but-correct runs don't get

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,15 +8,20 @@
 # that branch protection requires.
 name: python-ci
 
+# All OpenAI-compatible traffic (judge LLMs, TTS, STT) rides the LangWatch
+# AI Gateway: OPENAI_API_KEY holds a LangWatch virtual key, and these base
+# URLs point every client family (openai SDK, litellm, ai-sdk) at it.
+env:
+  CI: true
+  OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+  OPENAI_API_BASE: https://gateway.langwatch.ai/v1
+
 on:
   push:
     branches:
       - main
   pull_request:
   workflow_dispatch:
-
-env:
-  CI: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -35,6 +40,8 @@ jobs:
           filters: |
             relevant:
               - 'python/**'
+              - 'Makefile'
+              - 'scripts/test-voice-pipecat-lifecycle.sh'
               - '.github/workflows/python-ci.yml'
 
   test:
@@ -72,6 +79,9 @@ jobs:
         run: uv sync --frozen
         working-directory: python
 
+      - name: Test voice Pipecat lifecycle
+        run: make test-voice-pipecat-lifecycle
+
       - name: Verify capability matrix is in sync with AdapterCapabilities
         run: |
           uv run python scripts/gen_capability_matrix.py
@@ -90,8 +100,9 @@ jobs:
         run: uv run pyright .
         working-directory: python
 
-      # Examples — skipped for Dependabot PRs since they don't have access to repo secrets
+      # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
       - name: Test (Examples)
+        if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         # Examples hit real LLMs over the network; they can legitimately take
         # well over the 60s per-test timeout that pytest.ini sets for the unit
         # suite. Override to 300s here so slow-but-correct runs don't get

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help setup \
-	voice-pipecat-up voice-pipecat-down \
+	voice-pipecat-up voice-pipecat-down test-voice-pipecat-lifecycle \
 	voice-elevenlabs-provision \
 	voice-demos-up voice-demos-down
 
@@ -70,32 +70,76 @@ build-docs:
 # ---------------------------------------------------------------------------
 
 # Start the bundled stub bot in the background.
-# Writes its PID to .voice-bot.pid and polls until :8765 accepts connections.
+# The PID file points directly to the Python server, not the uv wrapper.
 voice-pipecat-up:
+	@test -x "$(CURDIR)/python/.venv/bin/python" || \
+		(echo "ERROR: run 'make python/install' first"; exit 1)
+	@if python3 -c "import socket; socket.create_connection(('127.0.0.1', 8765), 0.5)" 2>/dev/null; then \
+		echo "ERROR: port 8765 is already in use"; \
+		exit 1; \
+	fi
 	@echo "Starting voice stub bot on :8765 ..."
-	@( cd python && uv run python examples/voice/_bot/bot.py >> /tmp/voice-pipecat-bot.log 2>&1 ) & \
-		echo $$! > $(CURDIR)/.voice-bot.pid
+	@(cd "$(CURDIR)/python" && \
+		exec "$(CURDIR)/python/.venv/bin/python" \
+			"$(CURDIR)/python/examples/voice/_bot/bot.py" \
+			>> /tmp/voice-pipecat-bot.log 2>&1) & \
+		echo $$! > "$(CURDIR)/.voice-bot.pid"
 	@echo "Waiting for bot on :8765 (up to 15 s)..."
 	@for i in $$(seq 1 30); do \
+		PID=$$(cat "$(CURDIR)/.voice-bot.pid"); \
+		if ! kill -0 "$$PID" 2>/dev/null; then \
+			echo "ERROR: voice stub bot exited before becoming ready"; \
+			rm -f "$(CURDIR)/.voice-bot.pid"; \
+			cat /tmp/voice-pipecat-bot.log 2>/dev/null || true; \
+			exit 1; \
+		fi; \
 		if python3 -c "import socket; socket.create_connection(('127.0.0.1', 8765), 0.5)" 2>/dev/null; then \
-			echo "voice stub bot: ready (PID=$$(cat $(CURDIR)/.voice-bot.pid))"; \
+			echo "voice stub bot: ready (PID=$$PID)"; \
 			exit 0; \
 		fi; \
 		sleep 0.5; \
 	done; \
-	echo "ERROR: voice stub bot did not start within 15 s. Check /tmp/voice-pipecat-bot.log"; \
+	echo "ERROR: voice stub bot did not start within 15 s"; \
+	$(MAKE) voice-pipecat-down; \
 	cat /tmp/voice-pipecat-bot.log 2>/dev/null || true; \
 	exit 1
 
-# Stop the bundled stub bot.
+# Stop the bundled stub bot and wait until :8765 is free.
 voice-pipecat-down:
-	@if [ -f $(CURDIR)/.voice-bot.pid ]; then \
-		PID=$$(cat $(CURDIR)/.voice-bot.pid); \
-		kill -TERM "$$PID" 2>/dev/null && echo "Stopped voice stub bot (PID=$$PID)" || true; \
-		rm -f $(CURDIR)/.voice-bot.pid; \
+	@if [ -f "$(CURDIR)/.voice-bot.pid" ]; then \
+		PID=$$(cat "$(CURDIR)/.voice-bot.pid"); \
+		ARGS=$$(ps -p "$$PID" -o args= 2>/dev/null || true); \
+		case "$$ARGS" in \
+			*"$(CURDIR)/python/examples/voice/_bot/bot.py"*) ;; \
+			"") rm -f "$(CURDIR)/.voice-bot.pid"; exit 0 ;; \
+			*) echo "ERROR: refusing to stop unrelated PID $$PID"; exit 1 ;; \
+		esac; \
+		echo "Stopping voice stub bot (PID=$$PID) ..."; \
+		kill -TERM "$$PID" 2>/dev/null || true; \
+		for i in $$(seq 1 40); do \
+			kill -0 "$$PID" 2>/dev/null || break; \
+			sleep 0.25; \
+		done; \
+		if kill -0 "$$PID" 2>/dev/null; then \
+			echo "Voice stub bot did not stop after SIGTERM; sending SIGKILL (PID=$$PID)"; \
+			kill -KILL "$$PID" 2>/dev/null || true; \
+		fi; \
+		rm -f "$(CURDIR)/.voice-bot.pid"; \
+		for i in $$(seq 1 20); do \
+			if ! python3 -c "import socket; socket.create_connection(('127.0.0.1', 8765), 0.5)" 2>/dev/null; then \
+				echo "Stopped voice stub bot (PID=$$PID)"; \
+				exit 0; \
+			fi; \
+			sleep 0.25; \
+		done; \
+		echo "ERROR: port 8765 is still bound"; \
+		exit 1; \
 	else \
 		echo "voice stub bot: no .voice-bot.pid found (already down?)"; \
 	fi
+
+test-voice-pipecat-lifecycle:
+	@./scripts/test-voice-pipecat-lifecycle.sh
 
 # Provision (or reuse) the ElevenLabs throwaway test agent.
 # Idempotent — safe to re-run. Requires ELEVENLABS_API_KEY in env or python/.env.

--- a/python/examples/voice/_bot/bot.py
+++ b/python/examples/voice/_bot/bot.py
@@ -54,6 +54,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from types import FrameType
 from typing import Callable, Optional
 
 
@@ -792,7 +793,7 @@ async def serve(host: str = "127.0.0.1", port: int = 8765) -> None:
         if not stop.done():
             stop.set_result(None)
 
-    def _handle_signal(signum, frame):  # type: ignore[no-untyped-def]
+    def _handle_signal(signum: int, frame: FrameType | None) -> None:
         # Wake the selector-backed event loop before completing the Future.
         # Directly mutating it here can leave the loop blocked in epoll_wait.
         loop.call_soon_threadsafe(_request_stop, signum)

--- a/python/examples/voice/_bot/bot.py
+++ b/python/examples/voice/_bot/bot.py
@@ -784,12 +784,18 @@ async def serve(host: str = "127.0.0.1", port: int = 8765) -> None:
         logger.error("websockets package not found — install with: pip install websockets>=12")
         raise
 
-    stop = asyncio.get_event_loop().create_future()
+    loop = asyncio.get_running_loop()
+    stop = loop.create_future()
 
-    def _handle_signal(signum, frame):  # type: ignore[no-untyped-def]
+    def _request_stop(signum: int) -> None:
         logger.info("received signal %s — shutting down", signum)
         if not stop.done():
             stop.set_result(None)
+
+    def _handle_signal(signum, frame):  # type: ignore[no-untyped-def]
+        # Wake the selector-backed event loop before completing the Future.
+        # Directly mutating it here can leave the loop blocked in epoll_wait.
+        loop.call_soon_threadsafe(_request_stop, signum)
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)

--- a/scripts/test-voice-pipecat-lifecycle.sh
+++ b/scripts/test-voice-pipecat-lifecycle.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PID_FILE="${ROOT}/.voice-bot.pid"
+ACTIVE_PID=""
+
+port_is_free() {
+    python3 - <<'PY'
+import socket
+
+try:
+    connection = socket.create_connection(("127.0.0.1", 8765), timeout=0.5)
+except OSError:
+    raise SystemExit(0)
+else:
+    connection.close()
+    raise SystemExit(1)
+PY
+}
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+cleanup() {
+    cd "${ROOT}"
+    make voice-pipecat-down >/dev/null 2>&1 || true
+
+    if [[ "${ACTIVE_PID}" =~ ^[0-9]+$ ]] \
+        && kill -0 "${ACTIVE_PID}" 2>/dev/null; then
+        args="$(ps -p "${ACTIVE_PID}" -o args= 2>/dev/null || true)"
+        if [[ "${args}" == *"${ROOT}/python/examples/voice/_bot/bot.py"* ]]; then
+            kill -KILL "${ACTIVE_PID}" 2>/dev/null || true
+        fi
+    fi
+
+    rm -f "${PID_FILE}"
+}
+
+trap cleanup EXIT
+cd "${ROOT}"
+
+port_is_free || fail "port 8765 is already in use before test"
+
+for cycle in 1 2; do
+    echo "=== lifecycle cycle ${cycle} ==="
+
+    make voice-pipecat-up
+
+    [[ -f "${PID_FILE}" ]] || fail "PID file was not created"
+    ACTIVE_PID="$(cat "${PID_FILE}")"
+
+    args="$(ps -p "${ACTIVE_PID}" -o args= 2>/dev/null || true)"
+    [[ "${args}" == *"${ROOT}/python/examples/voice/_bot/bot.py"* ]] \
+        || fail "PID does not point to the voice bot: ${args}"
+    [[ "${args}" != *"uv run"* ]] \
+        || fail "PID still points to the uv wrapper"
+
+    output="$(make voice-pipecat-down)"
+    printf '%s\n' "${output}"
+
+    [[ "${output}" != *"SIGKILL"* ]] \
+        || fail "voice bot did not shut down gracefully"
+    [[ ! -f "${PID_FILE}" ]] \
+        || fail "PID file remains after shutdown"
+    ! kill -0 "${ACTIVE_PID}" 2>/dev/null \
+        || fail "voice bot process remains after shutdown"
+    port_is_free || fail "port 8765 remains bound after shutdown"
+
+    ACTIVE_PID=""
+done
+
+make voice-pipecat-down
+trap - EXIT
+
+echo "VOICE_PIPECAT_LIFECYCLE_TEST_OK"


### PR DESCRIPTION
## Why

`voice-pipecat-down` could terminate the `uv run` wrapper while leaving the actual virtualenv Python bot process alive, which kept port `8765` bound and broke subsequent start/stop cycles.

This change makes the Pipecat voice bot lifecycle deterministic and ensures the actual server process is stopped cleanly.

Closes #564

## What changed

- Chose to launch the bundled Pipecat bot directly with the virtualenv Python executable so `.voice-bot.pid` tracks the actual server process instead of the `uv run` wrapper.
- Added process identity validation before signaling the recorded PID to avoid terminating an unrelated process.
- Added bounded graceful shutdown with `SIGTERM`, port-release verification, and a targeted `SIGKILL` fallback only when required.
- Updated the bot signal handler to hand shutdown back to the asyncio event loop safely.
- Added a lifecycle regression test covering two consecutive `up -> down` cycles and idempotent shutdown.
- Wired `make test-voice-pipecat-lifecycle` into `python-ci`, including path gating for the root `Makefile` and lifecycle test script.

## Test plan

```bash
make test-voice-pipecat-lifecycle
bash -n scripts/test-voice-pipecat-lifecycle.sh
python/.venv/bin/python -m py_compile python/examples/voice/_bot/bot.py
git diff --check
pre-commit run --files Makefile python/examples/voice/_bot/bot.py scripts/test-voice-pipecat-lifecycle.sh
```

The lifecycle regression test verifies that:

- `.voice-bot.pid` points to the real Python bot process rather than the `uv` wrapper
- the recorded process is validated before it is signaled
- `SIGTERM` completes graceful WebSocket server shutdown without requiring `SIGKILL`
- port `8765`, the PID file, and the bot process are gone after shutdown
- two consecutive `up -> down` cycles succeed without manual cleanup
- repeated shutdown is safe

## Human verification

Run:

```bash
make test-voice-pipecat-lifecycle
```

A successful run completes two full lifecycle cycles and ends with:

```text
VOICE_PIPECAT_LIFECYCLE_TEST_OK
```

## How I can prove I was successful

No playable artifact — see Test plan.

The lifecycle regression test exercises the process-management behavior end-to-end and verifies the real bot PID, graceful termination, PID-file cleanup, port `8765` release, and successful repeated startup/shutdown.

<!-- no-ui-surface -->