### PR TITLE
fix(voice): wake blocked Twilio receive on disconnect

### DIFF
--- a/python/scenario/voice/adapters/twilio.py
+++ b/python/scenario/voice/adapters/twilio.py
@@ -354,6 +354,13 @@ class TwilioAgentAdapter(VoiceAgentAdapter):
         self._stream_sid = None
         self._stream_connected = None
         self._stream_ws = None
+        if self._inbound_queue is not None:
+            # A recv_audio() task may already be blocked in get() on this queue.
+            # Wake that in-flight consumer before dropping our reference; setting
+            # _inbound_queue to None alone leaves it parked until its receive
+            # timeout expires (#757). An empty chunk is the adapter's existing
+            # end-of-stream signal and lets the shared drain finish cleanly.
+            self._inbound_queue.put_nowait(AudioChunk(data=b""))
         self._inbound_queue = None
         self._stream_ended = False
         self._frames_received = 0

--- a/python/tests/voice/test_twilio_adapter.py
+++ b/python/tests/voice/test_twilio_adapter.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 import pytest
 
-from scenario.voice import TwilioAgentAdapter
+from scenario.voice import AudioChunk, TwilioAgentAdapter
 
 
 def _make_adapter(**overrides: Any) -> TwilioAgentAdapter:
@@ -112,11 +112,43 @@ def _install_fake_rest(monkeypatch: Any) -> list[FakeREST]:
 
 # ---------------------------------------------------------------- connect/disconnect
 
+
+class _ObservableAudioQueue(asyncio.Queue[AudioChunk]):
+    """Queue double that exposes when a consumer has entered ``get()``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.consumer_waiting = asyncio.Event()
+
+    async def get(self) -> AudioChunk:
+        self.consumer_waiting.set()
+        return await super().get()
+
+
 @pytest.mark.asyncio
 async def test_connect_requires_public_base_url():
     a = _make_adapter(public_base_url=None)
     with pytest.raises(RuntimeError, match="public_base_url"):
         await a.connect()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_wakes_recv_audio_waiting_on_inbound_queue():
+    """A disconnect racing an in-flight receive must not wait for its 60s budget."""
+    a = _make_adapter()
+    queue = _ObservableAudioQueue()
+    a._rest = object()  # type: ignore[assignment]  # connected-state sentinel
+    a._inbound_queue = queue
+    a._stream_ws = object()
+    a._stream_sid = "MZ757"
+
+    receive = asyncio.create_task(a.recv_audio(timeout=60.0))
+    await asyncio.wait_for(queue.consumer_waiting.wait(), timeout=1.0)
+
+    await a.disconnect()
+
+    chunk = await asyncio.wait_for(receive, timeout=1.0)
+    assert chunk.data == b""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

When the Python Twilio adapter disconnects while `recv_audio()` is already
blocked on the inbound queue, clearing the adapter's queue reference does not
wake that consumer. It remains parked until its receive timeout expires.

Closes #757

## What changed

- Reuse the adapter's existing empty `AudioChunk` end-of-stream sentinel to
  wake an in-flight receiver before the inbound queue is discarded.
- Keep the public API and normal stream shutdown behavior unchanged.
- Cover the disconnect/receive race with an observable queue double, avoiding
  fixed sleeps and external services.

## Test plan

- Confirmed the new regression test fails before the source fix with
  `TimeoutError`.
- `pytest tests/voice/test_twilio_adapter.py -q` — 24 passed
- `pytest tests/test_scenario.py -q` — 17 passed
- `pyright scenario/voice/adapters/twilio.py tests/voice/test_twilio_adapter.py`
  — 0 errors
- Capability matrix byte-identity test — passed

## How I can prove I was successful

No playable artifact is applicable for this library-only concurrency fix.
The regression test deterministically waits until `recv_audio()` has entered
the queue's `get()` before disconnecting, then verifies it returns the existing
empty end-of-stream chunk within a bounded observation window.
