### PR TITLE
fix(python): support public tracer providers

### DIFF
--- a/python/scenario/_tracing/setup.py
+++ b/python/scenario/_tracing/setup.py
@@ -10,7 +10,7 @@ Supports:
 
 import logging
 import os
-from typing import List, Optional, Sequence
+from typing import List, Optional, Protocol, Sequence, cast
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider, SpanProcessor
@@ -23,6 +23,10 @@ from .filtering_exporter import FilteringSpanExporter
 logger = logging.getLogger("scenario.tracing")
 
 _initialized = False
+
+
+class _SpanProcessorProvider(Protocol):
+    def add_span_processor(self, span_processor: SpanProcessor) -> None: ...
 
 
 def setup_scenario_tracing(
@@ -88,7 +92,7 @@ def ensure_tracing_initialized(observability: Optional[dict] = None) -> None:
     _initialized = True
 
 
-def _get_concrete_provider(provider) -> Optional[TracerProvider]:
+def _get_concrete_provider(provider) -> Optional[_SpanProcessorProvider]:
     """Returns the concrete TracerProvider if one exists.
 
     Checks the provider itself and one level of delegation
@@ -96,6 +100,12 @@ def _get_concrete_provider(provider) -> Optional[TracerProvider]:
     """
     if isinstance(provider, TracerProvider):
         return provider
+
+    # OpenTelemetry's public provider interface does not require an SDK
+    # TracerProvider subclass. Providers such as Temporal's replay-safe wrapper
+    # expose the processor hook directly and are safe to configure in place.
+    if callable(getattr(provider, "add_span_processor", None)):
+        return cast(_SpanProcessorProvider, provider)
 
     # Check delegation pattern
     delegate = None
@@ -122,16 +132,17 @@ def _do_setup(
     concrete = _get_concrete_provider(existing_provider)
 
     if concrete is not None:
-        _attach_to_existing(concrete, span_filter, span_processors, trace_exporter)
+        _attach_to_existing(concrete, span_filter, span_processors, trace_exporter, instrumentors)
     else:
         _full_setup(span_filter, span_processors, trace_exporter, instrumentors)
 
 
 def _attach_to_existing(
-    provider: TracerProvider,
+    provider: _SpanProcessorProvider,
     span_filter: Optional[SpanFilter],
     span_processors: Optional[List[SpanProcessor]],
     trace_exporter: Optional[SpanExporter],
+    instrumentors: Optional[Sequence],
 ) -> None:
     """Attach processors to an existing TracerProvider."""
     provider.add_span_processor(judge_span_collector)
@@ -149,6 +160,10 @@ def _attach_to_existing(
 
     # Add LangWatch exporter
     _add_langwatch_exporter(provider, span_filter)
+
+    if instrumentors:
+        for instrumentor in instrumentors:
+            instrumentor.instrument(tracer_provider=provider)
 
 
 def _full_setup(

--- a/python/tests/test_tracing_setup.py
+++ b/python/tests/test_tracing_setup.py
@@ -8,6 +8,7 @@ from scenario._tracing.setup import (
     setup_scenario_tracing,
     ensure_tracing_initialized,
     _get_concrete_provider,
+    _do_setup,
     _reset_tracing_for_tests,
 )
 
@@ -92,6 +93,17 @@ class TestGetConcreteProvider:
 
         assert result is provider
 
+    def test_returns_public_provider_with_span_processor_support(self) -> None:
+        class PublicProvider:
+            def add_span_processor(self, span_processor) -> None:
+                del span_processor
+
+        provider = PublicProvider()
+
+        result = _get_concrete_provider(provider)
+
+        assert result is provider
+
     def test_returns_delegate_from_get_delegate(self) -> None:
         concrete = TracerProvider()
 
@@ -127,6 +139,20 @@ class TestGetConcreteProvider:
         result = _get_concrete_provider(proxy)
 
         assert result is None
+
+
+def test_instruments_an_existing_public_provider() -> None:
+    class PublicProvider:
+        def add_span_processor(self, span_processor) -> None:
+            del span_processor
+
+    provider = PublicProvider()
+    instrumentor = MagicMock()
+
+    with patch("scenario._tracing.setup.trace.get_tracer_provider", return_value=provider):
+        _do_setup(instrumentors=[instrumentor])
+
+    instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
 
 
 class TestResetTracingForTests:


### PR DESCRIPTION
Scenario currently recognizes only the SDK `TracerProvider` (or one delegated SDK provider). OpenTelemetry’s public provider API allows other implementations to expose `add_span_processor`; Temporal 1.30 uses that shape for its replay-safe provider. Detect the public processor hook before proxy unwrapping so Scenario attaches its collector/exporters to the existing provider instead of attempting to replace the global provider. Includes a focused regression test.