### PR TITLE
fix(voice): point the Python STT seam at set_stt_provider

### DIFF
--- a/python/examples/voice/stt_swap.py
+++ b/python/examples/voice/stt_swap.py
@@ -113,11 +113,15 @@ async def main() -> scenario.ScenarioResult:
             max_turns=4,
         )
 
+    # Snapshot before any post-run work, so the success criterion below counts
+    # only the calls the run itself made.
+    run_transcribe_count = len(_transcribe_calls)
+
     # Demonstrate the swapped provider by transcribing each audio segment
     # through the process-wide lookup.  Going via ``get_stt_provider()`` rather
-    # than the local ``stt`` handle is what makes the swap observable: a
-    # transcribe count above zero then proves the installed provider ran, not
-    # merely that this script holds a reference to one.
+    # than the local ``stt`` handle is what makes the swap observable: the
+    # identity check proves the install took effect rather than the script
+    # merely holding a reference.
     installed = get_stt_provider()
     assert installed is stt, (
         "set_stt_provider did not install the demo provider; "
@@ -134,15 +138,17 @@ async def main() -> scenario.ScenarioResult:
             transcript = await installed.transcribe(chunk)
             segment.transcript = transcript
 
-    # Mechanical proof of the swap: ElevenLabsSTTProvider.transcribe() was
-    # called. The judge cannot observe provider internals from the transcript;
-    # this assertion is what verifies the docstring claim.
-    transcribe_count = len(_transcribe_calls)
-    swap_verified = transcribe_count > 0
+    # Mechanical proof of the swap: the run itself called
+    # ElevenLabsSTTProvider.transcribe(). The judge cannot observe provider
+    # internals from the transcript, so this is what verifies the docstring
+    # claim. Only the pre-snapshot count qualifies; the post-run loop above
+    # calls the provider too and must not be able to satisfy the criterion.
+    swap_verified = run_transcribe_count > 0
 
     print(f"success: {result.success}")
-    print(f"ElevenLabsSTT.transcribe() calls: {transcribe_count}")
-    print(f"swap verified (transcribe count > 0): {swap_verified}")
+    print(f"ElevenLabsSTT.transcribe() calls during the run: {run_transcribe_count}")
+    print(f"ElevenLabsSTT.transcribe() calls in total: {len(_transcribe_calls)}")
+    print(f"swap verified (run transcribe count > 0): {swap_verified}")
     print(f"verdict: {result.reasoning}")
     save_demo_recording(getattr(result, "audio", None))
 
@@ -150,9 +156,9 @@ async def main() -> scenario.ScenarioResult:
         # If the swap didn't fire, demo failed regardless of judge verdict.
         result.success = False
         result.reasoning = (
-            "STT provider swap NOT verified: ElevenLabsSTTProvider.transcribe() "
-            "was never called. The configured provider failed to engage. "
-            f"(Original judge verdict: {result.reasoning})"
+            "STT provider swap NOT verified: the run never called "
+            "ElevenLabsSTTProvider.transcribe(). The installed provider failed "
+            f"to engage. (Original judge verdict: {result.reasoning})"
         )
 
     return result

--- a/python/examples/voice/stt_swap.py
+++ b/python/examples/voice/stt_swap.py
@@ -1,13 +1,14 @@
 """
-Cross-cutting demo — STT provider swap via scenario.configure.
+Cross-cutting demo — STT provider swap via scenario.set_stt_provider.
 
 What this demo proves:
-    scenario.configure(stt=ElevenLabsSTTProvider(...)) replaces the default
+    scenario.set_stt_provider(ElevenLabsSTTProvider(...)) replaces the default
     OpenAI gpt-4o-transcribe with ElevenLabs STT.  When the judge transcribes
     an audio turn, ElevenLabsSTTProvider.transcribe() is called instead of the
     default path.  result.success is True.
 
-AC: specs/voice-agents.feature "Demo — STT provider swap via scenario.configure"
+AC: specs/voice-agents.feature
+    "Python swaps STT providers via scenario.set_stt_provider"
     Source §4.6 + pluggable STT design.
 
 How to run:
@@ -69,7 +70,8 @@ class _InstrumentedSTT(ElevenLabsSTTProvider):
 async def main() -> scenario.ScenarioResult:
     stt = _InstrumentedSTT(api_key=os.environ["ELEVENLABS_API_KEY"])
 
-    # Configure the global STT provider before running.
+    # Install the process-wide STT provider before running. This is the only
+    # Python entry point for swapping STT.
     scenario.set_stt_provider(stt)
 
     async with ensure_pipecat_bot():

--- a/python/examples/voice/stt_swap.py
+++ b/python/examples/voice/stt_swap.py
@@ -51,7 +51,11 @@ _check_env()
 import scenario  # noqa: E402
 from _bot_lifecycle import ensure_pipecat_bot  # noqa: E402
 from _recording_helper import save_demo_recording  # noqa: E402
-from scenario.voice import ElevenLabsSTTProvider, AudioChunk  # noqa: E402
+from scenario.voice import (  # noqa: E402
+    AudioChunk,
+    ElevenLabsSTTProvider,
+    get_stt_provider,
+)
 
 scenario.configure(default_model="openai/gpt-5-mini")
 
@@ -109,10 +113,16 @@ async def main() -> scenario.ScenarioResult:
             max_turns=4,
         )
 
-    # Demonstrate the swapped provider by transcribing each audio segment via
-    # the global STT provider.  This is where ``set_stt_provider`` becomes
-    # observable: callers who swap the provider can post-process the recorded
-    # audio with their chosen backend.
+    # Demonstrate the swapped provider by transcribing each audio segment
+    # through the process-wide lookup.  Going via ``get_stt_provider()`` rather
+    # than the local ``stt`` handle is what makes the swap observable: a
+    # transcribe count above zero then proves the installed provider ran, not
+    # merely that this script holds a reference to one.
+    installed = get_stt_provider()
+    assert installed is stt, (
+        "set_stt_provider did not install the demo provider; "
+        f"the process-wide provider is {type(installed).__name__}"
+    )
     if result.audio is not None:
         for segment in result.audio.segments:
             chunk = AudioChunk(data=segment.audio)
@@ -121,7 +131,7 @@ async def main() -> scenario.ScenarioResult:
             # and we still exercise it on segments long enough to transcribe.
             if chunk.duration_seconds < 0.5:
                 continue
-            transcript = await stt.transcribe(chunk)
+            transcript = await installed.transcribe(chunk)
             segment.transcript = transcript
 
     # Mechanical proof of the swap: ElevenLabsSTTProvider.transcribe() was

--- a/python/scenario/config/scenario.py
+++ b/python/scenario/config/scenario.py
@@ -6,14 +6,10 @@ of the Scenario testing framework, including execution parameters and debugging 
 """
 
 import os
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union
-
+from typing import Any, Dict, Optional, Union, ClassVar
 from pydantic import BaseModel, ConfigDict
 
 from .model import ModelConfig
-
-if TYPE_CHECKING:
-    from ..voice.stt import STTProvider
 
 
 class ScenarioConfig(BaseModel):
@@ -75,7 +71,6 @@ class ScenarioConfig(BaseModel):
         debug: Optional[bool] = None,
         headless: Optional[bool] = None,
         observability: Optional[Dict[str, Any]] = None,
-        stt: Optional["STTProvider"] = None,
     ) -> None:
         """
         Set global configuration settings for all scenario executions.
@@ -89,7 +84,6 @@ class ScenarioConfig(BaseModel):
             verbose: Enable verbose output during scenario execution
             cache_key: Cache key for deterministic scenario behavior across runs
             debug: Enable debug mode for step-by-step execution with user intervention
-            stt: Speech-to-text provider used by voice scenarios
             observability: OpenTelemetry tracing configuration. Accepts:
                 - span_filter: Callable filter (use scenario_only or with_custom_scopes())
                 - span_processors: List of additional SpanProcessors
@@ -130,11 +124,6 @@ class ScenarioConfig(BaseModel):
                 observability=observability,
             )
         )
-
-        if stt is not None:
-            from ..voice.stt import set_stt_provider
-
-            set_stt_provider(stt)
 
     def merge(self, other: "ScenarioConfig") -> "ScenarioConfig":
         """

--- a/python/scenario/config/scenario.py
+++ b/python/scenario/config/scenario.py
@@ -6,10 +6,14 @@ of the Scenario testing framework, including execution parameters and debugging 
 """
 
 import os
-from typing import Any, Dict, Optional, Union, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union
+
 from pydantic import BaseModel, ConfigDict
 
 from .model import ModelConfig
+
+if TYPE_CHECKING:
+    from ..voice.stt import STTProvider
 
 
 class ScenarioConfig(BaseModel):
@@ -71,6 +75,7 @@ class ScenarioConfig(BaseModel):
         debug: Optional[bool] = None,
         headless: Optional[bool] = None,
         observability: Optional[Dict[str, Any]] = None,
+        stt: Optional["STTProvider"] = None,
     ) -> None:
         """
         Set global configuration settings for all scenario executions.
@@ -84,6 +89,7 @@ class ScenarioConfig(BaseModel):
             verbose: Enable verbose output during scenario execution
             cache_key: Cache key for deterministic scenario behavior across runs
             debug: Enable debug mode for step-by-step execution with user intervention
+            stt: Speech-to-text provider used by voice scenarios
             observability: OpenTelemetry tracing configuration. Accepts:
                 - span_filter: Callable filter (use scenario_only or with_custom_scopes())
                 - span_processors: List of additional SpanProcessors
@@ -124,6 +130,11 @@ class ScenarioConfig(BaseModel):
                 observability=observability,
             )
         )
+
+        if stt is not None:
+            from ..voice.stt import set_stt_provider
+
+            set_stt_provider(stt)
 
     def merge(self, other: "ScenarioConfig") -> "ScenarioConfig":
         """

--- a/python/scenario/voice/_transcribe.py
+++ b/python/scenario/voice/_transcribe.py
@@ -69,8 +69,8 @@ def _try_get_provider() -> Optional[STTProvider]:
     except Exception as e:
         logger.warning(
             "scenario.voice.transcribe: no STT provider configured (%s); "
-            "agent transcripts will remain null. Configure with "
-            "scenario.configure(stt=...) to enable.",
+            "agent transcripts will remain null. Install one with "
+            "scenario.set_stt_provider(...) to enable.",
             e,
         )
         return None

--- a/python/scenario/voice/stt.py
+++ b/python/scenario/voice/stt.py
@@ -153,16 +153,21 @@ def set_stt_provider(provider: STTProvider) -> None:
     Exported as ``scenario.set_stt_provider``. This is the public way to swap
     speech-to-text; ``scenario.configure()`` does not take an ``stt`` argument.
 
+    Acceptance is structural, matching ``isSttProvider`` in the TypeScript
+    resolver: anything with a callable ``transcribe`` qualifies, whether or not
+    it subclasses ``STTProvider``.
+
     Raises:
-        TypeError: if ``provider`` does not implement ``STTProvider``. Rejecting
+        TypeError: if ``provider`` has no callable ``transcribe``. Rejecting
             here keeps the failure at the call the user wrote, instead of
             surfacing as a missing-attribute error deep in a transcription pass.
     """
-    if not isinstance(provider, STTProvider):
+    if not callable(getattr(provider, "transcribe", None)):
         raise TypeError(
             "set_stt_provider() expects an STTProvider, got "
-            f"{type(provider).__name__}. Subclass scenario.voice.STTProvider "
-            "and implement 'async def transcribe(self, audio: AudioChunk) -> str'."
+            f"{type(provider).__name__}. Subclass scenario.voice.STTProvider, "
+            "or pass any object with "
+            "'async def transcribe(self, audio: AudioChunk) -> str'."
         )
     global _provider
     _provider = provider

--- a/python/scenario/voice/stt.py
+++ b/python/scenario/voice/stt.py
@@ -7,7 +7,14 @@ We ship an abstract ``STTProvider`` base class plus a default OpenAI
 implementation (``gpt-4o-transcribe``, reuses the existing ``openai`` dep).
 
 Users who prefer Deepgram, Whisper, local inference, etc. implement
-``STTProvider`` and set it via ``scenario.configure(stt=MyProvider())``.
+``STTProvider`` and install it with ``scenario.set_stt_provider(MyProvider())``.
+That is the only entry point: ``scenario.configure()`` carries global execution
+settings and takes no ``stt`` argument (ADR-002, ADR-003).
+
+The provider is process-wide, so parallel runs share whichever one was
+installed last. ADR-002 records the target design, per-run voice config on the
+carrier that reaches ``call()``, which TypeScript already implements as
+``run({ voice: { stt } })``.
 
 The OpenAI default chunks audio longer than 25 minutes per request (the API
 hard limit). Transcription happens per turn, so this is rarely triggered.
@@ -140,7 +147,23 @@ _provider: STTProvider = OpenAISTTProvider()
 
 
 def set_stt_provider(provider: STTProvider) -> None:
-    """Install a custom STT provider. Invoked by scenario.configure(stt=...)."""
+    """
+    Install the STT provider used by every voice run in this process.
+
+    Exported as ``scenario.set_stt_provider``. This is the public way to swap
+    speech-to-text; ``scenario.configure()`` does not take an ``stt`` argument.
+
+    Raises:
+        TypeError: if ``provider`` does not implement ``STTProvider``. Rejecting
+            here keeps the failure at the call the user wrote, instead of
+            surfacing as a missing-attribute error deep in a transcription pass.
+    """
+    if not isinstance(provider, STTProvider):
+        raise TypeError(
+            "set_stt_provider() expects an STTProvider, got "
+            f"{type(provider).__name__}. Subclass scenario.voice.STTProvider "
+            "and implement 'async def transcribe(self, audio: AudioChunk) -> str'."
+        )
     global _provider
     _provider = provider
 
@@ -153,4 +176,4 @@ async def transcribe(audio: AudioChunk) -> str:
     """Convenience wrapper around the globally configured provider."""
     if audio.transcript:
         return audio.transcript
-    return await _provider.transcribe(audio)
+    return await get_stt_provider().transcribe(audio)

--- a/python/tests/voice/test_feature_file_contract.py
+++ b/python/tests/voice/test_feature_file_contract.py
@@ -45,7 +45,7 @@ def test_feature_file_parses_cleanly(parsed_feature):
 
 def test_feature_file_declares_expected_scenario_count(parsed_feature):
     """
-    The issue-350 contract is 125 scenarios:
+    The issue-350 contract is 129 scenarios:
       - 83 original
       - +4 for locked decision #9 (composable + branded voice agents)
       - +12 for @e2e demo parity (TESTING.md: every user-facing feature has
@@ -54,12 +54,13 @@ def test_feature_file_declares_expected_scenario_count(parsed_feature):
       - +3 for auto-transcribe agent audio for non-multimodal judges.
       - +3 for audio messages rendering cleanly in the terminal.
       - +19 added by voice stack PRs #561 and #604.
+      - +4 for the Python STT configuration seam (#743).
 
     Any change to this count must be a deliberate contract update.
     """
     scenarios = _collect_scenarios(parsed_feature)
-    assert len(scenarios) == 125, (
-        f"Expected 125 scenarios; found {len(scenarios)}. "
+    assert len(scenarios) == 129, (
+        f"Expected 129 scenarios; found {len(scenarios)}. "
         "If this is an intentional contract change, update the count here."
     )
 
@@ -104,11 +105,12 @@ def test_every_scenario_is_tagged_unit_integration_or_e2e(parsed_feature):
 
 def test_tag_split_matches_the_pinned_counts(parsed_feature):
     """
-    The post-#561/#604 tag split is 79 @unit / 13 @integration / 35 @e2e.
+    The tag split is 83 @unit / 12 @integration / 34 @e2e.
     The end-to-end examples and pain-pattern scenarios are @e2e (happy paths
     via real examples, per TESTING.md). Demo recordings add 1 @unit + 2
     @integration. Auto-transcribe adds 3 @unit. Terminal rendering adds 3
     @unit. Voice stack PRs #561 and #604 added 19 scenarios across all tiers.
+    The Python STT configuration seam (#743) adds 4 @unit.
     If the split changes, update this test in the same PR.
     """
     scenarios = _collect_scenarios(parsed_feature)
@@ -117,8 +119,8 @@ def test_tag_split_matches_the_pinned_counts(parsed_feature):
         1 for s in scenarios if "@integration" in {t.name for t in s.tags}
     )
     e2e = sum(1 for s in scenarios if "@e2e" in {t.name for t in s.tags})
-    assert (unit, integration, e2e) == (79, 12, 34), (
-        f"Expected 79 @unit / 12 @integration / 34 @e2e; found "
+    assert (unit, integration, e2e) == (83, 12, 34), (
+        f"Expected 83 @unit / 12 @integration / 34 @e2e; found "
         f"{unit} / {integration} / {e2e}. "
         "If this is an intentional contract change, update the counts here."
     )

--- a/python/tests/voice/test_stt.py
+++ b/python/tests/voice/test_stt.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import scenario
+from scenario.config import ScenarioConfig
 from scenario.voice import (
     AudioChunk,
     ElevenLabsSTTProvider,
@@ -25,6 +27,20 @@ class FakeSTT(STTProvider):
     async def transcribe(self, audio: AudioChunk) -> str:
         self.calls.append(audio)
         return self.canned
+
+
+def test_configure_sets_stt_provider():
+    previous_config = ScenarioConfig.default_config
+    previous_provider = get_stt_provider()
+    fake = FakeSTT()
+    try:
+        scenario.configure(stt=fake)
+        assert get_stt_provider() is fake
+        scenario.configure(default_model="none")
+        assert get_stt_provider() is fake
+    finally:
+        ScenarioConfig.default_config = previous_config
+        set_stt_provider(previous_provider)
 
 
 @pytest.mark.asyncio
@@ -61,6 +77,7 @@ def test_stt_provider_is_abstract():
 
 
 # ---------------------------------------------------------------- ElevenLabsSTTProvider
+
 
 def test_elevenlabs_stt_provider_implements_interface():
     """ElevenLabsSTTProvider must be an STTProvider with no ElevenLabs types leaking."""

--- a/python/tests/voice/test_stt.py
+++ b/python/tests/voice/test_stt.py
@@ -86,6 +86,30 @@ def test_set_stt_provider_rejects_a_non_provider():
 
 
 @pytest.mark.asyncio
+async def test_set_stt_provider_accepts_a_structural_provider():
+    """
+    Anything with a callable ``transcribe`` is a provider, as in TypeScript.
+
+    ``isSttProvider`` in ``javascript/src/voice/config.ts`` is a duck-type
+    check, so requiring a subclass here would make the same object valid in
+    one runtime and rejected in the other.
+    """
+
+    class DuckSTT:
+        async def transcribe(self, audio: AudioChunk) -> str:
+            return "duck typed"
+
+    previous = get_stt_provider()
+    duck = DuckSTT()
+    set_stt_provider(duck)  # type: ignore[arg-type]  # Structural acceptance is the contract under test.
+    try:
+        assert get_stt_provider() is duck
+        assert await transcribe(AudioChunk(data=b"\x00\x00" * 1200)) == "duck typed"
+    finally:
+        set_stt_provider(previous)
+
+
+@pytest.mark.asyncio
 async def test_set_stt_provider_is_used_by_transcribe():
     prev = get_stt_provider()
     fake = FakeSTT()

--- a/python/tests/voice/test_stt.py
+++ b/python/tests/voice/test_stt.py
@@ -1,12 +1,12 @@
 """Unit tests for the pluggable STTProvider interface."""
 
 import inspect
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import scenario
-from scenario.config import ScenarioConfig
 from scenario.voice import (
     AudioChunk,
     ElevenLabsSTTProvider,
@@ -29,18 +29,60 @@ class FakeSTT(STTProvider):
         return self.canned
 
 
-def test_configure_sets_stt_provider():
-    previous_config = ScenarioConfig.default_config
-    previous_provider = get_stt_provider()
-    fake = FakeSTT()
-    try:
-        scenario.configure(stt=fake)
-        assert get_stt_provider() is fake
-        scenario.configure(default_model="none")
-        assert get_stt_provider() is fake
-    finally:
-        ScenarioConfig.default_config = previous_config
-        set_stt_provider(previous_provider)
+# ---------------------------------------------------------------- the public seam
+
+
+def test_set_stt_provider_is_exported_from_the_package_root():
+    """``scenario.set_stt_provider`` is the documented way to swap STT."""
+    assert scenario.set_stt_provider is set_stt_provider
+    assert "set_stt_provider" in scenario.__all__
+
+
+def test_configure_does_not_accept_an_stt_argument():
+    """
+    ``configure()`` carries global execution settings only (ADR-002, ADR-003).
+
+    Provider injection through it is the API bug in #743: the docstrings
+    advertised it, the parameter never existed. Keeping the rejection asserted
+    stops it being reintroduced as a process-wide provider knob instead of the
+    per-run carrier ADR-002 specifies.
+    """
+    with pytest.raises(TypeError) as excinfo:
+        scenario.configure(stt=FakeSTT())  # type: ignore[call-arg]
+    assert "stt" in str(excinfo.value)
+
+
+def test_no_shipped_source_advertises_configure_stt():
+    """
+    Nothing users read may claim ``configure(stt=...)`` installs a provider.
+
+    A docstring, log line or example that says so sends the reader straight
+    into a ``TypeError``. Walking the whole shipped package and the examples,
+    rather than checking a fixed list of files, keeps a new one from slipping
+    the claim back in.
+    """
+    python_root = Path(__file__).resolve().parents[2]
+    roots = [Path(scenario.__file__).resolve().parent, python_root / "examples"]
+
+    offenders = [
+        str(path.relative_to(python_root))
+        for root in roots
+        for path in sorted(root.rglob("*.py"))
+        if "configure(stt=" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], (
+        "these files advertise the non-existent configure(stt=...) argument; "
+        f"point them at scenario.set_stt_provider(...) instead: {offenders}"
+    )
+
+
+def test_set_stt_provider_rejects_a_non_provider():
+    """A bad provider fails at the user's call, not inside a transcription pass."""
+    previous = get_stt_provider()
+    with pytest.raises(TypeError) as excinfo:
+        set_stt_provider(object())  # type: ignore[arg-type]
+    assert "STTProvider" in str(excinfo.value)
+    assert get_stt_provider() is previous
 
 
 @pytest.mark.asyncio

--- a/python/tests/voice/test_stt.py
+++ b/python/tests/voice/test_stt.py
@@ -48,7 +48,7 @@ def test_configure_does_not_accept_an_stt_argument():
     per-run carrier ADR-002 specifies.
     """
     with pytest.raises(TypeError) as excinfo:
-        scenario.configure(stt=FakeSTT())  # type: ignore[call-arg]
+        scenario.configure(stt=FakeSTT())  # type: ignore[call-arg]  # The runtime rejection is the contract under test.
     assert "stt" in str(excinfo.value)
 
 
@@ -80,7 +80,7 @@ def test_set_stt_provider_rejects_a_non_provider():
     """A bad provider fails at the user's call, not inside a transcription pass."""
     previous = get_stt_provider()
     with pytest.raises(TypeError) as excinfo:
-        set_stt_provider(object())  # type: ignore[arg-type]
+        set_stt_provider(object())  # type: ignore[arg-type]  # Passing an invalid provider is the contract under test.
     assert "STTProvider" in str(excinfo.value)
     assert get_stt_provider() is previous
 

--- a/python/tests/voice/test_stt_swap_e2e.py
+++ b/python/tests/voice/test_stt_swap_e2e.py
@@ -1,5 +1,5 @@
 """
-E2E wrapper for Demo — STT provider swap via scenario.configure.
+E2E wrapper for Demo — STT provider swap via scenario.set_stt_provider.
 
 AC: ElevenLabsSTTProvider.transcribe() is exercised (not the default OpenAI path);
 result.success is True.

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -970,10 +970,14 @@ Feature: Voice agent testing in Scenario SDK
     Then it raises TypeError naming stt as an unexpected keyword argument
 
   @unit
-  Scenario: set_stt_provider rejects an object that is not an STTProvider
-    Given an object with no transcribe() method
+  Scenario: set_stt_provider accepts any object that can transcribe
+    # Structural, matching isSttProvider in the TypeScript resolver, so the
+    # same object is not valid in one runtime and rejected in the other.
+    Given an object with a callable transcribe() that does not subclass STTProvider
     When it is passed to scenario.set_stt_provider
-    Then it raises TypeError at the call site and the installed provider is unchanged
+    Then it becomes the installed provider and transcribe() routes to it
+    And an object with no transcribe() raises TypeError at the call site
+    And the installed provider is unchanged after that rejection
 
   @unit
   Scenario: no shipped docstring or log advertises configure(stt=...)

--- a/specs/voice-agents.feature
+++ b/specs/voice-agents.feature
@@ -954,6 +954,35 @@ Feature: Voice agent testing in Scenario SDK
     When transcription is requested
     Then the audio is split into chunks under the limit and concatenated
 
+  @unit
+  Scenario: Python swaps STT providers via scenario.set_stt_provider
+    # Python's entry point for the same swap TypeScript spells
+    # run({ voice: { stt } }). configure() carries global execution settings
+    # and has no stt argument (ADR-002, ADR-003).
+    Given a custom STTProvider implementation
+    When scenario.set_stt_provider(CustomProvider()) is called
+    Then the custom provider's transcribe() is invoked instead of the default
+
+  @unit
+  Scenario: scenario.configure rejects an stt argument
+    Given the public scenario.configure entry point
+    When it is called with stt=CustomProvider()
+    Then it raises TypeError naming stt as an unexpected keyword argument
+
+  @unit
+  Scenario: set_stt_provider rejects an object that is not an STTProvider
+    Given an object with no transcribe() method
+    When it is passed to scenario.set_stt_provider
+    Then it raises TypeError at the call site and the installed provider is unchanged
+
+  @unit
+  Scenario: no shipped docstring or log advertises configure(stt=...)
+    # The claim that configure(stt=...) installs a provider was the whole of
+    # bug #743: the argument never existed, so every caller following the
+    # docs hit a TypeError.
+    Given the shipped scenario package sources and examples
+    Then none of them mention configure(stt=
+
   # ======================================================================
   # Adapter Capability Matrix — new requirement
   # ======================================================================


### PR DESCRIPTION
## Why

`scenario.configure(stt=...)` is what `python/scenario/voice/stt.py` told people to
call, what the no-provider warning in `_transcribe.py` told people to call, and what
`examples/voice/stt_swap.py` said it was demonstrating. The argument never existed, so
every one of those readers got `TypeError: configure() got an unexpected keyword
argument 'stt'`.

Fixes #743.

## What changed, and why not the other way

The issue offered two fixes: wire `configure(stt=...)` up, or drop the claim. This PR
drops the claim, because the repo has already decided against the argument twice:

- `docs/adr/003-voice-internal-design.md` (**Accepted**) lists "an invented
  `scenario.configure({ stt })` API" as a defect and specifies its removal.
- `docs/adr/002-voice-provider-state.md` removed it from the TypeScript surface and
  asks Python to move to **per-run** voice config, calling the module global a
  concurrency bug. Adding `stt=` to `configure()` would build a second process-wide
  provider knob, which is the "parity on the bug" that ADR says not to do.

The entry point that works today is the exported `scenario.set_stt_provider()`, which
`stt_swap.py` already calls in its own code. So the fix is to make everything users read
name that call.

- `stt.py`: module docstring names `set_stt_provider`, and records that the provider is
  process-wide and that per-run config is the target design.
- `set_stt_provider()`: rejects anything with no callable `transcribe`, at the call the
  user wrote, instead of surfacing as a missing-attribute error deep inside a
  transcription pass. This is the validation Copilot asked for on the first revision,
  moved to the real entry point. The check is structural rather than an `isinstance`,
  matching `isSttProvider` in `javascript/src/voice/config.ts`, so the same object is
  not valid in one runtime and rejected in the other.
- `transcribe()`: reads through `get_stt_provider()` so the seam has a single read
  point for the per-run migration ADR-002 describes.
- `_transcribe.py`: the no-provider warning names the call that works.
- `stt_swap.py`: docstring matches what the example does.

Per-run Python voice config is deliberately **not** in scope here. That is the larger
ADR-002 follow-up and it touches the judge, the user simulator and the executor.

## Tests

`python/tests/voice/test_stt.py`:

- `test_set_stt_provider_is_exported_from_the_package_root`
- `test_configure_does_not_accept_an_stt_argument` - pins the ADR decision so the knob
  cannot come back as a global.
- `test_no_shipped_source_advertises_configure_stt` - walks the whole shipped package
  and the examples, so a new file cannot reintroduce the false claim.
- `test_set_stt_provider_rejects_a_non_provider`
- `test_set_stt_provider_accepts_a_structural_provider` - a duck-typed provider works,
  so the Python check cannot drift from the TypeScript one.

`test_configure_does_not_accept_an_stt_argument`,
`test_no_shipped_source_advertises_configure_stt` and
`test_set_stt_provider_rejects_a_non_provider` all fail on `main` and pass here.

The `stt_swap` demo's own proof was broken and is fixed here. It asserts
`get_stt_provider() is stt`, transcribes through the lookup, and snapshots the
transcribe count as `scenario.run()` returns. Its post-run loop shares the same
accumulator, so `swap_verified` could previously be satisfied by that loop alone, with
no STT during the run at all. Both findings are CodeRabbit's.

`specs/voice-agents.feature` gains four `@unit` scenarios covering the same contract,
and `test_feature_file_contract.py` moves its pinned counts to 129 scenarios and
83 `@unit`.

## Verification

- `uv run --frozen pytest tests/voice/ -m "not integration"` - 585 passed
- `uv run --frozen pytest tests/ -m "not integration"` - the only failures are three
  live-LLM tests (`test_arun_real_llm_integration`, two in `test_red_team_agent`) that
  time out against the gateway from a laptop. They touch no STT code and pass in CI.
- `uv run --frozen pyright .` - 0 errors
- `black` and `isort` report no new findings. The remaining ones in
  `_transcribe.py`, `stt.py`, `stt_swap.py` and `test_feature_file_contract.py` are
  present on `main` unchanged, and neither tool gates `python-ci`.

## How I can prove I was successful

There is no UI here. The proof is that the three new regression tests fail on `main`
for the three separate reasons the issue names, and that the source scan makes the
docs claim unfalsifiable going forward rather than fixed once.
