### PR TITLE
fix(realtime): stop the virtual key leaking into the realtime websocket, move live judges to gpt-5.6-luna

### DIFF
--- a/javascript/examples/vitest/tests/multimodal-audio-to-text.test.ts
+++ b/javascript/examples/vitest/tests/multimodal-audio-to-text.test.ts
@@ -94,7 +94,7 @@ describe.skipIf(skipInCi)("Multimodal Audio to Text Tests", () => {
     } satisfies UserModelMessage;
 
     const audioJudge = wrapJudgeForAudioTranscription(
-      scenario.judgeAgent({ model: openai("gpt-5") }),
+      scenario.judgeAgent({ model: openai("gpt-5.6-luna") }),
     );
 
     const result = await scenario.run({

--- a/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
@@ -1,0 +1,90 @@
+/**
+ * RealtimeAgentAdapter.connect() API-key resolution.
+ *
+ * The Realtime API is a direct websocket to api.openai.com that an
+ * OpenAI-compatible gateway cannot proxy. When CI routes OPENAI_API_KEY
+ * through a gateway (a LangWatch virtual key), the dedicated
+ * OPENAI_REALTIME_API_KEY must win, mirroring OpenAIRealtimeAdapter.
+ * Regression: the virtual key leaked into the websocket and OpenAI
+ * rejected it with invalid_api_key.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { RealtimeAgentAdapter } from "../realtime/realtime-agent.adapter";
+import { AgentRole } from "../../domain";
+
+type ConnectParams = { apiKey?: string };
+
+function makeAdapter(recorded: ConnectParams[]): RealtimeAgentAdapter {
+  const session = {
+    transport: { on: () => undefined, sendEvent: () => undefined },
+    connect: async (params: ConnectParams) => {
+      recorded.push(params);
+    },
+    close: () => undefined,
+    sendMessage: () => undefined,
+  } as unknown as ConstructorParameters<
+    typeof RealtimeAgentAdapter
+  >[0]["session"];
+
+  return new RealtimeAgentAdapter({
+    session,
+    role: AgentRole.AGENT,
+    agentName: "Key Resolution Test Agent",
+    responseTimeout: 1000,
+  });
+}
+
+describe("RealtimeAgentAdapter.connect API-key resolution", () => {
+  const savedRealtimeKey = process.env.OPENAI_REALTIME_API_KEY;
+  const savedOpenAIKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.OPENAI_REALTIME_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedRealtimeKey === undefined) {
+      delete process.env.OPENAI_REALTIME_API_KEY;
+    } else {
+      process.env.OPENAI_REALTIME_API_KEY = savedRealtimeKey;
+    }
+    if (savedOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = savedOpenAIKey;
+    }
+  });
+
+  it("an explicit params.apiKey wins over both env vars", async () => {
+    process.env.OPENAI_REALTIME_API_KEY = "sk-realtime";
+    process.env.OPENAI_API_KEY = "vk-lw-virtual";
+    const recorded: ConnectParams[] = [];
+    await makeAdapter(recorded).connect({ apiKey: "sk-explicit" });
+    expect(recorded[0]?.apiKey).toBe("sk-explicit");
+  });
+
+  it("OPENAI_REALTIME_API_KEY wins over OPENAI_API_KEY", async () => {
+    process.env.OPENAI_REALTIME_API_KEY = "sk-realtime";
+    process.env.OPENAI_API_KEY = "vk-lw-virtual";
+    const recorded: ConnectParams[] = [];
+    await makeAdapter(recorded).connect();
+    expect(recorded[0]?.apiKey).toBe("sk-realtime");
+  });
+
+  it("falls back to OPENAI_API_KEY when no realtime key is set", async () => {
+    process.env.OPENAI_API_KEY = "sk-plain";
+    const recorded: ConnectParams[] = [];
+    await makeAdapter(recorded).connect();
+    expect(recorded[0]?.apiKey).toBe("sk-plain");
+  });
+
+  it("throws a clear error when no key is available anywhere", async () => {
+    const recorded: ConnectParams[] = [];
+    await expect(makeAdapter(recorded).connect()).rejects.toThrow(
+      /OPENAI_REALTIME_API_KEY \/ OPENAI_API_KEY/,
+    );
+    expect(recorded).toHaveLength(0);
+  });
+});

--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -122,10 +122,17 @@ export class RealtimeAgentAdapter extends AgentAdapter {
     params?: Parameters<RealtimeSession["connect"]>[0] | undefined
   ): Promise<void> {
     const { apiKey, ...rest } = params ?? {};
-    const resolvedApiKey = apiKey ?? process.env.OPENAI_API_KEY;
+    // The Realtime API is a direct websocket to api.openai.com that an
+    // OpenAI-compatible gateway cannot proxy. When OPENAI_API_KEY holds a
+    // gateway credential (e.g. a LangWatch virtual key), the dedicated
+    // OPENAI_REALTIME_API_KEY must win, same as OpenAIRealtimeAdapter.
+    const resolvedApiKey =
+      apiKey ??
+      process.env.OPENAI_REALTIME_API_KEY ??
+      process.env.OPENAI_API_KEY;
     if (!resolvedApiKey) {
       throw new Error(
-        "RealtimeAgentAdapter.connect requires an API key: pass params.apiKey or set OPENAI_API_KEY.",
+        "RealtimeAgentAdapter.connect requires an API key: pass params.apiKey or set OPENAI_REALTIME_API_KEY / OPENAI_API_KEY.",
       );
     }
     await this.session.connect({

--- a/python/examples/test_audio_to_audio.py
+++ b/python/examples/test_audio_to_audio.py
@@ -117,7 +117,7 @@ async def test_audio_to_audio():
     # Wrap with audio handler to transcribe audio before judging
     audio_judge = wrap_judge_for_audio(
         scenario.JudgeAgent(
-            model="openai/gpt-4o",
+            model="openai/gpt-5.6-luna",
             criteria=[
                 "The agent identifies or guesses the voice is male",
                 "The agent acknowledges the input was audio (not text)",
@@ -131,7 +131,7 @@ async def test_audio_to_audio():
         description="User sends audio file, agent analyzes and responds with audio",
         agents=[
             my_agent,
-            scenario.UserSimulatorAgent(model="openai/gpt-4o"),
+            scenario.UserSimulatorAgent(model="openai/gpt-5.6-luna"),
             audio_judge,
         ],
         script=[

--- a/python/examples/test_audio_to_text.py
+++ b/python/examples/test_audio_to_text.py
@@ -213,7 +213,7 @@ async def test_audio_to_text():
     # Wrap with audio handler in case the judge needs to process audio
     audio_judge = wrap_judge_for_audio(
         scenario.JudgeAgent(
-            model="openai/gpt-4o",
+            model="openai/gpt-5.6-luna",
             criteria=[
                 "The agent's response demonstrates it processed the audio content (e.g. it addresses what was in the audio, attempts to answer the audio question, or acknowledges what it heard)",
                 "The agent provides a coherent, on-topic response — not an error message, refusal, or unrelated reply",
@@ -228,7 +228,7 @@ async def test_audio_to_text():
         description="User sends audio file, agent analyzes and responds with text",
         agents=[
             AudioToTextAgent(),
-            scenario.UserSimulatorAgent(model="openai/gpt-4o"),
+            scenario.UserSimulatorAgent(model="openai/gpt-5.6-luna"),
             audio_judge,
         ],
         script=[


### PR DESCRIPTION
## What

Fixes the one remaining `javascript-ci` failure on `main` after the gateway swap, and moves the live judges and user simulators off gpt-4o / gpt-5 onto gpt-5.6-luna.

## The failure

`tests/scenario-expert-realtime.test.ts` timed out on `main` and reproduced locally with the exact CI env. The websocket error underneath was decisive:

```
invalid_api_key: Incorrect API key provided: vk-lw-01********************4S7C
```

`RealtimeAgentAdapter.connect()` resolved its key as `params.apiKey ?? OPENAI_API_KEY` only. The Realtime API is a direct websocket to api.openai.com that the gateway cannot proxy, so once CI made `OPENAI_API_KEY` a LangWatch virtual key, the virtual key leaked into the websocket. `OpenAIRealtimeAdapter` (the voice adapter) already preferred `OPENAI_REALTIME_API_KEY` since #848; `RealtimeAgentAdapter` (the agents-sdk adapter this test uses) never got the same treatment.

The resolution order is now `params.apiKey ?? OPENAI_REALTIME_API_KEY ?? OPENAI_API_KEY`, with unit tests covering all four cases (explicit param wins, realtime key wins, plain key fallback, clear error when none).

## Model swap: live judges to gpt-5.6-luna

Per catalog prices (per token): gpt-5.6-luna in $1/M out $6/M vs gpt-4o in $2.5/M out $10/M and gpt-5 in $1.25/M out $10/M. The five live-call sites on those models (python audio examples' judges + user simulators, js multimodal judge) move to luna. Mini models (gpt-5-mini, gpt-4o-mini, gpt-4.1-mini) stay: they are still 3-4x cheaper than luna. Both swapped judges are transcript-readers (wrapped with the audio-transcription helpers), and gpt-4o had no audio-input capability either, so this is capability-neutral. Model strings inside mocked unit tests are inert and left untouched.

## Verification

- New unit tests: 4/4 green.
- `tests/scenario-expert-realtime.test.ts` live with the CI env (virtual key + gateway base URL + realtime key): full voice-to-voice conversation passes in 33s, previously invalid_api_key.
- `tests/multimodal-audio-to-text.test.ts` live with the luna judge through the production gateway: passes in 10s.
- The python audio examples run in this PR's own `python-ci` examples step with repo secrets, which is the same-lane verification for the luna swap there.
