### PR TITLE
fix(voice): ignore empty first chunk for speaking event

### DIFF
--- a/javascript/src/voice/__tests__/interrupt-truncation.test.ts
+++ b/javascript/src/voice/__tests__/interrupt-truncation.test.ts
@@ -135,6 +135,19 @@ describe("defaultVoiceCall publishes the agent speaking event", () => {
     expect(adapter.agentSpeakingEvent!.isSet()).toBe(false);
   });
 
+  it("sets the speaking event when audio follows a leading empty chunk", async () => {
+    const adapter = new SpeakingAdapter([
+      new AudioChunk({ data: new Uint8Array(0) }),
+      tone(0.1, "after empty"),
+    ]);
+
+    await defaultVoiceCall(adapter, bareInput);
+
+    expect(adapter.agentSpeakingEvent).toBeDefined();
+    expect(adapter.agentSpeakingEvent!.isSet()).toBe(true);
+    await expect(adapter.agentSpeakingEvent!.wait()).resolves.toBeUndefined();
+  });
+
   it("clears the event at the start of the next turn (re-armed)", async () => {
     // Turn-2's first chunk is delayed so the cleared-but-not-yet-set window is
     // observable across a macrotask yield. Without it the immediate chunk would

--- a/javascript/src/voice/__tests__/interrupt-truncation.test.ts
+++ b/javascript/src/voice/__tests__/interrupt-truncation.test.ts
@@ -124,6 +124,17 @@ describe("defaultVoiceCall publishes the agent speaking event", () => {
     await expect(adapter.agentSpeakingEvent!.wait()).resolves.toBeUndefined();
   });
 
+  it("does not set the speaking event when the first chunk is empty", async () => {
+    const adapter = new SpeakingAdapter([
+      new AudioChunk({ data: new Uint8Array(0) }),
+    ]);
+
+    await defaultVoiceCall(adapter, bareInput);
+
+    expect(adapter.agentSpeakingEvent).toBeDefined();
+    expect(adapter.agentSpeakingEvent!.isSet()).toBe(false);
+  });
+
   it("clears the event at the start of the next turn (re-armed)", async () => {
     // Turn-2's first chunk is delayed so the cleared-but-not-yet-set window is
     // observable across a macrotask yield. Without it the immediate chunk would

--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -721,8 +721,8 @@ async function drainInner(
   );
   if (first.data.length > 0) {
     onFirstChunk();
+    speakingEvent.set();
   }
-  speakingEvent.set();
 
   const chunks: AudioChunk[] = [first];
   let accumulated = first.durationSeconds;

--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -719,10 +719,16 @@ async function drainInner(
     "voice.audio.first_chunk_latency_ms",
     Math.round(performance.now() - receiveStart),
   );
-  if (first.data.length > 0) {
+  // The initial receive can be an empty prefix while the drain still yields
+  // audio. Publish speech on the first playable chunk wherever it appears.
+  let sawPlayableChunk = false;
+  const markFirstPlayableChunk = (chunk: AudioChunk): void => {
+    if (sawPlayableChunk || chunk.data.length === 0) return;
+    sawPlayableChunk = true;
     onFirstChunk();
     speakingEvent.set();
-  }
+  };
+  markFirstPlayableChunk(first);
 
   const chunks: AudioChunk[] = [first];
   let accumulated = first.durationSeconds;
@@ -761,6 +767,7 @@ async function drainInner(
       terminatedReason = "terminal_chunk";
       break;
     }
+    markFirstPlayableChunk(next);
     chunks.push(next);
     accumulated += next.durationSeconds;
     maybeWarnSoftCap();


### PR DESCRIPTION
## Why

An empty first audio chunk does not itself prove that the agent spoke, but the TypeScript voice runtime resolved `AgentSpeakingEvent` immediately. That could make interruption logic treat a silent turn as active speech, while simply gating on the first chunk could miss real audio that follows an empty prefix.

Closes #569

## What changed

- Resolve `AgentSpeakingEvent` and start playback timing only when the drain observes its first playable audio chunk, whether that is the initial chunk or a later one.
- Keep the event unset for a response containing only empty terminal chunks, and preserve the public API.
- Cover both empty-only and empty-prefix-then-audio paths with deterministic in-memory regression tests.

## Test plan

- Confirmed `does not set the speaking event when the first chunk is empty` failed before the runtime fix (`expected false`, received `true`).
- Confirmed `sets the speaking event when audio follows a leading empty chunk` failed before the review fix (`expected true`, received `false`).
- `pnpm exec vitest run src/voice/__tests__/interrupt-truncation.test.ts` — 12 passed.
- `pnpm exec vitest run src/voice/__tests__ src/voice/adapters/__tests__` — 45 files passed, 1 skipped; 436 tests passed, 1 skipped.
- `pnpm test:ci` — 89 files passed, 1 skipped; 1036 tests passed, 4 skipped.
- `pnpm lint:all`
- `pnpm typecheck:all`
- `pnpm build:all`
- `pnpm smoke:dist` — CJS and ESM distributions load successfully.

## How I can prove I was successful

No playable artifact — this is an internal voice-runtime state fix. Run the named regression tests in the Test plan; they verify the event stays unset for an empty-only response and becomes set when playable audio follows an empty prefix.
