### PR TITLE
fix(voice/#718): surface a dead Gemini Live session instead of hanging

### DIFF
--- a/python/scenario/voice/__init__.py
+++ b/python/scenario/voice/__init__.py
@@ -12,6 +12,7 @@ Public surface:
     - FirstChunkTimeoutError — attributable first-chunk recv timeout
     - AgentStreamEndedError — recv_audio's transport terminated (crash/clean close)
     - PipecatRecvError — Pipecat recv-loop ended (attributable; subclass of above)
+    - GeminiLiveRecvError — Gemini Live session task ended (attributable; subclass of above)
     - VoiceRecording / VoiceEvent / LatencyMetrics — result-side types
     - AudioSegment — per-speaker slice of the recording
     - synthesize / STTProvider / set_stt_provider / get_stt_provider —
@@ -30,6 +31,7 @@ from .adapters import (
     ElevenLabsAgentAdapter,
     ElevenLabsVoiceAgent,
     GeminiLiveAgentAdapter,
+    GeminiLiveRecvError,
     LiveKitAgentAdapter,
     OpenAIRealtimeAgentAdapter,
     PipecatAgentAdapter,
@@ -70,6 +72,7 @@ __all__ = [
     "ElevenLabsVoiceAgent",
     "FirstChunkTimeoutError",
     "GeminiLiveAgentAdapter",
+    "GeminiLiveRecvError",
     "InterruptionConfig",
     "LatencyMetrics",
     "LiveKitAgentAdapter",

--- a/python/scenario/voice/adapters/__init__.py
+++ b/python/scenario/voice/adapters/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from ._stub import PendingTransportError
 from .composable import ComposableVoiceAgent, ElevenLabsVoiceAgent
 from .elevenlabs import ElevenLabsAgentAdapter
-from .gemini_live import GeminiLiveAgentAdapter
+from .gemini_live import GeminiLiveAgentAdapter, GeminiLiveRecvError
 from .livekit import LiveKitAgentAdapter
 from .openai_realtime import OpenAIRealtimeAgentAdapter
 from .pipecat import PipecatAgentAdapter, PipecatRecvError
@@ -26,6 +26,7 @@ __all__ = [
     "ElevenLabsAgentAdapter",
     "ElevenLabsVoiceAgent",
     "GeminiLiveAgentAdapter",
+    "GeminiLiveRecvError",
     "LiveKitAgentAdapter",
     "OpenAIRealtimeAgentAdapter",
     "PendingTransportError",

--- a/python/scenario/voice/adapters/gemini_live.py
+++ b/python/scenario/voice/adapters/gemini_live.py
@@ -33,6 +33,7 @@ Resampling uses numpy linear interpolation — scipy is not required.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 from typing import Any, ClassVar, Optional
@@ -40,13 +41,23 @@ from typing import Any, ClassVar, Optional
 from opentelemetry import trace as _otel_trace
 
 from ...config.voice_models import GEMINI_LIVE_MODEL
-from ..adapter import VoiceAgentAdapter
+from ..adapter import AgentStreamEndedError, VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
 from ..capabilities import AdapterCapabilities
 from .._telemetry import set_span_attributes
 
 
 logger = logging.getLogger("scenario.voice.gemini_live")
+
+
+class GeminiLiveRecvError(AgentStreamEndedError):
+    """recv_audio could get no more audio because the background session task
+    ended — a crash in ``_session_lifetime`` (chained via ``__cause__``), a
+    clean return, or a cancellation. Named so a dead session surfaces an
+    attributable error (issue #718) instead of starving the consumer parked
+    on ``session.receive()``'s cached iterator — the ``PipecatRecvError``
+    (#498/#692) precedent for a different transport.
+    """
 
 # Gemini Live ingests PCM16 at 16kHz.
 GEMINI_INPUT_RATE = 16000
@@ -405,10 +416,38 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
             # iterator) and a real mid-reply interrupt (audio arrived
             # earlier on this iterator).
             saw_interrupted = False
+            # Captured ONCE, before any parking: this is what lets a wake-up
+            # still work even after disconnect() nulls ``self._session_task``
+            # (:298) while we're mid-race — we hold the actual task object,
+            # not a re-readable attribute (#718 AC4b).
+            session_task = self._session_task
             while True:
+                assert self._recv_iter is not None
+                anext_task: "asyncio.Task[Any]" = asyncio.ensure_future(
+                    self._recv_iter.__anext__()  # type: ignore[union-attr]
+                )
                 try:
-                    assert self._recv_iter is not None
-                    message = await self._recv_iter.__anext__()  # type: ignore[union-attr]
+                    if session_task is not None:
+                        # Race the parked __anext__() against the session task
+                        # itself — task-done is the trigger (not
+                        # _session_error, which a cancellation or clean return
+                        # never sets; see module docstring point 3). This is
+                        # what wakes a consumer ALREADY SUSPENDED inside
+                        # __anext__() when the session dies underneath it,
+                        # not just one that checks on entry (#718 AC3).
+                        done, _pending = await asyncio.wait(
+                            {anext_task, session_task},
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        if anext_task not in done:
+                            anext_task.cancel()
+                            with contextlib.suppress(BaseException):
+                                await anext_task
+                            raise GeminiLiveRecvError(
+                                "GeminiLiveAgentAdapter: session task ended; "
+                                "no further audio will arrive"
+                            ) from self._session_error
+                    message = await anext_task
                 except StopAsyncIteration:
                     # The previous turn ended (turn_complete already
                     # consumed). Surface end-of-turn to the drain loop

--- a/python/scenario/voice/adapters/gemini_live.py
+++ b/python/scenario/voice/adapters/gemini_live.py
@@ -426,6 +426,19 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
                 anext_task: "asyncio.Task[Any]" = asyncio.ensure_future(
                     self._recv_iter.__anext__()  # type: ignore[union-attr]
                 )
+                # Set True only once anext_task's result (or exception) has
+                # actually been consumed via `message = await anext_task`
+                # below. Anything that exits this iteration WITHOUT that —
+                # notably the outer asyncio.wait_for(...) timing out while
+                # we're parked in `await asyncio.wait(...)` or `await
+                # anext_task` — leaves anext_task running against the shared
+                # self._recv_iter generator. The `finally` cancels+awaits it
+                # in that case so a later __anext__() call on the same
+                # generator (this call's next iteration, or the NEXT
+                # recv_audio call) never collides with an orphaned one still
+                # in flight, which is what raises "anext(): asynchronous
+                # generator is already running" (#872).
+                consumed = False
                 try:
                     if session_task is not None:
                         # Race the parked __anext__() against the session task
@@ -443,21 +456,41 @@ class GeminiLiveAgentAdapter(VoiceAgentAdapter):
                             anext_task.cancel()
                             with contextlib.suppress(BaseException):
                                 await anext_task
+                            consumed = True  # already cancelled+awaited above
                             raise GeminiLiveRecvError(
                                 "GeminiLiveAgentAdapter: session task ended; "
                                 "no further audio will arrive"
                             ) from self._session_error
                     message = await anext_task
+                    consumed = True
                 except StopAsyncIteration:
-                    # The previous turn ended (turn_complete already
-                    # consumed). Surface end-of-turn to the drain loop
+                    # anext_task itself raised this — it's already done, no
+                    # cleanup needed. The previous turn ended (turn_complete
+                    # already consumed). Surface end-of-turn to the drain loop
                     # and reset the iterator so the next user turn
                     # can re-enter session.receive() afresh.
+                    consumed = True
                     self._recv_iter = None
                     return AudioChunk(
                         data=b"",
                         transcript=pending_delta or None,
                     )
+                finally:
+                    # Covers a plain outer-timeout cancellation (and any other
+                    # exception we didn't already clean up above): if we're
+                    # leaving without having consumed anext_task's outcome,
+                    # it must be fully finished — cancelled and awaited —
+                    # before control returns to the caller, who may issue a
+                    # fresh __anext__() on the same generator either in the
+                    # next loop iteration or the next recv_audio() call.
+                    # This does not swallow the CancelledError propagating
+                    # through THIS frame from the outer wait_for — only the
+                    # cancellation of the now-orphaned anext_task is
+                    # suppressed.
+                    if not consumed:
+                        anext_task.cancel()
+                        with contextlib.suppress(BaseException):
+                            await anext_task
 
                 if message.go_away is not None:
                     raise RuntimeError(

--- a/python/tests/voice/test_gemini_live_stream_ended.py
+++ b/python/tests/voice/test_gemini_live_stream_ended.py
@@ -1,0 +1,816 @@
+"""A dead Gemini Live session must surface ``AgentStreamEndedError`` from
+``recv_audio`` instead of starving it (issue #718).
+
+``_session_lifetime`` (``gemini_live.py:234-254``) records a session failure on
+``self._session_error`` and then RETURNS — which exits the ``async with
+client.aio.live.connect(...)`` block and closes the SDK session. ``recv_audio``
+holds a cached iterator obtained from that same session (``:389``), parks on
+``await self._recv_iter.__anext__()`` (``:411``), and never consults
+``_session_error`` or ``_session_task``. A dead session therefore starves the
+consumer until the caller's own timeout.
+
+Three properties are pinned separately, because each is a distinct way a naive
+fix still ships the bug:
+
+1. ``recv_audio`` never reads the crash state at all.
+2. An ENTRY-ONLY check is insufficient. The production hang is a consumer
+   ALREADY PARKED inside ``__anext__()`` when the session dies — the same lesson
+   as #648: a sentinel test only discriminates if a consumer is already blocked
+   when the stream ends.
+3. ``_session_error`` is assigned ONLY inside ``except Exception:``, so a task
+   that was cancelled (``CancelledError`` is a ``BaseException``) or returned
+   cleanly leaves it ``None`` while the hang persists. Task-done is the trigger;
+   ``_session_error`` only supplies the cause when there is one.
+
+Expected status against UNMODIFIED production code (the #718 AC5 red-before):
+
+    RED   test_crashed_session_task_surfaces_stream_ended
+    RED   test_clean_task_exit_surfaces_stream_ended[clean_return]
+    RED   test_clean_task_exit_surfaces_stream_ended[cancelled]
+    RED   test_parked_recv_audio_wakes_on_session_death          <- discriminating
+    RED   test_teardown_recv_iter_aclose_wakes_parked_recv
+    RED   test_teardown_session_task_cleared_wakes_parked_recv
+    RED   test_teardown_session_error_cleared_wakes_parked_recv
+    GREEN test_pre_connect_failure_propagates_unchanged          <- regression lock
+    GREEN test_clean_turn_reports_terminal_chunk                 <- regression lock
+
+Every RED node fails by HANGING to its 5s ``asyncio.wait_for`` guard, which is
+the evidence shape AC5 requires. That is why ``GeminiLiveRecvError`` is resolved
+with ``getattr`` INSIDE the assertions rather than imported at module level: a
+module-level import of a symbol that does not exist yet errors COLLECTION, and a
+collection error is not a hang — it would make the red-before signal
+unobtainable and mask which nodes genuinely fail. Only
+``AgentStreamEndedError`` (which exists today) is imported up top.
+
+Mock strategy — creds-free, and structurally so:
+- The vendor transport is faked at the NETWORK CLIENT boundary (``genai.Client``),
+  never by substituting a stub for adapter privates — the ban PR #697 exists for.
+  The REAL ``connect()`` therefore runs: the real ``LiveConnectConfig``, the real
+  ``_session_lifetime`` background task, the real ``except Exception`` capture.
+- Credentials are removed with ``monkeypatch.delenv`` INSIDE the test, because
+  ``tests/voice/conftest.py`` calls ``load_dotenv(python/.env)`` at import time
+  and silently restores anything the process was started without (#871) — so a
+  process-level ``env -u`` proves nothing here.
+- No ``skipif`` / ``importorskip`` / ``pytestmark`` / ``pytest.skip``, and no
+  ``@pytest.mark.integration`` (CI runs ``-m "not integration"``, which would
+  silently deselect the node).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any, List, NamedTuple, Optional
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.util._once import Once
+
+import scenario.voice as scenario_voice
+from scenario.voice import AgentStreamEndedError
+from scenario.voice.adapters.gemini_live import GeminiLiveAgentAdapter
+from scenario.voice.audio_chunk import AudioChunk
+from scenario.voice.testing import drive_call, make_agent_input
+
+from ._span_assert import attrs
+
+
+# The adapter never reaches a real Google endpoint here — ``genai.Client`` is
+# replaced — so this is a placeholder, not a credential.
+_FAKE_KEY = "test-gk-not-a-real-key"
+
+# Outer guard on every direct ``recv_audio(timeout=30.0)`` call. A blind hang
+# must FAIL the test fast, not pass slowly: if the guard fires we get
+# ``asyncio.TimeoutError`` instead of the expected error type, and
+# ``_assert_stream_ended`` names the hang explicitly.
+_RECV_GUARD_SECONDS = 5.0
+
+# What ``recv_audio`` is asked for. Deliberately far above the guard so "the
+# call returned because ITS OWN timeout elapsed" can never be mistaken for
+# "the guard woke it".
+_RECV_TIMEOUT_SECONDS = 30.0
+
+
+# --------------------------------------------------------------------------- #
+# Creds-free floor                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _creds_free_env(monkeypatch):
+    """Delete every credential these tests must never need, INSIDE the test.
+
+    ``monkeypatch.delenv`` rather than a process-level ``env -u``: the voice
+    conftest reloads ``python/.env`` at import time, which re-populates any var
+    the process was started without (#871), so only an in-test deletion holds.
+    """
+    for key in (
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "LANGWATCH_API_KEY",
+        "LANGWATCH_ENDPOINT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def in_memory_spans():
+    """Install a fresh in-memory TracerProvider and hand back its exporter.
+
+    The provider is set-once globally, so the guard is reset on both edges —
+    otherwise a provider installed by an earlier module wins and this module's
+    span assertions read an empty exporter.
+    """
+
+    def _reset() -> None:
+        trace._TRACER_PROVIDER = None
+        trace._TRACER_PROVIDER_SET_ONCE = Once()
+
+    _reset()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    yield exporter
+    _reset()
+
+
+# --------------------------------------------------------------------------- #
+# Duck-typed SDK stand-ins (no google.genai types are constructed here)        #
+# --------------------------------------------------------------------------- #
+
+
+class _ParkingReceiveStream:
+    """Stand-in for the async generator ``session.receive()`` returns.
+
+    ``__anext__`` parks forever — the session is alive but silent — which is the
+    state the production consumer is in when the session dies underneath it.
+
+    ``aclose()`` models the NATIVE async-generator semantics a parked consumer
+    provokes: ``RuntimeError('aclose(): asynchronous generator is already
+    running')``, which ``disconnect()`` swallows at ``gemini_live.py:279-284``.
+    Modelling it on a plain object (rather than relying on a real generator)
+    is what lets the teardown node PROVE it reached that line, via
+    ``aclose_calls`` / ``aclose_raised``.
+    """
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.aclose_calls = 0
+        self.aclose_raised = False
+        self._running = False
+
+    def __aiter__(self) -> "_ParkingReceiveStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        self.entered.set()
+        self._running = True
+        try:
+            await asyncio.sleep(3600)
+        finally:
+            self._running = False
+        raise AssertionError("unreachable: the parking stream never yields")
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        if self._running:
+            self.aclose_raised = True
+            raise RuntimeError("aclose(): asynchronous generator is already running")
+
+
+class _SilentSession:
+    """Duck-typed ``AsyncSession`` whose ``receive()`` never yields.
+
+    One shared stream across calls: these nodes drive exactly one turn, and a
+    stable handle is what ``_park_recv`` waits on to prove the consumer really
+    suspended inside ``__anext__()``.
+    """
+
+    def __init__(self) -> None:
+        self.stream = _ParkingReceiveStream()
+        self.sent: List[Any] = []
+
+    def receive(self) -> _ParkingReceiveStream:
+        return self.stream
+
+    async def send_realtime_input(self, **kwargs: Any) -> None:
+        self.sent.append(kwargs)
+
+    async def close(self) -> None:
+        pass
+
+
+class _FakeInlineData:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+
+class _FakePart:
+    def __init__(self, data: bytes) -> None:
+        self.inline_data = _FakeInlineData(data)
+
+
+class _FakeModelTurn:
+    def __init__(self, parts: List[_FakePart]) -> None:
+        self.parts = parts
+
+
+class _FakeTranscription:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeServerContent:
+    def __init__(
+        self,
+        *,
+        output_transcription: Any = None,
+        model_turn: Any = None,
+        turn_complete: bool = False,
+        interrupted: bool = False,
+    ) -> None:
+        self.output_transcription = output_transcription
+        self.model_turn = model_turn
+        self.turn_complete = turn_complete
+        self.interrupted = interrupted
+
+
+class _FakeLiveServerMessage:
+    def __init__(self, server_content: Any) -> None:
+        self.go_away = None
+        self.server_content = server_content
+
+
+class _ScriptedSession:
+    """Duck-typed ``AsyncSession`` serving one scheduled turn per ``receive()``.
+
+    Mirrors ``test_gemini_live_echo_safe.py``'s ``_FakeSession``: the real SDK's
+    ``receive()`` generator yields one model turn then completes, so a FRESH
+    generator per call is the faithful contract.
+    """
+
+    def __init__(self, turns: List[List[Any]]) -> None:
+        self._turns = list(turns)
+        self._turn_idx = 0
+        self.sent: List[Any] = []
+
+    def receive(self):
+        if self._turn_idx < len(self._turns):
+            msgs = self._turns[self._turn_idx]
+            self._turn_idx += 1
+        else:
+            msgs = []
+
+        async def _gen():
+            for message in msgs:
+                await asyncio.sleep(0)
+                yield message
+
+        return _gen()
+
+    async def send_realtime_input(self, **kwargs: Any) -> None:
+        self.sent.append(kwargs)
+
+    async def close(self) -> None:
+        pass
+
+
+def _make_pcm(n_samples: int = 2400) -> bytes:
+    """Silent PCM16 mono @24kHz."""
+    return b"\x00\x00" * n_samples
+
+
+def _clean_agent_turn(transcript: str = "hello there") -> List[_FakeLiveServerMessage]:
+    """One clean agent turn: audio + transcript, then ``turn_complete``.
+
+    The transcript rides along so the base ``_ensure_transcript`` short-circuits
+    and no STT provider is reached.
+    """
+    return [
+        _FakeLiveServerMessage(
+            _FakeServerContent(
+                output_transcription=_FakeTranscription(transcript),
+                model_turn=_FakeModelTurn([_FakePart(_make_pcm(2400))]),
+            )
+        ),
+        _FakeLiveServerMessage(_FakeServerContent(turn_complete=True)),
+    ]
+
+
+def _install_fake_client(
+    monkeypatch,
+    session: Any,
+    *,
+    enter_error: Optional[BaseException] = None,
+    exit_error: Optional[BaseException] = None,
+) -> None:
+    """Fake ``genai.Client`` so the REAL ``connect()`` runs without credentials.
+
+    ``enter_error`` fails the handshake BEFORE ``connect()`` returns (the
+    ``gemini_live.py:260-261`` window). ``exit_error`` fails the SDK context
+    manager on the way out — the one production path that reaches
+    ``_session_lifetime``'s ``except Exception`` and stores ``_session_error``.
+    """
+    from google import genai  # noqa: PLC0415 — deferred like the adapter's own import
+
+    class _CM:
+        async def __aenter__(self):
+            if enter_error is not None:
+                raise enter_error
+            return session
+
+        async def __aexit__(self, *exc_info: Any) -> bool:
+            if exit_error is not None:
+                raise exit_error
+            return False
+
+    class _Live:
+        def connect(self, *, model, config):
+            return _CM()
+
+    class _Aio:
+        live = _Live()
+
+    class _Client:
+        def __init__(self, api_key=None):
+            self.aio = _Aio()
+
+    monkeypatch.setattr(genai, "Client", _Client)
+
+
+# --------------------------------------------------------------------------- #
+# recv_audio guard plumbing                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class _Outcome(NamedTuple):
+    """How a guarded ``recv_audio`` settled: a returned chunk, or a raise."""
+
+    value: Optional[AudioChunk]
+    error: Optional[BaseException]
+
+
+def _guarded_recv(adapter: GeminiLiveAgentAdapter) -> "asyncio.Task[Any]":
+    """Start ``recv_audio(timeout=30.0)`` under the mandated 5s outer guard.
+
+    Every direct ``recv_audio`` call in this file goes through here, so a call
+    that blinds-hangs fails the test at 5s instead of passing slowly at 30s.
+    """
+    return asyncio.ensure_future(
+        asyncio.wait_for(
+            adapter.recv_audio(timeout=_RECV_TIMEOUT_SECONDS),
+            timeout=_RECV_GUARD_SECONDS,
+        )
+    )
+
+
+async def _settle(task: "asyncio.Task[Any]") -> _Outcome:
+    """Await a guarded ``recv_audio`` task and classify the result AFTERWARDS.
+
+    Classification is deliberately post-await: resolving ``GeminiLiveRecvError``
+    before the call settles would pre-empt the exact signal this file exists to
+    produce on unmodified production code — a parked consumer hanging to its 5s
+    guard (#718 AC5).
+    """
+    try:
+        return _Outcome(value=await task, error=None)
+    except BaseException as exc:  # noqa: BLE001 — classified by _assert_stream_ended
+        return _Outcome(value=None, error=exc)
+
+
+def _assert_stream_ended(outcome: _Outcome, *, when: str) -> BaseException:
+    """Assert a settled ``recv_audio`` raised ``GeminiLiveRecvError``.
+
+    Rejects each forbidden outcome with its own message, in the order that makes
+    the red-before evidence legible: a returned (empty) chunk, then a hang, then
+    the wrong type, then the base class instead of the named subclass.
+    """
+    assert outcome.error is not None, (
+        f"{when}: recv_audio RETURNED {outcome.value!r} instead of raising. A dead "
+        "Gemini Live session must surface an AgentStreamEndedError — an empty "
+        "AudioChunk reads to the drain loop as a normal end-of-turn, which is the "
+        "#718 bug wearing a different mask."
+    )
+    exc = outcome.error
+    assert not isinstance(exc, asyncio.TimeoutError), (
+        f"{when}: recv_audio stayed parked until the {_RECV_GUARD_SECONDS}s "
+        f"asyncio.wait_for guard fired ({type(exc).__name__}). THAT IS the #718 "
+        "starvation bug: the session is dead and nothing wakes the consumer."
+    )
+    assert isinstance(exc, AgentStreamEndedError), (
+        f"{when}: expected an AgentStreamEndedError, got {type(exc).__name__}: {exc!r}"
+    )
+    assert "GeminiLive" in str(exc), (
+        f"{when}: the error must name the adapter so the failure is attributable; "
+        f"str() was {str(exc)!r}"
+    )
+    # Resolved dynamically: this symbol does not exist on unmodified main, and a
+    # module-level import of it would error collection rather than fail the node.
+    subclass = getattr(scenario_voice, "GeminiLiveRecvError", None)
+    assert subclass is not None, (
+        f"{when}: scenario.voice.GeminiLiveRecvError is not exported. The guard "
+        "must raise a NAMED AgentStreamEndedError subclass — the PipecatRecvError "
+        "precedent (#692) — not the base class."
+    )
+    assert issubclass(subclass, AgentStreamEndedError) and (
+        subclass is not AgentStreamEndedError
+    ), f"GeminiLiveRecvError must be a STRICT subclass of AgentStreamEndedError; got {subclass!r}"
+    assert type(exc) is subclass, (
+        f"{when}: expected exactly GeminiLiveRecvError, got {type(exc).__name__} — "
+        "raising the base class leaves the adapter unattributable at the catch site."
+    )
+    return exc
+
+
+async def _park_recv(
+    adapter: GeminiLiveAgentAdapter, session: _SilentSession
+) -> "asyncio.Task[Any]":
+    """Start a guarded ``recv_audio`` and return once it is PROVABLY suspended.
+
+    ``entered`` is set from inside ``__anext__`` before it parks, so awaiting it
+    proves the consumer reached the suspension point rather than merely having
+    been scheduled. Without that proof an entry-only guard passes these nodes and
+    still ships the production hang (#718 AC3).
+    """
+    task = _guarded_recv(adapter)
+    await asyncio.wait_for(session.stream.entered.wait(), timeout=2.0)
+    await asyncio.sleep(0)
+    assert not task.done(), (
+        "recv_audio settled before it could park inside __anext__(); this node "
+        "cannot discriminate an entry-only guard from a real one"
+    )
+    return task
+
+
+async def _end_session_task(adapter: GeminiLiveAgentAdapter) -> None:
+    """Release the REAL ``_session_lifetime`` body and let it run to completion.
+
+    ``_session_lifetime`` parks on ``await self._shutdown.wait()`` INSIDE the SDK
+    context manager, so setting that event is the only in-process way to reach the
+    block's exit — and therefore the only way to reach its ``except Exception``
+    handler (``:247-248``) through production code instead of fabricating
+    ``_session_error`` by hand.
+
+    Returns with the task DONE but a parked consumer's wake-up still queued:
+    ``Event.set`` schedules the lifetime task's step ahead of this coroutine's
+    resumption, and the task's own done-callbacks land behind it. That ordering is
+    what lets a caller mirror ``disconnect()``'s ``:297-301`` state BEFORE the
+    guard observes it.
+    """
+    assert adapter._shutdown is not None, "adapter was never connected"
+    task = adapter._session_task
+    assert task is not None, "adapter was never connected"
+    adapter._shutdown.set()
+    await asyncio.sleep(0)
+    assert task.done(), (
+        "the _session_lifetime task did not finish in one loop turn; the teardown "
+        "ordering these nodes depend on no longer holds"
+    )
+
+
+async def _cancel_session_task(adapter: GeminiLiveAgentAdapter) -> None:
+    """Cancel ``_session_lifetime`` — the death that leaves ``_session_error`` unset.
+
+    ``CancelledError`` is a ``BaseException``, so ``except Exception:`` never sees
+    it; the task ends done-and-cancelled with no recorded cause, while a consumer
+    parked on ``__anext__()`` keeps waiting.
+    """
+    task = adapter._session_task
+    assert task is not None, "adapter was never connected"
+    task.cancel()
+    await asyncio.sleep(0)
+    if not task.done():
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    assert task.cancelled(), "expected the session task to end cancelled"
+
+
+async def _quiet_disconnect(adapter: GeminiLiveAgentAdapter) -> None:
+    """Best-effort teardown so a failing node cannot leak a live task into the next.
+
+    ``CancelledError`` is suppressed alongside ``Exception`` because
+    ``disconnect()`` awaits ``self._session_task`` under ``except
+    (asyncio.TimeoutError, Exception)`` (``:290-296``) — which does not cover
+    ``BaseException``, so a CANCELLED session task re-raises out of
+    ``disconnect()``. Suppressing here is safe: this coroutine is never itself
+    the cancellation target, so nothing real is being swallowed.
+    """
+    with contextlib.suppress(Exception, asyncio.CancelledError):
+        await asyncio.wait_for(adapter.disconnect(), timeout=5.0)
+
+
+def _by_name(spans):
+    return {s.name: s for s in spans}
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — a crashed session task surfaces, with the recorded cause chained       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_crashed_session_task_surfaces_stream_ended(monkeypatch):
+    """RED on main. The session task died with an exception recorded on
+    ``_session_error``; the next ``recv_audio`` must raise GeminiLiveRecvError
+    naming the adapter, chaining that EXACT object as ``__cause__`` — not return
+    an empty chunk, not raise a bare RuntimeError, not time out.
+    """
+    session = _SilentSession()
+    boom = ConnectionResetError("gemini live socket dropped")
+    _install_fake_client(monkeypatch, session, exit_error=boom)
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        await _end_session_task(adapter)
+        assert adapter._session_error is boom, (
+            "precondition: _session_lifetime must have recorded the crash on "
+            f"_session_error; got {adapter._session_error!r}"
+        )
+
+        outcome = await _settle(_guarded_recv(adapter))
+        exc = _assert_stream_ended(outcome, when="after the session task crashed")
+        assert exc.__cause__ is boom, (
+            "the raised error must chain the EXACT exception stored on "
+            f"_session_error, so the real cause survives; got {exc.__cause__!r}"
+        )
+    finally:
+        await _quiet_disconnect(adapter)
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — a task that died WITHOUT an exception is terminal too                  #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("death", ["clean_return", "cancelled"])
+async def test_clean_task_exit_surfaces_stream_ended(monkeypatch, death):
+    """RED on main. ``_session_error`` is written only inside ``except
+    Exception:``, so a clean return and a cancellation both leave it ``None``
+    while the session is just as dead. Task-done must be the trigger.
+
+    ``__cause__`` is legitimately ``None`` here and is deliberately NOT asserted
+    non-None. The cancelled arm additionally pins the ``BaseException`` hazard: a
+    guard that calls ``task.exception()`` on a cancelled task re-raises
+    ``CancelledError`` out of ``recv_audio`` instead of the attributable error.
+    """
+    session = _SilentSession()
+    _install_fake_client(monkeypatch, session)  # __aexit__ returns False → clean exit
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        if death == "clean_return":
+            await _end_session_task(adapter)
+            task = adapter._session_task
+            assert task is not None and task.exception() is None, (
+                "precondition: this arm needs a task that returned cleanly"
+            )
+        else:
+            await _cancel_session_task(adapter)
+        assert adapter._session_error is None, (
+            "precondition: a non-Exception death must leave _session_error unset; "
+            f"got {adapter._session_error!r}"
+        )
+
+        outcome = await _settle(_guarded_recv(adapter))
+        _assert_stream_ended(
+            outcome, when=f"after the session task ended without an exception ({death})"
+        )
+    finally:
+        await _quiet_disconnect(adapter)
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — the discriminating node: an ALREADY-PARKED consumer must wake          #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_parked_recv_audio_wakes_on_session_death(monkeypatch):
+    """RED on main. THE node that separates a real fix from an entry-only check.
+
+    The consumer is confirmed suspended inside ``await
+    self._recv_iter.__anext__()`` BEFORE the session task is killed, so a guard
+    that only inspects state on entry passes AC1 and AC2 and still fails here —
+    which is exactly the production hang (#718; same lesson as #648).
+
+    The kill must reach the parked call through the 5s guard, not by waiting out
+    ``recv_audio``'s own 30s timeout.
+    """
+    session = _SilentSession()
+    boom = ConnectionResetError("gemini live socket dropped mid-turn")
+    _install_fake_client(monkeypatch, session, exit_error=boom)
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        parked = await _park_recv(adapter, session)
+        assert adapter._recv_iter is session.stream, (
+            "precondition: recv_audio must be parked on the session's own iterator"
+        )
+
+        # Only NOW does the session die — the whole point of this node.
+        await _end_session_task(adapter)
+
+        outcome = await _settle(parked)
+        exc = _assert_stream_ended(
+            outcome, when="for a consumer already parked in __anext__() when the session died"
+        )
+        assert exc.__cause__ is boom, (
+            "the woken call must still chain the recorded cause; "
+            f"got {exc.__cause__!r}"
+        )
+    finally:
+        await _quiet_disconnect(adapter)
+
+
+# --------------------------------------------------------------------------- #
+# AC4a — the connect() window is untouched                                     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pre_connect_failure_propagates_unchanged(monkeypatch):
+    """GREEN on main (regression lock). ``connect()`` already reads and raises
+    ``_session_error`` at ``gemini_live.py:260-261``. A failure that lands BEFORE
+    ``connect()`` returns must keep surfacing the ORIGINAL exception object — the
+    new recv guard must neither swallow it, re-wrap it as an
+    AgentStreamEndedError, nor double-raise.
+    """
+    boom = RuntimeError("gemini live handshake rejected")
+    _install_fake_client(monkeypatch, _SilentSession(), enter_error=boom)
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            await asyncio.wait_for(adapter.connect(), timeout=5.0)
+
+        assert excinfo.value is boom, (
+            "connect() must re-raise the EXACT recorded exception object; "
+            f"got {excinfo.value!r}"
+        )
+        assert not isinstance(excinfo.value, AgentStreamEndedError), (
+            "a pre-connect handshake failure is owned by connect(), not by the "
+            f"recv guard; got {type(excinfo.value).__name__}"
+        )
+        assert adapter._session is None, "a failed connect() must leave no session"
+    finally:
+        await _quiet_disconnect(adapter)
+
+
+# --------------------------------------------------------------------------- #
+# AC4b — a parked consumer at each disconnect() teardown point                 #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_teardown_recv_iter_aclose_wakes_parked_recv(monkeypatch):
+    """RED on main. The REAL ``disconnect()`` runs with a consumer parked.
+
+    ``disconnect()`` calls ``self._recv_iter.aclose()`` (``:278``) on an iterator
+    a consumer is actively awaiting, which raises ``aclose(): asynchronous
+    generator is already running`` and is swallowed by ``except Exception: pass``.
+    That swallow must not become the parked consumer's problem: the call must end
+    in GeminiLiveRecvError, never a RuntimeError, an AttributeError from the
+    half-torn-down adapter, an empty chunk, or a hang.
+    """
+    session = _SilentSession()
+    _install_fake_client(monkeypatch, session)
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        parked = await _park_recv(adapter, session)
+
+        await asyncio.wait_for(adapter.disconnect(), timeout=5.0)
+
+        assert session.stream.aclose_calls == 1, (
+            "precondition: disconnect() must have reached gemini_live.py:278; "
+            f"aclose() was called {session.stream.aclose_calls} time(s)"
+        )
+        assert session.stream.aclose_raised, (
+            "precondition: a PARKED consumer must make aclose() raise "
+            "'already running' — otherwise this node is not covering :278's swallow"
+        )
+
+        outcome = await _settle(parked)
+        _assert_stream_ended(
+            outcome, when="after disconnect() closed the parked receive iterator (:278)"
+        )
+    finally:
+        await _quiet_disconnect(adapter)
+
+
+@pytest.mark.asyncio
+async def test_teardown_session_task_cleared_wakes_parked_recv(monkeypatch):
+    """RED on main. Teardown has advanced past ``self._session_task = None``
+    (``:298``) — the line that nulls the guard's OWN trigger, and the one that
+    actually strands a parked consumer.
+
+    The teardown state is mirrored synchronously, before yielding, so the woken
+    guard deterministically observes the post-``:298`` world rather than racing
+    it. A guard that re-reads ``self._session_task`` after waking raises
+    ``AttributeError: 'NoneType' object has no attribute 'done'``; one that polls
+    it hangs. Both are failures here.
+    """
+    session = _SilentSession()
+    _install_fake_client(monkeypatch, session)
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        parked = await _park_recv(adapter, session)
+        await _end_session_task(adapter)  # :287 fires, :290 joins
+
+        # gemini_live.py :285 / :297 / :298, applied without an intervening await.
+        adapter._recv_iter = None
+        adapter._session = None
+        adapter._session_task = None
+
+        outcome = await _settle(parked)
+        _assert_stream_ended(
+            outcome, when="with _session_task already cleared by teardown (:298)"
+        )
+    finally:
+        await _quiet_disconnect(adapter)
+
+
+@pytest.mark.asyncio
+async def test_teardown_session_error_cleared_wakes_parked_recv(monkeypatch):
+    """RED on main. Teardown has advanced past ``self._session_error = None``
+    (``:301``): the session task is done and the recorded cause is gone.
+
+    A guard keyed on ``_session_error`` being set — rather than on the task being
+    done — strands the parked consumer here. ``__cause__`` is legitimately ``None``
+    once the cause has been reset and is deliberately NOT asserted non-None.
+    """
+    session = _SilentSession()
+    boom = ConnectionResetError("gemini live socket dropped")
+    _install_fake_client(monkeypatch, session, exit_error=boom)
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        parked = await _park_recv(adapter, session)
+        await _end_session_task(adapter)
+        assert adapter._session_error is boom, (
+            "precondition: the crash must have been recorded before teardown clears it"
+        )
+
+        # gemini_live.py :301, applied without an intervening await.
+        adapter._session_error = None
+
+        outcome = await _settle(parked)
+        _assert_stream_ended(
+            outcome, when="with _session_error already cleared by teardown (:301)"
+        )
+    finally:
+        await _quiet_disconnect(adapter)
+
+
+# --------------------------------------------------------------------------- #
+# AC6 — a clean turn must NOT be reclassified as a dead stream                 #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_clean_turn_reports_terminal_chunk(monkeypatch, in_memory_spans):
+    """GREEN on main (regression lock). Gemini's normal end-of-turn is an empty
+    ``AudioChunk``, and the drain must keep reporting it as ``terminal_chunk`` —
+    not ``stream_ended``. Pinning it on the gemini clean-turn boundary is what
+    catches the new guard over-firing on a healthy session; without this node that
+    regression goes green.
+    """
+    session = _ScriptedSession([_clean_agent_turn()])
+    _install_fake_client(monkeypatch, session)
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        result = await asyncio.wait_for(
+            drive_call(
+                adapter, make_agent_input(user_audio=AudioChunk(data=_make_pcm(2400)))
+            ),
+            timeout=10.0,
+        )
+    finally:
+        await _quiet_disconnect(adapter)
+
+    assert isinstance(result, dict) and result.get("role") == "assistant", (
+        f"a clean turn must still produce an assistant audio message; got {result!r}"
+    )
+
+    recv = _by_name(in_memory_spans.get_finished_spans())["voice.audio.receive"]
+    assert attrs(recv)["voice.audio.terminated_reason"] == "terminal_chunk", (
+        "a clean Gemini turn ends on the empty terminal chunk; reporting anything "
+        "else (notably 'stream_ended') means the #718 guard fired on a healthy "
+        f"session. Got {attrs(recv).get('voice.audio.terminated_reason')!r}"
+    )

--- a/python/tests/voice/test_gemini_live_stream_ended.py
+++ b/python/tests/voice/test_gemini_live_stream_ended.py
@@ -157,6 +157,12 @@ class _ParkingReceiveStream:
     Modelling it on a plain object (rather than relying on a real generator)
     is what lets the teardown node PROVE it reached that line, via
     ``aclose_calls`` / ``aclose_raised``.
+
+    ``__anext__`` itself ALSO enforces the same reentrancy a real async
+    generator would (``RuntimeError('anext(): asynchronous generator is
+    already running')``) — needed by the #872 leaked-``anext_task``
+    regression test below, which proves a second call does NOT collide with
+    an orphaned first one still in flight.
     """
 
     def __init__(self) -> None:
@@ -169,6 +175,10 @@ class _ParkingReceiveStream:
         return self
 
     async def __anext__(self) -> Any:
+        if self._running:
+            raise RuntimeError(
+                "anext(): asynchronous generator is already running"
+            )
         self.entered.set()
         self._running = True
         try:
@@ -814,3 +824,58 @@ async def test_clean_turn_reports_terminal_chunk(monkeypatch, in_memory_spans):
         "else (notably 'stream_ended') means the #718 guard fired on a healthy "
         f"session. Got {attrs(recv).get('voice.audio.terminated_reason')!r}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# #872 — a plain timeout must not leak the parked anext_task                   #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_plain_timeout_does_not_leak_anext_task(monkeypatch):
+    """RED before the #872 fix.
+
+    ``_next_chunk()`` spawns ``anext_task = asyncio.ensure_future(self.
+    _recv_iter.__anext__())`` fresh each loop iteration. The "session died"
+    branch already cancels+awaits it before raising. But when the OUTER
+    ``asyncio.wait_for(_next_chunk(), timeout=timeout)`` times out instead —
+    on a perfectly HEALTHY session, no audio ever arrives before the
+    caller's own ``timeout`` — only ``_next_chunk()``'s own frame gets
+    cancelled; the separate ``anext_task`` is untouched and keeps running
+    against the shared ``self._recv_iter`` generator.
+
+    The NEXT ``recv_audio`` call issues a fresh ``__anext__()`` on that same
+    (shared, one-per-session) iterator while the orphaned one may still be
+    in flight. ``_ParkingReceiveStream.__anext__`` enforces the same
+    reentrancy a real async generator would, so the leak reproduces as
+    ``RuntimeError: anext(): asynchronous generator is already running`` —
+    the exact production symptom — instead of a silent hang.
+
+    Both calls here race only the caller's own short ``timeout`` against
+    silence, never ``_session_task`` dying, which isolates this leak from
+    the AC1-AC4 death-path nodes above.
+    """
+    session = _SilentSession()
+    _install_fake_client(monkeypatch, session)  # healthy session throughout
+
+    adapter = GeminiLiveAgentAdapter(api_key=_FAKE_KEY)
+    await adapter.connect()
+    try:
+        # First call: nothing ever arrives, so this must time out on its own
+        # short timeout, not hang and not raise GeminiLiveRecvError (the
+        # session stays alive the whole time).
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                adapter.recv_audio(timeout=0.05), timeout=_RECV_GUARD_SECONDS
+            )
+
+        # Second call, same adapter/session, same still-silent stream: with
+        # the leak, the first call's orphaned anext_task collides with this
+        # call's fresh __anext__() on the same iterator and raises
+        # RuntimeError instead of timing out cleanly again.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                adapter.recv_audio(timeout=0.05), timeout=_RECV_GUARD_SECONDS
+            )
+    finally:
+        await _quiet_disconnect(adapter)

--- a/specs/voice-gemini-live-stream-ended.feature
+++ b/specs/voice-gemini-live-stream-ended.feature
@@ -36,6 +36,15 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
   # would contradict the pre-connect-failure scenario, and would be inapplicable
   # to the static-check scenarios entirely. Preconditions are stated per scenario.
   #
+  # ⚠ THE @integration TAGS BELOW ARE GHERKIN TAGS, NOT PYTEST MARKERS. Do NOT
+  # transcribe them into @pytest.mark.integration on the test nodes. CI runs
+  # `-m "not integration"` (.github/workflows/python-ci.yml:91), so a node marked
+  # that way is DESELECTED in CI while every local run stays green — the test
+  # would never execute on the gate it exists to satisfy. The auto-marker in
+  # tests/voice/conftest.py keys on the `_e2e.py` filename only, so
+  # test_gemini_live_stream_ended.py is not auto-gated; the only way to break
+  # this is by hand. AC10 pins it.
+  #
   # SCOPE. The sweep that produced #718 named five adapters; only gemini_live has
   # an unfixed gap. pipecat was fixed by #692, twilio is already guarded.
   # openai_realtime, elevenlabs and websocket read their transport inline.

--- a/specs/voice-gemini-live-stream-ended.feature
+++ b/specs/voice-gemini-live-stream-ended.feature
@@ -27,25 +27,32 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
   #      leaves it None while the hang persists. Task-done is the trigger;
   #      _session_error only supplies the cause when there is one.
   #
-  # The scoping sweep that produced #718 named five adapters. Only gemini_live
-  # has an unfixed gap; pipecat was fixed by #692 and twilio is already guarded.
-  # openai_realtime, elevenlabs, websocket and composable read their transport
-  # inline; livekit and vapi are transportless stubs; webrtc has the queue half
-  # of the shape but nothing in-tree fills it. The remaining terminal-vs-transient
-  # design calls are deferred to #868, #869, #870 and #871.
-
-  Background:
-    Given a GeminiLiveAgentAdapter connected against a duck-typed fake Live session
-    And the fake session never imports the google-genai SDK and needs no credentials
-    And every recv_audio call in this spec is wrapped in a 5 second guard so a
-      blind hang fails the scenario instead of passing slowly
+  # TEARDOWN ORDER MATTERS. disconnect() runs aclose() (:278, inside an
+  # `except Exception: pass`), then nulls _session_task (:298), then nulls
+  # _session_error (:301). Because the guard triggers on task-done, :298 is the
+  # line that actually strands it — not :301.
+  #
+  # NO Background section here on purpose: the connected-adapter precondition
+  # would contradict the pre-connect-failure scenario, and would be inapplicable
+  # to the static-check scenarios entirely. Preconditions are stated per scenario.
+  #
+  # SCOPE. The sweep that produced #718 named five adapters; only gemini_live has
+  # an unfixed gap. pipecat was fixed by #692, twilio is already guarded.
+  # openai_realtime, elevenlabs and websocket read their transport inline.
+  # composable has no transport at all (synchronous LLM+TTS) — a different
+  # negative from the inline three, and marked with different wording.
+  # livekit and vapi are transportless stubs; webrtc has the queue half of the
+  # shape but nothing in-tree fills it. Remaining terminal-vs-transient design
+  # calls are deferred to #868, #869, #870 and #871.
 
   # AC1 — the direct gap: a crashed session task is terminal and attributable.
   @integration @gemini-stream-ended
   Scenario: A session task that crashed surfaces an attributable stream-ended error
-    Given the background session task has terminated by raising an exception
-    When recv_audio is called
-    Then it raises AgentStreamEndedError within the 5 second guard
+    Given a GeminiLiveAgentAdapter connected against a credential-free fake Live session
+    And the background session task has terminated by raising an exception
+    When recv_audio is called within a 5 second guard
+    Then it raises AgentStreamEndedError
+    And the error is the GeminiLive-specific subclass, not the base class
     And the error's string representation names the GeminiLive transport
     And the error's __cause__ is the exact exception object the session task recorded
     And it does not return an empty AudioChunk, an asyncio.TimeoutError, or a bare RuntimeError
@@ -53,50 +60,59 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
   # AC2 — a death with no exception is terminal too (the None-cause case).
   @integration @gemini-stream-ended
   Scenario: A session task that ended without an exception is still terminal
-    Given the background session task is done and its exception is None
-    When recv_audio is called
-    Then it raises AgentStreamEndedError within the 5 second guard
+    Given a GeminiLiveAgentAdapter connected against a credential-free fake Live session
+    And the background session task is done and its exception is None
+    When recv_audio is called within a 5 second guard
+    Then it raises AgentStreamEndedError
     And the message names the task as ended without an error
     And a __cause__ of None is accepted rather than treated as a failure
 
   # AC3 — the discriminating case: an ALREADY-PARKED consumer must wake.
+  # An entry-only guard passes AC1 and AC2 and still ships the production hang.
   @integration @gemini-stream-ended
   Scenario: A recv_audio already parked on the session iterator wakes when the session dies
-    Given the fake session yields nothing so recv_audio suspends inside the iterator
+    Given a GeminiLiveAgentAdapter connected against a credential-free fake Live session
+    And the fake session yields nothing so recv_audio suspends inside the iterator
     And the call is confirmed pending before anything else happens
     When the background session task is then killed
-    Then the parked call raises AgentStreamEndedError within the 5 second guard
+    Then the parked call raises AgentStreamEndedError within a 5 second guard
     And it does not wait out its own 30 second recv timeout
     And it does not raise asyncio.TimeoutError or return an empty AudioChunk
 
-  # AC4 — the guard's window against the pre-existing reader and teardown.
+  # AC4a — the pre-connect path stays owned by connect(), not by the new guard.
   @integration @gemini-stream-ended
   Scenario: A pre-connect failure still surfaces through connect unchanged
-    Given the session fails before connect returns
+    Given a GeminiLiveAgentAdapter whose fake Live session fails before connect returns
     When connect is awaited
     Then the original connect-time exception propagates unchanged
     And it is not swallowed, double-raised, or replaced by AgentStreamEndedError
 
+  # AC4b — all three teardown points, in the order disconnect() executes them.
   @integration @gemini-stream-ended
-  Scenario: A recv_audio in flight when disconnect clears the error state still raises
-    Given a recv_audio call is in flight against a dead session
-    When disconnect resets the recorded session error to None
-    Then the in-flight call still raises AgentStreamEndedError within the 5 second guard
-    And it does not revert to hanging
+  Scenario: A recv_audio parked during disconnect raises at every teardown point
+    Given a GeminiLiveAgentAdapter connected against a credential-free fake Live session
+    And a recv_audio call is parked on the session iterator
+    When disconnect closes the iterator, then nulls the session task, then nulls the session error
+    Then the parked call raises AgentStreamEndedError within a 5 second guard at each of those three points
+    And nulling the session task does not strand the guard that triggers on it
+    And no point yields a RuntimeError, an AttributeError, a hang, or an empty AudioChunk
 
   # AC5 — the bug is demonstrated behaviourally, not merely by code shape.
+  # Without this, nothing rules out the SDK already raising on context-manager
+  # exit, which would make the entire guard dead code.
   @integration @gemini-stream-ended
   Scenario: The parked-consumer test fails by hanging against unmodified production code
-    Given the production guard is absent
-    When the already-parked scenario's test is run
-    Then it fails by reaching its 5 second guard
-    And this rules out the SDK already raising on context-manager exit, which would
-      make the guard dead code
+    Given the production adapter files are restored to their origin/main contents
+    And the new tests are kept in place
+    When the whole new test file is run
+    Then the parked-consumer scenario fails by reaching its 5 second guard
+    And the expected red or green status of every other new node is stated and observed
 
   # AC6 — the regression this change is most likely to introduce.
   @integration @gemini-stream-ended
   Scenario: A clean end of turn is not reclassified as a terminal error
-    Given the fake session completes one model turn normally
+    Given a GeminiLiveAgentAdapter connected against a credential-free fake Live session
+    And the fake session completes one model turn normally
     When the drain reads the turn to completion
     Then recv_audio returns an empty AudioChunk at the turn boundary
     And turn_complete continues to return an empty chunk
@@ -104,44 +120,48 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
     And no pre-existing gemini test changes behaviour
 
   # AC7 — no regression on the already-correct adapters.
+  # The count is pinned because an exit-0 on a skip-marked suite changes no
+  # assert line, so the assert-diff check alone cannot catch a silent skip.
   @integration @gemini-stream-ended
   Scenario: The pipecat and twilio suites stay green with untouched assertions
     Given the pipecat recv-loop suite and the twilio silent-stop suite
     When they are run against this change
-    Then every node passes
+    Then the run reports seventeen passed with no skips
     And the change adds or removes no assertion line in either file
 
   # AC8 — the negative result is durable, recorded in code rather than in the issue.
+  # A bare substring search for 718 is insufficient: it matches a sample rate, a
+  # byte count, or 1718. The marker must sit between the def line and the
+  # docstring, since the six lines after the def are all docstring body.
   @unit @gemini-stream-ended
   Scenario: Each no-shape adapter records why it has no starvation surface
-    Given the adapters that read their transport inline
+    Given the adapters that have no dead-loop starvation surface
     When each one's recv_audio definition is inspected
-    Then openai_realtime, elevenlabs and websocket each carry the literal marker
-      "no queue, no background reader (#718)"
-    And webrtc carries a #718 marker stating its inbound queue is unfilled in-tree
-      so a subclass that populates it reintroduces the shape
-    And a bare substring search for "718" is rejected as insufficient, since it
-      matches a sample rate, a byte count, or an unrelated number
+    Then openai_realtime, elevenlabs and websocket each carry the inline-transport marker
+    And webrtc carries a marker stating its inbound queue is unfilled in-tree
+    And composable carries a distinct marker stating it has no transport at all
+    And each marker is found within six lines of the recv_audio definition
 
   # AC9 — transportless stubs stay untouched.
+  # The diff must be taken against origin/main; a working-tree diff is empty on a
+  # committed branch regardless of what changed.
   @unit @gemini-stream-ended
   Scenario: The transportless stub adapters are not modified
     Given livekit and vapi raise PendingTransportError unconditionally
-    When the branch is diffed against origin/main
-    Then neither file appears in the diff
-    And the diff is taken against origin/main rather than the working tree, because a
-      working-tree diff is empty on a committed branch regardless of what changed
+    When the branch is compared against origin/main and the working tree is checked
+    Then neither file appears in the committed diff
+    And neither file appears as uncommitted
 
   # AC10 — coverage is genuinely ungated, proven structurally.
+  # Clearing the variables in the process environment is not proof: the voice
+  # conftest reloads the .env file at import time and silently restores them.
   @unit @gemini-stream-ended
   Scenario: The new tests are creds-free by construction rather than by environment
     Given the voice conftest reloads the .env file at import time
     When the new test file is inspected and the voice suite is run
-    Then no new test is skipped on a credential environment variable
-    And each new test deletes those variables itself
-    And every new node appears as passed and none appears in the skip report
-    And clearing the variables in the process environment is rejected as proof,
-      because the conftest silently restores them
+    Then the new file contains no skipif, importorskip, pytestmark or inline skip
+    And each new test deletes the credential variables itself
+    And every new node appears by name in the passed summary and none appears as skipped
 
   # AC11 — the shared drain contract both branches depend on.
   @integration @gemini-stream-ended
@@ -149,24 +169,34 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
     Given an adapter whose recv_audio raises AgentStreamEndedError
     When the error arrives on the first chunk
     Then the drain propagates it unchanged rather than relabelling it a first-chunk timeout
-    When the error instead arrives on a tail chunk
-    Then the drain ends the turn normally and returns the audio collected so far
+    And when the error instead arrives on a tail chunk the drain ends the turn normally
     And the recv span records a terminated_reason of stream_ended for that exit path
 
   # AC12 — the cross-language half is out of scope but has a home.
   @unit @gemini-stream-ended
   Scenario: JavaScript parity is excluded from this change and tracked elsewhere
     Given the TypeScript SDK has no AgentStreamEndedError at all
-    When the branch is diffed against origin/main
-    Then no file under javascript/ appears in the diff
+    When the branch is compared against origin/main and the working tree is checked
+    Then no file under javascript is committed or uncommitted in this change
     And the TypeScript work is tracked by an open follow-up issue
+
+  # AC13 — the error type and its export path carry their own obligation.
+  # Without this, AC1 is satisfiable by raising the base class with a crafted
+  # message, and the subclass-and-export deliverable has no gate at all.
+  @unit @gemini-stream-ended
+  Scenario: The GeminiLive error subclass is exported from both public modules
+    Given the adapter defines a GeminiLive-specific recv error
+    When it is imported from the voice package and from the adapters package
+    Then both imports resolve to the same object
+    And that object is a subclass of AgentStreamEndedError
+    And it appears in the __all__ of both modules
 
   # --- AC Coverage Map ---
   # AC1  "crashed session task is attributable"        -> Scenario: A session task that crashed surfaces an attributable stream-ended error
   # AC2  "death without an exception is terminal"      -> Scenario: A session task that ended without an exception is still terminal
   # AC3  "already-parked consumer wakes"               -> Scenario: A recv_audio already parked on the session iterator wakes when the session dies
   # AC4  "window vs connect reader"                    -> Scenario: A pre-connect failure still surfaces through connect unchanged
-  # AC4  "window vs disconnect reset"                  -> Scenario: A recv_audio in flight when disconnect clears the error state still raises
+  # AC4  "all three teardown points"                   -> Scenario: A recv_audio parked during disconnect raises at every teardown point
   # AC5  "bug demonstrated behaviourally (red-before)" -> Scenario: The parked-consumer test fails by hanging against unmodified production code
   # AC6  "clean turn not reclassified (regression)"    -> Scenario: A clean end of turn is not reclassified as a terminal error
   # AC7  "pipecat + twilio unaffected (regression)"    -> Scenario: The pipecat and twilio suites stay green with untouched assertions
@@ -175,3 +205,4 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
   # AC10 "ungated coverage proven structurally"        -> Scenario: The new tests are creds-free by construction rather than by environment
   # AC11 "base drain contract pinned"                  -> Scenario: The base drain still distinguishes a first-chunk end from a tail end
   # AC12 "JS parity out of scope, tracked"             -> Scenario: JavaScript parity is excluded from this change and tracked elsewhere
+  # AC13 "error subclass exported both ways"           -> Scenario: The GeminiLive error subclass is exported from both public modules

--- a/specs/voice-gemini-live-stream-ended.feature
+++ b/specs/voice-gemini-live-stream-ended.feature
@@ -44,9 +44,11 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
   #
   #   1. By hand — transcribing @integration into @pytest.mark.integration on a
   #      test node. AC10 pins this case.
-  #   2. AUTOMATICALLY, if this file is ever bound with pytest-bdd `scenarios()`.
-  #      pytest-bdd's default `pytest_bdd_apply_tag` hook does
-  #      `mark = getattr(pytest.mark, tag)` (plugin.py:136), so EVERY Gherkin tag
+  #   2. AUTOMATICALLY, if this file is ever bound with pytest-bdd — via EITHER
+  #      `scenarios()` (plural) or a `@scenario(...)` decorator; both route through
+  #      `_get_scenario_decorator` (scenario.py:319), which calls the hook.
+  #      pytest-bdd's default `pytest_bdd_apply_tag` does
+  #      `mark = getattr(pytest.mark, tag)` (plugin.py:137), so EVERY Gherkin tag
   #      here becomes a pytest marker with nobody typing one. pytest-bdd>=8.1.0 is
   #      already a declared dependency (pyproject.toml:138), and
   #      tests/voice/test_feature_file_contract.py's own docstring names full

--- a/specs/voice-gemini-live-stream-ended.feature
+++ b/specs/voice-gemini-live-stream-ended.feature
@@ -1,0 +1,177 @@
+Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
+  As a developer running a Gemini Live voice scenario
+  I want a terminated Live session to raise an attributable AgentStreamEndedError
+  So that a dead transport surfaces its real cause instead of silently starving
+  recv_audio until the caller's own response_timeout fires on audio that can
+  never arrive
+
+  # ROOT CAUSE (issue #718, verified in code on main @ 88aec40):
+  # GeminiLiveAgentAdapter._session_lifetime opens the SDK session inside an
+  # `async with client.aio.live.connect(...)` block, catches a failure into
+  # self._session_error (gemini_live.py:247-248), and then RETURNS — which exits
+  # the context manager and closes the session. recv_audio (:364) holds a cached
+  # iterator obtained from that same session and NEVER consults _session_error,
+  # so the call parks on `await self._recv_iter.__anext__()` (:411) against a
+  # session nothing will ever feed.
+  #
+  # Three properties of that mechanism drive this spec, and each is a distinct
+  # way a naive fix ships the bug anyway:
+  #   1. recv_audio never reads _session_error at all.
+  #   2. An ENTRY-ONLY check is insufficient. The production hang is a consumer
+  #      ALREADY PARKED inside __anext__() when the session dies. A guard that
+  #      only checks on function entry passes the obvious tests and still hangs.
+  #      (Same lesson as #648: a sentinel test only discriminates if a consumer
+  #      is already blocked when the stream ends.)
+  #   3. _session_error is assigned ONLY inside `except Exception:`, so a task
+  #      that is cancelled (CancelledError is a BaseException) or returns cleanly
+  #      leaves it None while the hang persists. Task-done is the trigger;
+  #      _session_error only supplies the cause when there is one.
+  #
+  # The scoping sweep that produced #718 named five adapters. Only gemini_live
+  # has an unfixed gap; pipecat was fixed by #692 and twilio is already guarded.
+  # openai_realtime, elevenlabs, websocket and composable read their transport
+  # inline; livekit and vapi are transportless stubs; webrtc has the queue half
+  # of the shape but nothing in-tree fills it. The remaining terminal-vs-transient
+  # design calls are deferred to #868, #869, #870 and #871.
+
+  Background:
+    Given a GeminiLiveAgentAdapter connected against a duck-typed fake Live session
+    And the fake session never imports the google-genai SDK and needs no credentials
+    And every recv_audio call in this spec is wrapped in a 5 second guard so a
+      blind hang fails the scenario instead of passing slowly
+
+  # AC1 — the direct gap: a crashed session task is terminal and attributable.
+  @integration @gemini-stream-ended
+  Scenario: A session task that crashed surfaces an attributable stream-ended error
+    Given the background session task has terminated by raising an exception
+    When recv_audio is called
+    Then it raises AgentStreamEndedError within the 5 second guard
+    And the error's string representation names the GeminiLive transport
+    And the error's __cause__ is the exact exception object the session task recorded
+    And it does not return an empty AudioChunk, an asyncio.TimeoutError, or a bare RuntimeError
+
+  # AC2 — a death with no exception is terminal too (the None-cause case).
+  @integration @gemini-stream-ended
+  Scenario: A session task that ended without an exception is still terminal
+    Given the background session task is done and its exception is None
+    When recv_audio is called
+    Then it raises AgentStreamEndedError within the 5 second guard
+    And the message names the task as ended without an error
+    And a __cause__ of None is accepted rather than treated as a failure
+
+  # AC3 — the discriminating case: an ALREADY-PARKED consumer must wake.
+  @integration @gemini-stream-ended
+  Scenario: A recv_audio already parked on the session iterator wakes when the session dies
+    Given the fake session yields nothing so recv_audio suspends inside the iterator
+    And the call is confirmed pending before anything else happens
+    When the background session task is then killed
+    Then the parked call raises AgentStreamEndedError within the 5 second guard
+    And it does not wait out its own 30 second recv timeout
+    And it does not raise asyncio.TimeoutError or return an empty AudioChunk
+
+  # AC4 — the guard's window against the pre-existing reader and teardown.
+  @integration @gemini-stream-ended
+  Scenario: A pre-connect failure still surfaces through connect unchanged
+    Given the session fails before connect returns
+    When connect is awaited
+    Then the original connect-time exception propagates unchanged
+    And it is not swallowed, double-raised, or replaced by AgentStreamEndedError
+
+  @integration @gemini-stream-ended
+  Scenario: A recv_audio in flight when disconnect clears the error state still raises
+    Given a recv_audio call is in flight against a dead session
+    When disconnect resets the recorded session error to None
+    Then the in-flight call still raises AgentStreamEndedError within the 5 second guard
+    And it does not revert to hanging
+
+  # AC5 — the bug is demonstrated behaviourally, not merely by code shape.
+  @integration @gemini-stream-ended
+  Scenario: The parked-consumer test fails by hanging against unmodified production code
+    Given the production guard is absent
+    When the already-parked scenario's test is run
+    Then it fails by reaching its 5 second guard
+    And this rules out the SDK already raising on context-manager exit, which would
+      make the guard dead code
+
+  # AC6 — the regression this change is most likely to introduce.
+  @integration @gemini-stream-ended
+  Scenario: A clean end of turn is not reclassified as a terminal error
+    Given the fake session completes one model turn normally
+    When the drain reads the turn to completion
+    Then recv_audio returns an empty AudioChunk at the turn boundary
+    And turn_complete continues to return an empty chunk
+    And the recv span records a terminated_reason of terminal_chunk, not stream_ended
+    And no pre-existing gemini test changes behaviour
+
+  # AC7 — no regression on the already-correct adapters.
+  @integration @gemini-stream-ended
+  Scenario: The pipecat and twilio suites stay green with untouched assertions
+    Given the pipecat recv-loop suite and the twilio silent-stop suite
+    When they are run against this change
+    Then every node passes
+    And the change adds or removes no assertion line in either file
+
+  # AC8 — the negative result is durable, recorded in code rather than in the issue.
+  @unit @gemini-stream-ended
+  Scenario: Each no-shape adapter records why it has no starvation surface
+    Given the adapters that read their transport inline
+    When each one's recv_audio definition is inspected
+    Then openai_realtime, elevenlabs and websocket each carry the literal marker
+      "no queue, no background reader (#718)"
+    And webrtc carries a #718 marker stating its inbound queue is unfilled in-tree
+      so a subclass that populates it reintroduces the shape
+    And a bare substring search for "718" is rejected as insufficient, since it
+      matches a sample rate, a byte count, or an unrelated number
+
+  # AC9 — transportless stubs stay untouched.
+  @unit @gemini-stream-ended
+  Scenario: The transportless stub adapters are not modified
+    Given livekit and vapi raise PendingTransportError unconditionally
+    When the branch is diffed against origin/main
+    Then neither file appears in the diff
+    And the diff is taken against origin/main rather than the working tree, because a
+      working-tree diff is empty on a committed branch regardless of what changed
+
+  # AC10 — coverage is genuinely ungated, proven structurally.
+  @unit @gemini-stream-ended
+  Scenario: The new tests are creds-free by construction rather than by environment
+    Given the voice conftest reloads the .env file at import time
+    When the new test file is inspected and the voice suite is run
+    Then no new test is skipped on a credential environment variable
+    And each new test deletes those variables itself
+    And every new node appears as passed and none appears in the skip report
+    And clearing the variables in the process environment is rejected as proof,
+      because the conftest silently restores them
+
+  # AC11 — the shared drain contract both branches depend on.
+  @integration @gemini-stream-ended
+  Scenario: The base drain still distinguishes a first-chunk end from a tail end
+    Given an adapter whose recv_audio raises AgentStreamEndedError
+    When the error arrives on the first chunk
+    Then the drain propagates it unchanged rather than relabelling it a first-chunk timeout
+    When the error instead arrives on a tail chunk
+    Then the drain ends the turn normally and returns the audio collected so far
+    And the recv span records a terminated_reason of stream_ended for that exit path
+
+  # AC12 — the cross-language half is out of scope but has a home.
+  @unit @gemini-stream-ended
+  Scenario: JavaScript parity is excluded from this change and tracked elsewhere
+    Given the TypeScript SDK has no AgentStreamEndedError at all
+    When the branch is diffed against origin/main
+    Then no file under javascript/ appears in the diff
+    And the TypeScript work is tracked by an open follow-up issue
+
+  # --- AC Coverage Map ---
+  # AC1  "crashed session task is attributable"        -> Scenario: A session task that crashed surfaces an attributable stream-ended error
+  # AC2  "death without an exception is terminal"      -> Scenario: A session task that ended without an exception is still terminal
+  # AC3  "already-parked consumer wakes"               -> Scenario: A recv_audio already parked on the session iterator wakes when the session dies
+  # AC4  "window vs connect reader"                    -> Scenario: A pre-connect failure still surfaces through connect unchanged
+  # AC4  "window vs disconnect reset"                  -> Scenario: A recv_audio in flight when disconnect clears the error state still raises
+  # AC5  "bug demonstrated behaviourally (red-before)" -> Scenario: The parked-consumer test fails by hanging against unmodified production code
+  # AC6  "clean turn not reclassified (regression)"    -> Scenario: A clean end of turn is not reclassified as a terminal error
+  # AC7  "pipecat + twilio unaffected (regression)"    -> Scenario: The pipecat and twilio suites stay green with untouched assertions
+  # AC8  "negative result recorded in code"            -> Scenario: Each no-shape adapter records why it has no starvation surface
+  # AC9  "stub adapters untouched"                     -> Scenario: The transportless stub adapters are not modified
+  # AC10 "ungated coverage proven structurally"        -> Scenario: The new tests are creds-free by construction rather than by environment
+  # AC11 "base drain contract pinned"                  -> Scenario: The base drain still distinguishes a first-chunk end from a tail end
+  # AC12 "JS parity out of scope, tracked"             -> Scenario: JavaScript parity is excluded from this change and tracked elsewhere

--- a/specs/voice-gemini-live-stream-ended.feature
+++ b/specs/voice-gemini-live-stream-ended.feature
@@ -36,14 +36,26 @@ Feature: Gemini Live voice adapter surfaces a dead session instead of hanging
   # would contradict the pre-connect-failure scenario, and would be inapplicable
   # to the static-check scenarios entirely. Preconditions are stated per scenario.
   #
-  # ⚠ THE @integration TAGS BELOW ARE GHERKIN TAGS, NOT PYTEST MARKERS. Do NOT
-  # transcribe them into @pytest.mark.integration on the test nodes. CI runs
-  # `-m "not integration"` (.github/workflows/python-ci.yml:91), so a node marked
-  # that way is DESELECTED in CI while every local run stays green — the test
-  # would never execute on the gate it exists to satisfy. The auto-marker in
-  # tests/voice/conftest.py keys on the `_e2e.py` filename only, so
-  # test_gemini_live_stream_ended.py is not auto-gated; the only way to break
-  # this is by hand. AC10 pins it.
+  # ⚠ THE @integration TAGS BELOW ARE GHERKIN TAGS. Under CI's selector
+  # `-m "not integration"` (.github/workflows/python-ci.yml:91), anything that
+  # becomes a pytest marker of that name is DESELECTED in CI while every local
+  # run stays green — the test would never execute on the gate it exists to
+  # satisfy. TWO ways that happens, not one:
+  #
+  #   1. By hand — transcribing @integration into @pytest.mark.integration on a
+  #      test node. AC10 pins this case.
+  #   2. AUTOMATICALLY, if this file is ever bound with pytest-bdd `scenarios()`.
+  #      pytest-bdd's default `pytest_bdd_apply_tag` hook does
+  #      `mark = getattr(pytest.mark, tag)` (plugin.py:136), so EVERY Gherkin tag
+  #      here becomes a pytest marker with nobody typing one. pytest-bdd>=8.1.0 is
+  #      already a declared dependency (pyproject.toml:138), and
+  #      tests/voice/test_feature_file_contract.py's own docstring names full
+  #      pytest-bdd binding as a tracked follow-up — so this is the repo's
+  #      DOCUMENTED next step for this file, not a hypothetical.
+  #
+  # If this file is ever bound, override `pytest_bdd_apply_tag` or rename the tag
+  # first. The auto-marker in tests/voice/conftest.py keys on the `_e2e.py`
+  # filename only, so test_gemini_live_stream_ended.py is not auto-gated today.
   #
   # SCOPE. The sweep that produced #718 named five adapters; only gemini_live has
   # an unfixed gap. pipecat was fixed by #692, twilio is already guarded.


### PR DESCRIPTION
**Contract only — no production code yet.** This PR currently carries the behavioural spec for #718. The fix follows.

## What this is

#718 reported that PR #692's "dead recv loop starves `recv_audio`" shape existed in five sibling voice adapters. A grounded read of `main` found the premise holds for **exactly one** unfixed adapter — `gemini_live` — so the scope was narrowed with the owner and the AC set rewritten (8 → 13) before any code was written.

| | |
|---|---|
| **Adapters with the shape** | `pipecat` (fixed by #692), `twilio` (already guarded → #868), `gemini_live` (**the real gap**) |
| **No shape** | `openai_realtime`, `elevenlabs`, `websocket`, `composable` — read their transport inline |
| **No transport** | `livekit`, `vapi` — stubs raising `PendingTransportError` |
| **Latent** | `webrtc` — has the queue, nothing in-tree fills it |

All 14 files in `scenario/voice/adapters/` are accounted for; the issue's original table covered 7.

## Why it hangs

`_session_lifetime` records a crash into `self._session_error` and then **returns**, exiting the `async with` and closing the SDK session. `recv_audio` holds a cached iterator from that session and never consults the crash state — so it parks on `__anext__()` against a session nothing will feed.

Two properties make a naive fix insufficient, and each has its own AC:

1. **An entry-only check still ships the bug.** The production hang is a consumer *already parked* inside `__anext__()` when the session dies. AC3 is the discriminating test.
2. **`_session_error` is `None` for a non-`Exception` death.** It is assigned only inside `except Exception:`, so a cancelled task (`CancelledError` is a `BaseException`) leaves it unset while the hang persists. The guard triggers on task-done, not on that field.

Teardown order matters too: `disconnect()` nulls `_session_task` (`:298`) *before* `_session_error` (`:301`), so `:298` is what actually strands a task-done-triggered guard.

## Follow-ups filed from the gate

#868 twilio sentinel · #869 EL/websocket `ConnectionClosed` · #870 TypeScript has no `AgentStreamEndedError` at all · #871 the voice conftest reloads `.env` at import time, invalidating every `env -u` creds-free proof in the repo.

## How I can prove I was successful

Not yet — no production code. The demonstration will be the falsifiability pair AC5 requires: the parked-consumer test **failing by hanging to its 5s guard** against unmodified production code, paired with the green-after run. This change has no user-observable surface without live Gemini credentials, so that pair *is* the demonstration and will be embedded here.

## Review notes

The AC set went through five independent `ac-reviewer` passes (9 → 6 → 4 → 2 → 0 Must-Fix). Several original ACs were **unfailable** — e.g. `git diff -- javascript/` run from `python/` returns empty even when `javascript/` changed, and `pytest tests/voice -rA -q` never terminates. Every evidence command in the issue is now dry-run verified.

Closes #718

<sub>🤖 Opened by the `issue718` worker session on behalf of the fleet, under the owner's GitHub token for API access.</sub>
