### PR TITLE
refactor(execution): consolidate the two next-agent-for-role lookups (#210)

### DIFF
--- a/javascript/src/execution/__tests__/script-call-role-pending.test.ts
+++ b/javascript/src/execution/__tests__/script-call-role-pending.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Pins the one behavioural difference between the two agent lookups that #210
+ * consolidated into `findNextAgentForRole`.
+ *
+ * The automatic loop requires the role to still be pending on the turn; a
+ * scripted call does not. Before this test nothing observed that: flipping the
+ * scripted path to the automatic path's semantics left all 1079 other JS tests
+ * green, while silently adding a `newTurn()` and so changing turn counting.
+ *
+ * Reaching the case takes two scripted steps in one turn. `agent()` runs
+ * `consumeUntilRole(AGENT)`, which drains USER off `pendingRolesOnTurn` while
+ * leaving the user simulator on `pendingAgentsOnTurn`. The following `user()`
+ * then asks for a role the turn no longer lists, but whose agent is still
+ * available.
+ *
+ * Python's `_next_agent_for_role` always applies the guard, so the value
+ * asserted here is a TypeScript-only behaviour. It is pinned rather than
+ * aligned: aligning it is a turn-count change and belongs to whoever decides
+ * the parity question on #210, with this test failing to mark the decision.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentAdapter,
+  type AgentInput,
+  type AgentReturnTypes,
+  AgentRole,
+  UserSimulatorAgentAdapter,
+} from "../../domain";
+import { ScenarioExecution } from "../scenario-execution";
+
+class MockAgent extends AgentAdapter {
+  role = AgentRole.AGENT;
+  calls = 0;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    this.calls += 1;
+    return { role: "assistant" as const, content: "agent reply" };
+  }
+}
+
+class CountingUserSim extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  calls = 0;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    this.calls += 1;
+    return `user turn ${this.calls}`;
+  }
+}
+
+async function runAgentThenUser() {
+  const sim = new CountingUserSim();
+  const agent = new MockAgent();
+  const turnsSeen: number[] = [];
+
+  const exec = new ScenarioExecution(
+    {
+      name: "script-call-role-pending",
+      description: "scripted call for a role the turn no longer lists",
+      agents: [agent, sim],
+    },
+    [
+      async (state, executor) => {
+        await executor.agent();
+        turnsSeen.push(state.currentTurn);
+        await executor.user();
+        turnsSeen.push(state.currentTurn);
+      },
+    ],
+    "test-batch-id",
+  );
+
+  await exec.execute();
+
+  return { sim, agent, turnsSeen };
+}
+
+describe("scripted call for a role already consumed from the turn (#210)", () => {
+  describe("when agent() has drained USER off the pending roles and user() follows in the same turn", () => {
+    it("calls the user simulator", async () => {
+      const { sim } = await runAgentThenUser();
+
+      expect(sim.calls).toBe(1);
+    });
+
+    it("does not open a new turn to do it", async () => {
+      const { turnsSeen } = await runAgentThenUser();
+
+      // 0 after agent(), still 0 after user(). Requiring the role to be
+      // pending would make the first lookup miss, take the newTurn() retry
+      // branch, and land on 1 here.
+      expect(turnsSeen).toEqual([0, 0]);
+    });
+  });
+});

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -919,8 +919,8 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     }
 
     const currentRole = this.pendingRolesOnTurn[0];
-    const { idx, agent: nextAgent } = this.nextAgentForRole(currentRole);
-    if (!nextAgent) {
+    const next = this.findNextAgentForRole(currentRole);
+    if (!next) {
       this.logger.debug(
         `[${this.config.id}] No agent for role ${currentRole}, removing role`
       );
@@ -928,15 +928,16 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
       return this._step(goToNextTurn, onTurn);
     }
 
+    const { index, agent: nextAgent } = next;
     this.logger.debug(`[${this.config.id}] Calling agent`, {
       role: currentRole,
-      agentIdx: idx,
+      agentIdx: index,
       agentName: nextAgent.name ?? nextAgent.constructor.name,
     });
 
     this.removePendingAgent(nextAgent);
 
-    await this.callAgent(idx, currentRole);
+    await this.callAgent(index, currentRole);
   }
 
   /**
@@ -1748,17 +1749,16 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     // Walk pendingRolesOnTurn to find the next role that will actually run.
     let nextRole: AgentRole | null = null;
     for (const r of this.pendingRolesOnTurn) {
-      const { agent } = this.nextAgentForRole(r);
-      if (agent !== null) {
+      if (this.findNextAgentForRole(r)) {
         nextRole = r;
         break;
       }
     }
     if (nextRole !== AgentRole.AGENT) return null;
 
-    const { idx, agent } = this.nextAgentForRole(AgentRole.AGENT);
-    if (!agent) return null;
-    return { idx, agent };
+    const next = this.findNextAgentForRole(AgentRole.AGENT);
+    if (!next) return null;
+    return { idx: next.index, agent: next.agent };
   }
 
   /**
@@ -2267,12 +2267,12 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
 
     this.consumeUntilRole(role);
 
-    let nextAgent = this.getNextAgentForRole(role);
+    let nextAgent = this.findNextAgentForRole(role);
     if (!nextAgent) {
       this.newTurn();
       this.consumeUntilRole(role);
 
-      nextAgent = this.getNextAgentForRole(role);
+      nextAgent = this.findNextAgentForRole(role);
     }
 
     if (!nextAgent) {
@@ -2412,21 +2412,40 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     return { metCriteria, unmetCriteria };
   }
 
-  private nextAgentForRole(role: AgentRole): {
-    idx: number;
-    agent: AgentAdapter | null;
-  } {
-    for (const agent of this.agents) {
-      if (
-        agent.role === role &&
-        this.pendingAgentsOnTurn.has(agent) &&
-        this.pendingRolesOnTurn.includes(role)
-      ) {
-        return { idx: this.agents.indexOf(agent), agent };
+  /**
+   * Finds the next agent that may act for `role` on the current turn: the
+   * first agent of that role still pending on the turn.
+   *
+   * The two lookups this replaced differed by one extra condition,
+   * `pendingRolesOnTurn.includes(role)`, present on the automatic-loop side
+   * and absent on the scripted side. That condition cannot be false at any of
+   * the automatic call sites, so dropping it changes nothing there:
+   *
+   * - {@link _step} passes `pendingRolesOnTurn[0]`, so the condition asks
+   *   whether an array contains its own head. When the queue is empty the role
+   *   is `undefined` and no agent matches on role either way.
+   * - The inline-barge lookup iterates `for (const r of pendingRolesOnTurn)`,
+   *   and its second call asks for AGENT only after `nextRole` was assigned
+   *   from that same iteration, with no mutation of the array in between.
+   *
+   * On the scripted side the absence is load-bearing rather than incidental:
+   * {@link scriptCallAgent} has already run {@link consumeUntilRole}, which
+   * drains the queue entirely when the role is not in it, and the agent must
+   * still be reachable afterwards. Python's `_next_agent_for_role` keeps the
+   * condition and so takes a `newTurn()` there instead, a turn-count
+   * divergence pinned by `script-call-role-pending.test.ts`. See issue #210.
+   */
+  private findNextAgentForRole(
+    role: AgentRole
+  ): { index: number; agent: AgentAdapter } | null {
+    for (let index = 0; index < this.agents.length; index++) {
+      const agent = this.agents[index];
+      if (agent.role === role && this.pendingAgentsOnTurn.has(agent)) {
+        return { index, agent };
       }
     }
 
-    return { idx: -1, agent: null };
+    return null;
   }
 
   /**
@@ -2493,18 +2512,6 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
 
   private removePendingAgent(agent: AgentAdapter): void {
     this.pendingAgentsOnTurn.delete(agent);
-  }
-
-  private getNextAgentForRole(
-    role: AgentRole
-  ): { index: number; agent: AgentAdapter } | null {
-    for (let i = 0; i < this.agents.length; i++) {
-      const agent = this.agents[i];
-      if (agent.role === role && this.pendingAgentsOnTurn.has(agent)) {
-        return { index: i, agent };
-      }
-    }
-    return null;
   }
 
   private setAgents(agents: AgentAdapter[]): void {


### PR DESCRIPTION
## Ticket

Closes #210. `nextAgentForRole` and `getNextAgentForRole` in `scenario-execution.ts` answered the same question with different return shapes. Now one `findNextAgentForRole` returning `{ index, agent } | null`, used by all five call sites.

## The ticket's premise needed one correction

The issue calls them "nearly identical" and proposes consolidating on a body that keeps `pendingRolesOnTurn.includes(role)`. Consolidating that way would have changed behaviour, because the condition is exactly what the two did not share, and its absence on the scripted side is load-bearing.

**Dropping it is the behaviour-preserving direction.** The condition cannot be false at any of the three call sites that had it:

- `_step` (`:921`) passes `pendingRolesOnTurn[0]`, so `includes` asks whether an array contains its own head. On an empty queue the role is `undefined` and no agent matches on `agent.role` either way.
- The inline-barge lookup (`:1751`) iterates `for (const r of pendingRolesOnTurn)`, so `r` is in the array by construction.
- Its second call (`:1759`) asks for `AGENT` only after `nextRole` was assigned from that same iteration, and nothing mutates the array in between.

**Keeping it would have changed the scripted path.** `scriptCallAgent` runs `consumeUntilRole(role)` first, which drains `pendingRolesOnTurn` entirely when the role is not in it; the agent has to remain reachable after that. Adding the condition there makes the first lookup miss and takes the `newTurn()` retry branch.

## A parity finding, pinned rather than fixed

Python's `_next_agent_for_role` (`python/scenario/scenario_executor.py:538`) is a single method that **does** keep `_pending_roles_on_turn`, and its `script_call_agent` (`:1673`) uses it. So Python takes the `newTurn()` that TypeScript skips, and the two languages differ on turn counting in this case.

I have not aligned them. It is a behaviour change with `maxTurns` consequences, and which side is right is a decision for whoever owns the parity question, not something to smuggle into a DRY refactor. This PR pins today's TypeScript value so the choice becomes a visible failing test rather than a silent drift.

## Evidence

**Before:** 92 files, 1079 tests, green. **After:** 93 files, 1081 tests, green. `pnpm typecheck` and `pnpm lint:lib` clean.

**Nothing observed any of this before.** Restoring `pendingRolesOnTurn.includes(role)` for all call sites, which is the naive consolidation the issue proposes:

```
pnpm test
Test Files  93 passed | 1 skipped (94)
      Tests  1081 passed | 4 skipped (1085)
```

All green, while `currentTurn` after a scripted `agent()` then `user()` moves from `0` to `1`. That is the entire reason this PR ships a test as well as a refactor.

**The new test discriminates.** `script-call-role-pending.test.ts` reaches the state through the public API: `agent()` runs `consumeUntilRole(AGENT)`, which drains USER off `pendingRolesOnTurn` while leaving the user simulator on `pendingAgentsOnTurn`; the following `user()` then asks for a role the turn no longer lists.

| Source state | `script-call-role-pending.test.ts` | Full JS suite |
|---|---|---|
| this PR | 2 passed | 1081 passed |
| condition restored (Python semantics) | 1 failed / 1 passed | 1081 passed |

The suite cannot tell the two apart; the new test can.

**Also checked:** the old `nextAgentForRole` used `this.agents.indexOf(agent)` rather than the loop position. Equivalent here, and not a behaviour change: it returns the first occurrence, and the first occurrence is what the loop reaches first, since `pendingAgentsOnTurn` is a `Set` of instances and so cannot distinguish two copies of one adapter anyway.

## Notes

The single parameter stays positional. A `requireRolePending` flag was the first shape I tried, and the tautology above makes it dead weight; it would also have been exactly the magic boolean parameter #209 asks the repo to stop adding.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.
