### PR TITLE
feat(sdk): reuse the LangWatch tab instead of opening one per run

### DIFF
--- a/docs/docs/pages/basics/configuration.mdx
+++ b/docs/docs/pages/basics/configuration.mdx
@@ -35,8 +35,8 @@ You can control Scenario's behavior with environment variables. Set these in you
 ## The browser tab
 
 When a run starts, Scenario prints the URL to follow it live and opens it in your
-browser. Running a suite over and over — especially from a coding agent working in
-the background — would otherwise bury you in tabs, so Scenario reuses the tab you
+browser. Running a suite over and over, especially from a coding agent working in
+the background, would otherwise bury you in tabs, so Scenario reuses the tab you
 already have open.
 
 Before opening anything, the SDK asks LangWatch whether a simulations tab from this
@@ -48,7 +48,7 @@ The tab is identified by a key stored in `~/.langwatch/scenario-tab-key`, create
 the first time you run a scenario. Both SDKs read the same file, so a tab opened by
 `pytest` is reused by `vitest`. The key never leaves your machine except as a query
 param on the tab Scenario opens, and LangWatch scrubs it from the address bar on
-arrival — so a copied link never carries it.
+arrival, so a copied link never carries it.
 
 To stop a tab from following new runs, use **Stop following** in the toast. That
 choice is remembered in that browser.

--- a/docs/docs/pages/basics/configuration.mdx
+++ b/docs/docs/pages/basics/configuration.mdx
@@ -28,7 +28,7 @@ You can control Scenario's behavior with environment variables. Set these in you
 | `SCENARIO_BATCH_RUN_ID`                   | string | `batch_<random_id>`        | Unique ID for a batch of scenario runs (useful for CI).              | ✅         | ❌     |
 | `SCENARIO_HEADLESS`                       | bool   | `false`                    | Disables opening the browser window when scenario starts.            | ✅         | ✅     |
 | `SCENARIO_BROWSER`                        | enum   | `auto`                     | Controls if a browser should open when a scenario runs: `auto` reuses an already-open simulations tab and opens one only if none is open, `never` never opens one, `always` opens a new tab every run. | ✅         | ✅     |
-| `SCENARIO_BROWSER_REOPEN_SECONDS`         | int    | `300`                      | Seconds before a scenario set may open a second tab, for LangWatch instances too old to support tab reuse. | ✅         | ✅     |
+| `SCENARIO_BROWSER_REOPEN_SECONDS`         | int    | `300`                      | Seconds before a scenario set may open a second tab, used when the SDK can't confirm whether a tab is already open (unreachable LangWatch, timeout, or an instance too old to answer). | ✅         | ✅     |
 
 ---
 

--- a/docs/docs/pages/basics/configuration.mdx
+++ b/docs/docs/pages/basics/configuration.mdx
@@ -28,7 +28,7 @@ You can control Scenario's behavior with environment variables. Set these in you
 | `SCENARIO_BATCH_RUN_ID`                   | string | `batch_<random_id>`        | Unique ID for a batch of scenario runs (useful for CI).              | ✅         | ❌     |
 | `SCENARIO_HEADLESS`                       | bool   | `false`                    | Disables opening the browser window when scenario starts.            | ✅         | ✅     |
 | `SCENARIO_BROWSER`                        | enum   | `auto`                     | Controls if a browser should open when a scenario runs: `auto` reuses an already-open simulations tab and opens one only if none is open, `never` never opens one, `always` opens a new tab every run. | ✅         | ✅     |
-| `SCENARIO_BROWSER_REOPEN_SECONDS`         | int    | `300`                      | Seconds before a scenario set may open a second tab, used when the SDK can't confirm whether a tab is already open (unreachable LangWatch, timeout, or an instance too old to answer). | ✅         | ✅     |
+| `SCENARIO_BROWSER_REOPEN_SECONDS`         | int    | `300`                      | Seconds before a scenario set may open a second tab, used as a fallback whenever the SDK can't confirm whether a tab is already open. | ✅         | ✅     |
 
 ---
 

--- a/docs/docs/pages/basics/configuration.mdx
+++ b/docs/docs/pages/basics/configuration.mdx
@@ -41,8 +41,10 @@ already have open.
 
 Before opening anything, the SDK asks LangWatch whether a simulations tab from this
 machine is still connected. If one is, the run is handed to that tab, which moves
-itself to the new batch and shows a toast; nothing new is opened and your focus is
-never stolen. If no tab is listening, a fresh one opens as before.
+itself to the new batch; nothing new is opened and your focus is never stolen. If
+no tab is listening, a fresh one opens as before. The reused tab carries a small
+"Connected to local run" badge in the set header, so you can tell it apart from
+tabs you opened yourself.
 
 The tab is identified by a key stored in `~/.langwatch/scenario-tab-key`, created
 the first time you run a scenario. Both SDKs read the same file, so a tab opened by
@@ -50,8 +52,9 @@ the first time you run a scenario. Both SDKs read the same file, so a tab opened
 param on the tab Scenario opens, and LangWatch scrubs it from the address bar on
 arrival, so a copied link never carries it.
 
-To stop a tab from following new runs, use **Stop following** in the toast. That
-choice is remembered in that browser.
+Only the tab Scenario opened is steered. For a view that stays put, close that
+tab and open the simulations page yourself: a tab opened by hand never follows
+runs.
 
 ### Choosing a policy
 

--- a/docs/docs/pages/basics/configuration.mdx
+++ b/docs/docs/pages/basics/configuration.mdx
@@ -27,6 +27,53 @@ You can control Scenario's behavior with environment variables. Set these in you
 | `LOG_LEVEL`                               | enum   | `info`                     | Log level: `error`, `warn`, `info`, `debug`.                         | ✅         | ❌     |
 | `SCENARIO_BATCH_RUN_ID`                   | string | `batch_<random_id>`        | Unique ID for a batch of scenario runs (useful for CI).              | ✅         | ❌     |
 | `SCENARIO_HEADLESS`                       | bool   | `false`                    | Disables opening the browser window when scenario starts.            | ✅         | ✅     |
+| `SCENARIO_BROWSER`                        | enum   | `auto`                     | Browser policy: `auto`, `never`, `always`. See below.                | ✅         | ✅     |
+| `SCENARIO_BROWSER_REOPEN_SECONDS`         | int    | `300`                      | Fallback window before a set may open a second tab. See below.       | ✅         | ✅     |
+
+---
+
+## The browser tab
+
+When a run starts, Scenario prints the URL to follow it live and opens it in your
+browser. Running a suite over and over — especially from a coding agent working in
+the background — would otherwise bury you in tabs, so Scenario reuses the tab you
+already have open.
+
+Before opening anything, the SDK asks LangWatch whether a simulations tab from this
+machine is still connected. If one is, the run is handed to that tab, which moves
+itself to the new batch and shows a toast; nothing new is opened and your focus is
+never stolen. If no tab is listening, a fresh one opens as before.
+
+The tab is identified by a key stored in `~/.langwatch/scenario-tab-key`, created
+the first time you run a scenario. Both SDKs read the same file, so a tab opened by
+`pytest` is reused by `vitest`. The key never leaves your machine except as a query
+param on the tab Scenario opens, and LangWatch scrubs it from the address bar on
+arrival — so a copied link never carries it.
+
+To stop a tab from following new runs, use **Stop following** in the toast. That
+choice is remembered in that browser.
+
+### Choosing a policy
+
+`SCENARIO_BROWSER` decides whether a browser may be opened at all:
+
+| Value    | Behaviour                                                                       |
+| -------- | ------------------------------------------------------------------------------- |
+| `auto`   | Default. Reuse an open tab; open a new one only when none is listening.          |
+| `never`  | Never open a browser. Equivalent to `SCENARIO_HEADLESS=true`.                    |
+| `always` | Open a tab for every run, skipping reuse entirely. The pre-1.0 behaviour.        |
+
+`SCENARIO_BROWSER` wins over `SCENARIO_HEADLESS` and over `headless` in your config,
+so you can force a tab open from an otherwise headless setup. CI never opens a
+browser: a `CI` environment variable is treated as `never`.
+
+### Older LangWatch instances
+
+Reuse needs a LangWatch that can answer the handoff. Against an older self-hosted
+instance the SDK cannot tell whether a tab is open, so it falls back to a time
+window: a scenario set will not open a second tab within
+`SCENARIO_BROWSER_REOPEN_SECONDS` (300 by default). Set it to `0` to opt out of that
+guard and open a tab for every run.
 
 ---
 

--- a/docs/docs/pages/basics/configuration.mdx
+++ b/docs/docs/pages/basics/configuration.mdx
@@ -27,56 +27,8 @@ You can control Scenario's behavior with environment variables. Set these in you
 | `LOG_LEVEL`                               | enum   | `info`                     | Log level: `error`, `warn`, `info`, `debug`.                         | ✅         | ❌     |
 | `SCENARIO_BATCH_RUN_ID`                   | string | `batch_<random_id>`        | Unique ID for a batch of scenario runs (useful for CI).              | ✅         | ❌     |
 | `SCENARIO_HEADLESS`                       | bool   | `false`                    | Disables opening the browser window when scenario starts.            | ✅         | ✅     |
-| `SCENARIO_BROWSER`                        | enum   | `auto`                     | Browser policy: `auto`, `never`, `always`. See below.                | ✅         | ✅     |
-| `SCENARIO_BROWSER_REOPEN_SECONDS`         | int    | `300`                      | Fallback window before a set may open a second tab. See below.       | ✅         | ✅     |
-
----
-
-## The browser tab
-
-When a run starts, Scenario prints the URL to follow it live and opens it in your
-browser. Running a suite over and over, especially from a coding agent working in
-the background, would otherwise bury you in tabs, so Scenario reuses the tab you
-already have open.
-
-Before opening anything, the SDK asks LangWatch whether a simulations tab from this
-machine is still connected. If one is, the run is handed to that tab, which moves
-itself to the new batch; nothing new is opened and your focus is never stolen. If
-no tab is listening, a fresh one opens as before. The reused tab carries a small
-"Connected to local run" badge in the set header, so you can tell it apart from
-tabs you opened yourself.
-
-The tab is identified by a key stored in `~/.langwatch/scenario-tab-key`, created
-the first time you run a scenario. Both SDKs read the same file, so a tab opened by
-`pytest` is reused by `vitest`. The key never leaves your machine except as a query
-param on the tab Scenario opens, and LangWatch scrubs it from the address bar on
-arrival, so a copied link never carries it.
-
-Only the tab Scenario opened is steered. For a view that stays put, close that
-tab and open the simulations page yourself: a tab opened by hand never follows
-runs.
-
-### Choosing a policy
-
-`SCENARIO_BROWSER` decides whether a browser may be opened at all:
-
-| Value    | Behaviour                                                                       |
-| -------- | ------------------------------------------------------------------------------- |
-| `auto`   | Default. Reuse an open tab; open a new one only when none is listening.          |
-| `never`  | Never open a browser. Equivalent to `SCENARIO_HEADLESS=true`.                    |
-| `always` | Open a tab for every run, skipping reuse entirely. The pre-1.0 behaviour.        |
-
-`SCENARIO_BROWSER` wins over `SCENARIO_HEADLESS` and over `headless` in your config,
-so you can force a tab open from an otherwise headless setup. CI never opens a
-browser: a `CI` environment variable is treated as `never`.
-
-### Older LangWatch instances
-
-Reuse needs a LangWatch that can answer the handoff. Against an older self-hosted
-instance the SDK cannot tell whether a tab is open, so it falls back to a time
-window: a scenario set will not open a second tab within
-`SCENARIO_BROWSER_REOPEN_SECONDS` (300 by default). Set it to `0` to opt out of that
-guard and open a tab for every run.
+| `SCENARIO_BROWSER`                        | enum   | `auto`                     | Controls if a browser should open when a scenario runs: `auto` reuses an already-open simulations tab and opens one only if none is open, `never` never opens one, `always` opens a new tab every run. | ✅         | ✅     |
+| `SCENARIO_BROWSER_REOPEN_SECONDS`         | int    | `300`                      | Seconds before a scenario set may open a second tab, for LangWatch instances too old to support tab reuse. | ✅         | ✅     |
 
 ---
 

--- a/javascript/src/browser/__tests__/tab-handoff.test.ts
+++ b/javascript/src/browser/__tests__/tab-handoff.test.ts
@@ -269,7 +269,11 @@ describe("browser tab handoff", () => {
   });
 
   it("only disables reuse when the state directory is unusable", async () => {
-    process.env.LANGWATCH_STATE_DIR = "/proc/nonexistent/cannot-write";
+    // A regular file where a directory has to go: unusable on every platform,
+    // unlike a hardcoded /proc path that only fails on Linux.
+    const blocker = path.join(stateDir, "not-a-directory");
+    fs.writeFileSync(blocker, "");
+    process.env.LANGWATCH_STATE_DIR = path.join(blocker, "state");
 
     const server = await FakeLangWatch.start({ delivered: true });
     try {

--- a/javascript/src/browser/__tests__/tab-handoff.test.ts
+++ b/javascript/src/browser/__tests__/tab-handoff.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Browser tab reuse, exercised against a real HTTP server.
+ *
+ * Covers specs/browser-tab-reuse.feature. The LangWatch side is a real
+ * `node:http` server answering the browser-tab handoff endpoint, and the state
+ * files are real files in a temp directory, so requests, headers, timeouts and
+ * on-disk formats are the genuine article. The only injected seam is the
+ * opener: tests need to know which URL would have been opened without spawning
+ * twenty browsers on the machine running them.
+ */
+
+import * as fs from "fs";
+import * as http from "http";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resolveBrowserPolicy,
+  scenarioTabKey,
+  showBatchRun,
+  type BatchRunLocation,
+} from "../tab-handoff";
+
+const BROWSER_ENV_VARS = [
+  "SCENARIO_BROWSER",
+  "SCENARIO_BROWSER_REOPEN_SECONDS",
+  "SCENARIO_HEADLESS",
+  "CI",
+  "LANGWATCH_STATE_DIR",
+] as const;
+
+interface RecordedRequest {
+  path: string;
+  body: Record<string, unknown>;
+  headers: http.IncomingHttpHeaders;
+}
+
+/** A real HTTP server standing in for a LangWatch instance. */
+class FakeLangWatch {
+  private constructor(
+    private readonly server: http.Server,
+    readonly endpoint: string,
+    readonly requests: RecordedRequest[]
+  ) {}
+
+  static async start(options: {
+    delivered?: boolean;
+    status?: number;
+    delayMs?: number;
+  }): Promise<FakeLangWatch> {
+    const { delivered = false, status = 200, delayMs = 0 } = options;
+    const requests: RecordedRequest[] = [];
+
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf-8") || "{}";
+        requests.push({
+          path: req.url ?? "",
+          body: JSON.parse(raw) as Record<string, unknown>,
+          headers: req.headers,
+        });
+
+        const respond = () => {
+          if (status !== 200) {
+            res.writeHead(status, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "nope" }));
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ delivered, url: "http://example.test/batch" })
+          );
+        };
+
+        if (delayMs) setTimeout(respond, delayMs);
+        else respond();
+      });
+    });
+
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve)
+    );
+
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected a TCP address");
+    }
+
+    return new FakeLangWatch(
+      server,
+      `http://127.0.0.1:${address.port}`,
+      requests
+    );
+  }
+
+  async close(): Promise<void> {
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+}
+
+function makeLocation(scenarioSetId = "checkout-flow"): BatchRunLocation {
+  return {
+    batchUrl:
+      "https://app.langwatch.test/proj/simulations/checkout-flow/batch-1",
+    batchRunId: "batch-1",
+    scenarioSetId,
+  };
+}
+
+describe("browser tab handoff", () => {
+  let stateDir: string;
+  let opened: string[];
+  const savedEnv = new Map<string, string | undefined>();
+
+  const opener = (url: string) => {
+    opened.push(url);
+  };
+
+  beforeEach(() => {
+    for (const name of BROWSER_ENV_VARS) {
+      savedEnv.set(name, process.env[name]);
+      delete process.env[name];
+    }
+
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "scenario-tab-"));
+    process.env.LANGWATCH_STATE_DIR = stateDir;
+    opened = [];
+  });
+
+  afterEach(() => {
+    for (const [name, value] of savedEnv) {
+      if (value === void 0) delete process.env[name];
+      else process.env[name] = value;
+    }
+    savedEnv.clear();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  const show = async (
+    server: FakeLangWatch | null,
+    overrides: Parameters<typeof showBatchRun>[1] & {
+      location?: BatchRunLocation;
+    } = {}
+  ) => {
+    const { location = makeLocation(), ...options } = overrides;
+    return showBatchRun(location, {
+      endpoint: server?.endpoint,
+      apiKey: "sk-lw-test",
+      opener,
+      ...options,
+    });
+  };
+
+  // -------------------------------------------------------------------------
+  // The happy path: one tab, forever
+  // -------------------------------------------------------------------------
+
+  it("stamps the machine key on the tab it opens first time round", async () => {
+    const server = await FakeLangWatch.start({ delivered: false });
+    try {
+      expect(await show(server)).toBe("opened");
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0]).toContain(`scenarioTab=${scenarioTabKey()}`);
+    expect(opened[0]).toContain(
+      "https://app.langwatch.test/proj/simulations/checkout-flow/batch-1"
+    );
+  });
+
+  it("sends the batch and set ids with the api key", async () => {
+    const server = await FakeLangWatch.start({ delivered: false });
+    try {
+      await show(server);
+    } finally {
+      await server.close();
+    }
+
+    expect(server.requests[0]?.path).toBe("/api/scenario-events/browser-tab");
+    expect(server.requests[0]?.body).toEqual({
+      tabKey: scenarioTabKey(),
+      batchRunId: "batch-1",
+      scenarioSetId: "checkout-flow",
+    });
+    expect(server.requests[0]?.headers.authorization).toBe("Bearer sk-lw-test");
+  });
+
+  it("opens nothing when a listening tab takes the run", async () => {
+    const server = await FakeLangWatch.start({ delivered: true });
+    try {
+      expect(await show(server)).toBe("handed_off");
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toEqual([]);
+  });
+
+  it("keeps handing repeat runs to the same tab", async () => {
+    const server = await FakeLangWatch.start({ delivered: true });
+    try {
+      for (let i = 0; i < 5; i++) {
+        expect(await show(server)).toBe("handed_off");
+      }
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toEqual([]);
+    expect(server.requests).toHaveLength(5);
+  });
+
+  it("opens again once the tab is gone", async () => {
+    const listening = await FakeLangWatch.start({ delivered: true });
+    try {
+      expect(await show(listening)).toBe("handed_off");
+    } finally {
+      await listening.close();
+    }
+
+    const gone = await FakeLangWatch.start({ delivered: false });
+    try {
+      expect(await show(gone)).toBe("opened");
+    } finally {
+      await gone.close();
+    }
+
+    expect(opened).toHaveLength(1);
+  });
+
+  it("lets an authoritative no-tab answer override the throttle", async () => {
+    const server = await FakeLangWatch.start({ delivered: false });
+    try {
+      expect(await show(server)).toBe("opened");
+      expect(await show(server)).toBe("opened");
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toHaveLength(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Machine scoping
+  // -------------------------------------------------------------------------
+
+  it("keeps the tab key stable across calls", () => {
+    expect(scenarioTabKey()).toBe(scenarioTabKey());
+  });
+
+  it("stores the tab key where the Python SDK reads it", () => {
+    const key = scenarioTabKey();
+    const keyFile = path.join(stateDir, "scenario-tab-key");
+
+    expect(fs.readFileSync(keyFile, "utf-8").trim()).toBe(key);
+  });
+
+  it("reuses a key an earlier process already wrote", () => {
+    fs.writeFileSync(
+      path.join(stateDir, "scenario-tab-key"),
+      "written-by-python"
+    );
+
+    expect(scenarioTabKey()).toBe("written-by-python");
+  });
+
+  it("only disables reuse when the state directory is unusable", async () => {
+    process.env.LANGWATCH_STATE_DIR = "/proc/nonexistent/cannot-write";
+
+    const server = await FakeLangWatch.start({ delivered: true });
+    try {
+      expect(await show(server)).toBe("opened");
+    } finally {
+      await server.close();
+    }
+
+    expect(server.requests).toEqual([]);
+    expect(opened).toEqual([makeLocation().batchUrl]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Degrading gracefully
+  // -------------------------------------------------------------------------
+
+  it("still opens a tab against a LangWatch without the endpoint", async () => {
+    const server = await FakeLangWatch.start({ status: 404 });
+    try {
+      expect(await show(server)).toBe("opened");
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toHaveLength(1);
+  });
+
+  it("stops spamming tabs when LangWatch cannot answer", async () => {
+    const server = await FakeLangWatch.start({ status: 404 });
+    try {
+      expect(await show(server)).toBe("opened");
+      expect(await show(server)).toBe("suppressed_by_throttle");
+      expect(await show(server)).toBe("suppressed_by_throttle");
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toHaveLength(1);
+  });
+
+  it("throttles per scenario set, not globally", async () => {
+    const server = await FakeLangWatch.start({ status: 404 });
+    try {
+      await show(server, { location: makeLocation("checkout-flow") });
+      expect(await show(server, { location: makeLocation("onboarding") })).toBe(
+        "opened"
+      );
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toHaveLength(2);
+  });
+
+  it("honours a configured throttle window", async () => {
+    process.env.SCENARIO_BROWSER_REOPEN_SECONDS = "0";
+
+    const server = await FakeLangWatch.start({ status: 404 });
+    try {
+      expect(await show(server)).toBe("opened");
+      expect(await show(server)).toBe("opened");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("never stalls a run on a hanging LangWatch", async () => {
+    const server = await FakeLangWatch.start({ delivered: true, delayMs: 5000 });
+    const started = Date.now();
+    try {
+      expect(await show(server)).toBe("opened");
+    } finally {
+      await server.close();
+    }
+
+    expect(Date.now() - started).toBeLessThan(4500);
+  });
+
+  it("falls back to opening when LangWatch is unreachable", async () => {
+    expect(
+      await showBatchRun(makeLocation(), {
+        endpoint: "http://127.0.0.1:1",
+        apiKey: "sk-lw-test",
+        opener,
+      })
+    ).toBe("opened");
+
+    expect(opened).toHaveLength(1);
+  });
+
+  it("skips the handoff without credentials", async () => {
+    const server = await FakeLangWatch.start({ delivered: true });
+    try {
+      expect(await show(server, { apiKey: void 0 })).toBe("opened");
+    } finally {
+      await server.close();
+    }
+
+    expect(server.requests).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Policy
+  // -------------------------------------------------------------------------
+
+  it.each([
+    ["auto", "auto"],
+    ["never", "never"],
+    ["always", "always"],
+    ["ALWAYS", "always"],
+    ["nonsense", "auto"],
+  ])("resolves SCENARIO_BROWSER=%s to %s", (value, expected) => {
+    process.env.SCENARIO_BROWSER = value;
+    expect(resolveBrowserPolicy()).toBe(expected);
+  });
+
+  it("suppresses the browser when the project config is headless", () => {
+    expect(resolveBrowserPolicy(true)).toBe("never");
+  });
+
+  it("suppresses the browser on CI", () => {
+    process.env.CI = "true";
+    expect(resolveBrowserPolicy()).toBe("never");
+  });
+
+  it("treats CI=false as not CI", () => {
+    process.env.CI = "false";
+    expect(resolveBrowserPolicy()).toBe("auto");
+  });
+
+  it("lets an explicit policy beat headless", () => {
+    process.env.SCENARIO_BROWSER = "always";
+    expect(resolveBrowserPolicy(true)).toBe("always");
+  });
+
+  it("opens nothing and asks nothing under never", async () => {
+    process.env.SCENARIO_BROWSER = "never";
+
+    const server = await FakeLangWatch.start({ delivered: false });
+    try {
+      expect(await show(server)).toBe("suppressed_by_policy");
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toEqual([]);
+    expect(server.requests).toEqual([]);
+  });
+
+  it("opens every time under always, without consulting the server", async () => {
+    process.env.SCENARIO_BROWSER = "always";
+
+    const server = await FakeLangWatch.start({ delivered: true });
+    try {
+      expect(await show(server)).toBe("opened");
+      expect(await show(server)).toBe("opened");
+    } finally {
+      await server.close();
+    }
+
+    expect(server.requests).toEqual([]);
+    expect(opened).toHaveLength(2);
+  });
+
+  it("suppresses the browser for a headless project config", async () => {
+    const server = await FakeLangWatch.start({ delivered: false });
+    try {
+      expect(await show(server, { headless: true })).toBe(
+        "suppressed_by_policy"
+      );
+    } finally {
+      await server.close();
+    }
+
+    expect(opened).toEqual([]);
+  });
+});

--- a/javascript/src/browser/tab-handoff.ts
+++ b/javascript/src/browser/tab-handoff.ts
@@ -288,7 +288,7 @@ export async function showBatchRun(
     if (delivered === false) {
       // Authoritative "no tab is listening": open one and skip the throttle,
       // which only exists for servers that cannot answer.
-      return openTab(location, tabKey, opener);
+      return await openTab(location, tabKey, opener);
     }
   }
 
@@ -299,20 +299,25 @@ export async function showBatchRun(
     return "suppressed_by_throttle";
   }
 
-  return openTab(location, tabKey, opener, { setKey, nowSeconds });
+  return await openTab(location, tabKey, opener, { setKey, nowSeconds });
 }
 
-function openTab(
+/**
+ * Awaited on purpose. `open()` only spawns the launcher a few ticks in, so a
+ * fire-and-forget call loses the tab entirely when the scenario process exits
+ * promptly after its last run — and reports success while doing it.
+ */
+async function openTab(
   location: BatchRunLocation,
   tabKey: string | null,
   opener?: (url: string) => void,
   record?: { setKey: string; nowSeconds: number }
-): BrowserOutcome {
+): Promise<BrowserOutcome> {
   const url = tabKey ? withTabKey(location.batchUrl, tabKey) : location.batchUrl;
 
   try {
     if (opener) opener(url);
-    else void open(url);
+    else await open(url);
   } catch (error) {
     logger.debug("Could not open a browser", { error });
     return "failed_to_open";

--- a/javascript/src/browser/tab-handoff.ts
+++ b/javascript/src/browser/tab-handoff.ts
@@ -150,7 +150,7 @@ function readThrottle(): Record<string, number> {
       return entries;
     }
   } catch {
-    // No record yet, or an unreadable one — either way, nothing to honour.
+    // No record yet, or an unreadable one; either way, nothing to honour.
   }
   return {};
 }
@@ -200,7 +200,7 @@ function withTabKey(url: string, tabKey: string): string {
  * Ask LangWatch to push this batch to an already-open tab.
  *
  * Resolves true when a tab took it, false when none was listening, and null
- * when the instance cannot answer — an old server, a network hiccup — which
+ * when the instance cannot answer (an old server, a network hiccup), which
  * tells the caller to fall back to its own heuristics.
  */
 async function requestHandoff(params: {
@@ -305,7 +305,7 @@ export async function showBatchRun(
 /**
  * Awaited on purpose. `open()` only spawns the launcher a few ticks in, so a
  * fire-and-forget call loses the tab entirely when the scenario process exits
- * promptly after its last run — and reports success while doing it.
+ * promptly after its last run, and reports success while doing it.
  */
 async function openTab(
   location: BatchRunLocation,

--- a/javascript/src/browser/tab-handoff.ts
+++ b/javascript/src/browser/tab-handoff.ts
@@ -7,9 +7,10 @@
  * 1. **Handoff.** LangWatch knows whether a simulations tab opened by this
  *    machine still has a live connection. If one does, the run is pushed to
  *    that tab and nothing is opened locally.
- * 2. **Throttle.** When the LangWatch instance is too old to answer that
- *    question, a small on-disk record keeps repeat runs of the same set from
- *    opening a second tab within a short window.
+ * 2. **Throttle.** When that question can't be answered (unreachable
+ *    LangWatch, a timeout, or an instance too old to support it), a small
+ *    on-disk record keeps repeat runs of the same set from opening a second
+ *    tab within a short window.
  * 3. **Policy.** `SCENARIO_BROWSER` (and the older `SCENARIO_HEADLESS`) decide
  *    whether a browser may be opened at all; CI never opens one.
  *

--- a/javascript/src/browser/tab-handoff.ts
+++ b/javascript/src/browser/tab-handoff.ts
@@ -1,0 +1,324 @@
+/**
+ * Keep scenario runs in one browser tab instead of opening a new one every time.
+ *
+ * Running a suite in a loop used to leave a trail of twenty LangWatch tabs. The
+ * fix has three layers, tried in order:
+ *
+ * 1. **Handoff.** LangWatch knows whether a simulations tab opened by this
+ *    machine still has a live connection. If one does, the run is pushed to
+ *    that tab and nothing is opened locally.
+ * 2. **Throttle.** When the LangWatch instance is too old to answer that
+ *    question, a small on-disk record keeps repeat runs of the same set from
+ *    opening a second tab within a short window.
+ * 3. **Policy.** `SCENARIO_BROWSER` (and the older `SCENARIO_HEADLESS`) decide
+ *    whether a browser may be opened at all; CI never opens one.
+ *
+ * The state files are shared byte-for-byte with the Python SDK, so a tab opened
+ * by `pytest` is reused by `vitest` and the other way around.
+ *
+ * Every step fails open: a broken handoff, an unwritable state directory, or a
+ * missing browser must never disturb the scenario run itself.
+ */
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import open from "open";
+import { Logger } from "../utils/logger";
+
+const logger = new Logger("scenario.browser.tabHandoff");
+
+/** Query param carrying this machine's tab key into the page the SDK opens. */
+export const SCENARIO_TAB_QUERY_PARAM = "scenarioTab";
+
+/** How long the SDK waits on the handoff before giving up and opening a tab. */
+export const HANDOFF_TIMEOUT_MS = 2000;
+
+/**
+ * Default window during which the same scenario set will not reopen a tab,
+ * used only when the LangWatch instance cannot answer the handoff.
+ */
+export const DEFAULT_REOPEN_INTERVAL_SECONDS = 300;
+
+export type BrowserPolicy = "auto" | "never" | "always";
+
+export type BrowserOutcome =
+  | "handed_off"
+  | "opened"
+  | "suppressed_by_policy"
+  | "suppressed_by_throttle"
+  | "failed_to_open";
+
+export interface BatchRunLocation {
+  batchUrl: string;
+  batchRunId: string;
+  scenarioSetId?: string;
+}
+
+function stateDir(): string {
+  const override = process.env.LANGWATCH_STATE_DIR;
+  if (override) return override;
+  return path.join(os.homedir(), ".langwatch");
+}
+
+function isTruthy(value: string | undefined): boolean {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false" && normalized !== "no";
+}
+
+/**
+ * Decide the opening policy for this process.
+ *
+ * An explicit `SCENARIO_BROWSER` always wins, including over `headless`, so a
+ * developer can force a tab open from a headless-by-default setup.
+ */
+export function resolveBrowserPolicy(headless = false): BrowserPolicy {
+  const raw = (process.env.SCENARIO_BROWSER ?? "").trim().toLowerCase();
+
+  if (raw) {
+    if (raw === "auto" || raw === "never" || raw === "always") return raw;
+    logger.warn(
+      `Unrecognized SCENARIO_BROWSER=${raw}, expected one of auto/never/always; falling back to auto`
+    );
+    return "auto";
+  }
+
+  if (headless || isTruthy(process.env.CI)) return "never";
+
+  return "auto";
+}
+
+/**
+ * Stable identifier for this machine's scenario tab, created on first use.
+ *
+ * Returns null when the state directory cannot be used, which simply disables
+ * reuse.
+ */
+export function scenarioTabKey(): string | null {
+  const keyPath = path.join(stateDir(), "scenario-tab-key");
+
+  try {
+    const existing = fs.readFileSync(keyPath, "utf-8").trim();
+    if (existing) return existing;
+  } catch {
+    // Not created yet.
+  }
+
+  const key = crypto.randomUUID().replace(/-/g, "");
+
+  try {
+    fs.mkdirSync(path.dirname(keyPath), { recursive: true });
+    // Exclusive create: when two processes start at once, the loser reads the
+    // winner's key instead of overwriting it.
+    fs.writeFileSync(keyPath, key, { flag: "wx", encoding: "utf-8" });
+    return key;
+  } catch {
+    try {
+      return fs.readFileSync(keyPath, "utf-8").trim() || null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function reopenIntervalSeconds(): number {
+  const raw = process.env.SCENARIO_BROWSER_REOPEN_SECONDS;
+  if (!raw) return DEFAULT_REOPEN_INTERVAL_SECONDS;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) {
+    logger.warn(`Ignoring non-numeric SCENARIO_BROWSER_REOPEN_SECONDS=${raw}`);
+    return DEFAULT_REOPEN_INTERVAL_SECONDS;
+  }
+
+  return Math.max(0, parsed);
+}
+
+function throttlePath(): string {
+  return path.join(stateDir(), "scenario-tab-opens.json");
+}
+
+function readThrottle(): Record<string, number> {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(throttlePath(), "utf-8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const entries: Record<string, number> = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "number") entries[key] = value;
+      }
+      return entries;
+    }
+  } catch {
+    // No record yet, or an unreadable one — either way, nothing to honour.
+  }
+  return {};
+}
+
+function openedRecently(setKey: string, nowSeconds: number): boolean {
+  const interval = reopenIntervalSeconds();
+  if (interval <= 0) return false;
+
+  const last = readThrottle()[setKey];
+  return last !== void 0 && nowSeconds - last < interval;
+}
+
+function recordOpen(setKey: string, nowSeconds: number): void {
+  const entries = readThrottle();
+  entries[setKey] = nowSeconds;
+
+  // Keep the file from growing forever on long-lived machines.
+  const horizon = Math.max(reopenIntervalSeconds(), 1) * 10;
+  const pruned: Record<string, number> = {};
+  for (const [key, seen] of Object.entries(entries)) {
+    if (nowSeconds - seen < horizon) pruned[key] = seen;
+  }
+
+  const target = throttlePath();
+  const tmp = `${target}.${process.pid}.tmp`;
+
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(tmp, JSON.stringify(pruned), "utf-8");
+    fs.renameSync(tmp, target);
+  } catch (error) {
+    logger.debug("Could not record the browser open time", { error });
+  }
+}
+
+function withTabKey(url: string, tabKey: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set(SCENARIO_TAB_QUERY_PARAM, tabKey);
+    return parsed.href;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Ask LangWatch to push this batch to an already-open tab.
+ *
+ * Resolves true when a tab took it, false when none was listening, and null
+ * when the instance cannot answer — an old server, a network hiccup — which
+ * tells the caller to fall back to its own heuristics.
+ */
+async function requestHandoff(params: {
+  endpoint: string;
+  apiKey: string;
+  projectId?: string;
+  tabKey: string;
+  location: BatchRunLocation;
+}): Promise<boolean | null> {
+  const { endpoint, apiKey, projectId, tabKey, location } = params;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+  if (projectId) headers["X-Project-Id"] = projectId;
+
+  const body: Record<string, string> = {
+    tabKey,
+    batchRunId: location.batchRunId,
+  };
+  if (location.scenarioSetId) body.scenarioSetId = location.scenarioSetId;
+
+  try {
+    const response = await fetch(
+      new URL("/api/scenario-events/browser-tab", endpoint).href,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(HANDOFF_TIMEOUT_MS),
+      }
+    );
+
+    // A LangWatch that predates the endpoint, or any other refusal: let the
+    // caller fall back rather than guessing.
+    if (!response.ok) {
+      logger.debug(`Browser tab handoff returned ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { delivered?: boolean };
+    return Boolean(data.delivered);
+  } catch (error) {
+    logger.debug("Browser tab handoff request failed", { error });
+    return null;
+  }
+}
+
+/**
+ * Put this batch of runs in front of the user, reusing their tab when possible.
+ */
+export async function showBatchRun(
+  location: BatchRunLocation,
+  options: {
+    headless?: boolean;
+    endpoint?: string;
+    apiKey?: string;
+    projectId?: string;
+    /**
+     * Exists so tests can watch what would have been opened; production callers
+     * leave it alone and get the platform's default browser.
+     */
+    opener?: (url: string) => void;
+  } = {}
+): Promise<BrowserOutcome> {
+  const { headless = false, endpoint, apiKey, projectId, opener } = options;
+  const policy = resolveBrowserPolicy(headless);
+
+  if (policy === "never") return "suppressed_by_policy";
+
+  const tabKey = scenarioTabKey();
+
+  if (policy === "auto" && tabKey && endpoint && apiKey) {
+    const delivered = await requestHandoff({
+      endpoint,
+      apiKey,
+      projectId,
+      tabKey,
+      location,
+    });
+
+    if (delivered === true) return "handed_off";
+
+    if (delivered === false) {
+      // Authoritative "no tab is listening": open one and skip the throttle,
+      // which only exists for servers that cannot answer.
+      return openTab(location, tabKey, opener);
+    }
+  }
+
+  const nowSeconds = Date.now() / 1000;
+  const setKey = location.scenarioSetId ?? location.batchUrl;
+
+  if (policy === "auto" && openedRecently(setKey, nowSeconds)) {
+    return "suppressed_by_throttle";
+  }
+
+  return openTab(location, tabKey, opener, { setKey, nowSeconds });
+}
+
+function openTab(
+  location: BatchRunLocation,
+  tabKey: string | null,
+  opener?: (url: string) => void,
+  record?: { setKey: string; nowSeconds: number }
+): BrowserOutcome {
+  const url = tabKey ? withTabKey(location.batchUrl, tabKey) : location.batchUrl;
+
+  try {
+    if (opener) opener(url);
+    else void open(url);
+  } catch (error) {
+    logger.debug("Could not open a browser", { error });
+    return "failed_to_open";
+  }
+
+  if (record) recordOpen(record.setKey, record.nowSeconds);
+
+  return "opened";
+}

--- a/javascript/src/browser/tab-handoff.ts
+++ b/javascript/src/browser/tab-handoff.ts
@@ -7,10 +7,9 @@
  * 1. **Handoff.** LangWatch knows whether a simulations tab opened by this
  *    machine still has a live connection. If one does, the run is pushed to
  *    that tab and nothing is opened locally.
- * 2. **Throttle.** When that question can't be answered (unreachable
- *    LangWatch, a timeout, or an instance too old to support it), a small
- *    on-disk record keeps repeat runs of the same set from opening a second
- *    tab within a short window.
+ * 2. **Throttle.** When that question can't be answered, a small on-disk
+ *    record keeps repeat runs of the same set from opening a second tab
+ *    within a short window.
  * 3. **Policy.** `SCENARIO_BROWSER` (and the older `SCENARIO_HEADLESS`) decide
  *    whether a browser may be opened at all; CI never opens one.
  *

--- a/javascript/src/events/event-alert-message-logger.ts
+++ b/javascript/src/events/event-alert-message-logger.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import open from "open";
+import { showBatchRun } from "../browser/tab-handoff";
 import { getEnv, getProjectConfig } from "../config";
 import { getBatchRunId } from "../utils/ids";
 
@@ -58,6 +58,9 @@ export class EventAlertMessageLogger {
     scenarioSetId: string;
     scenarioRunId: string;
     setUrl: string;
+    endpoint?: string;
+    apiKey?: string;
+    projectId?: string;
   }): Promise<void> {
     if (this.isGreetingDisabled()) {
       return;
@@ -93,26 +96,43 @@ export class EventAlertMessageLogger {
     }
   }
 
-  private async displayWatchMessage(params: { setUrl: string }): Promise<void> {
+  private async displayWatchMessage(params: {
+    setUrl: string;
+    scenarioSetId?: string;
+    endpoint?: string;
+    apiKey?: string;
+    projectId?: string;
+  }): Promise<void> {
     const separator = "─".repeat(60);
     const setUrl = params.setUrl;
-    const batchUrl = `${setUrl}/${getBatchRunId()}`;
+    const batchRunId = getBatchRunId();
+    const batchUrl = `${setUrl}/${batchRunId}`;
 
     console.log(`\n${separator}`);
     console.log("🎭  Running Scenario Tests");
     console.log(`${separator}`);
     console.log(`Follow it live: ${batchUrl}`);
-    console.log(`${separator}\n`);
 
     const projectConfig = await getProjectConfig();
 
-    if (!projectConfig?.headless) {
-      try {
-        open(batchUrl);
-        // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
-      } catch (_) {
-        // Do nothing
+    const outcome = await showBatchRun(
+      {
+        batchUrl,
+        batchRunId,
+        scenarioSetId: params.scenarioSetId,
+      },
+      {
+        headless: Boolean(projectConfig?.headless),
+        endpoint: params.endpoint,
+        apiKey: params.apiKey,
+        projectId: params.projectId,
       }
+    );
+
+    if (outcome === "handed_off") {
+      console.log("↻ Sent to the LangWatch tab you already have open");
     }
+
+    console.log(`${separator}\n`);
   }
 }

--- a/javascript/src/events/event-bus.ts
+++ b/javascript/src/events/event-bus.ts
@@ -5,8 +5,6 @@ import {
   Subject,
   Observable,
   Subscription,
-  tap,
-  map,
 } from "rxjs";
 import { EventAlertMessageLogger } from "./event-alert-message-logger";
 import { EventReporter } from "./event-reporter";
@@ -74,15 +72,18 @@ export class EventBus {
     this.processingPromise = new Promise<void>((resolve, reject) => {
       this.events$
         .pipe(
-          // Post events and get results
+          // Post events, then settle the watch message before moving on.
+          //
+          // The watch message is awaited inside this stage rather than handed
+          // to a `tap`: `tap` drops the promise, so a suite that finishes and
+          // exits promptly could kill the process while the browser handoff
+          // was still in flight — the run would be reported as opened with no
+          // tab to show for it. It runs once per batch and off the scenario's
+          // own critical path.
           concatMap(async (event: ScenarioEvent) => {
             this.logger.debug(`[${event.type}] Processing event`, { event });
             const result = await this.eventReporter.postEvent(event);
-            return { event, result };
-          }),
 
-          // Handle watch messages reactively
-          tap(async ({ event, result }) => {
             if (event.type === ScenarioEventType.RUN_STARTED && result.setUrl) {
               // The browser-tab handoff talks to the same LangWatch instance
               // the events were just reported to.
@@ -95,10 +96,9 @@ export class EventBus {
                 projectId: this.config.projectId,
               });
             }
-          }),
 
-          // Extract just the event for downstream processing
-          map(({ event }) => event),
+            return event;
+          }),
 
           catchError((error: unknown) => {
             this.logger.error("Error in event stream:", error);

--- a/javascript/src/events/event-bus.ts
+++ b/javascript/src/events/event-bus.ts
@@ -21,11 +21,17 @@ export class EventBus {
   private events$ = new Subject<ScenarioEvent>();
   private eventReporter: EventReporter;
   private eventAlertMessageLogger: EventAlertMessageLogger;
+  private readonly config: {
+    endpoint: string;
+    apiKey: string | undefined;
+    projectId?: string;
+  };
   private processingPromise: Promise<void> | null = null;
   private logger = new Logger("scenario.events.EventBus");
   private static globalListeners: Array<(bus: EventBus) => void> = [];
 
   constructor(config: { endpoint: string; apiKey: string | undefined; projectId?: string }) {
+    this.config = config;
     this.eventReporter = new EventReporter(config);
     this.eventAlertMessageLogger = new EventAlertMessageLogger();
     EventBus.registry.add(this);
@@ -78,10 +84,15 @@ export class EventBus {
           // Handle watch messages reactively
           tap(async ({ event, result }) => {
             if (event.type === ScenarioEventType.RUN_STARTED && result.setUrl) {
+              // The browser-tab handoff talks to the same LangWatch instance
+              // the events were just reported to.
               await this.eventAlertMessageLogger.handleWatchMessage({
                 scenarioSetId: event.scenarioSetId,
                 scenarioRunId: event.scenarioRunId,
                 setUrl: result.setUrl,
+                endpoint: this.config.endpoint,
+                apiKey: this.config.apiKey,
+                projectId: this.config.projectId,
               });
             }
           }),

--- a/python/scenario/_browser/__init__.py
+++ b/python/scenario/_browser/__init__.py
@@ -1,0 +1,24 @@
+"""
+Deciding whether a scenario run needs a browser tab, and reusing one when it doesn't.
+
+Public surface is intentionally tiny: :func:`show_batch_run` takes a batch URL
+and does the right thing for the environment it finds itself in.
+"""
+
+from .tab_handoff import (
+    BatchRunLocation,
+    BrowserOutcome,
+    BrowserPolicy,
+    resolve_browser_policy,
+    scenario_tab_key,
+    show_batch_run,
+)
+
+__all__ = [
+    "BatchRunLocation",
+    "BrowserOutcome",
+    "BrowserPolicy",
+    "resolve_browser_policy",
+    "scenario_tab_key",
+    "show_batch_run",
+]

--- a/python/scenario/_browser/tab_handoff.py
+++ b/python/scenario/_browser/tab_handoff.py
@@ -7,8 +7,7 @@ fix has three layers, tried in order:
 1. **Handoff.** LangWatch knows whether a simulations tab opened by this machine
    still has a live connection. If one does, the run is pushed to that tab and
    nothing is opened locally.
-2. **Throttle.** When that question can't be answered (unreachable LangWatch,
-   a timeout, or an instance too old to support it), a small on-disk record
+2. **Throttle.** When that question can't be answered, a small on-disk record
    keeps repeat runs of the same set from opening a second tab within a
    short window.
 3. **Policy.** ``SCENARIO_BROWSER`` (and the older ``SCENARIO_HEADLESS``) decide

--- a/python/scenario/_browser/tab_handoff.py
+++ b/python/scenario/_browser/tab_handoff.py
@@ -170,7 +170,7 @@ def _read_throttle() -> Dict[str, float]:
     try:
         raw = json.loads(_throttle_path().read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        # No record yet, or an unreadable one — either way, nothing to honour.
+        # No record yet, or an unreadable one; either way, nothing to honour.
         return {}
 
     if not isinstance(raw, dict):
@@ -235,7 +235,7 @@ def _request_handoff(
     Ask LangWatch to push this batch to an already-open tab.
 
     Returns True when a tab took it, False when none was listening, and None
-    when the instance cannot answer — an old server, a network hiccup — which
+    when the instance cannot answer (an old server, a network hiccup), which
     tells the caller to fall back to its own heuristics.
     """
     payload: Dict[str, Any] = {

--- a/python/scenario/_browser/tab_handoff.py
+++ b/python/scenario/_browser/tab_handoff.py
@@ -126,6 +126,8 @@ def scenario_tab_key() -> Optional[str]:
         if existing:
             return existing
     except (OSError, ValueError):
+        # No key yet, or one we cannot read. Either way the answer is the same:
+        # mint a fresh one below.
         pass
 
     key = uuid.uuid4().hex
@@ -167,11 +169,22 @@ def _throttle_path() -> Path:
 def _read_throttle() -> Dict[str, float]:
     try:
         raw = json.loads(_throttle_path().read_text(encoding="utf-8"))
-        if isinstance(raw, dict):
-            return {str(k): float(v) for k, v in raw.items()}
-    except (OSError, ValueError, TypeError):
-        pass
-    return {}
+    except (OSError, ValueError):
+        # No record yet, or an unreadable one — either way, nothing to honour.
+        return {}
+
+    if not isinstance(raw, dict):
+        return {}
+
+    # One malformed entry must not throw away the rest: the file is a
+    # best-effort guard, and dropping it wholesale would reopen every set.
+    entries: Dict[str, float] = {}
+    for key, value in raw.items():
+        try:
+            entries[str(key)] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return entries
 
 
 def _opened_recently(set_key: str, now: float) -> bool:

--- a/python/scenario/_browser/tab_handoff.py
+++ b/python/scenario/_browser/tab_handoff.py
@@ -7,9 +7,10 @@ fix has three layers, tried in order:
 1. **Handoff.** LangWatch knows whether a simulations tab opened by this machine
    still has a live connection. If one does, the run is pushed to that tab and
    nothing is opened locally.
-2. **Throttle.** When the LangWatch instance is too old to answer that question,
-   a small on-disk record keeps repeat runs of the same set from opening a
-   second tab within a short window.
+2. **Throttle.** When that question can't be answered (unreachable LangWatch,
+   a timeout, or an instance too old to support it), a small on-disk record
+   keeps repeat runs of the same set from opening a second tab within a
+   short window.
 3. **Policy.** ``SCENARIO_BROWSER`` (and the older ``SCENARIO_HEADLESS``) decide
    whether a browser may be opened at all; CI never opens one.
 

--- a/python/scenario/_browser/tab_handoff.py
+++ b/python/scenario/_browser/tab_handoff.py
@@ -1,0 +1,342 @@
+"""
+Keep scenario runs in one browser tab instead of opening a new one every time.
+
+Running a suite in a loop used to leave a trail of twenty LangWatch tabs. The
+fix has three layers, tried in order:
+
+1. **Handoff.** LangWatch knows whether a simulations tab opened by this machine
+   still has a live connection. If one does, the run is pushed to that tab and
+   nothing is opened locally.
+2. **Throttle.** When the LangWatch instance is too old to answer that question,
+   a small on-disk record keeps repeat runs of the same set from opening a
+   second tab within a short window.
+3. **Policy.** ``SCENARIO_BROWSER`` (and the older ``SCENARIO_HEADLESS``) decide
+   whether a browser may be opened at all; CI never opens one.
+
+Every step fails open: a broken handoff, an unwritable state directory, or a
+missing browser must never disturb the scenario run itself.
+"""
+
+import json
+import logging
+import os
+import time
+import uuid
+import webbrowser
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+from urllib.parse import urlencode, urlparse, urlunparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+#: Query param carrying this machine's tab key into the page the SDK opens.
+SCENARIO_TAB_QUERY_PARAM = "scenarioTab"
+
+#: How long the SDK waits on the handoff before giving up and opening a tab.
+HANDOFF_TIMEOUT_SECONDS = 2.0
+
+#: Default window during which the same scenario set will not reopen a tab,
+#: used only when the LangWatch instance cannot answer the handoff.
+DEFAULT_REOPEN_INTERVAL_SECONDS = 300
+
+
+class BrowserPolicy(str, Enum):
+    """Whether this process is allowed to open a browser."""
+
+    AUTO = "auto"
+    NEVER = "never"
+    ALWAYS = "always"
+
+
+class BrowserOutcome(str, Enum):
+    """What actually happened, so callers can print something honest."""
+
+    HANDED_OFF = "handed_off"
+    OPENED = "opened"
+    SUPPRESSED_BY_POLICY = "suppressed_by_policy"
+    SUPPRESSED_BY_THROTTLE = "suppressed_by_throttle"
+    FAILED_TO_OPEN = "failed_to_open"
+
+
+@dataclass(frozen=True)
+class BatchRunLocation:
+    """Everything needed to point a browser at one batch of runs."""
+
+    batch_url: str
+    batch_run_id: str
+    scenario_set_id: Optional[str] = None
+
+
+def _state_dir() -> Path:
+    override = os.getenv("LANGWATCH_STATE_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".langwatch"
+
+
+def _is_truthy(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() not in ("", "0", "false", "no")
+
+
+def _is_ci() -> bool:
+    return _is_truthy(os.getenv("CI"))
+
+
+def resolve_browser_policy(headless: bool = False) -> BrowserPolicy:
+    """
+    Decide the opening policy for this process.
+
+    An explicit ``SCENARIO_BROWSER`` always wins, including over ``headless``,
+    so a developer can force a tab open from a headless-by-default setup.
+    """
+    raw = (os.getenv("SCENARIO_BROWSER") or "").strip().lower()
+    if raw:
+        try:
+            return BrowserPolicy(raw)
+        except ValueError:
+            logger.warning(
+                "Unrecognized SCENARIO_BROWSER=%r, expected one of "
+                "auto/never/always; falling back to auto",
+                raw,
+            )
+            return BrowserPolicy.AUTO
+
+    if headless or _is_ci():
+        return BrowserPolicy.NEVER
+
+    return BrowserPolicy.AUTO
+
+
+def scenario_tab_key() -> Optional[str]:
+    """
+    Stable identifier for this machine's scenario tab, created on first use.
+
+    Shared with the TypeScript SDK through the same file, so a tab opened by a
+    ``pytest`` run is reused by a ``vitest`` run and vice versa. Returns None
+    when the state directory cannot be used, which simply disables reuse.
+    """
+    path = _state_dir() / "scenario-tab-key"
+
+    try:
+        existing = path.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    except (OSError, ValueError):
+        pass
+
+    key = uuid.uuid4().hex
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Exclusive create: when two processes start at once, the loser reads
+        # the winner's key instead of overwriting it.
+        with open(path, "x", encoding="utf-8") as handle:
+            handle.write(key)
+        return key
+    except FileExistsError:
+        try:
+            return path.read_text(encoding="utf-8").strip() or None
+        except OSError:
+            return None
+    except OSError as error:
+        logger.debug("Could not persist the scenario tab key: %r", error)
+        return None
+
+
+def _reopen_interval_seconds() -> int:
+    raw = os.getenv("SCENARIO_BROWSER_REOPEN_SECONDS")
+    if not raw:
+        return DEFAULT_REOPEN_INTERVAL_SECONDS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "Ignoring non-numeric SCENARIO_BROWSER_REOPEN_SECONDS=%r", raw
+        )
+        return DEFAULT_REOPEN_INTERVAL_SECONDS
+
+
+def _throttle_path() -> Path:
+    return _state_dir() / "scenario-tab-opens.json"
+
+
+def _read_throttle() -> Dict[str, float]:
+    try:
+        raw = json.loads(_throttle_path().read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            return {str(k): float(v) for k, v in raw.items()}
+    except (OSError, ValueError, TypeError):
+        pass
+    return {}
+
+
+def _opened_recently(set_key: str, now: float) -> bool:
+    interval = _reopen_interval_seconds()
+    if interval <= 0:
+        return False
+    last = _read_throttle().get(set_key)
+    return last is not None and (now - last) < interval
+
+
+def _record_open(set_key: str, now: float) -> None:
+    path = _throttle_path()
+    entries = _read_throttle()
+    entries[set_key] = now
+
+    # Keep the file from growing forever on long-lived machines.
+    interval = max(_reopen_interval_seconds(), 1)
+    entries = {
+        key: seen for key, seen in entries.items() if now - seen < interval * 10
+    }
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(entries), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError as error:
+        logger.debug("Could not record the browser open time: %r", error)
+
+
+def _with_tab_key(url: str, tab_key: str) -> str:
+    parts = urlparse(url)
+    query = parts.query
+    extra = urlencode({SCENARIO_TAB_QUERY_PARAM: tab_key})
+    merged = f"{query}&{extra}" if query else extra
+    return urlunparse(parts._replace(query=merged))
+
+
+def _request_handoff(
+    *,
+    endpoint: str,
+    api_key: str,
+    tab_key: str,
+    location: BatchRunLocation,
+    project_id: Optional[str] = None,
+) -> Optional[bool]:
+    """
+    Ask LangWatch to push this batch to an already-open tab.
+
+    Returns True when a tab took it, False when none was listening, and None
+    when the instance cannot answer — an old server, a network hiccup — which
+    tells the caller to fall back to its own heuristics.
+    """
+    payload: Dict[str, Any] = {
+        "tabKey": tab_key,
+        "batchRunId": location.batch_run_id,
+    }
+    if location.scenario_set_id:
+        payload["scenarioSetId"] = location.scenario_set_id
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    if project_id:
+        headers["X-Project-Id"] = project_id
+
+    try:
+        response = httpx.post(
+            f"{endpoint.rstrip('/')}/api/scenario-events/browser-tab",
+            json=payload,
+            headers=headers,
+            timeout=HANDOFF_TIMEOUT_SECONDS,
+            follow_redirects=True,
+        )
+    except Exception as error:
+        logger.debug("Browser tab handoff request failed: %r", error)
+        return None
+
+    if response.status_code == 404:
+        # LangWatch predates the handoff endpoint.
+        return None
+
+    if not response.is_success:
+        logger.debug(
+            "Browser tab handoff returned %s: %s",
+            response.status_code,
+            response.text[:200],
+        )
+        return None
+
+    try:
+        return bool(response.json().get("delivered"))
+    except Exception:
+        return None
+
+
+def show_batch_run(
+    location: BatchRunLocation,
+    *,
+    headless: bool = False,
+    endpoint: Optional[str] = None,
+    api_key: Optional[str] = None,
+    project_id: Optional[str] = None,
+    opener: Optional[Callable[[str], Any]] = None,
+) -> BrowserOutcome:
+    """
+    Put this batch of runs in front of the user, reusing their tab when possible.
+
+    ``opener`` exists so tests can watch what would have been opened; production
+    callers leave it alone and get the platform's default browser.
+    """
+    policy = resolve_browser_policy(headless=headless)
+
+    if policy is BrowserPolicy.NEVER:
+        return BrowserOutcome.SUPPRESSED_BY_POLICY
+
+    tab_key = scenario_tab_key()
+
+    if policy is BrowserPolicy.AUTO and tab_key and endpoint and api_key:
+        delivered = _request_handoff(
+            endpoint=endpoint,
+            api_key=api_key,
+            tab_key=tab_key,
+            location=location,
+            project_id=project_id,
+        )
+
+        if delivered is True:
+            return BrowserOutcome.HANDED_OFF
+
+        if delivered is False:
+            # Authoritative "no tab is listening": open one and skip the
+            # throttle, which only exists for servers that cannot answer.
+            return _open(location, tab_key, record=False, opener=opener)
+
+    now = time.time()
+    set_key = location.scenario_set_id or location.batch_url
+
+    if policy is BrowserPolicy.AUTO and _opened_recently(set_key, now):
+        return BrowserOutcome.SUPPRESSED_BY_THROTTLE
+
+    return _open(
+        location, tab_key, record=True, now=now, set_key=set_key, opener=opener
+    )
+
+
+def _open(
+    location: BatchRunLocation,
+    tab_key: Optional[str],
+    *,
+    record: bool,
+    now: Optional[float] = None,
+    set_key: Optional[str] = None,
+    opener: Optional[Callable[[str], Any]] = None,
+) -> BrowserOutcome:
+    url = _with_tab_key(location.batch_url, tab_key) if tab_key else location.batch_url
+
+    try:
+        (opener or webbrowser.open)(url)
+    except Exception as error:
+        logger.debug("Could not open a browser: %r", error)
+        return BrowserOutcome.FAILED_TO_OPEN
+
+    if record and set_key is not None:
+        _record_open(set_key, now if now is not None else time.time())
+
+    return BrowserOutcome.OPENED

--- a/python/scenario/_events/event_alert_message_logger.py
+++ b/python/scenario/_events/event_alert_message_logger.py
@@ -1,7 +1,7 @@
 import os
-import webbrowser
-from typing import Set
+from typing import Optional, Set
 
+from .._browser import BatchRunLocation, BrowserOutcome, show_batch_run
 from ..config.scenario import ScenarioConfig
 from .._utils.ids import get_batch_run_id
 
@@ -33,7 +33,14 @@ class EventAlertMessageLogger:
         EventAlertMessageLogger._shown_batch_ids.add(batch_run_id)
         self._display_greeting(batch_run_id)
 
-    def handle_watch_message(self, set_url: str) -> None:
+    def handle_watch_message(
+        self,
+        set_url: str,
+        scenario_set_id: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        api_key: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> None:
         """
         Shows a fancy message about how to watch the simulation.
         Called when a run started event is received with a session ID.
@@ -45,7 +52,13 @@ class EventAlertMessageLogger:
             return
 
         EventAlertMessageLogger._shown_watch_urls.add(set_url)
-        self._display_watch_message(set_url)
+        self._display_watch_message(
+            set_url,
+            scenario_set_id=scenario_set_id,
+            endpoint=endpoint,
+            api_key=api_key,
+            project_id=project_id,
+        )
 
     def _is_greeting_disabled(self) -> bool:
         """Check if greeting messages are disabled via environment variable."""
@@ -66,21 +79,38 @@ class EventAlertMessageLogger:
             print("   • Set LANGWATCH_API_KEY environment variable")
             print(f"{separator}\n")
 
-    def _display_watch_message(self, set_url: str) -> None:
+    def _display_watch_message(
+        self,
+        set_url: str,
+        scenario_set_id: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        api_key: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> None:
         """Display the watch message with URLs for viewing the simulation."""
         separator = "─" * 60
-        batch_url = f"{set_url}/{get_batch_run_id()}"
+        batch_run_id = get_batch_run_id()
+        batch_url = f"{set_url}/{batch_run_id}"
 
         print(f"\n{separator}")
         print("🎭  Running Scenario Tests")
         print(f"{separator}")
         print(f"Follow it live: {batch_url}")
-        print(f"{separator}\n")
 
         config = ScenarioConfig.default_config or ScenarioConfig()
-        if config and not config.headless:
-            # Open the URL in the default browser (cross-platform)
-            try:
-                webbrowser.open(batch_url)
-            except Exception:
-                pass
+        outcome = show_batch_run(
+            BatchRunLocation(
+                batch_url=batch_url,
+                batch_run_id=batch_run_id,
+                scenario_set_id=scenario_set_id,
+            ),
+            headless=bool(config.headless),
+            endpoint=endpoint,
+            api_key=api_key,
+            project_id=project_id,
+        )
+
+        if outcome is BrowserOutcome.HANDED_OFF:
+            print("↻ Sent to the LangWatch tab you already have open")
+
+        print(f"{separator}\n")

--- a/python/scenario/_events/event_bus.py
+++ b/python/scenario/_events/event_bus.py
@@ -149,8 +149,14 @@ class ScenarioEventBus:
         """
         Handle watch message for scenario run started events.
         """
+        # The reporter already resolved the endpoint and credentials, and the
+        # browser-tab handoff talks to the same LangWatch instance.
         self._event_alert_message_logger.handle_watch_message(
             set_url=str(result["setUrl"]),
+            scenario_set_id=self._extract_scenario_set_id(event),
+            endpoint=self._event_reporter.endpoint,
+            api_key=self._event_reporter.api_key,
+            project_id=self._event_reporter.project_id,
         )
 
     def _extract_scenario_set_id(self, event: ScenarioEvent) -> str:

--- a/python/tests/test_browser_tab_handoff.py
+++ b/python/tests/test_browser_tab_handoff.py
@@ -1,0 +1,535 @@
+"""
+Browser tab reuse, exercised against a real HTTP server.
+
+Covers specs/browser-tab-reuse.feature. The LangWatch side is a real
+``ThreadingHTTPServer`` answering the browser-tab handoff endpoint, so the
+requests, headers, timeouts and status codes on the wire are the genuine
+article. The only injected seam is the opener: tests need to know which URL
+would have been opened without spawning twenty browsers on the machine running
+them, and one subprocess test at the bottom proves the real ``webbrowser`` path
+is wired up.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from scenario._browser import (
+    BatchRunLocation,
+    BrowserOutcome,
+    BrowserPolicy,
+    resolve_browser_policy,
+    scenario_tab_key,
+    show_batch_run,
+)
+from scenario._browser import tab_handoff
+
+BROWSER_ENV_VARS = (
+    "SCENARIO_BROWSER",
+    "SCENARIO_BROWSER_REOPEN_SECONDS",
+    "SCENARIO_HEADLESS",
+    "CI",
+    "LANGWATCH_STATE_DIR",
+)
+
+
+class FakeLangWatch:
+    """A real HTTP server standing in for a LangWatch instance."""
+
+    def __init__(self, *, delivered: bool = False, status: int = 200, delay: float = 0.0):
+        self.delivered = delivered
+        self.status = status
+        self.delay = delay
+        self.requests: List[Dict[str, Any]] = []
+        self.headers: List[Dict[str, str]] = []
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler_class())
+        self._server = server
+        self._thread = threading.Thread(target=server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def endpoint(self) -> str:
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    def _handler_class(self):
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args: Any) -> None:  # keep pytest output clean
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802 - stdlib naming
+                length = int(self.headers.get("Content-Length", "0"))
+                raw = self.rfile.read(length).decode("utf-8") if length else "{}"
+
+                outer.requests.append(
+                    {"path": self.path, "body": json.loads(raw)}
+                )
+                outer.headers.append(dict(self.headers))
+
+                if outer.delay:
+                    time.sleep(outer.delay)
+
+                if outer.status != 200:
+                    self.send_response(outer.status)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(b'{"error":"nope"}')
+                    return
+
+                body = json.dumps(
+                    {"delivered": outer.delivered, "url": "http://example.test/batch"}
+                ).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        return Handler
+
+
+def _run_in_subprocess(
+    body: str, env_overrides: Optional[Dict[str, str]] = None
+) -> "subprocess.CompletedProcess[str]":
+    """
+    Run a snippet against the real module in a fresh interpreter.
+
+    The module is loaded by path rather than as ``scenario._browser`` on
+    purpose: importing the whole package drags in litellm and friends, which
+    costs more than the test budget and proves nothing about tab handoff.
+    """
+    module_path = Path(tab_handoff.__file__)
+    program = textwrap.dedent(
+        f"""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "scenario_tab_handoff", {str(module_path)!r}
+        )
+        handoff = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(handoff)
+        """
+    ) + textwrap.dedent(body)
+
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", ""),
+        "PYTHONPATH": ":".join(sys.path),
+        "LANGWATCH_STATE_DIR": os.environ["LANGWATCH_STATE_DIR"],
+    }
+    env.update(env_overrides or {})
+
+    return subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        timeout=45,
+    )
+
+
+class RecordingOpener:
+    """Stands in for the platform browser and remembers what it was handed."""
+
+    def __init__(self) -> None:
+        self.urls: List[str] = []
+
+    def __call__(self, url: str) -> bool:
+        self.urls.append(url)
+        return True
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    """Give every test its own state directory and a clean environment."""
+    for name in BROWSER_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("LANGWATCH_STATE_DIR", str(tmp_path / "state"))
+    return tmp_path
+
+
+@pytest.fixture
+def opener() -> RecordingOpener:
+    return RecordingOpener()
+
+
+def location(set_id: Optional[str] = "checkout-flow") -> BatchRunLocation:
+    return BatchRunLocation(
+        batch_url="https://app.langwatch.test/proj/simulations/checkout-flow/batch-1",
+        batch_run_id="batch-1",
+        scenario_set_id=set_id,
+    )
+
+
+def show(server: Optional[FakeLangWatch], opener: RecordingOpener, **kwargs):
+    return show_batch_run(
+        kwargs.pop("location", location()),
+        endpoint=server.endpoint if server else None,
+        api_key=kwargs.pop("api_key", "sk-lw-test"),
+        opener=opener,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The happy path: one tab, forever
+# ---------------------------------------------------------------------------
+
+
+def test_first_run_opens_a_tab_stamped_with_the_machine_key(opener):
+    server = FakeLangWatch(delivered=False)
+    try:
+        outcome = show(server, opener)
+    finally:
+        server.close()
+
+    assert outcome is BrowserOutcome.OPENED
+    assert len(opener.urls) == 1
+    assert f"scenarioTab={scenario_tab_key()}" in opener.urls[0]
+    assert opener.urls[0].startswith(
+        "https://app.langwatch.test/proj/simulations/checkout-flow/batch-1"
+    )
+
+
+def test_handoff_carries_the_batch_and_set_ids_with_auth(opener):
+    server = FakeLangWatch(delivered=False)
+    try:
+        show(server, opener)
+    finally:
+        server.close()
+
+    assert server.requests[0]["path"] == "/api/scenario-events/browser-tab"
+    assert server.requests[0]["body"] == {
+        "tabKey": scenario_tab_key(),
+        "batchRunId": "batch-1",
+        "scenarioSetId": "checkout-flow",
+    }
+    assert server.headers[0]["Authorization"] == "Bearer sk-lw-test"
+
+
+def test_a_listening_tab_takes_the_run_and_no_browser_opens(opener):
+    server = FakeLangWatch(delivered=True)
+    try:
+        outcome = show(server, opener)
+    finally:
+        server.close()
+
+    assert outcome is BrowserOutcome.HANDED_OFF
+    assert opener.urls == []
+
+
+def test_repeat_runs_keep_landing_in_the_same_tab(opener):
+    server = FakeLangWatch(delivered=True)
+    try:
+        outcomes = [show(server, opener) for _ in range(5)]
+    finally:
+        server.close()
+
+    assert outcomes == [BrowserOutcome.HANDED_OFF] * 5
+    assert opener.urls == []
+    assert len(server.requests) == 5
+
+
+def test_closing_the_tab_brings_the_auto_open_back(opener):
+    listening = FakeLangWatch(delivered=True)
+    try:
+        assert show(listening, opener) is BrowserOutcome.HANDED_OFF
+    finally:
+        listening.close()
+
+    gone = FakeLangWatch(delivered=False)
+    try:
+        assert show(gone, opener) is BrowserOutcome.OPENED
+    finally:
+        gone.close()
+
+    assert len(opener.urls) == 1
+
+
+def test_an_authoritative_no_tab_answer_ignores_the_throttle(opener):
+    """The server knows better than the on-disk guess, every time."""
+    server = FakeLangWatch(delivered=False)
+    try:
+        first = show(server, opener)
+        second = show(server, opener)
+    finally:
+        server.close()
+
+    assert [first, second] == [BrowserOutcome.OPENED, BrowserOutcome.OPENED]
+    assert len(opener.urls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Machine scoping
+# ---------------------------------------------------------------------------
+
+
+def test_the_tab_key_is_stable_across_calls():
+    assert scenario_tab_key() == scenario_tab_key()
+
+
+def test_the_tab_key_is_shared_across_processes():
+    """A second process must read the key, never mint a competing one."""
+    mine = scenario_tab_key()
+    result = _run_in_subprocess("print(handoff.scenario_tab_key())")
+
+    assert result.stdout.strip() == mine
+
+
+def test_the_tab_key_is_shared_with_the_typescript_sdk(isolated_state):
+    """
+    Both SDKs read the same file, so a tab opened by pytest is reused by vitest.
+
+    Asserted on the file rather than by importing the TypeScript SDK: the shared
+    contract *is* the path and the plain-text contents.
+    """
+    key = scenario_tab_key()
+    key_file = isolated_state / "state" / "scenario-tab-key"
+
+    assert key_file.read_text(encoding="utf-8").strip() == key
+
+
+def test_a_missing_state_directory_only_disables_reuse(monkeypatch, opener):
+    monkeypatch.setenv("LANGWATCH_STATE_DIR", "/proc/nonexistent/cannot-write")
+
+    server = FakeLangWatch(delivered=True)
+    try:
+        outcome = show(server, opener)
+    finally:
+        server.close()
+
+    # No key means no handoff is even attempted; the run still gets a tab.
+    assert outcome is BrowserOutcome.OPENED
+    assert server.requests == []
+    assert opener.urls == [location().batch_url]
+
+
+# ---------------------------------------------------------------------------
+# Degrading gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_an_instance_without_the_endpoint_still_opens_a_tab(opener):
+    server = FakeLangWatch(status=404)
+    try:
+        outcome = show(server, opener)
+    finally:
+        server.close()
+
+    assert outcome is BrowserOutcome.OPENED
+    assert len(opener.urls) == 1
+
+
+def test_an_old_instance_stops_spamming_tabs_for_the_same_set(opener):
+    server = FakeLangWatch(status=404)
+    try:
+        first = show(server, opener)
+        second = show(server, opener)
+        third = show(server, opener)
+    finally:
+        server.close()
+
+    assert first is BrowserOutcome.OPENED
+    assert second is BrowserOutcome.SUPPRESSED_BY_THROTTLE
+    assert third is BrowserOutcome.SUPPRESSED_BY_THROTTLE
+    assert len(opener.urls) == 1
+
+
+def test_the_throttle_is_per_scenario_set(opener):
+    server = FakeLangWatch(status=404)
+    try:
+        show(server, opener, location=location("checkout-flow"))
+        outcome = show(server, opener, location=location("onboarding"))
+    finally:
+        server.close()
+
+    assert outcome is BrowserOutcome.OPENED
+    assert len(opener.urls) == 2
+
+
+def test_the_throttle_window_is_configurable(monkeypatch, opener):
+    monkeypatch.setenv("SCENARIO_BROWSER_REOPEN_SECONDS", "0")
+
+    server = FakeLangWatch(status=404)
+    try:
+        first = show(server, opener)
+        second = show(server, opener)
+    finally:
+        server.close()
+
+    assert [first, second] == [BrowserOutcome.OPENED, BrowserOutcome.OPENED]
+
+
+def test_a_hanging_langwatch_never_stalls_the_run(opener):
+    server = FakeLangWatch(delivered=True, delay=5.0)
+    started = time.monotonic()
+    try:
+        outcome = show(server, opener)
+    finally:
+        server.close()
+    elapsed = time.monotonic() - started
+
+    assert outcome is BrowserOutcome.OPENED
+    assert elapsed < 4.5, "the handoff must time out well before the server answers"
+
+
+def test_an_unreachable_langwatch_falls_back_to_opening(opener):
+    # Port 1 on loopback refuses connections immediately.
+    outcome = show_batch_run(
+        location(),
+        endpoint="http://127.0.0.1:1",
+        api_key="sk-lw-test",
+        opener=opener,
+    )
+
+    assert outcome is BrowserOutcome.OPENED
+    assert len(opener.urls) == 1
+
+
+def test_without_credentials_the_handoff_is_skipped(opener):
+    server = FakeLangWatch(delivered=True)
+    try:
+        outcome = show(server, opener, api_key=None)
+    finally:
+        server.close()
+
+    assert outcome is BrowserOutcome.OPENED
+    assert server.requests == []
+
+
+# ---------------------------------------------------------------------------
+# Policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("auto", BrowserPolicy.AUTO),
+        ("never", BrowserPolicy.NEVER),
+        ("always", BrowserPolicy.ALWAYS),
+        ("ALWAYS", BrowserPolicy.ALWAYS),
+        ("nonsense", BrowserPolicy.AUTO),
+    ],
+)
+def test_scenario_browser_selects_the_policy(monkeypatch, value, expected):
+    monkeypatch.setenv("SCENARIO_BROWSER", value)
+    assert resolve_browser_policy() is expected
+
+
+def test_headless_config_suppresses_the_browser():
+    assert resolve_browser_policy(headless=True) is BrowserPolicy.NEVER
+
+
+def test_ci_suppresses_the_browser(monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    assert resolve_browser_policy() is BrowserPolicy.NEVER
+
+
+def test_ci_set_to_false_does_not_suppress_the_browser(monkeypatch):
+    monkeypatch.setenv("CI", "false")
+    assert resolve_browser_policy() is BrowserPolicy.AUTO
+
+
+def test_an_explicit_policy_beats_headless(monkeypatch):
+    monkeypatch.setenv("SCENARIO_BROWSER", "always")
+    assert resolve_browser_policy(headless=True) is BrowserPolicy.ALWAYS
+
+
+def test_never_opens_nothing_and_asks_nothing(monkeypatch, opener):
+    monkeypatch.setenv("SCENARIO_BROWSER", "never")
+
+    server = FakeLangWatch(delivered=False)
+    try:
+        outcome = show(server, opener)
+    finally:
+        server.close()
+
+    assert outcome is BrowserOutcome.SUPPRESSED_BY_POLICY
+    assert opener.urls == []
+    assert server.requests == []
+
+
+def test_always_opens_even_when_a_tab_is_listening(monkeypatch, opener):
+    monkeypatch.setenv("SCENARIO_BROWSER", "always")
+
+    server = FakeLangWatch(delivered=True)
+    try:
+        first = show(server, opener)
+        second = show(server, opener)
+    finally:
+        server.close()
+
+    assert [first, second] == [BrowserOutcome.OPENED, BrowserOutcome.OPENED]
+    assert server.requests == [], "always means always; do not consult the server"
+    assert len(opener.urls) == 2
+
+
+def test_headless_true_suppresses_the_browser(opener):
+    server = FakeLangWatch(delivered=False)
+    try:
+        outcome = show(server, opener, headless=True)
+    finally:
+        server.close()
+
+    assert outcome is BrowserOutcome.SUPPRESSED_BY_POLICY
+    assert opener.urls == []
+
+
+# ---------------------------------------------------------------------------
+# The real browser path
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_opener_goes_through_webbrowser(tmp_path):
+    """
+    No injected opener: prove the production path really reaches ``webbrowser``.
+
+    ``BROWSER`` makes the stdlib shell out to a recorder instead of a browser,
+    and a fresh process guarantees ``webbrowser`` reads it during its own
+    lazy initialisation.
+    """
+    recorder = tmp_path / "opened.txt"
+    launcher = tmp_path / "record-url.sh"
+    launcher.write_text(f'#!/bin/sh\nprintf "%s" "$1" > {recorder}\n')
+    launcher.chmod(0o755)
+
+    result = _run_in_subprocess(
+        """
+        print(
+            handoff.show_batch_run(
+                handoff.BatchRunLocation(
+                    batch_url="https://app.langwatch.test/p/simulations/s/batch-9",
+                    batch_run_id="batch-9",
+                    scenario_set_id="s",
+                ),
+                endpoint="http://127.0.0.1:1",
+                api_key="sk-lw-test",
+            ).value
+        )
+        """,
+        env_overrides={"BROWSER": f"{launcher} %s"},
+    )
+
+    assert result.stdout.strip() == "opened"
+    assert recorder.exists(), "webbrowser never launched the configured browser"
+    assert recorder.read_text().startswith(
+        "https://app.langwatch.test/p/simulations/s/batch-9?scenarioTab="
+    )

--- a/python/tests/test_browser_tab_handoff.py
+++ b/python/tests/test_browser_tab_handoff.py
@@ -306,8 +306,14 @@ def test_the_tab_key_is_shared_with_the_typescript_sdk(isolated_state):
     assert key_file.read_text(encoding="utf-8").strip() == key
 
 
-def test_a_missing_state_directory_only_disables_reuse(monkeypatch, opener):
-    monkeypatch.setenv("LANGWATCH_STATE_DIR", "/proc/nonexistent/cannot-write")
+def test_a_missing_state_directory_only_disables_reuse(
+    monkeypatch, opener, tmp_path
+):
+    # A regular file where a directory has to go: unusable on every platform,
+    # unlike a hardcoded /proc path that only fails on Linux.
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("", encoding="utf-8")
+    monkeypatch.setenv("LANGWATCH_STATE_DIR", str(blocker / "state"))
 
     server = FakeLangWatch(delivered=True)
     try:

--- a/specs/browser-tab-reuse.feature
+++ b/specs/browser-tab-reuse.feature
@@ -45,7 +45,7 @@ Feature: Reuse a single browser tab for scenario runs
     And the SDK opens a fresh browser tab
 
   # ---------------------------------------------------------------------------
-  # Machine scoping — never touch someone else's browser
+  # Machine scoping: never touch someone else's browser
   # ---------------------------------------------------------------------------
 
   @unit
@@ -77,7 +77,7 @@ Feature: Reuse a single browser tab for scenario runs
     And the SDK opens its own tab
 
   # ---------------------------------------------------------------------------
-  # Degrading gracefully — old servers, offline, failures
+  # Degrading gracefully: old servers, offline, failures
   # ---------------------------------------------------------------------------
 
   @integration
@@ -109,7 +109,7 @@ Feature: Reuse a single browser tab for scenario runs
     Then the SDK opens a tab for "onboarding"
 
   # ---------------------------------------------------------------------------
-  # Policy — who decides whether a browser opens at all
+  # Policy: who decides whether a browser opens at all
   # ---------------------------------------------------------------------------
 
   @unit

--- a/specs/browser-tab-reuse.feature
+++ b/specs/browser-tab-reuse.feature
@@ -1,0 +1,164 @@
+Feature: Reuse a single browser tab for scenario runs
+  As a developer running scenario suites repeatedly, often from a coding agent
+  in the background
+  I want every run to land in the same LangWatch tab I already have open
+  So that a morning of iteration leaves me with one tab instead of twenty
+
+  Background:
+    Given the SDK is configured with a LangWatch API key
+    And the LangWatch instance supports the browser-tab handoff endpoint
+
+  # ---------------------------------------------------------------------------
+  # The happy path: one tab, forever
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The first run opens a tab because nothing is listening yet
+    Given no LangWatch simulations tab is open on this machine
+    When a scenario run starts
+    Then the SDK asks LangWatch to hand the run to an already-open tab
+    And LangWatch answers that no tab is listening
+    And the SDK opens the batch URL in the default browser
+    And the opened URL carries this machine's scenario tab key as a query param
+
+  @integration
+  Scenario: Later runs are handed to the tab that is already open
+    Given a LangWatch simulations tab is open and registered for this machine
+    When a scenario run starts
+    Then LangWatch answers that the run was delivered to an open tab
+    And the SDK does not open the default browser
+    And the console still prints the follow-it-live URL
+
+  @integration
+  Scenario: The already-open tab moves itself to the new run
+    Given a LangWatch simulations tab is open and registered for this machine
+    When a scenario run starts and LangWatch delivers the handoff
+    Then the open tab navigates to the new batch URL without a page reload
+    And the tab does not steal focus from whatever the user is doing
+
+  @integration
+  Scenario: Closing the tab restores the auto-open behaviour
+    Given a LangWatch simulations tab was open and registered for this machine
+    When the user closes that tab
+    And a scenario run starts after the registration has expired
+    Then LangWatch answers that no tab is listening
+    And the SDK opens a fresh browser tab
+
+  # ---------------------------------------------------------------------------
+  # Machine scoping — never touch someone else's browser
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: The scenario tab key is stable across processes on one machine
+    Given the scenario tab key file does not exist yet
+    When two separate SDK processes each resolve the scenario tab key
+    Then both processes read the same key
+    And the key is persisted under the user's LangWatch state directory
+
+  @unit
+  Scenario: Python and TypeScript SDKs share one scenario tab key
+    Given a scenario tab key was created by the Python SDK
+    When the TypeScript SDK resolves the scenario tab key on the same machine
+    Then it reads the identical key from the same file
+    And a run started from either SDK reuses the same tab
+
+  @integration
+  Scenario: A run from another machine never navigates my tab
+    Given my LangWatch simulations tab is registered with my scenario tab key
+    When a run starts on a different machine with a different scenario tab key
+    Then LangWatch answers that no tab is listening for that key
+    And my open tab is not navigated
+
+  @integration
+  Scenario: A manually opened simulations tab is left alone
+    Given the user opened the simulations page directly without a scenario tab key
+    When a scenario run starts on this machine
+    Then that tab does not register as a handoff target
+    And the SDK opens its own tab
+
+  # ---------------------------------------------------------------------------
+  # Degrading gracefully — old servers, offline, failures
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A LangWatch instance without the endpoint still works
+    Given the LangWatch instance returns 404 for the browser-tab handoff endpoint
+    When a scenario run starts
+    Then the SDK opens the browser as it always did
+    And no error is surfaced to the user
+
+  @integration
+  Scenario: A slow or unreachable LangWatch never delays a scenario run
+    Given the browser-tab handoff endpoint hangs past the SDK's timeout
+    When a scenario run starts
+    Then the SDK stops waiting within the handoff timeout
+    And the scenario run proceeds normally
+
+  @integration
+  Scenario: Without the handoff endpoint, repeat runs still stop spamming tabs
+    Given the LangWatch instance does not support the browser-tab handoff
+    And the SDK opened a tab for this scenario set moments ago
+    When another scenario run starts for the same set within the reopen interval
+    Then the SDK does not open a second tab
+    And the console still prints the follow-it-live URL
+
+  @unit
+  Scenario: The reopen interval is per scenario set, not global
+    Given the SDK opened a tab for set "checkout-flow" moments ago
+    When a run starts for set "onboarding" within the reopen interval
+    Then the SDK opens a tab for "onboarding"
+
+  # ---------------------------------------------------------------------------
+  # Policy — who decides whether a browser opens at all
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario Outline: SCENARIO_BROWSER decides the opening policy
+    Given SCENARIO_BROWSER is set to "<policy>"
+    When a scenario run starts with no tab listening
+    Then the SDK <behaviour>
+
+    Examples:
+      | policy | behaviour                                                  |
+      | auto   | asks for a handoff first and opens only if none happened    |
+      | never  | never opens a browser and never asks for a handoff          |
+      | always | opens a browser every run, skipping handoff and throttle    |
+
+  @unit
+  Scenario: SCENARIO_HEADLESS keeps working as the old opt-out
+    Given SCENARIO_HEADLESS is set to "true"
+    And SCENARIO_BROWSER is not set
+    When a scenario run starts
+    Then no browser is opened
+    And no browser-tab handoff request is sent
+
+  @unit
+  Scenario: An explicit SCENARIO_BROWSER wins over SCENARIO_HEADLESS
+    Given SCENARIO_HEADLESS is set to "true"
+    And SCENARIO_BROWSER is set to "always"
+    When a scenario run starts
+    Then a browser is opened
+
+  @unit
+  Scenario: CI never opens a browser
+    Given the CI environment variable is set
+    And SCENARIO_BROWSER is not set
+    When a scenario run starts
+    Then no browser is opened
+
+  @unit
+  Scenario: headless=True in code still suppresses the browser
+    Given the scenario config sets headless to true
+    When a scenario run starts
+    Then no browser is opened
+
+  # ---------------------------------------------------------------------------
+  # What the developer sees
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The console explains that a tab was reused
+    Given a LangWatch simulations tab is open and registered for this machine
+    When a scenario run starts
+    Then the console prints that the run was sent to the already-open tab
+    And the message appears once per batch, not once per scenario


### PR DESCRIPTION
## The problem

Every scenario batch opens a browser tab. Run a suite in a loop, or let a coding agent run it in the background while you work, and you end up with twenty LangWatch tabs that never close.

The SDK had no way to know a tab was already showing your runs, so it opened another one. The operating system cannot answer that question, and neither can the browser from the outside.

## The fix

LangWatch can answer it. The simulations page holds an SSE subscription while it is open, so it can tell the server it exists. Before opening anything, the SDK asks:

```
POST /api/scenario-events/browser-tab  { tabKey, batchRunId, scenarioSetId }
  -> { delivered: true }   a tab took it, open nothing
  -> { delivered: false }  nobody is listening, open a tab
```

When a tab takes it, the batch is broadcast to that tab, which routes itself to the new run silently: the user started the run, the page moving to it is the expected outcome, not news. The tab carries a quiet "Connected to local run" badge in the set header so it can be told apart from tabs opened by hand. Focus is never stolen: a background tab stays in the background, showing the newest run when you switch to it.

The server side lives in the companion PR: langwatch/langwatch#6137

## Identifying the machine

`~/.langwatch/scenario-tab-key` holds a random key created on first use. Both SDKs read the same file, so a tab opened by `pytest` is reused by `vitest`. It travels only as a query param on the tab the SDK opens, and LangWatch scrubs it from the address bar on arrival, so a copied link never carries it.

Presence is scoped by project and by that key, so a CI run or a colleague's suite can never steer a browser that is not theirs.

## Fallbacks, in order

| Situation | Behaviour |
| --- | --- |
| A tab is listening | Handed off, nothing opens |
| No tab is listening | A tab opens, stamped with the machine key |
| LangWatch too old to answer | A tab opens, then the same set will not reopen for `SCENARIO_BROWSER_REOPEN_SECONDS` (300 default, `0` disables) |
| LangWatch slow or unreachable | The handoff times out at 2s and a tab opens |
| Unwritable state directory | Reuse is off, a tab opens |

Nothing in this path can break a run.

## Policy

`SCENARIO_BROWSER` decides whether a browser may open at all:

- `auto` (default): reuse a tab, open only when none is listening
- `never`: never open, same as `SCENARIO_HEADLESS=true`
- `always`: open every run, skipping reuse. The old behaviour, if you want it back.

`SCENARIO_BROWSER` beats `SCENARIO_HEADLESS` and beats `headless` in config, so a tab can be forced open from an otherwise headless setup. A `CI` environment variable is treated as `never`.

## Dogfooded, not just tested

Driven end to end against a local LangWatch and a real Chromium, with the SDK's
own opener intercepted by a shim on PATH (and `BROWSER` for Python's stdlib) so
every tab either SDK would have spawned is counted rather than thrown at the
desktop.

Ten scenario runs, one tab:

```
=== 1. A developer has the simulations page open ===
PASS  the scenarioTab key is scrubbed from the address bar

=== 2. Five scenario runs, the way an agent would ===
PASS  run 1..5 were handed to the open tab
PASS  no browser tab was opened for any of the five runs — opened=[]
PASS  the one tab moved to a new batch on every run — batches=5
PASS  only one page is open in the browser — pages=1

=== 3. The user closes the tab ===
PASS  with no tab listening, exactly one tab is opened
PASS  the opened URL carries this machine's tab key
PASS  the console does not claim a handoff that did not happen

=== 4. Reopening that URL brings the tab back ===
PASS  the revived tab takes the next run
PASS  and still nothing new was opened

=== 5/6/7. never opens nothing · CI opens nothing · always still opens ===
ALL CHECKS PASSED
```

And the same again driven by the TypeScript SDK, including a Python run and a
TypeScript run back to back on one machine key — the point of sharing the key
file.

The open tab wears its badge and follows runs without interrupting anyone:

![Connected to local run badge](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-847/browser-tab/connected-badge.png)

Hovering the badge explains what it means:

![Badge popover on hover](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-847/browser-tab/connected-badge-popover.png)

And when no tab is listening, the one the SDK opens lands on the run:

![Reopened from the URL the SDK opened](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-847/browser-tab/reopened-from-sdk-url.png)

## Two bugs the dogfooding caught

Both were fire-and-forget hops that reported success without doing the work.
`open()` only spawns its launcher a few ticks in, so `void open(url)` lost the
tab when the process ended promptly; and the event bus handed the watch message
to an rxjs `tap`, which drops the promise. Both are awaited now.

## Tests

59 new tests, no mocked HTTP.

- **Python (30)**: a real `ThreadingHTTPServer` answers the handoff, so the requests, headers, status codes and timeouts on the wire are real. Real state files in a temp directory. One subprocess test drives the production path all the way through `webbrowser` with `BROWSER` pointed at a recording script, proving the default opener really launches.
- **TypeScript (29)**: a real `node:http` server and real state files, mirroring the Python suite case for case, including that both SDKs read the same key file.

The only injected seam is the opener, so the suites can assert which URL would have opened without spawning browsers on the machine running them.

## Specs

`specs/browser-tab-reuse.feature`

## Docs

`docs/docs/pages/basics/configuration.mdx` gains a "The browser tab" section plus the two new environment variables.


