### PR TITLE
fix(voice): real voice-in on Python ElevenLabs, per-call personalisation, agent hangup, and corrected docs

### DIFF
--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -8,6 +8,13 @@
 # that branch protection requires.
 name: javascript-ci
 
+# All OpenAI-compatible traffic (judge LLMs, TTS, STT) rides the LangWatch
+# AI Gateway: OPENAI_API_KEY holds a LangWatch virtual key, and these base
+# URLs point every client family (openai SDK, litellm, ai-sdk) at it.
+env:
+  OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+  OPENAI_API_BASE: https://gateway.langwatch.ai/v1
+
 on:
   push:
     branches:

--- a/.github/workflows/javascript-voice-integration.yml
+++ b/.github/workflows/javascript-voice-integration.yml
@@ -1,5 +1,15 @@
 name: javascript-voice-integration
 
+# All OpenAI-compatible HTTP traffic (judge and user-sim LLMs, TTS, STT)
+# rides the LangWatch AI Gateway: OPENAI_API_KEY holds a LangWatch virtual
+# key, and these base URLs point every client family (openai SDK, litellm,
+# ai-sdk) at the gateway. The OpenAI Realtime websocket connects directly
+# to OpenAI and uses OPENAI_REALTIME_API_KEY (a real provider key) instead.
+env:
+  OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+  OPENAI_API_BASE: https://gateway.langwatch.ai/v1
+  OPENAI_REALTIME_API_KEY: ${{ secrets.OPENAI_REALTIME_API_KEY }}
+
 # On-demand workflow for the JavaScript voice e2e demos that hit live providers
 # (OpenAI Realtime, ElevenLabs, Gemini Live) and the bundled Pipecat stub bot.
 # These tests cost real API money, so they do NOT run on every PR and do NOT run

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,6 +8,13 @@
 # that branch protection requires.
 name: python-ci
 
+# All OpenAI-compatible traffic (judge LLMs, TTS, STT) rides the LangWatch
+# AI Gateway: OPENAI_API_KEY holds a LangWatch virtual key, and these base
+# URLs point every client family (openai SDK, litellm, ai-sdk) at it.
+env:
+  OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+  OPENAI_API_BASE: https://gateway.langwatch.ai/v1
+
 on:
   push:
     branches:

--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -1,5 +1,15 @@
 name: voice-integration
 
+# All OpenAI-compatible HTTP traffic (judge and user-sim LLMs, TTS, STT)
+# rides the LangWatch AI Gateway: OPENAI_API_KEY holds a LangWatch virtual
+# key, and these base URLs point every client family (openai SDK, litellm,
+# ai-sdk) at the gateway. The OpenAI Realtime websocket connects directly
+# to OpenAI and uses OPENAI_REALTIME_API_KEY (a real provider key) instead.
+env:
+  OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
+  OPENAI_API_BASE: https://gateway.langwatch.ai/v1
+  OPENAI_REALTIME_API_KEY: ${{ secrets.OPENAI_REALTIME_API_KEY }}
+
 # On-demand workflow for voice tests that hit live providers (OpenAI Realtime,
 # Twilio, ElevenLabs, Gemini Live). These tests cost real API money and/or
 # provision real phone lines, so they do NOT run on every PR and do NOT run on

--- a/docs/docs/pages/voice/adapters/elevenlabs.mdx
+++ b/docs/docs/pages/voice/adapters/elevenlabs.mdx
@@ -84,6 +84,32 @@ adapter = scenario.ElevenLabsAgentAdapter(
 )
 ```
 
+## Turn boundaries
+
+ElevenLabs delivers agent audio in bursts. A delivery gap longer than
+`response_tail_silence` (0.6s by default) closes the turn while the agent is
+still speaking, which would otherwise leave the rest of the utterance to surface
+as the *next* turn's opening audio — making reply N+1 look like an answer to
+question N.
+
+At each user-turn boundary the adapter sweeps up any agent audio still in flight
+and attributes it to the turn that produced it. When that happens you'll see:
+
+```
+ElevenLabsAgentAdapter: recovered 41280 bytes of agent audio stranded by an
+early turn close and attributed them to the preceding agent turn. Raise
+response_tail_silence if this recurs.
+```
+
+That warning is informational, not a failure. If it fires on most turns your
+agent's delivery is gappier than the default tolerates, so raise
+`response_tail_silence`:
+
+```python [python]
+adapter = scenario.ElevenLabsAgentAdapter(agent_id=..., api_key=...)
+adapter.response_tail_silence = 1.2
+```
+
 ## Agent-initiated hangup
 
 Hosted agents commonly end a call themselves by invoking the `end_call` system

--- a/docs/docs/pages/voice/adapters/elevenlabs.mdx
+++ b/docs/docs/pages/voice/adapters/elevenlabs.mdx
@@ -78,7 +78,7 @@ STT and turn-taking.
 | `"text"` | Sends a `user_message` text commit and **no audio**. Deterministic, but your agent's STT and VAD never run, so a green run says nothing about either. Opt in only when scripted audio cannot drive your agent's turn-taking. |
 | `"silence"` | Streams the PCM followed by a fixed silence tail. Superseded by `"audio"`; a bounded tail does not reliably close a scripted turn. |
 
-```python [python]
+```python
 adapter = scenario.ElevenLabsAgentAdapter(
     agent_id=..., api_key=..., turn_commit_mode="text",  # opt out of real voice-in
 )
@@ -105,7 +105,7 @@ That warning is informational, not a failure. If it fires on most turns your
 agent's delivery is gappier than the default tolerates, so raise
 `response_tail_silence`:
 
-```python [python]
+```python
 adapter = scenario.ElevenLabsAgentAdapter(agent_id=..., api_key=...)
 adapter.response_tail_silence = 1.2
 ```

--- a/docs/docs/pages/voice/adapters/elevenlabs.mdx
+++ b/docs/docs/pages/voice/adapters/elevenlabs.mdx
@@ -22,9 +22,9 @@ import scenario
 adapter = scenario.ElevenLabsAgentAdapter(
     agent_id=os.environ["ELEVENLABS_AGENT_ID"],
     api_key=os.environ["ELEVENLABS_API_KEY"],
-    # Optional per-session overrides (sent via conversation_initiation_client_data):
-    # system_prompt_override="Be terse for this test.",
-    # first_message_override="Hi — this is the test harness.",
+    # Personalise this call without touching the deployed agent:
+    dynamic_variables={"tenant_id": "acme", "seat_tier": 2, "is_vip": True},
+    overrides={"agent": {"language": "es"}},
 )
 ```
 
@@ -34,23 +34,66 @@ import scenario from "@langwatch/scenario";
 const adapter = scenario.elevenLabsAgent({
   agentId: process.env.ELEVENLABS_AGENT_ID!,
   apiKey: process.env.ELEVENLABS_API_KEY!,
-  // Optional per-session overrides (sent via conversation_initiation_client_data):
-  // systemPromptOverride: "Be terse for this test.",
-  // firstMessageOverride: "Hi — this is the test harness.",
+  // Personalise this call without touching the deployed agent:
+  dynamicVariables: { tenant_id: "acme", seat_tier: 2, is_vip: true },
+  overrides: { agent: { language: "es" } },
 });
 ```
 
 :::
 
-The two optional per-session override fields let you adjust the hosted agent's
-behaviour for a specific test run without modifying the shared ElevenLabs dashboard
-configuration. They are transmitted in the WebSocket
-`conversation_initiation_client_data` handshake at connect time:
+All per-session options are transmitted in the WebSocket
+`conversation_initiation_client_data` handshake at connect time. ElevenLabs
+applies each one **only if the agent allowlists it** server-side (Agent →
+Security → Overrides in the dashboard); anything not opted in is ignored.
 
 | Python | TypeScript | Description |
 |---|---|---|
-| `system_prompt_override` | `systemPromptOverride` | Replaces the agent's system prompt for this session only. Useful for pinning a test persona without touching the shared dashboard agent. |
+| `dynamic_variables` | `dynamicVariables` | Per-call values that fill the **deployed** prompt's `{{template}}` placeholders. Text, numeric, and boolean values pass through with their JSON type intact. This is how production integrations personalise an agent per call. Omitted entirely when unset. |
+| `overrides` | `overrides` | Any `conversation_config_override` the narrow knobs below do not cover, e.g. `{"agent": {"language": "es"}}` or `{"tts": {"stability": 0.3}}`. Deep-merged, so your `agent.language` and the adapter's `agent.prompt` both survive. |
+| `system_prompt_override` | `systemPromptOverride` | Replaces the agent's system prompt for this session only. **See the warning below before using this on a hosted agent.** |
 | `first_message_override` | `firstMessageOverride` | Overrides the agent's opening message for this session. |
+
+<Callout type="warning">
+**`system_prompt_override` drops your agent's tools.** ElevenLabs replaces the
+*entire* prompt object, `tool_ids` included. A hosted agent that relies on server
+tools silently loses them and then stalls waiting for tool responses that can
+never arrive, which surfaces as a confirmation loop or a `receiveAudio` timeout.
+
+To personalise a deployed agent, prefer `dynamic_variables` to fill its prompt
+template, plus a narrow `overrides` entry for things like language. Reach for the
+prompt override only when the agent has no tools, as in a purpose-built test
+agent.
+</Callout>
+
+## Turn commit modes
+
+How the adapter tells ElevenLabs a user turn is over. The default streams the
+user's real voice, which is what makes the run evidence about your agent's own
+STT and turn-taking.
+
+| Mode | Behaviour |
+|---|---|
+| `"audio"` (default) | Streams the turn's real PCM as 20 ms frames at microphone cadence, then unbounded closing silence. EL's server VAD closes the turn on that audio→silence transition, and its STT transcribes what you sent. |
+| `"text"` | Sends a `user_message` text commit and **no audio**. Deterministic, but your agent's STT and VAD never run, so a green run says nothing about either. Opt in only when scripted audio cannot drive your agent's turn-taking. |
+| `"silence"` | Streams the PCM followed by a fixed silence tail. Superseded by `"audio"`; a bounded tail does not reliably close a scripted turn. |
+
+```python [python]
+adapter = scenario.ElevenLabsAgentAdapter(
+    agent_id=..., api_key=..., turn_commit_mode="text",  # opt out of real voice-in
+)
+```
+
+## Agent-initiated hangup
+
+Hosted agents commonly end a call themselves by invoking the `end_call` system
+tool (or a `transfer_to_*` tool) right after their farewell, which closes the
+WebSocket. When that happens the adapter records it and any remaining scripted
+turn concludes the conversation and falls through to the judge, rather than
+failing a run in which the agent behaved exactly as designed.
+
+Read `adapter.agent_hung_up` (Python) / `adapter.agentHungUp` (TypeScript) to
+assert on who ended the call.
 
 ## Capabilities
 

--- a/docs/docs/pages/voice/getting-started.mdx
+++ b/docs/docs/pages/voice/getting-started.mdx
@@ -58,7 +58,7 @@ The assistant reads your codebase, detects which voice transport your agent is o
 
 Here's what the generated test looks like for a **Pipecat WS bot**, the most common path — the `url` is the connection point to YOUR running bot:
 
-> **Note:** `proceed()` drives auto-generated turns reliably on composable/pipecat/realtime voice adapters, but **not** on the hosted `elevenLabsAgent` (single-exchange only — see the [multi-turn recipe](/voice/recipes/multi-turn)).
+> **Note:** `proceed()` drives auto-generated turns on every shipping voice adapter, hosted `elevenLabsAgent` included — see the [multi-turn recipe](/voice/recipes/multi-turn).
 
 :::code-group
 

--- a/docs/docs/pages/voice/happy-path-elevenlabs.mdx
+++ b/docs/docs/pages/voice/happy-path-elevenlabs.mdx
@@ -11,7 +11,7 @@ description: Step-by-step guide to test a deployed ElevenLabs Conversational AI 
 
 ## Prerequisites
 
-- Python 3.11+
+- Python 3.11+ **or** Node.js 20+
 - An ElevenLabs account with a deployed Conversational AI agent (`agent_id`)
 - `ELEVENLABS_API_KEY`
 - `OPENAI_API_KEY` — for the judge LLM and the default user simulator's TTS
@@ -22,11 +22,19 @@ description: Step-by-step guide to test a deployed ElevenLabs Conversational AI 
 
 ## Step 1 — Install
 
-```bash
+:::code-group
+
+```bash [python]
 pip install scenario
 ```
 
-Voice is first-class — no `[voice]` extras flag, no separate install step. ffmpeg ships bundled via `imageio-ffmpeg`. You're ready.
+```bash [typescript]
+npm install @langwatch/scenario
+```
+
+:::
+
+Voice is first-class — no extras flag, no separate install step. On Python, ffmpeg ships bundled via `imageio-ffmpeg`. You're ready.
 
 ---
 
@@ -46,9 +54,10 @@ OPENAI_API_KEY=your-openai-key
 
 ## Step 3 — Write a scenario
 
-Create `test_my_voice_agent.py`:
+:::code-group
 
-```python
+```python [python]
+# test_my_voice_agent.py
 import os
 import pytest
 import scenario
@@ -83,6 +92,43 @@ async def test_greeting_is_warm():
     assert result.success, result.reasoning
 ```
 
+```typescript [typescript]
+// my-voice-agent.test.ts
+import scenario from "@langwatch/scenario";
+import { describe, it, expect } from "vitest";
+
+describe("greeting", () => {
+  it("is warm", async () => {
+    const result = await scenario.run({
+      name: "greeting_warmth",
+      description: "User calls in; agent should greet warmly and offer help.",
+      agents: [
+        // The agent under test — your real ElevenLabs agent.
+        scenario.elevenLabsAgent({
+          agentId: process.env.ELEVENLABS_AGENT_ID!,
+          apiKey: process.env.ELEVENLABS_API_KEY!,
+        }),
+        // The simulated caller — what your agent would hear.
+        scenario.userSimulatorAgent({ voice: "openai/nova" }),
+        // The judge — LLM-evaluates whether criteria were met.
+        scenario.judgeAgent({
+          criteria: ["The agent greeted warmly and offered to help"],
+        }),
+      ],
+      script: [
+        scenario.agent(), // greeting drains first (EL sends first_message on connect)
+        scenario.user("Hi, I have a question about my account"),
+        scenario.agent(),
+        scenario.judge(),
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+:::
+
 **How the three agents fit together:**
 - `ElevenLabsAgentAdapter` is **your real agent under test** — the one whose behavior regressions you're catching.
 - `UserSimulatorAgent` plays the human caller — TTS-es scripted lines so your agent hears real audio.
@@ -97,9 +143,17 @@ async def test_greeting_is_warm():
 
 ## Step 4 — Run it
 
-```bash
+:::code-group
+
+```bash [python]
 pytest test_my_voice_agent.py -v
 ```
+
+```bash [typescript]
+npx vitest run my-voice-agent.test.ts
+```
+
+:::
 
 A pass means your agent met the criteria. A failure includes the judge's reasoning:
 
@@ -114,7 +168,9 @@ That verdict points at the exact drift. Drop the scenario into CI and it fires o
 
 ## Step 5 — What you get back
 
-```python
+:::code-group
+
+```python [python]
 result = await scenario.run(...)
 
 result.success              # bool
@@ -127,6 +183,21 @@ result.timeline                    # ordered VoiceEvent list
 result.latency                     # LatencyMetrics: TTFB, p50, p95
 ```
 
+```typescript [typescript]
+const result = await scenario.run({ ... });
+
+result.success;                // boolean
+result.reasoning;              // judge's verdict text
+result.audio;                  // VoiceRecording object
+result.audio.save("out.wav");  // save full conversation as WAV
+result.audio.save("out.mp3");  // or MP3 (ffmpeg)
+result.audio.segments;         // AudioSegment[] per speaker
+result.timeline;               // ordered VoiceEvent list
+result.latency;                // LatencyMetrics: TTFB, p50, p95
+```
+
+:::
+
 Good next step: `result.audio.save("captured.wav")` after a failed run and listen to the actual conversation. The judge is an LLM — sometimes you need ears.
 
 ---
@@ -135,13 +206,27 @@ Good next step: `result.audio.save("captured.wav")` after a failed run and liste
 
 A noisier scenario:
 
-```python
+:::code-group
+
+```python [python]
 scenario.UserSimulatorAgent(
     voice="openai/nova",
     persona="Frustrated customer calling from a busy cafe",
     audio_effects=[scenario.background_noise("cafe", 0.3)],
 )
 ```
+
+```typescript [typescript]
+import scenario, { voice } from "@langwatch/scenario";
+
+scenario.userSimulatorAgent({
+  voice: "openai/nova",
+  persona: "Frustrated customer calling from a busy cafe",
+  audioEffects: [voice.effects.backgroundNoise("cafe", 0.3)],
+});
+```
+
+:::
 
 **Bundled noise presets** (ship in the SDK, no download):
 - `cafe` — restaurant/coffee shop hum
@@ -168,10 +253,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Python
       - uses: actions/setup-python@v5
         with: { python-version: '3.12' }
       - run: pip install scenario
       - run: pytest test_my_voice_agent.py
+      # …or TypeScript
+      # - uses: actions/setup-node@v4
+      #   with: { node-version: '22' }
+      # - run: npm ci && npx vitest run
         env:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           ELEVENLABS_AGENT_ID: ${{ secrets.ELEVENLABS_AGENT_ID }}

--- a/docs/docs/pages/voice/happy-path-elevenlabs.mdx
+++ b/docs/docs/pages/voice/happy-path-elevenlabs.mdx
@@ -29,7 +29,7 @@ pip install scenario
 ```
 
 ```bash [typescript]
-npm install @langwatch/scenario
+pnpm install @langwatch/scenario vitest
 ```
 
 :::
@@ -261,7 +261,7 @@ jobs:
       # …or TypeScript
       # - uses: actions/setup-node@v4
       #   with: { node-version: '22' }
-      # - run: npm ci && npx vitest run
+      # - run: pnpm install --frozen-lockfile && npx vitest run
         env:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           ELEVENLABS_AGENT_ID: ${{ secrets.ELEVENLABS_AGENT_ID }}

--- a/docs/docs/pages/voice/happy-path-openai-realtime.mdx
+++ b/docs/docs/pages/voice/happy-path-openai-realtime.mdx
@@ -18,6 +18,8 @@ description: Step-by-step guide to test an OpenAI Realtime voice model with Scen
 
 > **All-in-one key**: unlike the ElevenLabs path, everything here runs on OpenAI: the Realtime model itself, the user simulator TTS, the judge LLM, and the default STT. One key, one provider.
 
+> **Routing through an OpenAI-compatible gateway?** TTS, STT, and the judge LLM follow `OPENAI_BASE_URL` (and `OPENAI_API_BASE` for litellm), so they work with a gateway virtual key. The Realtime websocket always connects directly to OpenAI; set `OPENAI_REALTIME_API_KEY` to a real provider key for it, and the adapter prefers that variable over `OPENAI_API_KEY`.
+
 ---
 
 ## Step 1 — Install

--- a/docs/docs/pages/voice/recipes/multi-turn.mdx
+++ b/docs/docs/pages/voice/recipes/multi-turn.mdx
@@ -7,11 +7,11 @@ import { Callout } from "vocs/components";
 
 # Multi-Turn Conversations
 
-<Callout type="warning">
-**Multi-turn is not supported on hosted `elevenLabsAgent` (ElevenLabs Conversational AI).** That transport is server-VAD-driven: it segments turns from a continuous audio stream, so a *scripted* second `user()` turn after the agent has already replied does not re-engage its turn-taking, and the next `agent()` fails with `receiveAudio timed out`. Hosted ElevenLabs supports only a **single greeting-led exchange** (`agent() → user() → agent() → judge()`) — see [happy-path-elevenlabs](/voice/happy-path-elevenlabs) and [troubleshooting](/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs).
-
-**For multi-turn voice, use a composable adapter with full in-process turn control:** `ElevenLabsVoiceAgent` (ElevenLabs STT + LLM + ElevenLabs TTS), `pipecatAgent`, Gemini Live, or OpenAI Realtime. `proceed(n)` is also reliable on these adapters but NOT on hosted `elevenLabsAgent`. The script below is validated on those adapters — the worked example uses `pipecatAgent`.
-</Callout>
+Multi-turn works on every shipping adapter, hosted `elevenLabsAgent` included.
+The user's real audio is streamed at microphone cadence followed by closing
+silence, which is what a server-VAD transport measures end-of-turn against, so a
+scripted second `user()` turn re-engages the agent the same way a real caller
+would. `proceed(n)` works on the same adapters.
 
 This recipe shows how to script a voice scenario with multiple back-and-forth turns, and
 how to configure the `JudgeAgent` to verify the agent maintains conversational continuity

--- a/docs/docs/pages/voice/troubleshooting.mdx
+++ b/docs/docs/pages/voice/troubleshooting.mdx
@@ -188,17 +188,35 @@ never appended to the internal `VoiceRecording` buffer, so `save_segments()`
 
 ## `receiveAudio timed out` (hosted ElevenLabs)
 
-If a hosted `elevenLabsAgent` scenario fails with `ElevenLabsAgentAdapter: receiveAudio timed out`, you almost certainly scripted **more than one `user()` turn**. The hosted ElevenLabs Conversational AI transport is **server-VAD-driven** and supports only a **single greeting-led exchange**: a scripted second `user()` turn does not re-engage the server's turn-taking, so the following `agent()` waits for a response that never arrives and times out.
+Multi-turn on hosted ElevenLabs works — if you are hitting this on a scripted
+turn 2+, check these in order.
 
-**Fix:**
-- Use the single greeting-led shape: `agent() → user("...") → agent() → judge()`. **Lead with `agent()`** so the on-connect greeting (`first_message`) drains before your user audio hits the wire.
-- For genuine **multi-turn** voice (more than one user→agent exchange), switch to a composable adapter — `ElevenLabsVoiceAgent`, `pipecatAgent`, Gemini Live, or OpenAI Realtime — which own turn-taking in-process. See the [multi-turn recipe](/voice/recipes/multi-turn).
+**Lead with `agent()`.** The on-connect greeting (`first_message`) has to drain
+before your user audio hits the wire, so the canonical shape is
+`agent() → user("…") → agent() → … → judge()`.
+
+**Check your turn-commit mode.** The adapter defaults to streaming the user's
+real PCM (`turn_commit_mode="audio"` in Python), which is what EL's server VAD
+closes a turn on. If you explicitly set `"silence"`, the bounded silence tail is
+not a reliable end-of-turn signal for a scripted, non-mic stream — EL ConvAI 2.0
+uses a hybrid VAD plus a deep-learning turn-detector, not a pure silence
+threshold. Drop back to the default, or use `"text"` if your agent genuinely
+cannot be driven by scripted audio (at the cost of its STT never running).
+
+**Rule out a deliberate hangup.** If the agent invoked `end_call` (or a
+`transfer_to_*` tool), the transport is closed because the agent chose to end the
+call. That is now reported on the adapter's `agent_hung_up` / `agentHungUp` flag
+and concludes the scenario rather than timing out.
+
+**Rule out a wedged tool call.** A hosted agent that keeps ping-ing but never
+sends audio (a stuck server tool or RAG lookup) is bounded by a 45s absolute
+ceiling and then surfaces this timeout. Check the agent's tool configuration.
 
 ---
 
 ## "Audio duration mismatch" / "non-continuous audio input" warning
 
-This warning is emitted **by the ElevenLabs server, not the Scenario SDK**. It is benign: it reflects that a *scripted* voice turn sends a discrete speech chunk plus a short silence pad rather than the continuous microphone stream ElevenLabs' VAD expects. It does not by itself indicate an SDK bug, and the single greeting-led exchange completes normally despite it. If you also see `receiveAudio timed out`, the cause is the multi-turn limitation above, not this warning.
+This warning is emitted **by the ElevenLabs server, not the Scenario SDK**. It is benign: it reflects that a *scripted* voice turn does not carry the perfectly continuous microphone stream ElevenLabs' VAD expects — the pump feeds real speech frames and then closing silence, which is close enough for turn detection but not byte-for-byte a live mic. It does not by itself indicate an SDK bug, and turns complete normally despite it.
 
 ---
 

--- a/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
@@ -85,12 +85,11 @@ if (hasHostedKey || hasComposableKey) {
               // wire (mirrors the Python twin's script).
               //
               // MULTI-TURN (≥2 scripted exchanges) over the LIVE hosted ConvAI
-              // socket — un-gated by #567. The adapter now commits each user turn
-              // with an explicit `user_message` event instead of leaning on
-              // mic-style server VAD, so a scripted 2nd user turn after the agent
-              // has already replied reliably re-engages the next agent response
-              // (the old single-exchange limit + `receiveAudio timed out` are
-              // fixed). This is the load-bearing live proof for #567.
+              // socket. Each user turn is streamed as real PCM at microphone
+              // cadence followed by unbounded closing silence — the audio→silence
+              // transition EL's server VAD closes a turn on — so a scripted 2nd
+              // user turn re-engages the next agent response the way a real
+              // caller would, and EL's own STT runs on what we sent.
               script: [
                 scenario.agent(),
                 scenario.user("Hello, I have a question about my account."),

--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -323,6 +323,21 @@ export async function defaultVoiceCall(
   // PendingTransportError across every leaf, not a transport-specific
   // null-deref or silent hang.
   if (!adapter.isConnected()) {
+    if (adapter.agentHungUp) {
+      // The AGENT ended the call on purpose (#839) — hosted agents routinely
+      // invoke a hangup tool right after their farewell, which closes the
+      // transport. Any scripted turn left over has nobody to talk to, but the
+      // agent did exactly what it was designed to do, so concluding here and
+      // letting the script fall through to the judge is the correct outcome;
+      // failing would punish correct behaviour. Returning no messages leaves
+      // the transcript ending on the agent's farewell, which is what the judge
+      // should assess.
+      logger.info(
+        `${adapter.constructor.name}: agent ended the call; concluding the ` +
+          `conversation instead of failing the remaining scripted turn(s)`,
+      );
+      return [];
+    }
     throw new PendingTransportError(adapter.constructor.name);
   }
   // voice.turn — one span per call(), nesting under the executor's existing

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -58,6 +58,15 @@ export abstract class VoiceAgentAdapter extends AgentAdapter {
   abstract readonly capabilities: AdapterCapabilities;
 
   /**
+   * SET when the AGENT deliberately ended the call (e.g. an ElevenLabs hosted
+   * agent invoking the `end_call` system tool), as opposed to the transport
+   * dropping. A scripted turn arriving after this concludes the conversation
+   * instead of failing the run — the agent behaved as designed. Assertions and
+   * judges can read it to reason about WHO ended the call.
+   */
+  agentHungUp = false;
+
+  /**
    * Default `call()` body, ported from Python `VoiceAgentAdapter.call`.
    *
    * Threads the latest user-message audio through {@link sendAudio},

--- a/javascript/src/voice/adapters/__tests__/elevenlabs-agent-hangup.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs-agent-hangup.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Issue #839 — an agent-initiated hangup ends the scenario gracefully.
+ *
+ * Hosted voice agents commonly hang up on purpose: an ElevenLabs agent invokes
+ * the `end_call` system tool right after its farewell, which closes the
+ * WebSocket. When the scripted scenario still has `agent()` / `user()` steps
+ * left, the next `agent()` used to throw `PendingTransportError` and fail a run
+ * in which the agent behaved exactly as designed.
+ *
+ * The adapter now recognises the `agent_tool_response` frame EL emits for a
+ * successful hangup tool and records it on `agentHungUp`; `defaultVoiceCall`'s
+ * connected-state gate then concludes instead of throwing.
+ *
+ * Wire shape captured live from the real EL ConvAI transport:
+ *
+ *   {"type": "agent_tool_response",
+ *    "agent_tool_response": {"tool_name": "end_call",
+ *      "tool_call_id": "end_call_bf80…", "tool_type": "system",
+ *      "is_error": false, "is_blocked": false, "event_id": 20,
+ *      "is_called": true}}
+ *
+ * …followed by a clean close (code 1000).
+ *
+ * No real network: the SDK runs against the in-memory fake socket.
+ */
+import { describe, it, expect } from "vitest";
+
+import type { AgentInput } from "../../../domain/agents";
+import { PendingTransportError } from "../pending-transport-error";
+import { ElevenLabsAgentAdapter } from "../index";
+import { FakeWebSocket, makeFakeConv } from "./fixtures/fake-elevenlabs-conversation";
+
+/** Feed one inbound EL ConvAI frame to the SDK over the fake socket. */
+function emit(socket: FakeWebSocket, event: Record<string, unknown>): void {
+  socket.emit("message", Buffer.from(JSON.stringify(event), "utf-8"));
+}
+
+function hangupFrame(
+  toolName = "end_call",
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    type: "agent_tool_response",
+    agent_tool_response: {
+      tool_name: toolName,
+      tool_call_id: `${toolName}_abc123`,
+      tool_type: "system",
+      is_error: false,
+      is_blocked: false,
+      event_id: 20,
+      is_called: true,
+      ...overrides,
+    },
+  };
+}
+
+async function makeConnected(): Promise<{
+  adapter: ElevenLabsAgentAdapter;
+  socket: FakeWebSocket;
+}> {
+  const fake = makeFakeConv();
+  const adapter = new ElevenLabsAgentAdapter({
+    agentId: "agt-hangup",
+    apiKey: "sk-hangup",
+    webSocketFactory: fake.webSocketFactory,
+    conversationClient: fake.conversationClient,
+  });
+  await adapter.connect();
+  return { adapter, socket: fake.socket.current! };
+}
+
+const agentInput = () =>
+  ({
+    threadId: "t-839",
+    messages: [],
+    newMessages: [],
+  }) as unknown as AgentInput;
+
+describe("#839 — agent-initiated hangup", () => {
+  it("marks agentHungUp when the agent successfully invokes end_call", async () => {
+    const { adapter, socket } = await makeConnected();
+    expect(adapter.agentHungUp).toBe(false);
+
+    emit(socket, hangupFrame());
+
+    expect(adapter.agentHungUp).toBe(true);
+    await adapter.disconnect();
+  });
+
+  it.each(["transfer_to_agent", "transfer_to_number", "transfer_to_genesys"])(
+    "treats %s as the agent ending this session",
+    async (toolName) => {
+      const { adapter, socket } = await makeConnected();
+
+      emit(socket, hangupFrame(toolName));
+
+      expect(adapter.agentHungUp).toBe(true);
+      await adapter.disconnect();
+    },
+  );
+
+  it.each([
+    ["not called", { is_called: false }],
+    ["errored", { is_error: true }],
+    ["blocked", { is_blocked: true }],
+  ])(
+    "does NOT mark a hangup when the tool was %s",
+    async (_label, overrides) => {
+      const { adapter, socket } = await makeConnected();
+
+      emit(socket, hangupFrame("end_call", overrides));
+
+      expect(adapter.agentHungUp).toBe(false);
+      await adapter.disconnect();
+    },
+  );
+
+  it("ignores unrelated agent tool responses", async () => {
+    const { adapter, socket } = await makeConnected();
+
+    emit(socket, hangupFrame("language_detection"));
+
+    expect(adapter.agentHungUp).toBe(false);
+    await adapter.disconnect();
+  });
+
+  it("concludes a scripted turn issued after the hangup instead of throwing", async () => {
+    const { adapter, socket } = await makeConnected();
+
+    emit(socket, hangupFrame());
+    await adapter.disconnect(); // EL closes the socket right after the tool frame
+
+    expect(adapter.agentHungUp).toBe(true);
+    expect(adapter.isConnected()).toBe(false);
+
+    // The leftover scripted agent() turn — used to throw PendingTransportError.
+    await expect(adapter.call(agentInput())).resolves.toEqual([]);
+  });
+
+  it("still throws for a dropped transport with no deliberate hangup", async () => {
+    const { adapter } = await makeConnected();
+    await adapter.disconnect();
+
+    expect(adapter.agentHungUp).toBe(false);
+    await expect(adapter.call(agentInput())).rejects.toThrow(PendingTransportError);
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-response-guard.test.ts
@@ -283,3 +283,37 @@ describe("OpenAIRealtimeAgentAdapter — response.create guard (#662)", () => {
     2000,
   );
 });
+
+describe("OpenAIRealtimeAgentAdapter api key resolution", () => {
+  it("prefers OPENAI_REALTIME_API_KEY over OPENAI_API_KEY for the direct ws", () => {
+    const prevRealtime = process.env.OPENAI_REALTIME_API_KEY;
+    const prevOpenai = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "vk-lw-virtual";
+    process.env.OPENAI_REALTIME_API_KEY = "sk-real-provider";
+    try {
+      const adapter = new OpenAIRealtimeAgentAdapter({});
+      expect((adapter as unknown as { _apiKey: string })._apiKey).toBe(
+        "sk-real-provider"
+      );
+    } finally {
+      process.env.OPENAI_REALTIME_API_KEY = prevRealtime;
+      process.env.OPENAI_API_KEY = prevOpenai;
+    }
+  });
+
+  it("falls back to OPENAI_API_KEY when no realtime key is set", () => {
+    const prevRealtime = process.env.OPENAI_REALTIME_API_KEY;
+    const prevOpenai = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_REALTIME_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-plain";
+    try {
+      const adapter = new OpenAIRealtimeAgentAdapter({});
+      expect((adapter as unknown as { _apiKey: string })._apiKey).toBe(
+        "sk-plain"
+      );
+    } finally {
+      process.env.OPENAI_REALTIME_API_KEY = prevRealtime;
+      process.env.OPENAI_API_KEY = prevOpenai;
+    }
+  });
+});

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -130,6 +130,19 @@ const PUMP_INTERVAL_MS = 20;
 const KEEPALIVE_HARD_CEILING_S = 45;
 
 /**
+ * EL system tools whose successful invocation means the AGENT ended the call, so
+ * the socket close that follows is deliberate rather than a dropped transport
+ * (#839). `transfer_to_*` also hands the caller off and ends this session, so it
+ * is a hangup from the harness's point of view.
+ */
+const HANGUP_TOOL_NAMES = new Set([
+  "end_call",
+  "transfer_to_agent",
+  "transfer_to_number",
+  "transfer_to_genesys",
+]);
+
+/**
  * One all-zero (silence) {@link PUMP_FRAME_BYTES} frame — the closing-silence frame
  * of the continuous mic pump. {@link ElevenLabsAgentAdapter.pumpTick} feeds this on
  * a tick whose outbound queue is empty AND whose user turn is still closing (before
@@ -906,6 +919,38 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
       // close/error drain.
       const waiter = this.waiters.shift();
       if (waiter) waiter(new AudioChunk({ data: new Uint8Array(0) }));
+      return;
+    }
+
+    if (etype === "agent_tool_response") {
+      // The agent invoked one of its own (server-side) tools. When that tool is
+      // `end_call`, the agent has deliberately hung up and EL closes the socket
+      // right after this frame with a clean 1000 (#839).
+      //
+      // Wire shape (captured live):
+      //   {"type": "agent_tool_response",
+      //    "agent_tool_response": {"tool_name": "end_call", "tool_type": "system",
+      //      "is_error": false, "is_blocked": false, "is_called": true, ...}}
+      //
+      // Recording it as a deliberate hangup — rather than letting the ensuing
+      // close look like a dropped transport — is what lets a leftover scripted
+      // turn conclude gracefully instead of failing a run in which the agent
+      // behaved exactly as designed.
+      const tool = (event.agent_tool_response ?? {}) as Record<string, unknown>;
+      const name = tool.tool_name as string | undefined;
+      if (
+        name !== undefined &&
+        HANGUP_TOOL_NAMES.has(name) &&
+        tool.is_called === true &&
+        tool.is_error !== true &&
+        tool.is_blocked !== true
+      ) {
+        this.logger.info(
+          `ElevenLabsAgentAdapter: agent invoked ${name} — treating the ` +
+            `upcoming close as a deliberate hangup`,
+        );
+        this.agentHungUp = true;
+      }
       return;
     }
 

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -88,7 +88,12 @@ export interface OpenAIRealtimeAgentAdapterInit {
   instructions?: string;
   /** Tool definitions passed straight through to the Realtime session. */
   tools?: RealtimeToolDef[];
-  /** Explicit API key; falls back to `process.env.OPENAI_API_KEY`. */
+  /**
+   * Explicit API key; falls back to `process.env.OPENAI_REALTIME_API_KEY`,
+   * then `process.env.OPENAI_API_KEY`. Realtime always connects directly to
+   * OpenAI, so keep a real provider key here when `OPENAI_API_KEY` holds a
+   * gateway virtual key.
+   */
   apiKey?: string;
   /**
    * `AGENT` (default) makes the model the agent under test. `USER` turns
@@ -197,7 +202,16 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     this.instructions = init.instructions ?? "";
     this.tools = init.tools ?? [];
     this.role = init.role ?? AgentRole.AGENT;
-    this._apiKey = init.apiKey ?? process.env.OPENAI_API_KEY ?? "";
+    // Explicit param, then OPENAI_REALTIME_API_KEY, then OPENAI_API_KEY.
+    // Realtime connects DIRECTLY to OpenAI's websocket (gateways that proxy
+    // the HTTP audio endpoints do not proxy realtime), so when
+    // OPENAI_API_KEY holds a gateway virtual key, OPENAI_REALTIME_API_KEY
+    // carries the real provider key.
+    this._apiKey =
+      init.apiKey ??
+      process.env.OPENAI_REALTIME_API_KEY ??
+      process.env.OPENAI_API_KEY ??
+      "";
     this._urlOverride = init.url ?? null;
     this._wsFactory = init.wsFactory ?? null;
   }

--- a/python/examples/voice/elevenlabs_hosted.py
+++ b/python/examples/voice/elevenlabs_hosted.py
@@ -59,9 +59,10 @@ async def main() -> scenario.ScenarioResult:
     result = await scenario.run(
         name="demo_elevenlabs_hosted",
         description=(
-            "Single greeting-led exchange against a live ElevenLabs Conversational AI "
-            "agent. Greeting plays on connect (real-voice convention), user "
-            "asks a question, agent responds; judge evaluates naturalness."
+            "Greeting-led multi-turn exchange against a live ElevenLabs "
+            "Conversational AI agent. Greeting plays on connect (real-voice "
+            "convention), then two scripted user turns are streamed as real "
+            "audio; judge evaluates naturalness and cross-turn coherence."
         ),
         agents=[
             scenario.ElevenLabsAgentAdapter(
@@ -73,23 +74,25 @@ async def main() -> scenario.ScenarioResult:
                 criteria=[
                     "The agent's initial greeting (sent on connect) is natural and conversational",
                     "The agent and user exchanged real audio turns via the live WebSocket",
-                    "The conversation is a coherent single-turn example of the hosted ElevenLabs Conversational AI path",
+                    "The agent's second reply follows on from the first exchange rather than restarting the conversation",
                 ]
             ),
         ],
         script=[
-            # Real voice convention: EL sends first_message on connect.
-            # Lead with agent() so the greeting drains before user audio
-            # hits the wire. Hosted ElevenLabs ConvAI supports a SINGLE
-            # greeting-led exchange only — a 2nd scripted user() turn times
-            # out (receiveAudio timed out). For multi-turn use a composable
-            # adapter (ElevenLabsVoiceAgent / pipecatAgent).
+            # Real voice convention: EL sends first_message on connect. Lead
+            # with agent() so the greeting drains before user audio hits the
+            # wire. Each user turn is then streamed as real PCM at microphone
+            # cadence followed by closing silence, which is what EL's server
+            # VAD closes a turn on — so a scripted 2nd turn re-engages the way
+            # a real caller would. Mirrors the TS twin.
             scenario.agent(),
             scenario.user("Hello, I have a question about my account."),
             scenario.agent(),
+            scenario.user("Thanks. Can you tell me your support hours?"),
+            scenario.agent(),
             scenario.judge(),
         ],
-        max_turns=6,
+        max_turns=8,
     )
 
     print(f"success: {result.success}")

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -332,6 +332,10 @@ class VoiceAgentAdapter(AgentAdapter):
                 await reconcile_prior_agent_audio(
                     self, recorder._executor, recorder._offset()
                 )
+                # The sweep is cleanup of the PREVIOUS turn, so re-stamp the
+                # start: leaving it would bill this turn for time spent draining
+                # the last one and inflate the reported turn latency.
+                _turn_started = time.monotonic()
                 # Wrap send_audio so user.start = "we began transmitting" and
                 # user.end = "we finished transmitting" — both real flow points.
                 recorder.mark_user_start()
@@ -651,9 +655,12 @@ async def reconcile_prior_agent_audio(adapter, executor, now: float) -> None:
 
     - Cursor-safe (an AGENT segment is still last — the user segment for this
       turn has not been written yet): grow it. Extending its ``end_time`` and
-      audio cannot overlap a later segment. The segment's transcript is cleared
-      so the finalize STT back-fill re-transcribes the now-longer audio rather
-      than leaving a transcript that covers only the head.
+      audio cannot overlap a later segment. The transcript is left ALONE: the
+      turn was cut short in AUDIO only — the provider's own ``agent_response``
+      text already covers the whole utterance — so appending the tail makes the
+      two consistent. Clearing it would discard a correct transcript and, for an
+      audio-capable judge (which never runs the STT back-fill), leave the
+      segment with none at all.
     - Cursor-unsafe (no recording, the opening greeting with no prior agent
       segment, or a barge-in where a user segment is last): the audio is already
       off the wire, so the bleed is prevented either way; it is dropped with a
@@ -682,9 +689,6 @@ async def reconcile_prior_agent_audio(adapter, executor, now: float) -> None:
         prior = segments[-1]
         prior.audio += leftover.data
         prior.end_time = max(prior.end_time, now)
-        # The existing transcript describes only the head of the utterance; let
-        # the finalize back-fill re-transcribe the whole thing.
-        prior.transcript = None
         _fire_audio_chunk(executor, leftover)
         logger.warning(
             "%s: recovered %d bytes of agent audio stranded by an early turn "

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -680,7 +680,7 @@ async def reconcile_prior_agent_audio(
         return
     try:
         leftover = await reconcile()
-    except Exception:
+    except Exception:  # noqa: BLE001 — opportunistic cleanup must never fail a turn
         logger.warning(
             "%s: turn-boundary reconcile raised; continuing.",
             type(adapter).__name__,

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -125,19 +125,24 @@ class VoiceAgentAdapter(AgentAdapter):
     # ``super().__init__()`` (mirrors the ``_agent_speaking`` safety-net).
     _voice_turn_context: Optional[Context] = None
 
+    #: SET when the AGENT deliberately ended the call (e.g. an ElevenLabs hosted
+    #: agent invoking the ``end_call`` system tool), as opposed to the transport
+    #: dropping. A scripted turn that arrives after this concludes the
+    #: conversation instead of failing the run — the agent behaved as designed.
+    #: Assertions and judges can read it to reason about WHO ended the call.
+    #:
+    #: Class-level default for the same reason as ``_voice_turn_context``: a
+    #: subclass that skips ``super().__init__()`` would otherwise raise
+    #: AttributeError from the ``call()`` gate instead of the intended
+    #: TransportNotConnectedError. Matches the TS field default (``agentHungUp``).
+    agent_hung_up: bool = False
+
     def __init__(self) -> None:
         # Per-instance event used by the interruption path to wait until
         # the agent is actually speaking before firing an interrupt — so
         # we don't fire ``clear`` at a silent SUT. Subclasses that
         # override ``__init__`` must call ``super().__init__()``.
         self._agent_speaking = asyncio.Event()
-        #: SET when the AGENT deliberately ended the call (e.g. an ElevenLabs
-        #: hosted agent invoking the ``end_call`` system tool), as opposed to
-        #: the transport dropping. A scripted turn that arrives after this
-        #: concludes the conversation instead of failing the run — the agent
-        #: behaved as designed. Assertions and judges can read it to reason
-        #: about WHO ended the call.
-        self.agent_hung_up: bool = False
 
     @property
     def _agent_speaking_event(self) -> asyncio.Event:
@@ -640,7 +645,9 @@ def write_user_segment(executor, chunk: AudioChunk, start: float, end: float) ->
     _append_event(executor, VoiceEvent(time=end, type="user_stop_speaking"))
 
 
-async def reconcile_prior_agent_audio(adapter, executor, now: float) -> None:
+async def reconcile_prior_agent_audio(
+    adapter: "VoiceAgentAdapter", executor: Any, now: float
+) -> None:
     """Sweep up agent audio stranded by an early turn close and give it back to
     the utterance that produced it (issue #749; TypeScript parity with #748).
 

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -699,9 +699,12 @@ async def reconcile_prior_agent_audio(adapter, executor, now: float) -> None:
         )
     else:
         logger.warning(
-            "%s: discarded %d bytes of stranded agent audio at a user-turn "
-            "boundary (no preceding agent segment to attribute them to). The "
-            "audio is off the wire, so it cannot bleed into the next turn.",
+            "%s: discarded %d bytes of agent audio at a user-turn boundary — "
+            "there is no preceding agent segment to attribute them to, and "
+            "growing an out-of-order segment would corrupt the recording. If "
+            "your script does not lead with agent(), this is the on-connect "
+            "greeting arriving after the first user turn was queued; lead with "
+            "agent() so the greeting is drained as its own turn.",
             type(adapter).__name__,
             len(leftover.data),
         )

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -324,6 +324,14 @@ class VoiceAgentAdapter(AgentAdapter):
                 extract_audio(input.new_messages[-1]) if input.new_messages else None
             )
             if incoming is not None:
+                # BEFORE the user's audio goes out (and before the user segment
+                # is written, so an agent segment is still last on the cursor):
+                # sweep up any agent audio an early turn close stranded in
+                # flight, so it lands on the turn that produced it instead of
+                # bleeding out as the next turn's opening audio (#749).
+                await reconcile_prior_agent_audio(
+                    self, recorder._executor, recorder._offset()
+                )
                 # Wrap send_audio so user.start = "we began transmitting" and
                 # user.end = "we finished transmitting" — both real flow points.
                 recorder.mark_user_start()
@@ -626,6 +634,73 @@ def write_user_segment(executor, chunk: AudioChunk, start: float, end: float) ->
     _append_segment(executor, "user", start, end, chunk)
     _append_event(executor, VoiceEvent(time=start, type="user_start_speaking"))
     _append_event(executor, VoiceEvent(time=end, type="user_stop_speaking"))
+
+
+async def reconcile_prior_agent_audio(adapter, executor, now: float) -> None:
+    """Sweep up agent audio stranded by an early turn close and give it back to
+    the utterance that produced it (issue #749; TypeScript parity with #748).
+
+    The drain ends a turn on ``response_tail_silence``. A delivery gap longer
+    than that leaves the rest of the agent's utterance in flight, and the next
+    drain shifts it out as the opening audio of the NEXT agent turn — so turn
+    N+1 appears to answer question N. Run at the pre-user-``send_audio``
+    boundary, where the agent cannot yet have begun its next reply, so anything
+    still arriving is unambiguously the prior turn's tail.
+
+    Attribution is position-gated, mirroring the TypeScript reconcile:
+
+    - Cursor-safe (an AGENT segment is still last — the user segment for this
+      turn has not been written yet): grow it. Extending its ``end_time`` and
+      audio cannot overlap a later segment. The segment's transcript is cleared
+      so the finalize STT back-fill re-transcribes the now-longer audio rather
+      than leaving a transcript that covers only the head.
+    - Cursor-unsafe (no recording, the opening greeting with no prior agent
+      segment, or a barge-in where a user segment is last): the audio is already
+      off the wire, so the bleed is prevented either way; it is dropped with a
+      warning rather than corrupting the append-only cursor.
+
+    Adapters that expose no ``reconcile_pending_audio`` are untouched.
+    """
+    reconcile = getattr(adapter, "reconcile_pending_audio", None)
+    if reconcile is None:
+        return
+    try:
+        leftover = await reconcile()
+    except Exception:
+        logger.warning(
+            "%s: turn-boundary reconcile raised; continuing.",
+            type(adapter).__name__,
+            exc_info=True,
+        )
+        return
+    if leftover is None or not leftover.data:
+        return
+
+    recording = getattr(executor, "_voice_recording", None) if executor else None
+    segments = getattr(recording, "segments", None) if recording is not None else None
+    if segments and segments[-1].speaker == "agent":
+        prior = segments[-1]
+        prior.audio += leftover.data
+        prior.end_time = max(prior.end_time, now)
+        # The existing transcript describes only the head of the utterance; let
+        # the finalize back-fill re-transcribe the whole thing.
+        prior.transcript = None
+        _fire_audio_chunk(executor, leftover)
+        logger.warning(
+            "%s: recovered %d bytes of agent audio stranded by an early turn "
+            "close and attributed them to the preceding agent turn. Raise "
+            "response_tail_silence if this recurs.",
+            type(adapter).__name__,
+            len(leftover.data),
+        )
+    else:
+        logger.warning(
+            "%s: discarded %d bytes of stranded agent audio at a user-turn "
+            "boundary (no preceding agent segment to attribute them to). The "
+            "audio is off the wire, so it cannot bleed into the next turn.",
+            type(adapter).__name__,
+            len(leftover.data),
+        )
 
 
 def _append_segment(executor, speaker: str, start: float, end: float, chunk: AudioChunk) -> None:

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -646,7 +646,7 @@ def write_user_segment(executor, chunk: AudioChunk, start: float, end: float) ->
 
 
 async def reconcile_prior_agent_audio(
-    adapter: "VoiceAgentAdapter", executor: Any, now: float
+    adapter: Any, executor: Any, now: float
 ) -> None:
     """Sweep up agent audio stranded by an early turn close and give it back to
     the utterance that produced it (issue #749; TypeScript parity with #748).
@@ -674,6 +674,13 @@ async def reconcile_prior_agent_audio(
       warning rather than corrupting the append-only cursor.
 
     Adapters that expose no ``reconcile_pending_audio`` are untouched.
+
+    ``adapter`` and ``executor`` are deliberately ``Any``: this helper is
+    duck-typed on both sides — it feature-detects ``reconcile_pending_audio``
+    rather than requiring :class:`VoiceAgentAdapter`, and reads the recording off
+    the executor with ``getattr`` so the lightweight test doubles the recorder
+    already tolerates work here too. Narrowing either to a concrete class would
+    describe a contract this function does not actually enforce.
     """
     reconcile = getattr(adapter, "reconcile_pending_audio", None)
     if reconcile is None:

--- a/python/scenario/voice/adapter.py
+++ b/python/scenario/voice/adapter.py
@@ -131,6 +131,13 @@ class VoiceAgentAdapter(AgentAdapter):
         # we don't fire ``clear`` at a silent SUT. Subclasses that
         # override ``__init__`` must call ``super().__init__()``.
         self._agent_speaking = asyncio.Event()
+        #: SET when the AGENT deliberately ended the call (e.g. an ElevenLabs
+        #: hosted agent invoking the ``end_call`` system tool), as opposed to
+        #: the transport dropping. A scripted turn that arrives after this
+        #: concludes the conversation instead of failing the run — the agent
+        #: behaved as designed. Assertions and judges can read it to reason
+        #: about WHO ended the call.
+        self.agent_hung_up: bool = False
 
     @property
     def _agent_speaking_event(self) -> asyncio.Event:
@@ -277,6 +284,22 @@ class VoiceAgentAdapter(AgentAdapter):
         # — rather than the base "implement your transport" guidance meant for
         # unshipped stubs.
         if not self.is_connected():
+            if self.agent_hung_up:
+                # The AGENT ended the call on purpose (issue #839) — hosted
+                # agents routinely invoke a hangup tool right after their
+                # farewell, which closes the transport. Any scripted turn left
+                # in the script has nobody to talk to, but the agent did
+                # exactly what it was designed to do, so concluding here and
+                # letting the script fall through to the judge is the correct
+                # outcome. Failing the run would punish correct behaviour.
+                # Returning no messages leaves the transcript ending on the
+                # agent's farewell, which is what the judge should assess.
+                logger.info(
+                    "%s: agent ended the call; concluding the conversation "
+                    "instead of failing the remaining scripted turn(s)",
+                    type(self).__name__,
+                )
+                return []
             from .adapters._stub import TransportNotConnectedError
 
             raise TransportNotConnectedError(type(self).__name__)

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -117,6 +117,15 @@ PUMP_INTERVAL_S = 0.02
 #: against. Mirrors TS ``SILENCE_FRAME`` (``adapters/elevenlabs.ts:144``).
 SILENCE_FRAME = b"\x00" * PUMP_FRAME_BYTES
 
+#: Wall-clock budget for one turn-boundary reconcile sweep. Long enough to
+#: recover a burst already in flight, short enough that a turn boundary never
+#: visibly stalls. See ``reconcile_pending_audio``.
+RECONCILE_BUDGET_S: Final[float] = 0.4
+
+#: Per-poll idle timeout inside a reconcile sweep. Once this much time passes
+#: with nothing arriving, the prior turn really is finished.
+RECONCILE_POLL_S: Final[float] = 0.12
+
 #: EL system tools whose successful invocation means the AGENT ended the call,
 #: so the socket close that follows is deliberate rather than a dropped
 #: transport (issue #839). ``transfer_to_*`` also hands the caller off and ends
@@ -565,6 +574,61 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
                 # zeros so the pump only ever feeds fixed-size frames.
                 slice_ = slice_ + b"\x00" * (PUMP_FRAME_BYTES - len(slice_))
             self._outbound_frames.append(slice_)
+
+    async def reconcile_pending_audio(self) -> Optional[AudioChunk]:
+        """Collect agent audio still in flight at a user-turn boundary.
+
+        The drain closes a turn on ``response_tail_silence``. EL delivers audio
+        in bursts, so a mid-utterance delivery gap longer than that silence ends
+        the turn while the agent is still speaking. Left alone, the remainder is
+        read by the NEXT drain and surfaces as the next agent turn's opening
+        audio — an answer to the previous question attributed to the current one
+        (the split-utterance bleed, issue #749; fixed for TypeScript in #748).
+
+        Called at the pre-user-``send_audio`` boundary and never while a drain is
+        in flight. At that instant the agent cannot have begun its next reply —
+        the user has not spoken yet — so anything still arriving is unambiguously
+        leftover from the PRIOR agent turn. That is what makes attributing it
+        backwards safe.
+
+        Bounded by :data:`RECONCILE_BUDGET_S` of wall clock so a turn boundary
+        never stalls: this recovers the burst already on the wire, it does not
+        wait out a slow agent.
+
+        Duck-typed convention (symmetric with ``last_agent_transcript``): the
+        shared runtime feature-detects this method, so adapters without buffered
+        audio are untouched.
+        """
+        if not self.is_connected():
+            return None
+        collected: list[bytes] = []
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + RECONCILE_BUDGET_S
+        while loop.time() < deadline:
+            try:
+                chunk = await asyncio.wait_for(
+                    self.recv_audio(timeout=RECONCILE_POLL_S),
+                    timeout=max(RECONCILE_POLL_S, deadline - loop.time()),
+                )
+            except asyncio.TimeoutError:
+                # Nothing more immediately available — the prior turn is done.
+                break
+            except Exception:  # noqa: BLE001 — best-effort sweep
+                # The socket went away mid-reconcile, or the transport raised.
+                # This is opportunistic cleanup at a turn boundary; surface it
+                # but never fail the turn over it.
+                logger.debug(
+                    "ElevenLabsAgentAdapter: reconcile sweep ended on transport "
+                    "error; keeping what was collected",
+                    exc_info=True,
+                )
+                break
+            if not chunk.data:
+                break
+            collected.append(chunk.data)
+        if not collected:
+            return None
+        return AudioChunk(data=b"".join(collected))
 
     def _on_agent_audio_begin(self) -> None:
         """Agent turn audio has arrived → engage the post-response pause: the

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -6,19 +6,18 @@ Exchanges PCM16 audio chunks.
 
 Wire protocol:
 - Send:
-  - JSON ``{"user_audio_chunk": "<base64 PCM16>"}`` (legacy ``"silence"``
-    turn-commit path, and the ``"text"`` fallback when a chunk carries no
-    transcript)
-  - JSON ``{"type": "user_message", "text": "<transcript>"}`` (default
-    ``"text"`` turn-commit path) — the only documented client→server event
-    that *deterministically* commits a user turn and forces an agent
-    response without relying on mic-style server VAD. EL ConvAI exposes NO
-    audio-flush / end-of-turn client event (verified against the official
-    EL Python + JS SDKs), and ConvAI 2.0's end-of-turn is a hybrid VAD +
-    deep-learning turn-detector (prosody, rhythm, micro-pauses), not a pure
-    silence threshold — so a fixed zero-byte tail does NOT reliably commit
-    a scripted, non-mic turn 2+ (issue #567). See ``send_audio`` and
-    ``TurnCommitMode``.
+  - JSON ``{"user_audio_chunk": "<base64 PCM16>"}`` — the default
+    ``"audio"`` turn-commit path. The continuous pump feeds the user's real
+    PCM as 20 ms frames at microphone cadence, then unbounded closing
+    silence; EL's server VAD closes the turn on that audio→silence
+    transition. This is the only path on which the agent's own STT and VAD
+    run against the user's voice.
+  - JSON ``{"type": "user_message", "text": "<transcript>"}`` — the opt-in
+    ``"text"`` turn-commit path. Deterministically commits a turn without
+    server VAD, but sends NO audio, so EL's STT never runs. EL ConvAI
+    exposes no audio-flush / end-of-turn client event (verified against the
+    official EL Python + JS SDKs), which is why this escape hatch exists at
+    all. See ``send_audio`` and ``TurnCommitMode``.
 - Recv events:
   - ``conversation_initiation_metadata`` — checked for audio-format
     mismatch against advertised capability; warning logged on drift
@@ -58,16 +57,17 @@ logger = logging.getLogger("scenario.voice.elevenlabs")
 
 CONVAI_URL_TEMPLATE = "wss://api.elevenlabs.io/v1/convai/conversation?agent_id={agent_id}"
 
-#: Default zero-byte silence-tail length for the legacy ``"silence"`` turn-commit
-#: path. 16000 zero bytes at pcm_24000 = ~333 ms of silence — the empirical
-#: middle ground that historically let the *greeting → first user turn* exchange
-#: work (see ``send_audio``).
+#: Zero-byte silence-tail length for the ``"silence"`` turn-commit path. 16000
+#: zero bytes at pcm_24000 = ~333 ms of silence — the empirical middle ground
+#: that historically let the *greeting → first user turn* exchange work.
 #:
-#: This tail is NOT reliable for scripted turn 2+ (issue #567): EL ConvAI 2.0's
-#: end-of-turn is a hybrid VAD + deep-learning turn-detector, not a pure silence
-#: threshold, so a fixed zero-byte blob does not deterministically trip it on a
-#: non-mic stream. The default commit mode is therefore ``"text"``; the silence
-#: tail survives as an opt-in for callers who want the pure server-VAD audio path.
+#: A BOUNDED tail is what made scripted turn 2+ unreliable (issue #567): EL
+#: ConvAI 2.0's end-of-turn is a hybrid VAD + deep-learning turn-detector, not a
+#: pure silence threshold, so a fixed zero-byte blob does not deterministically
+#: trip it. The default ``"audio"`` mode drops the bound entirely — the pump
+#: streams closing silence until the agent actually responds — which is what
+#: makes real voice-in work across turns. This constant only applies to the
+#: opt-in ``"silence"`` mode.
 SILENCE_TAIL_BYTES = 16000
 
 #: Absolute wall-clock ceiling (seconds) for a single :meth:`recv_audio` call
@@ -82,18 +82,24 @@ KEEPALIVE_HARD_CEILING_S: Final[float] = 45.0
 
 #: How :meth:`ElevenLabsAgentAdapter.send_audio` signals end-of-turn to EL ConvAI.
 #:
-#: - ``"text"`` (default): send an explicit
-#:   ``{"type": "user_message", "text": <transcript>}`` — the only documented
-#:   client→server event that *deterministically* commits a turn and forces an
-#:   agent response without relying on mic-style server VAD (issue #567).
-#:   Requires a transcript on the outgoing :class:`AudioChunk` (the voice
-#:   runtime threads the ``scenario.user("…")`` script text through as the chunk
-#:   transcript via TTS); when absent, falls back to the silence tail.
-#: - ``"silence"``: legacy behaviour — stream the audio then a fixed
-#:   ``silence_tail_bytes`` zero-byte tail and hope server VAD fires. Kept for
-#:   the pure-audio path and parity with the pre-#567 transport, but unreliable
-#:   for scripted turn 2+.
-TurnCommitMode = Literal["text", "silence"]
+#: - ``"audio"`` (default): stream the turn's real PCM as 20 ms
+#:   ``user_audio_chunk`` frames at microphone cadence and let the pump's
+#:   *unbounded* closing silence carry the audio→silence transition EL's server
+#:   VAD measures end-of-turn against. This is the only mode in which the
+#:   agent-under-test's own STT and VAD actually run on the user's voice, so it
+#:   is what a voice test must default to. Mirrors the TS adapter (#707).
+#: - ``"text"``: send an explicit
+#:   ``{"type": "user_message", "text": <transcript>}`` and send NO audio. This
+#:   deterministically commits a turn without relying on server VAD, but the
+#:   agent never hears the user — its STT and VAD are bypassed entirely, so a
+#:   passing run says nothing about either. Kept as an opt-in escape hatch for
+#:   agents whose turn-taking cannot be driven by scripted audio; requires a
+#:   transcript on the outgoing :class:`AudioChunk` and falls back to
+#:   ``"silence"`` when absent.
+#: - ``"silence"``: stream the audio then a fixed ``silence_tail_bytes``
+#:   zero-byte tail. The pre-pump behaviour, retained for callers pinned to a
+#:   bounded tail; ``"audio"`` supersedes it.
+TurnCommitMode = Literal["audio", "text", "silence"]
 
 #: One continuous-mic pump frame = 20 ms of PCM. Fixed at 960 bytes to match the
 #: TS reference (``PUMP_FRAME_BYTES``, ``adapters/elevenlabs.ts:107``); the pump
@@ -110,6 +116,43 @@ PUMP_INTERVAL_S = 0.02
 #: EL's server VAD has the audio→silence transition it measures end-of-turn
 #: against. Mirrors TS ``SILENCE_FRAME`` (``adapters/elevenlabs.ts:144``).
 SILENCE_FRAME = b"\x00" * PUMP_FRAME_BYTES
+
+#: EL system tools whose successful invocation means the AGENT ended the call,
+#: so the socket close that follows is deliberate rather than a dropped
+#: transport (issue #839). ``transfer_to_*`` also hands the caller off and ends
+#: this session, so it is a hangup from the harness's point of view.
+HANGUP_TOOL_NAMES: Final[frozenset[str]] = frozenset(
+    {"end_call", "transfer_to_agent", "transfer_to_number", "transfer_to_genesys"}
+)
+
+
+def _deep_merge(
+    base: dict[str, Any], layer: dict[str, Any]
+) -> dict[str, Any]:
+    """Recursively merge ``layer`` ON TOP OF ``base``, returning a NEW dict
+    (neither argument is mutated).
+
+    When a key holds a dict on BOTH sides the two are merged key-by-key, so a
+    shared parent like ``agent`` keeps keys from both; for every other shape —
+    scalar, list, or a key present on only one side — ``layer`` wins where it
+    supplies the key, else ``base``'s value is kept.
+
+    This is the precedence engine for ``conversation_config_override``: the
+    caller's ``overrides`` are the ``base`` and the adapter's narrow
+    ``{"agent": {"prompt", "first_message"}}`` is the ``layer``, so the narrow
+    knobs win on a shared LEAF while sibling caller keys (``agent.language``, a
+    top-level ``tts``) survive intact. A shallow ``{**base, **layer}`` would
+    instead DROP one side's nested ``agent``. Mirrors the TS ``deepMerge``
+    (``adapters/elevenlabs.ts:202``).
+    """
+    out = dict(base)
+    for key, layer_value in layer.items():
+        base_value = out.get(key)
+        if isinstance(base_value, dict) and isinstance(layer_value, dict):
+            out[key] = _deep_merge(base_value, layer_value)
+        else:
+            out[key] = layer_value
+    return out
 
 
 class ElevenLabsAgentAdapter(VoiceAgentAdapter):
@@ -157,7 +200,9 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         *,
         system_prompt_override: Optional[str] = None,
         first_message_override: Optional[str] = None,
-        turn_commit_mode: TurnCommitMode = "text",
+        dynamic_variables: Optional[dict[str, Any]] = None,
+        overrides: Optional[dict[str, Any]] = None,
+        turn_commit_mode: TurnCommitMode = "audio",
         silence_tail_bytes: int = SILENCE_TAIL_BYTES,
     ) -> None:
         super().__init__()
@@ -167,15 +212,36 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         # at the start of every WS connect. Used by demos that need a
         # different prompt shape (e.g. verbose for interrupt demos) without
         # mutating the shared test agent's persistent config.
+        #
+        # WARNING (issue #838): ``system_prompt_override`` replaces the agent's
+        # ENTIRE prompt object server-side, ``tool_ids`` included. A hosted
+        # agent that relies on server tools silently loses them and then stalls
+        # waiting for tool responses that can never arrive. To personalise a
+        # deployed agent without dropping its tools, use ``dynamic_variables``
+        # (fills the deployed prompt template) plus a narrow ``overrides``
+        # entry, and leave the prompt alone.
         self._system_prompt_override = system_prompt_override
         self._first_message_override = first_message_override
-        # How a user turn is committed. Defaults to ``"text"`` (explicit
-        # ``user_message`` commit) so scripted turn 2+ reliably re-engages an
-        # agent response (issue #567). ``"silence"`` selects the legacy
-        # pure-audio server-VAD path. See ``TurnCommitMode`` / ``send_audio``.
-        if turn_commit_mode not in ("text", "silence"):
+        #: Per-call dynamic variables, forwarded natively as the init
+        #: handshake's ``dynamic_variables``. EL personalises a hosted agent per
+        #: call from these. Values keep their JSON type — str / int / float /
+        #: bool — with NO ``str()`` coercion, matching EL's typed support.
+        #: Applied only if the agent declares them (server-side allowlist).
+        #: When unset, no ``dynamic_variables`` key is sent at all (not ``{}``).
+        self._dynamic_variables = dynamic_variables
+        #: Per-call conversation-config overrides, DEEP-merged UNDER the narrow
+        #: prompt/first-message knobs above. Use for anything those do not cover
+        #: (e.g. ``{"agent": {"language": "es"}, "tts": {"stability": 0.3}}``).
+        #: Applied only if the agent allowlists the key server-side.
+        self._overrides = overrides
+        # How a user turn is committed. Defaults to ``"audio"``: the turn's real
+        # PCM goes on the wire and the pump's unbounded closing silence closes
+        # the turn, so the agent's own STT and VAD run on the user's voice.
+        # ``"text"`` and ``"silence"`` are opt-in. See ``TurnCommitMode``.
+        if turn_commit_mode not in ("audio", "text", "silence"):
             raise ValueError(
-                f'Unknown turn_commit_mode: {turn_commit_mode!r}. Expected "text" or "silence".'
+                f"Unknown turn_commit_mode: {turn_commit_mode!r}. "
+                'Expected "audio", "text" or "silence".'
             )
         if not isinstance(silence_tail_bytes, int) or silence_tail_bytes <= 0:
             raise ValueError(
@@ -204,6 +270,12 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         # Transcript observability — updated on each transcript event.
         self.last_user_transcript: Optional[str] = None
         self.last_agent_transcript: Optional[str] = None
+
+        #: How many user turns were committed as REAL audio. Counted once per
+        #: non-empty :meth:`enqueue_speech`, not per 20 ms frame, so it counts
+        #: turns. Lets a test assert the agent actually heard the user rather
+        #: than merely replying (mirror TS ``audioCommitCount``).
+        self.audio_commit_count: int = 0
 
     @property
     def url(self) -> str:
@@ -244,20 +316,38 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             {"voice.elevenlabs.agent_id": self.agent_id},
         )
 
+        # The NARROW prompt/first-message knobs build an `agent` override that is
+        # always sent (an empty `agent` object is a no-op) so the handshake shape
+        # is stable; it carries the overrides when set.
         agent_override: dict[str, Any] = {}
         if self._system_prompt_override:
             agent_override["prompt"] = {"prompt": self._system_prompt_override}
         if self._first_message_override:
             agent_override["first_message"] = self._first_message_override
 
-        init = {
+        # DEEP-merge the caller's `overrides` (the base, lower precedence) UNDER
+        # the narrow `{"agent": agent_override}` (the layer, higher precedence),
+        # so a caller's `agent.language` and our `agent.prompt` BOTH survive.
+        conversation_config_override = _deep_merge(
+            self._overrides or {}, {"agent": agent_override}
+        )
+
+        init: dict[str, Any] = {
             "type": "conversation_initiation_client_data",
-            "conversation_config_override": {"agent": agent_override},
+            "conversation_config_override": conversation_config_override,
         }
+        # Omit the key entirely when unset — EL treats an empty object
+        # differently from an absent one.
+        if self._dynamic_variables is not None:
+            init["dynamic_variables"] = self._dynamic_variables
         await self._ws.send(json.dumps(init))
         logger.debug(
-            "ElevenLabsAgentAdapter: sent conversation_initiation_client_data with overrides=%s",
-            list(agent_override.keys()) or "none",
+            "ElevenLabsAgentAdapter: sent conversation_initiation_client_data "
+            "with config_override_keys=%s dynamic_variables=%s",
+            sorted(conversation_config_override.keys()) or "none",
+            sorted(self._dynamic_variables.keys())
+            if self._dynamic_variables
+            else "none",
         )
 
         # Start the continuous mic pump now that the socket is open, so the
@@ -460,11 +550,14 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         ``adapters/elevenlabs.ts:703-731``.
         """
         if not data:
-            # An empty chunk carries no speech: don't disturb the pause, don't
-            # enqueue a meaningless frame.
+            # An empty chunk carries no speech: don't count it as a real-audio
+            # turn, don't disturb the pause, don't enqueue a meaningless frame.
             return
         # A real user turn is starting → lift the post-response pause.
         self.awaiting_user_turn = False
+        # Count the turn ONCE per non-empty call (not once per 20 ms frame) so
+        # the counter still counts turns.
+        self.audio_commit_count += 1
         for offset in range(0, len(data), PUMP_FRAME_BYTES):
             slice_ = data[offset : offset + PUMP_FRAME_BYTES]
             if len(slice_) < PUMP_FRAME_BYTES:
@@ -496,26 +589,24 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         does NOT reliably fire on a scripted, non-mic stream, so the legacy
         "stream audio + silence tail" path stalls on turn 2+ (issue #567).
 
-        Two commit modes (see ``TurnCommitMode``):
+        Three commit modes (see ``TurnCommitMode``):
 
-        - ``"text"`` (default): when the chunk carries a transcript, send ONLY
-          a ``{"type": "user_message", "text": <transcript>}`` turn — the only
-          documented client event that deterministically forces an agent
-          response without mic-style VAD. We do NOT also stream the raw audio
-          here: sending ``user_audio_chunk`` and then ``user_message`` in the
-          same turn races the server's audio ingestion against the text commit
-          and was empirically flaky (the agent receive intermittently timed
-          out). The text turn alone re-engages every time. Nothing observable
-          is lost — the voice runtime records the user audio locally
-          (independent of this send), and EL echoes the committed text back as
-          a ``user_transcript`` event, so ``last_user_transcript`` still
-          populates.
-        - Fallback / ``"silence"``: stream the speech then a fixed
-          ``silence_tail_bytes`` zero-byte tail and let server VAD try. Used
-          when ``turn_commit_mode == "silence"``, or in ``"text"`` mode when
-          the chunk carries no transcript to commit.
+        - ``"audio"`` (default): enqueue the turn's real PCM for the pump and
+          stop. The pump feeds it as 20 ms ``user_audio_chunk`` frames at
+          microphone cadence, then streams *unbounded* closing silence until
+          the agent responds — the audio→silence transition EL's server VAD
+          measures end-of-turn against. No bounded tail to tune. This is the
+          only mode that puts the user's voice on the wire, so it is the only
+          mode in which the agent's own STT and VAD are exercised.
+        - ``"text"``: send ONLY ``{"type": "user_message", "text": …}``. The
+          audio is DISCARDED — EL's STT never runs and a green run proves
+          nothing about the agent's transcription or turn-taking. Opt-in only,
+          for agents whose turn-taking cannot be driven by scripted audio.
+        - ``"silence"``: stream the speech then a fixed ``silence_tail_bytes``
+          zero-byte tail. Superseded by ``"audio"``'s unbounded closing
+          silence; retained for callers pinned to a bounded tail.
 
-        Silence-tail size rationale (legacy path): 16000 zero bytes at
+        Silence-tail size rationale (``"silence"`` path): 16000 zero bytes at
         pcm_24000 = ~333ms — empirically the sweet spot for the greeting →
         first-turn exchange. Removing it entirely, or doubling to 24000, both
         reproduced the stall pattern.
@@ -533,28 +624,26 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             self.awaiting_user_turn = False
 
         if self._turn_commit_mode == "text" and transcript:
-            # Deterministic commit: send ONLY the user_message text turn (no
-            # racing user_audio_chunk). This is a single control frame, not
-            # audio, so it does not compete with the pump's audio cadence. See
-            # method docstring for the rationale.
+            # Text-only commit: no user_audio_chunk is sent, so EL's STT never
+            # sees this turn. See ``TurnCommitMode`` for why this is opt-in.
             await self._send_user_message(transcript)
             return
 
-        # Legacy / fallback path (turn_commit_mode == "silence", or "text" mode
-        # with no transcript to commit): stream the speech then a closing
-        # silence tail and let server VAD try.
-        #
         # The pump is the SINGLE owner of WS audio writes: rather than writing
-        # `chunk.data` and the 16KB silence tail DIRECTLY to `self._ws` (which
-        # would race the always-running background pump — two concurrent writers
-        # producing interleaved/oversized non-20ms `user_audio_chunk` frames),
-        # we ENQUEUE the speech and the closing-silence tail as fixed 960-byte
-        # pump frames. The pump drains them at the same 20ms cadence as every
-        # other frame, so there is exactly one writer and a consistent frame
-        # size on the wire. Returns promptly (continuous-mic model) — it does
-        # not block until the queue drains.
+        # `chunk.data` DIRECTLY to `self._ws` (which would race the always-
+        # running background pump — two concurrent writers producing
+        # interleaved/oversized non-20ms `user_audio_chunk` frames), we ENQUEUE
+        # the speech as fixed 960-byte pump frames. The pump drains them at the
+        # same 20ms cadence as every other frame, so there is exactly one writer
+        # and a consistent frame size on the wire. Returns promptly
+        # (continuous-mic model) — it does not block until the queue drains.
         self.enqueue_speech(chunk.data)
-        self._enqueue_silence_tail()
+        if self._turn_commit_mode != "audio":
+            # "silence" (and the "text" fallback when a chunk carries no
+            # transcript): append the bounded legacy tail. On the "audio" path
+            # the pump's unbounded closing silence already provides the
+            # end-of-turn transition, so a fixed tail would only cap it.
+            self._enqueue_silence_tail()
 
     async def _send_user_message(self, text: str) -> None:
         """Explicit turn-commit: tell EL the user is done and force an agent
@@ -695,6 +784,36 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
 
             elif etype == "agent_response":
                 self.last_agent_transcript = event.get("agent_response_event", {}).get("agent_response")
+
+            elif etype == "agent_tool_response":
+                # The agent invoked one of its own (server-side) tools. When
+                # that tool is the ``end_call`` system tool, the agent has
+                # deliberately hung up and EL closes the socket right after
+                # this frame with a clean 1000 (issue #839).
+                #
+                # Wire shape (captured live):
+                #   {"type": "agent_tool_response",
+                #    "agent_tool_response": {"tool_name": "end_call",
+                #      "tool_type": "system", "is_error": false,
+                #      "is_blocked": false, "is_called": true, ...}}
+                #
+                # Recording it as a deliberate hangup — rather than letting the
+                # ensuing close look like a dropped transport — is what lets a
+                # leftover scripted turn conclude gracefully instead of failing
+                # a run in which the agent behaved exactly as designed.
+                tool = event.get("agent_tool_response", {}) or {}
+                if (
+                    tool.get("tool_name") in HANGUP_TOOL_NAMES
+                    and tool.get("is_called")
+                    and not tool.get("is_error")
+                    and not tool.get("is_blocked")
+                ):
+                    logger.info(
+                        "ElevenLabsAgentAdapter: agent invoked %r — treating the "
+                        "upcoming close as a deliberate hangup",
+                        tool.get("tool_name"),
+                    )
+                    self.agent_hung_up = True
 
             elif etype == "agent_response_correction":
                 # EL signals a corrected agent reply (post server-side

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -100,8 +100,16 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         self.instructions = instructions
         self.tools = tools or []
         self.role = role  # type: ignore[misc]
-        # Resolve API key: explicit param takes precedence over env var.
-        self._api_key: str = api_key or os.environ.get("OPENAI_API_KEY", "")
+        # Resolve API key: explicit param, then OPENAI_REALTIME_API_KEY, then
+        # OPENAI_API_KEY. The Realtime API connects DIRECTLY to OpenAI's
+        # websocket (gateways that proxy the HTTP audio endpoints do not
+        # proxy realtime), so when OPENAI_API_KEY holds a gateway virtual
+        # key, OPENAI_REALTIME_API_KEY carries the real provider key.
+        self._api_key: str = (
+            api_key
+            or os.environ.get("OPENAI_REALTIME_API_KEY")
+            or os.environ.get("OPENAI_API_KEY", "")
+        )
         self._ws: Any = None
 
         # Transcript observability — updated on incoming transcript events.

--- a/python/tests/voice/test_elevenlabs_agent_hangup.py
+++ b/python/tests/voice/test_elevenlabs_agent_hangup.py
@@ -1,0 +1,224 @@
+"""
+Issue #839 — an agent-initiated hangup ends the scenario gracefully.
+
+Hosted voice agents commonly hang up on purpose: an ElevenLabs agent invokes the
+``end_call`` system tool right after its farewell, which closes the WebSocket.
+When the scripted scenario still has ``agent()`` / ``user()`` steps left, the
+next ``agent()`` used to raise ``TransportNotConnectedError`` and fail a run in
+which the agent behaved exactly as designed.
+
+The adapter now recognises the ``agent_tool_response`` frame EL emits for a
+successful hangup tool and records it on ``agent_hung_up``; the base ``call()``
+gate then concludes the conversation instead of raising.
+
+Wire shape captured live from the real EL ConvAI transport::
+
+    {"type": "agent_tool_response",
+     "agent_tool_response": {"tool_name": "end_call",
+       "tool_call_id": "end_call_bf80…", "tool_type": "system",
+       "is_error": false, "is_blocked": false, "event_id": 20,
+       "is_called": true}}
+
+…followed by a clean close (code 1000).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scenario.types import AgentInput
+from scenario.voice import ElevenLabsAgentAdapter
+
+
+def _hangup_frame(
+    tool_name: str = "end_call",
+    *,
+    is_called: bool = True,
+    is_error: bool = False,
+    is_blocked: bool = False,
+) -> dict[str, Any]:
+    return {
+        "type": "agent_tool_response",
+        "agent_tool_response": {
+            "tool_name": tool_name,
+            "tool_call_id": f"{tool_name}_abc123",
+            "tool_type": "system",
+            "is_error": is_error,
+            "is_blocked": is_blocked,
+            "event_id": 20,
+            "is_called": is_called,
+        },
+    }
+
+
+class FakeSocket:
+    """In-memory EL socket that can also simulate a server-side close."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._inbound: "asyncio.Queue[str]" = asyncio.Queue()
+        self.closed = False
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def recv(self) -> str:
+        raw = await self._inbound.get()
+        if raw == "__CLOSE__":
+            import websockets
+
+            self.closed = True
+            raise websockets.exceptions.ConnectionClosedOK(None, None)
+        return raw
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def deliver(self, event: dict[str, Any]) -> None:
+        self._inbound.put_nowait(json.dumps(event))
+
+    def deliver_audio(self, byte_len: int = 4) -> None:
+        self.deliver(
+            {
+                "type": "audio",
+                "audio_event": {
+                    "audio_base_64": base64.b64encode(b"\x01" * byte_len).decode()
+                },
+            }
+        )
+
+    def deliver_close(self) -> None:
+        self._inbound.put_nowait("__CLOSE__")
+
+
+async def _connected() -> tuple[ElevenLabsAgentAdapter, FakeSocket]:
+    socket = FakeSocket()
+    adapter = ElevenLabsAgentAdapter(agent_id="agent-test", api_key="xi-test")
+    with patch("websockets.connect", new=AsyncMock(return_value=socket)):
+        await adapter.connect()
+    await adapter.stop_pump()
+    return adapter, socket
+
+
+def _agent_input() -> AgentInput:
+    return AgentInput(
+        thread_id="t-839",
+        messages=[],
+        new_messages=[],
+        scenario_state=None,  # type: ignore[arg-type]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Detection                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_end_call_tool_response_marks_the_call_as_agent_hung_up():
+    adapter, socket = await _connected()
+    assert adapter.agent_hung_up is False
+
+    socket.deliver(_hangup_frame())
+    socket.deliver_audio()  # lets recv_audio return after consuming the frame
+    await adapter.recv_audio(timeout=1.0)
+
+    assert adapter.agent_hung_up is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_name", ["transfer_to_agent", "transfer_to_number", "transfer_to_genesys"]
+)
+async def test_transfer_tools_also_count_as_the_agent_ending_this_session(tool_name):
+    """A transfer hands the caller off — this session is over either way."""
+    adapter, socket = await _connected()
+
+    socket.deliver(_hangup_frame(tool_name))
+    socket.deliver_audio()
+    await adapter.recv_audio(timeout=1.0)
+
+    assert adapter.agent_hung_up is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"is_called": False},
+        {"is_error": True},
+        {"is_blocked": True},
+    ],
+    ids=["not-called", "errored", "blocked"],
+)
+async def test_unsuccessful_hangup_tool_does_not_mark_a_hangup(kwargs):
+    """A hangup the agent did not actually complete is not a hangup — a close
+    after one of these is a genuine transport failure and must still raise."""
+    adapter, socket = await _connected()
+
+    socket.deliver(_hangup_frame(**kwargs))
+    socket.deliver_audio()
+    await adapter.recv_audio(timeout=1.0)
+
+    assert adapter.agent_hung_up is False
+
+
+@pytest.mark.asyncio
+async def test_unrelated_agent_tool_response_does_not_mark_a_hangup():
+    adapter, socket = await _connected()
+
+    socket.deliver(_hangup_frame("language_detection"))
+    socket.deliver_audio()
+    await adapter.recv_audio(timeout=1.0)
+
+    assert adapter.agent_hung_up is False
+
+
+# --------------------------------------------------------------------------- #
+# The scripted turn that used to fail                                          #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_scripted_turn_after_a_hangup_concludes_instead_of_raising():
+    """The #839 shape: agent says goodbye, hangs up, and the script still has a
+    turn left. That turn must conclude, not fail the run."""
+    adapter, socket = await _connected()
+
+    # Farewell audio, then the hangup tool, then EL closes the socket.
+    socket.deliver_audio()
+    await adapter.recv_audio(timeout=1.0)
+    socket.deliver(_hangup_frame())
+    socket.deliver_close()
+    terminal = await adapter.recv_audio(timeout=1.0)
+    assert terminal.data == b"", "a close mid-receive ends the drain cleanly"
+
+    assert adapter.agent_hung_up is True
+    assert adapter.is_connected() is False
+
+    # The leftover scripted agent() turn.
+    result = await adapter.call(_agent_input())
+
+    assert result == [], "concluding adds no messages; the script falls through"
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_transport_still_raises():
+    """Without a deliberate hangup, a disconnected adapter is still an error —
+    the fix must not mask genuine transport failures."""
+    from scenario.voice.adapters._stub import TransportNotConnectedError
+
+    adapter, socket = await _connected()
+    socket.deliver_close()
+    await adapter.recv_audio(timeout=1.0)
+    await adapter.disconnect()
+
+    assert adapter.agent_hung_up is False
+    with pytest.raises(TransportNotConnectedError):
+        await adapter.call(_agent_input())

--- a/python/tests/voice/test_elevenlabs_agent_hangup.py
+++ b/python/tests/voice/test_elevenlabs_agent_hangup.py
@@ -111,7 +111,7 @@ def _agent_input() -> AgentInput:
         thread_id="t-839",
         messages=[],
         new_messages=[],
-        scenario_state=None,  # type: ignore[arg-type]
+        scenario_state=None,  # type: ignore[arg-type]  # the connected-state gate under test runs before scenario_state is read
     )
 
 

--- a/python/tests/voice/test_elevenlabs_init_overrides.py
+++ b/python/tests/voice/test_elevenlabs_init_overrides.py
@@ -1,0 +1,147 @@
+"""
+Issue #838 — ``dynamic_variables`` + ``overrides`` on the init handshake.
+
+Python parity with the TS adapter's ``dynamicVariables`` / ``overrides`` options.
+
+Production integrations personalise a hosted agent per call by sending
+``dynamic_variables`` (which fill the DEPLOYED prompt template) plus a narrow
+``agent.{language, first_message}`` override. They do NOT override the system
+prompt: on ElevenLabs that replaces the entire prompt object including
+``tool_ids``, so an agent relying on server tools silently loses them and then
+stalls waiting for tool responses that can never arrive.
+
+These tests drive the adapter through an injected fake WebSocket and prove the
+init frame the adapter puts on the wire:
+ 1. ``dynamic_variables`` are forwarded natively, keeping their JSON types;
+ 2. the key is OMITTED entirely when unset (EL distinguishes absent from ``{}``);
+ 3. caller ``overrides`` deep-merge UNDER the narrow prompt/first-message knobs,
+    so ``agent.language`` and ``agent.prompt`` both survive;
+ 4. the narrow knobs win on a shared leaf.
+
+The LIVE proof (real EL agent answering in Spanish from an injected plan tier)
+is in the PR description.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scenario.voice import ElevenLabsAgentAdapter
+
+
+class FakeSocket:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _init_frame(**kwargs: Any) -> dict[str, Any]:
+    """Connect an adapter over a fake socket and return the init frame it sent."""
+    socket = FakeSocket()
+    adapter = ElevenLabsAgentAdapter(agent_id="agent-test", api_key="xi-test", **kwargs)
+    with patch("websockets.connect", new=AsyncMock(return_value=socket)):
+        await adapter.connect()
+    await adapter.stop_pump()
+    init = json.loads(socket.sent[0])
+    assert init["type"] == "conversation_initiation_client_data"
+    return init
+
+
+# --------------------------------------------------------------------------- #
+# dynamic_variables                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_dynamic_variables_are_forwarded_with_native_json_types():
+    """Text / numeric / boolean pass through uncoerced — EL supports all three."""
+    init = await _init_frame(
+        dynamic_variables={"tenant_id": "acme", "seat_tier": 2, "is_vip": True}
+    )
+
+    assert init["dynamic_variables"] == {
+        "tenant_id": "acme",
+        "seat_tier": 2,
+        "is_vip": True,
+    }
+    # Not stringified — a str() coercion would break EL's typed variables.
+    assert isinstance(init["dynamic_variables"]["seat_tier"], int)
+    assert isinstance(init["dynamic_variables"]["is_vip"], bool)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_variables_key_is_absent_when_unset():
+    """Unset means NO key, not an empty object."""
+    init = await _init_frame()
+
+    assert "dynamic_variables" not in init
+
+
+@pytest.mark.asyncio
+async def test_empty_dynamic_variables_dict_is_still_sent():
+    """An explicitly-passed empty dict is the caller's choice — send it."""
+    init = await _init_frame(dynamic_variables={})
+
+    assert init["dynamic_variables"] == {}
+
+
+# --------------------------------------------------------------------------- #
+# overrides deep-merge                                                         #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_overrides_deep_merge_keeps_caller_language_and_adapter_prompt():
+    """The #838 shape: a caller's agent.language and the adapter's agent.prompt
+    must BOTH survive. A shallow spread would drop one side's nested `agent`."""
+    init = await _init_frame(
+        system_prompt_override="Be terse.",
+        first_message_override="Test harness here.",
+        overrides={"agent": {"language": "es"}, "tts": {"stability": 0.3}},
+    )
+
+    cco = init["conversation_config_override"]
+    assert cco["agent"]["language"] == "es"
+    assert cco["agent"]["prompt"] == {"prompt": "Be terse."}
+    assert cco["agent"]["first_message"] == "Test harness here."
+    # A top-level sibling key the narrow knobs never touch survives intact.
+    assert cco["tts"] == {"stability": 0.3}
+
+
+@pytest.mark.asyncio
+async def test_narrow_knob_wins_over_overrides_on_a_shared_leaf():
+    """On the same leaf the narrow override is the higher-precedence layer."""
+    init = await _init_frame(
+        system_prompt_override="narrow wins",
+        overrides={"agent": {"prompt": {"prompt": "base loses"}}},
+    )
+
+    assert init["conversation_config_override"]["agent"]["prompt"] == {
+        "prompt": "narrow wins"
+    }
+
+
+@pytest.mark.asyncio
+async def test_overrides_alone_do_not_require_the_narrow_knobs():
+    """`overrides` is usable on its own — the empty `agent` layer is a no-op."""
+    init = await _init_frame(overrides={"agent": {"language": "fr"}})
+
+    assert init["conversation_config_override"]["agent"] == {"language": "fr"}
+
+
+@pytest.mark.asyncio
+async def test_handshake_shape_is_stable_with_no_options():
+    """No options still sends a well-formed (empty) override block."""
+    init = await _init_frame()
+
+    assert init["conversation_config_override"] == {"agent": {}}

--- a/python/tests/voice/test_elevenlabs_turn_boundary_reconcile.py
+++ b/python/tests/voice/test_elevenlabs_turn_boundary_reconcile.py
@@ -1,0 +1,228 @@
+"""
+Issue #749 — split-utterance bleed at the user-turn boundary (Python parity
+with the TypeScript fix in #748).
+
+The drain closes an agent turn on ``response_tail_silence``. ElevenLabs delivers
+audio in bursts, so a mid-utterance delivery gap longer than that silence ends
+the turn while the agent is still speaking. Pre-fix, the remainder was read by
+the NEXT drain and surfaced as the next agent turn's opening audio — turn N+1
+appearing to answer question N. Observed live: a two-turn hosted run where the
+agent's reply to "can you tell me your support hours?" was its reply to the
+PREVIOUS question.
+
+The reconcile runs at the pre-user-``send_audio`` boundary, where the agent
+cannot have begun its next reply, so anything still arriving is unambiguously
+the prior turn's tail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scenario.voice import AudioChunk, ElevenLabsAgentAdapter
+from scenario.voice.adapter import reconcile_prior_agent_audio
+from scenario.voice.recording import AudioSegment
+
+
+class FakeSocket:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._inbound: "asyncio.Queue[str]" = asyncio.Queue()
+        self.closed = False
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def recv(self) -> str:
+        return await self._inbound.get()
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def deliver_audio(self, payload: bytes) -> None:
+        self._inbound.put_nowait(
+            json.dumps(
+                {
+                    "type": "audio",
+                    "audio_event": {"audio_base_64": base64.b64encode(payload).decode()},
+                }
+            )
+        )
+
+
+class FakeRecording:
+    def __init__(self, segments: list[AudioSegment]) -> None:
+        self.segments = segments
+
+
+class FakeExecutor:
+    def __init__(self, segments: list[AudioSegment]) -> None:
+        self._voice_recording = FakeRecording(segments)
+        self.fired: list[AudioChunk] = []
+
+    def _on_audio_chunk(self, chunk: AudioChunk) -> None:
+        self.fired.append(chunk)
+
+
+async def _connected() -> tuple[ElevenLabsAgentAdapter, FakeSocket]:
+    socket = FakeSocket()
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    with patch("websockets.connect", new=AsyncMock(return_value=socket)):
+        await adapter.connect()
+    await adapter.stop_pump()
+    return adapter, socket
+
+
+def _agent_segment(audio: bytes = b"\x01" * 100) -> AudioSegment:
+    return AudioSegment(
+        speaker="agent", start_time=1.0, end_time=2.0, audio=audio, transcript="head only"
+    )
+
+
+def _user_segment() -> AudioSegment:
+    return AudioSegment(
+        speaker="user", start_time=2.0, end_time=3.0, audio=b"\x02" * 10, transcript="hi"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Collecting the stranded audio                                                #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_reconcile_collects_audio_still_in_flight():
+    adapter, socket = await _connected()
+    socket.deliver_audio(b"\x11" * 40)
+    socket.deliver_audio(b"\x22" * 60)
+
+    leftover = await adapter.reconcile_pending_audio()
+
+    assert leftover is not None
+    assert leftover.data == b"\x11" * 40 + b"\x22" * 60
+
+
+@pytest.mark.asyncio
+async def test_reconcile_returns_none_when_nothing_is_in_flight():
+    adapter, _socket = await _connected()
+
+    assert await adapter.reconcile_pending_audio() is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_is_bounded_and_does_not_stall_the_turn():
+    """A silent-but-alive socket must not hold the turn boundary open."""
+    adapter, _socket = await _connected()
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    await adapter.reconcile_pending_audio()
+
+    assert loop.time() - start < 1.0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_on_a_disconnected_adapter_is_a_noop():
+    adapter, _socket = await _connected()
+    await adapter.disconnect()
+
+    assert await adapter.reconcile_pending_audio() is None
+
+
+# --------------------------------------------------------------------------- #
+# Attribution                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_stranded_audio_grows_the_preceding_agent_segment():
+    """Cursor-safe: an agent segment is still last, so the tail goes back onto
+    the utterance that produced it instead of bleeding into the next turn."""
+    adapter, socket = await _connected()
+    prior = _agent_segment()
+    executor = FakeExecutor([prior])
+    socket.deliver_audio(b"\x33" * 50)
+
+    await reconcile_prior_agent_audio(adapter, executor, now=4.0)
+
+    assert prior.audio == b"\x01" * 100 + b"\x33" * 50
+    assert prior.end_time == 4.0
+    # Cleared so the finalize STT back-fill re-transcribes the longer audio —
+    # the old transcript covered only the head.
+    assert prior.transcript is None
+    # Routed through the audio-chunk hook like every other recorded agent chunk.
+    assert [c.data for c in executor.fired] == [b"\x33" * 50]
+
+
+@pytest.mark.asyncio
+async def test_end_time_never_moves_backwards():
+    adapter, socket = await _connected()
+    prior = _agent_segment()
+    prior.end_time = 9.0
+    executor = FakeExecutor([prior])
+    socket.deliver_audio(b"\x44" * 10)
+
+    await reconcile_prior_agent_audio(adapter, executor, now=4.0)
+
+    assert prior.end_time == 9.0
+
+
+@pytest.mark.asyncio
+async def test_cursor_unsafe_drops_rather_than_corrupting_the_cursor():
+    """A user segment is last (barge-in shape): the audio is already off the
+    wire so it cannot bleed, but growing an out-of-order segment would corrupt
+    the append-only cursor. Drop it."""
+    adapter, socket = await _connected()
+    user_seg = _user_segment()
+    executor = FakeExecutor([_agent_segment(), user_seg])
+    socket.deliver_audio(b"\x55" * 30)
+
+    await reconcile_prior_agent_audio(adapter, executor, now=4.0)
+
+    assert user_seg.audio == b"\x02" * 10, "the user segment is untouched"
+    assert executor.fired == [], "dropped audio is not recorded"
+
+
+@pytest.mark.asyncio
+async def test_no_recording_is_tolerated():
+    """The opening greeting has no prior segment at all."""
+    adapter, socket = await _connected()
+    executor = FakeExecutor([])
+    socket.deliver_audio(b"\x66" * 20)
+
+    await reconcile_prior_agent_audio(adapter, executor, now=4.0)
+
+    assert executor.fired == []
+
+
+@pytest.mark.asyncio
+async def test_adapters_without_the_hook_are_untouched():
+    """Duck-typed: adapters with no buffered audio expose no such method."""
+
+    class Bare:
+        pass
+
+    executor = FakeExecutor([_agent_segment()])
+
+    await reconcile_prior_agent_audio(Bare(), executor, now=4.0)
+
+    assert executor.fired == []
+
+
+@pytest.mark.asyncio
+async def test_a_raising_reconcile_never_fails_the_turn():
+    class Exploding:
+        async def reconcile_pending_audio(self) -> Any:
+            raise RuntimeError("transport blew up")
+
+    executor = FakeExecutor([_agent_segment()])
+
+    await reconcile_prior_agent_audio(Exploding(), executor, now=4.0)
+
+    assert executor.fired == []

--- a/python/tests/voice/test_elevenlabs_turn_boundary_reconcile.py
+++ b/python/tests/voice/test_elevenlabs_turn_boundary_reconcile.py
@@ -193,8 +193,8 @@ async def test_cursor_unsafe_drops_rather_than_corrupting_the_cursor():
 
 
 @pytest.mark.asyncio
-async def test_no_recording_is_tolerated():
-    """The opening greeting has no prior segment at all."""
+async def test_empty_recording_is_tolerated():
+    """The opening greeting has no prior segment to attribute to."""
     adapter, socket = await _connected()
     executor = FakeExecutor([])
     socket.deliver_audio(b"\x66" * 20)
@@ -202,6 +202,35 @@ async def test_no_recording_is_tolerated():
     await reconcile_prior_agent_audio(adapter, executor, now=4.0)
 
     assert executor.fired == []
+
+
+@pytest.mark.asyncio
+async def test_executor_without_a_recording_is_tolerated():
+    """Test doubles (and the no-recording path) carry no ``_voice_recording``."""
+
+    class NoRecordingExecutor:
+        def __init__(self) -> None:
+            self.fired: list[AudioChunk] = []
+
+        def _on_audio_chunk(self, chunk: AudioChunk) -> None:
+            self.fired.append(chunk)
+
+    adapter, socket = await _connected()
+    executor = NoRecordingExecutor()
+    socket.deliver_audio(b"\x77" * 20)
+
+    await reconcile_prior_agent_audio(adapter, executor, now=4.0)
+
+    assert executor.fired == []
+
+
+@pytest.mark.asyncio
+async def test_a_null_executor_is_tolerated():
+    """``_AdapterRecorder`` degrades to a no-op executor on lightweight stubs."""
+    adapter, socket = await _connected()
+    socket.deliver_audio(b"\x88" * 20)
+
+    await reconcile_prior_agent_audio(adapter, None, now=4.0)
 
 
 @pytest.mark.asyncio

--- a/python/tests/voice/test_elevenlabs_turn_boundary_reconcile.py
+++ b/python/tests/voice/test_elevenlabs_turn_boundary_reconcile.py
@@ -153,9 +153,12 @@ async def test_stranded_audio_grows_the_preceding_agent_segment():
 
     assert prior.audio == b"\x01" * 100 + b"\x33" * 50
     assert prior.end_time == 4.0
-    # Cleared so the finalize STT back-fill re-transcribes the longer audio —
-    # the old transcript covered only the head.
-    assert prior.transcript is None
+    # The transcript is left alone: the turn was cut short in AUDIO only, and
+    # the provider's own agent_response text already covered the whole
+    # utterance, so appending the tail makes the two consistent. Clearing it
+    # would discard a correct transcript — and an audio-capable judge never runs
+    # the STT back-fill that would regenerate one.
+    assert prior.transcript == "head only"
     # Routed through the audio-chunk hook like every other recorded agent chunk.
     assert [c.data for c in executor.fired] == [b"\x33" * 50]
 

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -136,11 +136,6 @@ def _user_turn(text: str) -> AudioChunk:
     return AudioChunk(data=b"\x7f" * 8, transcript=text)
 
 
-def _speech_frames(socket: FakeElevenLabsSocket) -> list[bytes]:
-    """Emitted ``user_audio_chunk`` frames that carry speech (any non-zero byte)."""
-    return [f for f in (base64.b64decode(c) for c in socket.audio_chunks) if any(f)]
-
-
 # --------------------------------------------------------------------------- #
 # Audio turn-commit (default) — real voice-in                                  #
 # --------------------------------------------------------------------------- #

--- a/python/tests/voice/test_elevenlabs_turn_commit.py
+++ b/python/tests/voice/test_elevenlabs_turn_commit.py
@@ -10,29 +10,32 @@ re-engage a response for a scripted turn 2+ (EL ConvAI 2.0 end-of-turn is a
 hybrid VAD + deep-learning turn-detector, not a pure silence threshold), so the
 2nd ``recv_audio`` timed out.
 
-The fix sends an explicit ``{"type": "user_message", "text": <transcript>}``
-turn-commit — the only documented client→server event that deterministically
-forces an agent response without mic-style VAD. On the text path the raw audio
-is NOT also streamed to EL (audio + text in one turn raced the server's
-ingestion and was live-flaky); the user audio is still recorded locally by the
-voice runtime and EL echoes the text back as a ``user_transcript`` event.
+#567 was first fixed with an explicit
+``{"type": "user_message", "text": <transcript>}`` turn-commit. That
+deterministically re-engaged the agent, but it sent NO audio, so EL's STT never
+ran and a green run proved nothing about the agent's own transcription or
+turn-taking. The default is now ``"audio"``: the turn's real PCM is streamed as
+20 ms pump frames followed by *unbounded* closing silence, which is what EL's
+server VAD measures end-of-turn against. Text-commit survives as the opt-in
+``turn_commit_mode="text"`` escape hatch.
 
 These tests drive the adapter through an injected fake WebSocket (patching
 ``websockets.connect``, the same seam the existing EL transport tests use) and
 prove:
  1. a scripted 2nd user turn after an agent turn drives a 2nd ``recv_audio``
-    resolution (the bug), AND each user turn emits a ``user_message`` commit;
+    resolution (the #567 bug), AND each user turn goes out as REAL audio with
+    no text commit and no bounded tail;
  2. the post-interrupt shape (agent audio mid-flight → user re-engages) also
-    commits + re-engages, and ``agent_response_correction`` updates the
-    transcript;
- 3. the committed ``user_message`` is a server-accepted shape (type + text);
- 4. ``turn_commit_mode="silence"`` preserves the legacy pure-audio path;
+    re-engages, and ``agent_response_correction`` updates the transcript;
+ 3. ``turn_commit_mode="text"`` still emits a server-accepted ``user_message``
+    (type + text) and sends no audio;
+ 4. ``turn_commit_mode="silence"`` preserves the bounded-tail audio path;
  5. ``"text"`` mode with no transcript falls back to the silence tail;
  6. ``silence_tail_bytes`` resizes the fallback tail.
 
-Offline — no network, no real EL socket. The LIVE >=2-exchange proof lives in
-``examples/voice/elevenlabs_hosted.py`` (wrapped by
-``test_elevenlabs_hosted_e2e.py``).
+Offline — no network, no real EL socket. The LIVE proof that EL's STT actually
+transcribes the streamed PCM lives in ``examples/voice/elevenlabs_hosted.py``
+(wrapped by ``test_elevenlabs_hosted_e2e.py``).
 """
 
 from __future__ import annotations
@@ -112,7 +115,7 @@ class FakeElevenLabsSocket:
 
 async def _connected_adapter(
     *,
-    turn_commit_mode: str = "text",
+    turn_commit_mode: str = "audio",
     silence_tail_bytes: Optional[int] = None,
 ) -> tuple[ElevenLabsAgentAdapter, FakeElevenLabsSocket]:
     """Build an adapter wired to a fresh fake socket, already connected."""
@@ -127,12 +130,19 @@ async def _connected_adapter(
 
 
 def _user_turn(text: str) -> AudioChunk:
-    """A user audio chunk that carries its transcript (as the voice runtime threads it)."""
-    return AudioChunk(data=b"\x00" * 8, transcript=text)
+    """A user audio chunk that carries its transcript (as the voice runtime
+    threads it). The PCM is non-zero so a speech frame is distinguishable from
+    the pump's all-zero closing silence."""
+    return AudioChunk(data=b"\x7f" * 8, transcript=text)
+
+
+def _speech_frames(socket: FakeElevenLabsSocket) -> list[bytes]:
+    """Emitted ``user_audio_chunk`` frames that carry speech (any non-zero byte)."""
+    return [f for f in (base64.b64decode(c) for c in socket.audio_chunks) if any(f)]
 
 
 # --------------------------------------------------------------------------- #
-# Text turn-commit (default) — the #567 fix                                    #
+# Audio turn-commit (default) — real voice-in                                  #
 # --------------------------------------------------------------------------- #
 
 
@@ -159,16 +169,54 @@ async def test_scripted_second_user_turn_drives_second_recv_audio():
     agent2 = await adapter.recv_audio(timeout=1.0)
     assert len(agent2.data) > 0
 
-    # Each user turn emitted an explicit user_message turn-commit (not a
-    # silence tail) — the deterministic re-engagement signal.
-    assert socket.user_messages == [
-        {"type": "user_message", "text": "Hello, I have a question about my account."},
-        {"type": "user_message", "text": "Yes, can you check my balance?"},
-    ]
-    # The default "text" path sends ONLY the text commit — NO user_audio_chunk
-    # frames at all (audio + text in one turn raced EL's ingestion and was
-    # live-flaky; the text turn alone re-engages deterministically).
-    assert socket.audio_chunks == []
+    # Both user turns went out as REAL audio: the agent's own STT is what
+    # transcribes them, so a passing run actually exercises it.
+    assert adapter.audio_commit_count == 2
+    # No text commit anywhere — the audio path does not inject transcripts.
+    assert socket.user_messages == []
+
+
+@pytest.mark.asyncio
+async def test_audio_mode_streams_real_pcm_and_appends_no_bounded_tail():
+    """The default path puts the user's PCM on the wire and lets the pump's
+    UNBOUNDED closing silence end the turn — no fixed silence tail."""
+    adapter, socket = await _connected_adapter()
+    # Manual pump control so the drain below is deterministic.
+    await adapter.stop_pump()
+
+    await adapter.send_audio(_user_turn("Hello again."))
+
+    # Exactly the speech frame is queued — no bounded tail behind it. The
+    # closing silence comes from the pump ticking on an empty queue instead,
+    # which is what makes it unbounded (and what fixed scripted turn 2+).
+    assert len(adapter._outbound_frames) == 1
+    assert socket.user_messages == []
+
+    socket.sent.clear()
+    while adapter._outbound_frames:
+        await adapter._pump_tick()
+    emitted = [base64.b64decode(c) for c in socket.audio_chunks]
+    assert emitted, "expected the pump to emit the enqueued speech"
+    assert all(len(f) == 960 for f in emitted), "pump frames are fixed 20 ms"
+    assert any(any(f) for f in emitted), "the user's real PCM reached the wire"
+
+    # Ticking again with an empty queue yields closing silence, indefinitely.
+    socket.sent.clear()
+    for _ in range(3):
+        await adapter._pump_tick()
+    assert [base64.b64decode(c) for c in socket.audio_chunks] == [b"\x00" * 960] * 3
+
+
+@pytest.mark.asyncio
+async def test_empty_chunk_is_not_counted_as_an_audio_turn():
+    """An empty chunk carries no speech: no frame, no turn counted."""
+    adapter, _socket = await _connected_adapter()
+    await adapter.stop_pump()
+
+    await adapter.send_audio(AudioChunk(data=b"", transcript=""))
+
+    assert adapter.audio_commit_count == 0
+    assert len(adapter._outbound_frames) == 0
 
 
 @pytest.mark.asyncio
@@ -197,15 +245,36 @@ async def test_post_interrupt_user_turn_re_engages_and_correction_updates_transc
 
     assert len(corrected.data) > 0
     assert adapter.last_agent_transcript == "Okay, cancelled."
+    # The re-engaging turn went out as real audio, not an injected text commit.
+    assert adapter.audio_commit_count == 1
+    assert socket.user_messages == []
+
+
+# --------------------------------------------------------------------------- #
+# Text turn-commit — the opt-in escape hatch                                   #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_text_mode_commits_transcript_and_sends_no_audio():
+    """``turn_commit_mode="text"`` re-engages without server VAD, at the cost of
+    the agent never hearing the user — no ``user_audio_chunk`` is sent."""
+    adapter, socket = await _connected_adapter(turn_commit_mode="text")
+    await adapter.stop_pump()
+
+    await adapter.send_audio(_user_turn("Hello, I have a question about my account."))
+
     assert socket.user_messages == [
-        {"type": "user_message", "text": "Actually, wait — cancel that."}
+        {"type": "user_message", "text": "Hello, I have a question about my account."}
     ]
+    assert socket.audio_chunks == []
+    assert adapter.audio_commit_count == 0
 
 
 @pytest.mark.asyncio
 async def test_user_message_commit_echoes_through_as_user_transcript():
     """EL echoes the committed text back as user_transcript observability."""
-    adapter, socket = await _connected_adapter()
+    adapter, socket = await _connected_adapter(turn_commit_mode="text")
 
     await adapter.send_audio(_user_turn("What are your hours?"))
     socket.deliver(
@@ -223,7 +292,7 @@ async def test_user_message_commit_echoes_through_as_user_transcript():
 @pytest.mark.asyncio
 async def test_committed_user_message_is_server_accepted_shape():
     """The committed user_message carries exactly ``type`` + ``text``."""
-    adapter, socket = await _connected_adapter()
+    adapter, socket = await _connected_adapter(turn_commit_mode="text")
 
     await adapter.send_audio(_user_turn("ping"))
 
@@ -272,7 +341,7 @@ async def test_silence_mode_preserves_legacy_pure_audio_path():
 async def test_text_mode_without_transcript_falls_back_to_silence_tail():
     """``"text"`` mode with no transcript falls back to the silence tail —
     now queued as fixed 960-byte pump frames, not a direct blob write."""
-    adapter, socket = await _connected_adapter()  # default "text"
+    adapter, socket = await _connected_adapter(turn_commit_mode="text")
     # Take manual pump control (stop the background task, clear its queue) so
     # the drain below is deterministic; the pump is the single WS audio writer.
     await adapter.stop_pump()

--- a/python/tests/voice/test_openai_realtime_user_routing.py
+++ b/python/tests/voice/test_openai_realtime_user_routing.py
@@ -61,3 +61,24 @@ async def test_scripted_user_text_routes_to_realtime_send_text(monkeypatch):
     )
     assert result.success
     assert captured == ["hello from the test"]
+
+
+class TestApiKeyResolution:
+    """OPENAI_REALTIME_API_KEY outranks OPENAI_API_KEY for the direct ws."""
+
+    def test_realtime_key_preferred_over_openai_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "vk-lw-virtual")
+        monkeypatch.setenv("OPENAI_REALTIME_API_KEY", "sk-real-provider")
+        adapter = OpenAIRealtimeAgentAdapter()
+        assert adapter._api_key == "sk-real-provider"
+
+    def test_falls_back_to_openai_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-plain")
+        monkeypatch.delenv("OPENAI_REALTIME_API_KEY", raising=False)
+        adapter = OpenAIRealtimeAgentAdapter()
+        assert adapter._api_key == "sk-plain"
+
+    def test_explicit_param_wins(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_REALTIME_API_KEY", "sk-env")
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-param")
+        assert adapter._api_key == "sk-param"

--- a/scripts/provision_elevenlabs_agent.py
+++ b/scripts/provision_elevenlabs_agent.py
@@ -136,6 +136,10 @@ def _create_agent(api_key: str) -> str:
                 "conversation_config_override": {
                     "agent": {
                         "first_message": True,
+                        # Allowlisted so the adapter's `overrides` knob can be
+                        # exercised end-to-end (issue #838). EL rejects any
+                        # override the agent has not opted in to.
+                        "language": True,
                         "prompt": {"prompt": True},
                     }
                 }
@@ -182,6 +186,10 @@ def _patch_agent_prompt(api_key: str, agent_id: str) -> None:
                 "conversation_config_override": {
                     "agent": {
                         "first_message": True,
+                        # Allowlisted so the adapter's `overrides` knob can be
+                        # exercised end-to-end (issue #838). EL rejects any
+                        # override the agent has not opted in to.
+                        "language": True,
                         "prompt": {"prompt": True},
                     }
                 }

--- a/specs/elevenlabs-ts-keepalive.feature
+++ b/specs/elevenlabs-ts-keepalive.feature
@@ -82,7 +82,7 @@ Feature: TypeScript ElevenLabsAgentAdapter receiveAudio — keepalive-aware slid
   Scenario: The live hosted happy path no longer times out intermittently (AC-KA4)
     Given ELEVENLABS_API_KEY, ELEVENLABS_AGENT_ID, and OPENAI_API_KEY are all set
     When the greeting-led hosted test in
-      javascript/tests/voice/elevenlabs-hosted.test.ts runs twice consecutively
+      javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts runs twice consecutively
     Then both runs complete without a receiveAudio timed out error
     And the vitest summary shows PASSED (not skipped) for both runs
     Note: this AC is explicitly waivable — if keys are unavailable (as documented in the

--- a/specs/elevenlabs-ts-keepalive.feature
+++ b/specs/elevenlabs-ts-keepalive.feature
@@ -79,9 +79,9 @@ Feature: TypeScript ElevenLabsAgentAdapter receiveAudio — keepalive-aware slid
   # ============================================================
 
   @e2e @ts-elevenlabs
-  Scenario: Live single-exchange happy path no longer times out intermittently (AC-KA4)
+  Scenario: The live hosted happy path no longer times out intermittently (AC-KA4)
     Given ELEVENLABS_API_KEY, ELEVENLABS_AGENT_ID, and OPENAI_API_KEY are all set
-    When the greeting-led agent()→user→agent→judge test in
+    When the greeting-led hosted test in
       javascript/tests/voice/elevenlabs-hosted.test.ts runs twice consecutively
     Then both runs complete without a receiveAudio timed out error
     And the vitest summary shows PASSED (not skipped) for both runs
@@ -101,8 +101,8 @@ Feature: TypeScript ElevenLabsAgentAdapter receiveAudio — keepalive-aware slid
   # AC-KA3 (npm test exits 0, 0 failures, scope includes elevenlabs.test.ts 35 it-blocks)
   #        -> Scenario: All existing adapter unit tests pass after the timerResetters change (AC-KA3)
   #
-  # AC-KA4 (live single-exchange passes twice consecutively, or explicitly waived with AC-KA1 as merge gate)
-  #        -> Scenario: Live single-exchange happy path no longer times out intermittently (AC-KA4)
+  # AC-KA4 (the live hosted happy path passes twice consecutively, or explicitly waived with AC-KA1 as merge gate)
+  #        -> Scenario: The live hosted happy path no longer times out intermittently (AC-KA4)
   #
   # AC-KA5 (socket close drains cleanly; timerResetters cleared; no surviving timer)
   #        -> Scenario: A pending receiveAudio on socket close drains cleanly with no surviving timer (AC-KA5)

--- a/specs/voice-elevenlabs-hosted-e2e.feature
+++ b/specs/voice-elevenlabs-hosted-e2e.feature
@@ -1,187 +1,198 @@
-Feature: Voice E2E against hosted ElevenLabs — single-exchange ceiling, multi-turn routing, and reconciled docs
-  As a developer porting chatbox scenarios to voice against a hosted ElevenLabs ConvAI agent
-  I want the docs to teach the real hosted single-exchange ceiling and route multi-turn to the adapters that support it
-  So that I stop hitting `receiveAudio timed out` on patterns the docs implied were universal
-  And so the SDK fails informatively instead of with a bare timeout
+Feature: Voice E2E against hosted ElevenLabs — real voice-in, multi-turn, per-call personalisation, and agent hangup
+  As a developer testing a deployed ElevenLabs Conversational AI agent
+  I want the harness to speak to it the way a real caller does and to end the run the way a real call ends
+  So that a green scenario is evidence about the agent's own STT, turn-taking, and hangup behaviour
+  And so the docs describe what the adapter actually does
 
   Background:
-    Given the hosted ElevenLabs ConvAI transport is server-VAD-driven, so its ceiling is ONE greeting-led user↔agent exchange
-    And the adapter send-path is verified correct — user audio reaches ElevenLabs on the 2nd scripted turn (adapter.runtime.ts:261-266), the timeout is the server VAD not re-engaging, not a missing-audio bug
-    And the SILENCE_TAIL_BYTES end-of-turn pad (elevenlabs.ts:241-254) is the maintainers' acknowledged best-effort for hosted turn-taking
-    And multi-turn voice is supported only on the composable ElevenLabsVoiceAgent, pipecatAgent, Gemini Live, and OpenAI Realtime adapters
+    Given the hosted ElevenLabs ConvAI transport is server-VAD-driven, so it closes a turn on an audio→silence transition
+    And the adapter streams the user's real PCM as 20 ms frames at microphone cadence, then UNBOUNDED closing silence, which supplies that transition
+    And a bounded silence tail does NOT reliably close a scripted turn — EL ConvAI 2.0 uses a hybrid VAD plus a deep-learning turn-detector, not a pure silence threshold
+    And the TypeScript and Python adapters are at behavioural parity on this path
 
   # ============================================================
-  # Group: Reporter deliverable
+  # Group: Real voice-in — the agent actually hears the user
   # ============================================================
 
-  @e2e
-  Scenario: The resolving comment answers the reporter's three questions, each tied to a docs anchor
-    Given a developer reading the issue's resolving comment
-    When they look for the answers to the three reporter questions
-    Then the comment states the correct hosted script is the greeting-led single exchange `agent()→user→agent→judge`, anchored to happy-path-elevenlabs.mdx (AC4a)
-    And the comment states `proceed()` is NOT reliable on hosted `elevenLabsAgent` and works on composable/pipecat/realtime, anchored to recipes/multi-turn.mdx (AC11)
-    And the comment states 5–45-turn flows are unsupported on hosted ConvAI and route to `ElevenLabsVoiceAgent`/`pipecatAgent`, anchored to recipes/multi-turn.mdx (AC1, AC11)
-    And each of the three answers carries a clickable docs URL, not a bare claim
+  @unit
+  Scenario: A scripted user turn goes on the wire as real audio, not injected text
+    Given a connected hosted ElevenLabs adapter in its default turn-commit mode
+    When a scripted user turn carrying both PCM and a transcript is sent
+    Then the frames on the wire are `user_audio_chunk` carrying that PCM
+    And NO `user_message` text commit is sent
+    And the adapter's real-audio turn counter increments once for the turn, not once per frame
+
+  @unit
+  Scenario: The default path appends no bounded silence tail
+    Given a connected hosted ElevenLabs adapter in its default turn-commit mode
+    When a scripted user turn is sent and the pump drains it
+    Then only the speech frames were queued behind it
+    And ticking the pump on an empty queue yields closing silence indefinitely
+    And that unbounded closing silence — not a fixed tail — is what ends the turn
+
+  @unit
+  Scenario: An empty chunk is not a turn
+    Given a connected hosted ElevenLabs adapter
+    When a chunk carrying no PCM is sent
+    Then no frame is queued and the real-audio turn counter does not move
+
+  @unit
+  Scenario: Text turn-commit remains available as an explicit opt-in
+    Given a hosted ElevenLabs adapter constructed with the text turn-commit mode
+    When a scripted user turn carrying a transcript is sent
+    Then a `user_message` commit carrying exactly `type` and `text` is sent
+    And NO `user_audio_chunk` is sent, so the agent's STT never runs on that turn
+
+  @e2e @ts-elevenlabs
+  Scenario: ElevenLabs transcribes the streamed audio on every scripted turn
+    Given `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`, and `OPENAI_API_KEY` are set
+    When a greeting-led multi-turn scenario runs against the live hosted agent
+    Then EL emits a non-empty `user_transcript` for EACH scripted user turn
+    And those transcripts are EL's own transcription of our PCM, not an echo of the script text
+    And the real-audio turn counter is at least the number of scripted user turns
 
   # ============================================================
-  # Group: Docs reconciliation — hosted ceiling and multi-turn routing
+  # Group: Multi-turn
   # ============================================================
 
-  @e2e
-  Scenario: A reader of the multi-turn recipe learns the hosted ceiling and is routed to a working adapter
-    Given a developer opening docs/voice/recipes/multi-turn on the published site
-    When they read the page that teaches the `agent→user→agent→…→judge` pattern
-    Then the page states the multi-turn pattern is NOT supported on hosted `elevenLabsAgent`
-    And the page affirmatively routes multi-turn AND `proceed(n)` to the composable `ElevenLabsVoiceAgent`, `pipecatAgent`, Gemini Live, and OpenAI Realtime adapters
-    And the "worked example" link resolves to a multi-turn test using a composable/pipecat adapter, NOT `elevenLabsAgent`
+  @unit
+  Scenario: A scripted second user turn re-engages a second agent response
+    Given a connected hosted ElevenLabs adapter and a drained greeting
+    When a first user turn is sent and the agent responds
+    And a second user turn is sent
+    Then a second agent response resolves rather than timing out
+
+  @e2e @ts-elevenlabs
+  Scenario: Multi-turn passes live on the hosted transport
+    Given `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`, and `OPENAI_API_KEY` are set
+    When the greeting-led `agent()→user→agent→user→agent→judge` script runs live
+    Then the run passes and the summary shows it PASSED, not skipped
+    And `proceed(n)` drives the same transport without a per-adapter caveat
+
+  # ============================================================
+  # Group: Per-call personalisation (issue #838)
+  # ============================================================
+
+  @unit
+  Scenario: Dynamic variables are forwarded natively on the init handshake
+    Given a hosted ElevenLabs adapter constructed with text, numeric, and boolean dynamic variables
+    When the adapter connects
+    Then the init frame carries `dynamic_variables` with each value's JSON type preserved
+    And no value is coerced to a string
+
+  @unit
+  Scenario: The dynamic-variables key is absent when unset
+    Given a hosted ElevenLabs adapter constructed with no dynamic variables
+    When the adapter connects
+    Then the init frame carries NO `dynamic_variables` key, because EL distinguishes absent from empty
+
+  @unit
+  Scenario: Caller overrides deep-merge under the narrow prompt knobs
+    Given a hosted ElevenLabs adapter constructed with a system-prompt override and an `agent.language` override
+    When the adapter connects
+    Then the init frame's `conversation_config_override` carries BOTH `agent.language` and `agent.prompt`
+    And a sibling top-level key such as `tts` survives the merge intact
+    And on a shared leaf the narrow prompt knob wins over the caller's override
+
+  @e2e @ts-elevenlabs
+  Scenario: A per-call dynamic variable and language override land on the live agent
+    Given a live hosted agent whose prompt template references a dynamic variable
+    And the agent allowlists `agent.language` in its platform override settings
+    When a session supplies that variable and an `agent.language` override
+    Then the agent's reply contains the supplied value
+    And the reply is in the overridden language, proving both survived one handshake
+
+  @unit
+  Scenario: Overriding the system prompt is documented as dropping the agent's tools
+    Given the ElevenLabs adapter reference page
+    When a reader looks up the system-prompt override
+    Then the page warns that it replaces the ENTIRE prompt object including `tool_ids`
+    And it routes per-call personalisation to dynamic variables plus a narrow override instead
+
+  # ============================================================
+  # Group: Agent-initiated hangup (issue #839)
+  # ============================================================
+
+  @unit
+  Scenario: A successful end_call marks the call as ended by the agent
+    Given a connected hosted ElevenLabs adapter
+    When EL emits an `agent_tool_response` for `end_call` with `is_called` true and no error or block
+    Then the adapter records that the agent hung up
+
+  @unit
+  Scenario Outline: A transfer tool also ends this session
+    Given a connected hosted ElevenLabs adapter
+    When EL emits a successful `agent_tool_response` for <tool>
+    Then the adapter records that the agent hung up
+
+    Examples:
+      | tool                 |
+      | transfer_to_agent    |
+      | transfer_to_number   |
+      | transfer_to_genesys  |
+
+  @unit
+  Scenario Outline: An unsuccessful hangup tool is not a hangup
+    Given a connected hosted ElevenLabs adapter
+    When EL emits an `agent_tool_response` for `end_call` that was <outcome>
+    Then the adapter does NOT record a hangup, so a later close still surfaces as a transport failure
+
+    Examples:
+      | outcome     |
+      | not called  |
+      | errored     |
+      | blocked     |
+
+  @unit
+  Scenario: A scripted turn after a deliberate hangup concludes instead of failing
+    Given a hosted ElevenLabs agent that said its farewell and invoked `end_call`
+    And EL closed the socket cleanly afterwards
+    When the script still has an `agent()` step left
+    Then that step concludes the conversation and adds no messages
+    And the script falls through to the judge rather than raising a transport error
+
+  @unit
+  Scenario: A dropped transport with no hangup still raises
+    Given a connected hosted ElevenLabs adapter whose transport dropped with no hangup tool invoked
+    When a scripted `agent()` step runs
+    Then it raises the transport-not-connected error, so genuine failures are not masked
+
+  @e2e @ts-elevenlabs
+  Scenario: A live agent hangup ends the run cleanly
+    Given a live hosted agent instructed to say goodbye and invoke `end_call`
+    When the scripted scenario still has a turn left after the farewell
+    Then the adapter reports that the agent hung up
+    And the remaining turn concludes without raising
+
+  # ============================================================
+  # Group: Docs reflect the shipped behaviour
+  # ============================================================
 
   @integration
-  Scenario: The multi-turn recipe carries the hosted-NOT-supported caveat as a grep-gated invariant
-    Given recipes/multi-turn.mdx after the reconciliation pass
+  Scenario: The multi-turn recipe no longer excludes the hosted adapter
+    Given recipes/multi-turn.mdx
     When the docs-honesty grep gate runs in CI
-    Then `grep -nF 'not supported on hosted' docs/docs/pages/voice/recipes/multi-turn.mdx` returns a line
-    And `grep -nF 'elevenLabsAgent' docs/docs/pages/voice/recipes/multi-turn.mdx` returns the caveat line
-    And both tokens are ABSENT on the unmodified tree, so the gate goes red until the caveat lands (AC1)
+    Then `grep -niF 'not supported on hosted' docs/docs/pages/voice/recipes/multi-turn.mdx` returns NOTHING
+    And the page states multi-turn works on hosted `elevenLabsAgent`
 
   @integration
-  Scenario: The multi-turn recipe's positive-routing line is grep-gated to a composable adapter
-    Given recipes/multi-turn.mdx after the reconciliation pass
-    When the positive-routing grep gate runs in CI
-    Then `grep -nF 'ElevenLabsVoiceAgent' docs/docs/pages/voice/recipes/multi-turn.mdx` returns the routing line
-    And the worked-example link target resolves to a composable/pipecat multi-turn test, never `elevenLabsAgent` (AC11)
-
-  @integration
-  Scenario: The getting-started page caveats proceed() against hosted ConvAI next to each occurrence
-    Given docs/docs/pages/voice/getting-started.mdx which presents `proceed(n)` at lines 117 and 179
-    When `grep -nA3 'scenario.proceed' docs/docs/pages/voice/getting-started.mdx` runs in CI
-    Then a hosted-ConvAI caveat appears within 3 lines of EACH `proceed(` occurrence
-    And the page no longer presents `proceed(n)` as a universal voice driver (AC2)
-
-  # ============================================================
-  # Group: Docs reconciliation — troubleshooting
-  # ============================================================
-
-  @e2e
-  Scenario: A developer hitting the hosted timeout finds the diagnosis and the greeting-drain fix
-    Given a developer who hit `receiveAudio timed out` on hosted ElevenLabs
-    When they open docs/voice/troubleshooting on the published site
-    Then the page has a `receiveAudio timed out` entry naming the server-VAD single-exchange ceiling
-    And the entry states the "lead with `agent()` to drain the greeting" rule
-    And the entry documents the "Audio duration mismatch / non-continuous audio input" message as a benign server-side ConvAI warning, not an SDK error
-
-  @integration
-  Scenario: The troubleshooting timeout and duration-warning entries are grep-gated
-    Given troubleshooting.mdx after the reconciliation pass
+  Scenario: The troubleshooting entry diagnoses the real causes
+    Given troubleshooting.mdx
     When the troubleshooting grep gate runs in CI
-    Then `grep -nF 'receiveAudio timed out' docs/docs/pages/voice/troubleshooting.mdx` returns the entry (AC3)
-    And `grep -niE 'duration mismatch|non-continuous' docs/docs/pages/voice/troubleshooting.mdx` returns the benign-warning entry (AC5)
-    And both strings are ABSENT on the unmodified tree, so the gate goes red until the entries land
-
-  # ============================================================
-  # Group: Docs reconciliation — happy-path doc and example parity
-  # ============================================================
-
-  @e2e
-  Scenario: The happy-path doc teaches the greeting-led single exchange
-    Given a developer opening happy-path-elevenlabs.mdx on the published site
-    When they read the canonical hosted script block (currently user-first at lines 76-79)
-    Then the script leads with `scenario.agent()` to drain the on-connect greeting before the first `scenario.user(`
-    And the taught shape is `agent()→user→agent→judge`, the documented single-exchange ceiling
+    Then the `receiveAudio timed out` entry no longer claims a single-exchange ceiling
+    And it lists the greeting-drain rule, the turn-commit mode, a deliberate hangup, and a wedged tool call as the causes to check
+    And the "duration mismatch / non-continuous audio input" entry is still documented as a benign server-side warning
 
   @integration
-  Scenario: The happy-path script is grep-gated to greeting-led order
-    Given happy-path-elevenlabs.mdx after the reconciliation pass
-    When `grep -nB1 'scenario.user(' docs/docs/pages/voice/happy-path-elevenlabs.mdx` runs in CI
-    Then `scenario.agent()` immediately precedes the first `scenario.user(` in the script block (AC4a)
+  Scenario: The happy-path doc leads with agent() and carries both SDKs
+    Given happy-path-elevenlabs.mdx
+    When the docs gate runs in CI
+    Then `scenario.agent()` precedes the first scripted `user(` so the greeting drains first
+    And every code step is shown for BOTH Python and TypeScript
 
   @integration
-  Scenario: The python and TS hosted examples share one greeting-led script with no self-contradicting docstring
-    Given the python and TS hosted ElevenLabs example files
-    When the example-parity grep gate runs in CI
-    Then `grep -rnE 'scenario\.(agent|user|judge)' <python-hosted-example> <ts-hosted-example>` shows the identical ordered step sequence in both
-    And `grep -niE 'single.?turn' <python-hosted-example>` returns no "single-turn" docstring/comment sitting above a 2nd scripted `user()` turn (AC4b)
-
-  # ============================================================
-  # Group: Behavior / failure-mode (SDK boundary condition)
-  # ============================================================
-
-  @integration
-  Scenario: A 2nd scripted user turn on hosted elevenLabsAgent fails informatively, not with a bare timeout
-    Given a hosted `elevenLabsAgent` script with a 2nd scripted `user()` turn after the greeting exchange
-    When the 2nd `agent()` turn hits the server-VAD re-engagement failure
-    Then the emitted error/warning string contains "hosted ConvAI" AND one of "single exchange"/"single-turn ceiling"
-    And the message points to the troubleshooting anchor, not just the bare `receiveAudio timed out`
-    And the test log line quoting the emitted message is the evidence — OR a linked decision record accepts the bare timeout plus the AC3 troubleshooting entry as the contract, citing the troubleshooting URL (AC6)
-
-  @integration
-  Scenario: A voice agent-under-test receiving a text user turn gets a louder warning than silent passthrough
-    Given a no-voice-resolves path where `voiceify` falls through and a voice agent-under-test receives a TEXT user turn
-    When the turn is dispatched to the agent
-    Then the SDK emits a louder warning than silent text passthrough, and a test exercising the no-voice-resolves path quotes it
-    And the OR-branch is visible: if the reporter's posted `scenario.run({...})` config shows `voice:'openai/nova'` resolves with no pre-built ModelMessage user turns, AC7 is struck with that quoted config as the rationale (AC7)
-
-  # ============================================================
-  # Group: Regression + proven-path tests (gated live pass + ungated CI shape)
-  # ============================================================
-
-  @unit
-  Scenario: The hosted single-exchange shape is provable in keyless CI without a paid endpoint
-    Given the env-gated hosted suite skip-passes in keyless CI (describe.skip at line 224, hasHostedKey gate at lines 36-39), so a keyless green is VACUOUS
-    When the ungated shape assertion runs in keyless CI
-    Then `grep -nF 'scenario.agent(),' elevenlabs-hosted.test.ts` confirms the leading `agent()` drain step still precedes `user()` at lines 96-101
-    And the assertion invokes no paid LLM or ElevenLabs endpoint, so keyless-CI green proves the canonical shape is preserved, not skipped (AC8)
-
-  @e2e @ts-elevenlabs
-  Scenario: The hosted single-exchange recipe passes live with keys set
-    Given `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`, and `OPENAI_API_KEY` are all set
-    When the greeting-led `agent()→user→agent→judge` test at elevenlabs-hosted.test.ts:96-101 runs
-    Then the vitest summary line shows the hosted test PASSED, not skipped
-    And the script at lines 96-101 is unchanged after the docs/code work (AC8)
-
-  @unit
-  Scenario: The composable multi-turn shape is provable in keyless CI without live keys
-    Given the composable multi-turn recipe at elevenlabs-hosted.test.ts:184-190 with two `user↔agent` exchanges
-    When the ungated mock-transport / shape assertion runs in keyless CI
-    Then it confirms two scripted `user→agent` exchanges are dispatched without live keys
-    And keyless-CI green therefore means the multi-turn path was registered and exercised, not skipped (AC9)
-
-  @e2e @ts-elevenlabs
-  Scenario: The composable multi-turn recipe passes live with keys set
-    Given `ELEVENLABS_API_KEY` and `OPENAI_API_KEY` are set for the branded composable path
-    When the two-exchange recipe at elevenlabs-hosted.test.ts:184-190 runs
-    Then the vitest summary line shows the branded composable test PASSED, not skipped (AC9)
-
-  # ============================================================
-  # AC Coverage Map
-  # ============================================================
-  # AC1  (hosted ceiling stated in multi-turn.mdx — `not supported on hosted` + `elevenLabsAgent`)
-  #      -> Scenario: A reader of the multi-turn recipe learns the hosted ceiling and is routed to a working adapter
-  #      -> Scenario: The multi-turn recipe carries the hosted-NOT-supported caveat as a grep-gated invariant
-  # AC2  (getting-started.mdx hosted caveat within 3 lines of each proceed()
-  #      -> Scenario: The getting-started page caveats proceed() against hosted ConvAI next to each occurrence
-  # AC3  (troubleshooting.mdx `receiveAudio timed out` entry — server-VAD ceiling + greeting-drain rule)
-  #      -> Scenario: A developer hitting the hosted timeout finds the diagnosis and the greeting-drain fix
-  #      -> Scenario: The troubleshooting timeout and duration-warning entries are grep-gated
-  # AC4a (happy-path-elevenlabs.mdx greeting-led agent()→user→agent→judge, agent() precedes first user())
-  #      -> Scenario: The happy-path doc teaches the greeting-led single exchange
-  #      -> Scenario: The happy-path script is grep-gated to greeting-led order
-  # AC4b (python + TS hosted examples identical greeting-led script; no "single-turn" docstring above a 2nd user())
-  #      -> Scenario: The python and TS hosted examples share one greeting-led script with no self-contradicting docstring
-  # AC5  (troubleshooting.mdx duration-mismatch / non-continuous warning documented as benign server-side)
-  #      -> Scenario: A developer hitting the hosted timeout finds the diagnosis and the greeting-drain fix
-  #      -> Scenario: The troubleshooting timeout and duration-warning entries are grep-gated
-  # AC6  (2nd scripted user turn yields "hosted ConvAI" + single-exchange + anchor, OR linked decision record)
-  #      -> Scenario: A 2nd scripted user turn on hosted elevenLabsAgent fails informatively, not with a bare timeout
-  # AC7  (louder warning on text passthrough to a voice agent-under-test, OR struck on reporter config quote)
-  #      -> Scenario: A voice agent-under-test receiving a text user turn gets a louder warning than silent passthrough
-  # AC8  (greeting-led hosted script at elevenlabs-hosted.test.ts:96-101 unchanged + ungated CI shape assertion)
-  #      -> Scenario: The hosted single-exchange shape is provable in keyless CI without a paid endpoint
-  #      -> Scenario: The hosted single-exchange recipe passes live with keys set
-  # AC9  (composable multi-turn at elevenlabs-hosted.test.ts:184-190 passes live + ungated two-exchange assertion)
-  #      -> Scenario: The composable multi-turn shape is provable in keyless CI without live keys
-  #      -> Scenario: The composable multi-turn recipe passes live with keys set
-  # AC10 (resolving comment answers the 3 reporter questions, each tied to a docs anchor)
-  #      -> Scenario: The resolving comment answers the reporter's three questions, each tied to a docs anchor
-  # AC11 (multi-turn.mdx positive routing to composable/pipecat/gemini/realtime + worked link to a non-hosted test)
-  #      -> Scenario: A reader of the multi-turn recipe learns the hosted ceiling and is routed to a working adapter
-  #      -> Scenario: The multi-turn recipe's positive-routing line is grep-gated to a composable adapter
+  Scenario: The capability matrix and adapter page agree with the code
+    Given the generated capability matrix and the ElevenLabs adapter page
+    When the matrix regeneration gate runs in CI
+    Then the committed matrix matches what the adapters declare
+    And the adapter page documents dynamic variables, overrides, turn-commit modes, and the hangup flag

--- a/specs/voice-elevenlabs-hosted-e2e.feature
+++ b/specs/voice-elevenlabs-hosted-e2e.feature
@@ -102,7 +102,7 @@ Feature: Voice E2E against hosted ElevenLabs — real voice-in, multi-turn, per-
     Then the agent's reply contains the supplied value
     And the reply is in the overridden language, proving both survived one handshake
 
-  @unit
+  @integration
   Scenario: Overriding the system prompt is documented as dropping the agent's tools
     Given the ElevenLabs adapter reference page
     When a reader looks up the system-prompt override


### PR DESCRIPTION
## What & why

We're onboarding an ElevenLabs customer, so I audited how good our hosted-ElevenLabs support actually is across both SDKs. TypeScript was in good shape. Python was not, and the docs were actively wrong in a way that would have steered the customer off the adapter built for them.

Everything here was verified against a **real ElevenLabs ConvAI agent**, not mocks.

## The headline bug: Python never sent the user's voice

The Python hosted adapter defaulted to `turn_commit_mode="text"`. On every scripted turn it sent `{"type":"user_message","text":…}` and **discarded the audio**. The agent under test never heard the caller, so its STT and VAD never ran and a green run proved nothing about either. The existing test asserted this as correct behaviour (`assert socket.audio_chunks == []`).

TypeScript fixed this in #707 and names it a regression in its own source; Python never got the port (#727).

Measured live, before and after, on the same agent:

| | before (`"text"`) | after (`"audio"`) |
|---|---|---|
| speech frames on the wire | **0** | **376** |
| `user_message` text commits | 2 | 0 |
| EL `user_transcript` events | **none** | one per turn |

After, ElevenLabs returns its own transcription of our PCM:

```
"Hi there. I'd like to check on my account balance, please."
"Great. And can you also tell me when my next payment is due?"
```

Note the punctuation is ElevenLabs', not our input string's, which is what distinguishes genuine STT output from a text echo.

The default is now `"audio"`: real PCM streamed as 20 ms frames at microphone cadence, then *unbounded* closing silence, which is the audio→silence transition EL's server VAD closes a turn on. `"text"` and `"silence"` remain as opt-in escape hatches, with the tradeoff documented.

## Turn-boundary bleed (#749)

Found by running the demo repeatedly rather than by inspection. Roughly one run in three failed with the agent's second reply answering the *first* question. Cause: EL delivers audio in bursts, a delivery gap longer than `response_tail_silence` closes the turn early, and the remainder is read by the next drain as that turn's opening audio.

TypeScript fixed this in #748 by reconciling its buffered audio queue. Python reads the socket directly and has no queue, which is why the port was never a straight copy. Same safe point though: pre-user-`send_audio`, where the agent cannot have begun its next reply, so anything still arriving is unambiguously the prior turn's tail. Attribution is position-gated exactly as in TS (cursor-safe grows the preceding agent segment; cursor-unsafe drops with a warning).

## Per-call personalisation (#838)

Python gains `dynamic_variables` and deep-merged `overrides`, closing the gap with the TS twin. Verified live:

```
dynamic_variables={"plan_tier": "oro-anual"} + overrides={"agent": {"language": "es"}}
-> "Usted está en el plan oro-anual."
```

Spanish (the language override), the plan name (the dynamic variable), and the prompt override all survived one handshake, which is the deep-merge proof.

The issue also flags that `system_prompt_override` replaces ElevenLabs' *entire* prompt object including `tool_ids`, silently stripping a hosted agent's tools and stalling it on tool responses that never arrive. That's now a warning on the adapter page routing people to dynamic variables instead.

## Agent-initiated hangup (#839), both SDKs

Hosted agents routinely invoke `end_call` after their farewell, closing the socket. A leftover scripted turn then raised `TransportNotConnectedError` and failed a run in which the agent behaved exactly as designed.

I captured the real wire shape rather than guessing:

```json
{"type": "agent_tool_response",
 "agent_tool_response": {"tool_name": "end_call", "tool_type": "system",
   "is_error": false, "is_blocked": false, "is_called": true}}
```

followed by a clean close (1000). Both adapters now recognise it, expose `agent_hung_up` / `agentHungUp` so judges and assertions can reason about who ended the call, and conclude rather than raising. An *unsuccessful* tool, or a close with no hangup, still raises, so genuine transport failures aren't masked.

## The docs were wrong

`troubleshooting.mdx` and `recipes/multi-turn.mdx` both stated hosted ElevenLabs supported only a **single greeting-led exchange** and routed multi-turn users to a different adapter. That has been false since #596/#707. The CI guard already knew (`elevenlabs-hosted-shape.guard.test.ts`: *"the multi-turn adapter fix made multi-turn the expected shape"*), but the docs never caught up, and the same claim was baked into `getting-started.mdx` and into the `voice-elevenlabs-hosted-e2e.feature` Background.

All corrected. The troubleshooting entry now lists the real causes to check (greeting drain, turn-commit mode, deliberate hangup, wedged tool call) instead of a limitation that no longer exists. The spec is rewritten around the behaviour that actually ships.

`happy-path-elevenlabs.mdx` was Python-only, so a TypeScript reader landed on the better-supported path and saw none of it. It now has TypeScript throughout. Every documented snippet was compiled against the real API, which caught two I'd written wrong (`backgroundNoise` lives under `voice.effects`, and `audio.save()` is synchronous).

## Testing

- Python voice suite: **574 passed, 1 skipped** (28 new tests)
- TypeScript voice suite: **468 passed, 1 skipped** (10 new tests)
- `pyright` and `tsc` clean; capability matrix regenerates unchanged
- Live against the real agent: real-audio multi-turn with EL transcribing each turn, dynamic variable + Spanish override in one handshake, `end_call` concluding cleanly, and repeated demo runs to confirm the turn-boundary flake is gone

Provisioning now allowlists `agent.language` on the CI test agent so the overrides path is exercisable end to end.

## Not in this PR

The remaining Python-vs-TS gaps from the audit are separate: the transcript grace-wait + STT fallback (#734/#735) and the enriched hosted timeout error (#643) are still TS-only.
