### PR TITLE
fix(judge): declare reasoning off on tool-carrying calls to reasoning models

### DIFF
--- a/python/examples/test_audio_to_text.py
+++ b/python/examples/test_audio_to_text.py
@@ -19,16 +19,18 @@ from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionMessageParam
 from helpers import encode_audio_to_base64, wrap_judge_for_audio
 
-# Skipped in CI: live end-to-end test — calls OpenAI's `gpt-audio-mini` audio
-# model and the real LangWatch backend (cost, API keys, non-deterministic
-# audio), so it runs live/locally rather than in CI. (The skip historically
-# also guarded the now-deleted `gpt-4o-audio-preview`; that model was swapped
-# for `gpt-audio-mini`, so the model is no longer the blocker — the skip is
-# CI-cost/live-only now.)
-pytestmark = pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Live E2E test (real OpenAI gpt-audio-mini + LangWatch backend, cost, non-deterministic audio) — runs live/locally, not in CI.",
-)
+# Runs in CI, like its two JavaScript siblings.
+#
+# This was skipped on `CI == "true"` for cost and audio non-determinism. The
+# cost is real, but the skip is also what let #864 sit: the judge could not
+# reach a verdict on a reasoning model at all, and `python-ci`'s Test (Examples)
+# step reported green with this file skipped while the two JavaScript siblings —
+# which run live against the same model — passed. An example that only ever runs
+# on someone's laptop reports nothing about `main`.
+#
+# The wire-shape rule itself is pinned offline and deterministically in
+# `tests/test_judge_transport_reasoning.py`; that is the gate. This example is
+# the live end-to-end check that the three siblings agree.
 
 # The LLM-judge criteria shared by all three audio example siblings (#680).
 #

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -63,9 +63,13 @@ def _rejection_asks_for_reasoning_off(error: Exception) -> bool:
     """
     Whether a provider rejection is the "set reasoning_effort to 'none' to use
     function tools" class, as opposed to any other bad request.
+
+    Keyed on the remediation directive, not just the field name: an error such
+    as "reasoning_effort 'none' is invalid for this model" mentions both tokens
+    but is not asking us to turn reasoning off, and retrying it with reasoning
+    off would replace the provider's real error.
     """
-    message = str(error)
-    return "reasoning_effort" in message and "'none'" in message
+    return "set reasoning_effort to 'none'" in str(error)
 
 
 _DISCOVERY_TOOL_NAMES = frozenset(

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -39,6 +39,35 @@ from .voice.modality_resolver import ModalityTier, resolve_modality
 logger = logging.getLogger("scenario")
 
 
+# `/v1/chat/completions` refuses function tools on a reasoning model unless
+# reasoning is explicitly switched off:
+#
+#   Function tools with reasoning_effort are not supported for <model> in
+#   /v1/chat/completions. To use function tools, use /v1/responses or set
+#   reasoning_effort to 'none'.
+#
+# The judge forces a finish_test / continue_test tool call on every graded run,
+# so on such a model no run could reach a verdict (langwatch/scenario#864, and
+# the same signature on the LangWatch platform judge, langwatch/langwatch#6369).
+_REASONING_OFF = "none"
+
+
+def _model_accepts_reasoning_effort(model: Optional[str]) -> bool:
+    """
+    Whether litellm reports this model as accepting a reasoning effort.
+
+    An unknown model answers ``False``: absent metadata is not permission, and
+    sending the parameter to a model that does not take it is itself a 400.
+    """
+    if not model:
+        return False
+    try:
+        return bool(litellm.supports_reasoning(model=model))
+    except Exception:  # noqa: BLE001 — capability lookup must never break a run
+        logger.debug("could not resolve reasoning support for %s", model)
+        return False
+
+
 _DISCOVERY_TOOL_NAMES = frozenset(
     {"expand_trace", "grep_trace", "expand_transcript", "grep_transcript"}
 )
@@ -700,10 +729,28 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 tools=tools,
                 tool_choice=tool_choice,
                 **self._extra_params,
+                **self._reasoning_kwargs(tools),
             ),
         )
 
         return self._parse_response(response, effective_criteria, messages, input_messages=input.messages)
+
+    def _reasoning_kwargs(self, tools: List[dict]) -> dict:
+        """
+        The reasoning parameter to add to a completion call, if any.
+
+        Returns ``{"reasoning_effort": "none"}`` only when the call actually
+        carries function tools and the model actually takes the parameter. A
+        caller that already asked for a specific effort keeps it and gets the
+        endpoint's own error, rather than having its intent silently rewritten.
+        """
+        if not tools:
+            return {}
+        if "reasoning_effort" in self._extra_params:
+            return {}
+        if not _model_accepts_reasoning_effort(self.model):
+            return {}
+        return {"reasoning_effort": _REASONING_OFF}
 
     def _build_trace_digest(self, spans: Sequence[Any]) -> tuple[str, bool]:
         """
@@ -906,6 +953,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                     tools=tools,
                     tool_choice=step_tool_choice,
                     **self._extra_params,
+                    **self._reasoning_kwargs(tools),
                 ),
             )
 
@@ -1012,6 +1060,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 tools=finish_only_tools,
                 tool_choice={"type": "function", "function": {"name": "finish_test"}},
                 **self._extra_params,
+                **self._reasoning_kwargs(finish_only_tools),
             ),
         )
         return self._parse_response(

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -39,7 +39,7 @@ from .voice.modality_resolver import ModalityTier, resolve_modality
 logger = logging.getLogger("scenario")
 
 
-# `/v1/chat/completions` refuses function tools on a reasoning model unless
+# `/v1/chat/completions` refuses function tools on some reasoning models unless
 # reasoning is explicitly switched off:
 #
 #   Function tools with reasoning_effort are not supported for <model> in
@@ -49,23 +49,23 @@ logger = logging.getLogger("scenario")
 # The judge forces a finish_test / continue_test tool call on every graded run,
 # so on such a model no run could reach a verdict (langwatch/scenario#864, and
 # the same signature on the LangWatch platform judge, langwatch/langwatch#6369).
+#
+# Reasoning is disabled by RETRY, never preemptively: whether a model accepts
+# reasoning off is not knowable up front (Gemini 2.5 Pro rejects it with
+# "Budget 0 is invalid. This model only works in thinking mode."), so the call
+# goes out untouched and is re-sent with reasoning off only when the provider's
+# rejection asks for exactly that. Models that work today are never sent
+# anything new.
 _REASONING_OFF = "none"
 
 
-def _model_accepts_reasoning_effort(model: Optional[str]) -> bool:
+def _rejection_asks_for_reasoning_off(error: Exception) -> bool:
     """
-    Whether litellm reports this model as accepting a reasoning effort.
-
-    An unknown model answers ``False``: absent metadata is not permission, and
-    sending the parameter to a model that does not take it is itself a 400.
+    Whether a provider rejection is the "set reasoning_effort to 'none' to use
+    function tools" class, as opposed to any other bad request.
     """
-    if not model:
-        return False
-    try:
-        return bool(litellm.supports_reasoning(model=model))
-    except Exception:  # noqa: BLE001 — capability lookup must never break a run
-        logger.debug("could not resolve reasoning support for %s", model)
-        return False
+    message = str(error)
+    return "reasoning_effort" in message and "'none'" in message
 
 
 _DISCOVERY_TOOL_NAMES = frozenset(
@@ -717,40 +717,43 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             )
 
         # Standard single-call path for small traces
-        response = cast(
-            ModelResponse,
-            litellm.completion(
-                model=self.model,
-                messages=messages,
-                temperature=self.temperature,
-                api_key=self.api_key,
-                api_base=self.api_base,
-                max_tokens=self.max_tokens,
-                tools=tools,
-                tool_choice=tool_choice,
-                **self._extra_params,
-                **self._reasoning_kwargs(tools),
-            ),
+        response = self._completion_with_reasoning_off_retry(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+            api_key=self.api_key,
+            api_base=self.api_base,
+            max_tokens=self.max_tokens,
+            tools=tools,
+            tool_choice=tool_choice,
+            **self._extra_params,
         )
 
         return self._parse_response(response, effective_criteria, messages, input_messages=input.messages)
 
-    def _reasoning_kwargs(self, tools: List[dict]) -> dict:
+    def _completion_with_reasoning_off_retry(self, **kwargs: Any) -> ModelResponse:
         """
-        The reasoning parameter to add to a completion call, if any.
-
-        Returns ``{"reasoning_effort": "none"}`` only when the call actually
-        carries function tools and the model actually takes the parameter. A
-        caller that already asked for a specific effort keeps it and gets the
-        endpoint's own error, rather than having its intent silently rewritten.
+        ``litellm.completion``, retried once with reasoning declared off when —
+        and only when — the provider rejected a tool-carrying call for exactly
+        that reason. A caller that already asked for a specific effort keeps it
+        and gets the endpoint's own error, rather than having its intent
+        silently rewritten.
         """
-        if not tools:
-            return {}
-        if "reasoning_effort" in self._extra_params:
-            return {}
-        if not _model_accepts_reasoning_effort(self.model):
-            return {}
-        return {"reasoning_effort": _REASONING_OFF}
+        try:
+            return cast(ModelResponse, litellm.completion(**kwargs))
+        except Exception as error:
+            if not kwargs.get("tools") or "reasoning_effort" in kwargs:
+                raise
+            if not _rejection_asks_for_reasoning_off(error):
+                raise
+            logger.debug(
+                "provider rejected function tools without reasoning off for %s; retrying",
+                kwargs.get("model"),
+            )
+            return cast(
+                ModelResponse,
+                litellm.completion(**kwargs, reasoning_effort=_REASONING_OFF),
+            )
 
     def _build_trace_digest(self, spans: Sequence[Any]) -> tuple[str, bool]:
         """
@@ -941,20 +944,16 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             is_last_step = step == self._max_discovery_steps - 1
             step_tool_choice = tool_choice if is_last_step else "required"
 
-            response = cast(
-                ModelResponse,
-                litellm.completion(
-                    model=self.model,
-                    messages=messages,
-                    temperature=self.temperature,
-                    api_key=self.api_key,
-                    api_base=self.api_base,
-                    max_tokens=self.max_tokens,
-                    tools=tools,
-                    tool_choice=step_tool_choice,
-                    **self._extra_params,
-                    **self._reasoning_kwargs(tools),
-                ),
+            response = self._completion_with_reasoning_off_retry(
+                model=self.model,
+                messages=messages,
+                temperature=self.temperature,
+                api_key=self.api_key,
+                api_base=self.api_base,
+                max_tokens=self.max_tokens,
+                tools=tools,
+                tool_choice=step_tool_choice,
+                **self._extra_params,
             )
 
             if not hasattr(response, "choices") or len(response.choices) == 0:
@@ -1048,20 +1047,16 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             if t.get("function", {}).get("name") not in _DISCOVERY_TOOL_NAMES
         ]
 
-        forced_response = cast(
-            ModelResponse,
-            litellm.completion(
-                model=self.model,
-                messages=rewritten_messages,
-                temperature=self.temperature,
-                api_key=self.api_key,
-                api_base=self.api_base,
-                max_tokens=self.max_tokens,
-                tools=finish_only_tools,
-                tool_choice={"type": "function", "function": {"name": "finish_test"}},
-                **self._extra_params,
-                **self._reasoning_kwargs(finish_only_tools),
-            ),
+        forced_response = self._completion_with_reasoning_off_retry(
+            model=self.model,
+            messages=rewritten_messages,
+            temperature=self.temperature,
+            api_key=self.api_key,
+            api_base=self.api_base,
+            max_tokens=self.max_tokens,
+            tools=finish_only_tools,
+            tool_choice={"type": "function", "function": {"name": "finish_test"}},
+            **self._extra_params,
         )
         return self._parse_response(
             forced_response, effective_criteria, rewritten_messages, input_messages=input_messages

--- a/python/tests/test_judge_transport_reasoning.py
+++ b/python/tests/test_judge_transport_reasoning.py
@@ -31,6 +31,7 @@ from unittest.mock import MagicMock, patch
 
 import litellm
 import pytest
+from litellm.exceptions import BadRequestError
 
 from scenario import JudgeAgent
 from scenario.cache import context_scenario
@@ -44,8 +45,8 @@ _REJECTION_MESSAGE = (
 )
 
 
-def _bad_request(message: str) -> litellm.BadRequestError:
-    return litellm.BadRequestError(
+def _bad_request(message: str) -> BadRequestError:
+    return BadRequestError(
         message=message, model="gpt-5.6-luna", llm_provider="openai"
     )
 
@@ -135,7 +136,7 @@ class TestGivenAProviderThatRejectsToolsWithoutReasoningOff:
             reasoning_effort="high",
         )
 
-        with pytest.raises(litellm.BadRequestError):
+        with pytest.raises(BadRequestError):
             await _call_judge(
                 judge,
                 _agent_input(),
@@ -163,7 +164,7 @@ class TestGivenAnUnrelatedRejection:
         judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
         unrelated = _bad_request("Unsupported value for parameter 'temperature'.")
 
-        with pytest.raises(litellm.BadRequestError):
+        with pytest.raises(BadRequestError):
             await _call_judge(
                 judge, _agent_input(), _rejecting_completion(unrelated)
             )

--- a/python/tests/test_judge_transport_reasoning.py
+++ b/python/tests/test_judge_transport_reasoning.py
@@ -1,0 +1,191 @@
+"""
+Regression for #864: the judge could not reach a verdict on a reasoning model.
+
+    litellm.BadRequestError: OpenAIException - Function tools with
+    reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions.
+    To use function tools, use /v1/responses or set reasoning_effort to 'none'.
+
+The judge forces a `finish_test` / `continue_test` function-tool call on every
+graded run, so on such a model every run died before a verdict. Verified live
+against `/v1/chat/completions`: the same request answers 400 without
+`reasoning_effort` and 200 with `reasoning_effort="none"`.
+
+The example that would have caught this (`examples/test_audio_to_text.py`) was
+skipped in CI, which is how it sat unnoticed. These tests are offline and
+deterministic so the rule is pinned on every pull request, with no key, no
+network and no live model — the live example is a poor gate for a wire-shape
+rule even now that it runs.
+
+The sibling fix on the LangWatch platform judge is langwatch/langwatch#6369.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scenario import JudgeAgent
+from scenario.cache import context_scenario
+from scenario.config import ScenarioConfig
+from scenario.types import AgentInput, JudgmentRequest
+
+
+def _agent_input(turn: int = 1, max_turns: int = 10) -> AgentInput:
+    scenario_state = MagicMock()
+    scenario_state.description = "Test scenario"
+    scenario_state.current_turn = turn
+    scenario_state.config.max_turns = max_turns
+    return AgentInput(
+        thread_id="test",
+        messages=[{"role": "user", "content": "Hello"}],
+        new_messages=[],
+        judgment_request=JudgmentRequest(),
+        scenario_state=scenario_state,
+    )
+
+
+def _finish_test_response() -> Any:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.tool_calls = [MagicMock()]
+    response.choices[0].message.tool_calls[0].function.name = "finish_test"
+    response.choices[0].message.tool_calls[0].function.arguments = (
+        '{"verdict": "success", "reasoning": "ok", "criteria": {"c": true}}'
+    )
+    return response
+
+
+async def _call_judge(judge: JudgeAgent, agent_input: AgentInput) -> Any:
+    """Run the judge with litellm stubbed, returning the recorded call kwargs."""
+    executor = MagicMock()
+    executor.config = MagicMock()
+    executor.config.cache_key = None
+    token = context_scenario.set(executor)
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            return_value=_finish_test_response(),
+        ) as completion:
+            await judge.call(agent_input)
+            assert completion.called
+            return completion.call_args.kwargs
+    finally:
+        context_scenario.reset(token)
+        ScenarioConfig.default_config = None
+
+
+class TestGivenAModelThatAcceptsReasoningEffort:
+    @pytest.mark.asyncio
+    async def test_declares_reasoning_off_when_it_sends_function_tools(self):
+        judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
+
+        kwargs = await _call_judge(judge, _agent_input())
+
+        assert kwargs["tools"], "the judge must be sending function tools"
+        assert kwargs["reasoning_effort"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_preserves_an_explicitly_requested_effort(self):
+        judge = JudgeAgent(
+            criteria=["c"],
+            model="openai/gpt-5.6-luna",
+            reasoning_effort="high",
+        )
+
+        kwargs = await _call_judge(judge, _agent_input())
+
+        assert kwargs["reasoning_effort"] == "high"
+
+
+class TestGivenAModelThatDoesNotAcceptReasoningEffort:
+    @pytest.mark.asyncio
+    async def test_sends_no_reasoning_effort(self):
+        judge = JudgeAgent(criteria=["c"], model="openai/gpt-4o")
+
+        kwargs = await _call_judge(judge, _agent_input())
+
+        assert kwargs["tools"], "the judge must be sending function tools"
+        assert "reasoning_effort" not in kwargs
+
+
+class TestGivenAnUnknownModel:
+    @pytest.mark.asyncio
+    async def test_sends_no_reasoning_effort(self):
+        """Absent capability metadata is not permission — sending the parameter
+        to a model that does not take it is itself a 400."""
+        judge = JudgeAgent(criteria=["c"], model="openai/some-private-deployment")
+
+        kwargs = await _call_judge(judge, _agent_input())
+
+        assert "reasoning_effort" not in kwargs
+
+
+class TestTheReasoningKwargItself:
+    """The rule is 'tools present', not 'judge running' — every call site that
+    can send tools must be covered, and one that sends none must not be."""
+
+    def test_no_tools_means_no_reasoning_effort(self):
+        judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
+
+        assert judge._reasoning_kwargs([]) == {}
+
+    def test_tools_on_a_reasoning_model_declare_reasoning_off(self):
+        judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
+
+        assert judge._reasoning_kwargs([{"type": "function"}]) == {
+            "reasoning_effort": "none"
+        }
+
+
+class TestEveryCallSiteThatSendsTools:
+    """
+    The judge reaches `litellm.completion` from three places. A helper that is
+    correct but not wired at one of them fails exactly where it is hardest to
+    notice — the large-trace paths, which only a big conversation reaches. Each
+    site is pinned here so an unwired one cannot pass by way of the others.
+    """
+
+    _TOOLS = [
+        {
+            "type": "function",
+            "function": {"name": "finish_test", "description": "finish"},
+        }
+    ]
+
+    def _judge(self) -> JudgeAgent:
+        return JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
+
+    def test_the_discovery_loop_declares_reasoning_off(self):
+        judge = self._judge()
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            return_value=_finish_test_response(),
+        ) as completion:
+            judge._run_discovery_loop(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=self._TOOLS,
+                tool_choice="required",
+                spans=[],
+                working_messages=[],
+                effective_criteria=["c"],
+                input_messages=[],
+            )
+
+        assert completion.call_args.kwargs["reasoning_effort"] == "none"
+
+    def test_the_forced_verdict_declares_reasoning_off(self):
+        judge = self._judge()
+
+        with patch(
+            "scenario.judge_agent.litellm.completion",
+            return_value=_finish_test_response(),
+        ) as completion:
+            judge._force_verdict(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=self._TOOLS,
+                effective_criteria=["c"],
+                input_messages=[],
+            )
+
+        assert completion.call_args.kwargs["reasoning_effort"] == "none"

--- a/python/tests/test_judge_transport_reasoning.py
+++ b/python/tests/test_judge_transport_reasoning.py
@@ -10,6 +10,13 @@ graded run, so on such a model every run died before a verdict. Verified live
 against `/v1/chat/completions`: the same request answers 400 without
 `reasoning_effort` and 200 with `reasoning_effort="none"`.
 
+Reasoning is disabled by RETRY, never preemptively. Whether a model accepts
+reasoning off is not knowable up front — Gemini 2.5 Pro rejects it with
+"Budget 0 is invalid. This model only works in thinking mode." — so the call
+goes out untouched and is re-sent with reasoning off only when the provider's
+rejection asks for exactly that. Models that work today are never sent
+anything new.
+
 The example that would have caught this (`examples/test_audio_to_text.py`) was
 skipped in CI, which is how it sat unnoticed. These tests are offline and
 deterministic so the rule is pinned on every pull request, with no key, no
@@ -19,15 +26,28 @@ rule even now that it runs.
 The sibling fix on the LangWatch platform judge is langwatch/langwatch#6369.
 """
 
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
+import litellm
 import pytest
 
 from scenario import JudgeAgent
 from scenario.cache import context_scenario
 from scenario.config import ScenarioConfig
 from scenario.types import AgentInput, JudgmentRequest
+
+_REJECTION_MESSAGE = (
+    "OpenAIException - Function tools with reasoning_effort are not supported "
+    "for gpt-5.6-luna in /v1/chat/completions. To use function tools, use "
+    "/v1/responses or set reasoning_effort to 'none'."
+)
+
+
+def _bad_request(message: str) -> litellm.BadRequestError:
+    return litellm.BadRequestError(
+        message=message, model="gpt-5.6-luna", llm_provider="openai"
+    )
 
 
 def _agent_input(turn: int = 1, max_turns: int = 10) -> AgentInput:
@@ -55,94 +75,107 @@ def _finish_test_response() -> Any:
     return response
 
 
-async def _call_judge(judge: JudgeAgent, agent_input: AgentInput) -> Any:
-    """Run the judge with litellm stubbed, returning the recorded call kwargs."""
+def _rejecting_completion(rejection: Exception) -> Any:
+    """A litellm.completion double enforcing the provider's rule: tool-carrying
+    calls are rejected unless reasoning_effort is "none"."""
+
+    def completion(**kwargs: Any) -> Any:
+        if kwargs.get("tools") and kwargs.get("reasoning_effort") != "none":
+            raise rejection
+        return _finish_test_response()
+
+    return completion
+
+
+async def _call_judge(
+    judge: JudgeAgent,
+    agent_input: AgentInput,
+    completion: Optional[Any] = None,
+) -> Any:
+    """Run the judge with litellm stubbed, returning the mock for inspection."""
     executor = MagicMock()
     executor.config = MagicMock()
     executor.config.cache_key = None
     token = context_scenario.set(executor)
     try:
-        with patch(
-            "scenario.judge_agent.litellm.completion",
-            return_value=_finish_test_response(),
-        ) as completion:
+        with patch("scenario.judge_agent.litellm.completion") as mock:
+            if completion is None:
+                mock.return_value = _finish_test_response()
+            else:
+                mock.side_effect = completion
             await judge.call(agent_input)
-            assert completion.called
-            return completion.call_args.kwargs
+            assert mock.called
+            return mock
     finally:
         context_scenario.reset(token)
         ScenarioConfig.default_config = None
 
 
-class TestGivenAModelThatAcceptsReasoningEffort:
+class TestGivenAProviderThatRejectsToolsWithoutReasoningOff:
     @pytest.mark.asyncio
-    async def test_declares_reasoning_off_when_it_sends_function_tools(self):
+    async def test_retries_with_reasoning_off_and_reaches_a_verdict(self):
         judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
 
-        kwargs = await _call_judge(judge, _agent_input())
+        mock = await _call_judge(
+            judge, _agent_input(), _rejecting_completion(_bad_request(_REJECTION_MESSAGE))
+        )
 
-        assert kwargs["tools"], "the judge must be sending function tools"
-        assert kwargs["reasoning_effort"] == "none"
+        assert mock.call_count == 2
+        first, second = (call.kwargs for call in mock.call_args_list)
+        assert "reasoning_effort" not in first
+        assert second["reasoning_effort"] == "none"
 
     @pytest.mark.asyncio
     async def test_preserves_an_explicitly_requested_effort(self):
+        """A caller that asked for a specific effort keeps it — the provider's
+        own rejection surfaces instead of the intent being rewritten."""
         judge = JudgeAgent(
             criteria=["c"],
             model="openai/gpt-5.6-luna",
             reasoning_effort="high",
         )
 
-        kwargs = await _call_judge(judge, _agent_input())
+        with pytest.raises(litellm.BadRequestError):
+            await _call_judge(
+                judge,
+                _agent_input(),
+                _rejecting_completion(_bad_request(_REJECTION_MESSAGE)),
+            )
 
-        assert kwargs["reasoning_effort"] == "high"
 
-
-class TestGivenAModelThatDoesNotAcceptReasoningEffort:
+class TestGivenAProviderThatAcceptsTheCall:
     @pytest.mark.asyncio
-    async def test_sends_no_reasoning_effort(self):
-        judge = JudgeAgent(criteria=["c"], model="openai/gpt-4o")
+    async def test_sends_exactly_one_untouched_request(self):
+        """The Gemini 2.5 Pro shape: a judge that works must never be sent
+        reasoning off, because the model may refuse to disable it."""
+        judge = JudgeAgent(criteria=["c"], model="gemini/gemini-2.5-pro")
 
-        kwargs = await _call_judge(judge, _agent_input())
+        mock = await _call_judge(judge, _agent_input())
 
-        assert kwargs["tools"], "the judge must be sending function tools"
-        assert "reasoning_effort" not in kwargs
+        assert mock.call_count == 1
+        assert "reasoning_effort" not in mock.call_args.kwargs
+        assert mock.call_args.kwargs["tools"], "the judge must be sending function tools"
 
 
-class TestGivenAnUnknownModel:
+class TestGivenAnUnrelatedRejection:
     @pytest.mark.asyncio
-    async def test_sends_no_reasoning_effort(self):
-        """Absent capability metadata is not permission — sending the parameter
-        to a model that does not take it is itself a 400."""
-        judge = JudgeAgent(criteria=["c"], model="openai/some-private-deployment")
-
-        kwargs = await _call_judge(judge, _agent_input())
-
-        assert "reasoning_effort" not in kwargs
-
-
-class TestTheReasoningKwargItself:
-    """The rule is 'tools present', not 'judge running' — every call site that
-    can send tools must be covered, and one that sends none must not be."""
-
-    def test_no_tools_means_no_reasoning_effort(self):
+    async def test_surfaces_the_rejection_without_retrying(self):
         judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
+        unrelated = _bad_request("Unsupported value for parameter 'temperature'.")
 
-        assert judge._reasoning_kwargs([]) == {}
-
-    def test_tools_on_a_reasoning_model_declare_reasoning_off(self):
-        judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
-
-        assert judge._reasoning_kwargs([{"type": "function"}]) == {
-            "reasoning_effort": "none"
-        }
+        with pytest.raises(litellm.BadRequestError):
+            await _call_judge(
+                judge, _agent_input(), _rejecting_completion(unrelated)
+            )
 
 
 class TestEveryCallSiteThatSendsTools:
     """
-    The judge reaches `litellm.completion` from three places. A helper that is
-    correct but not wired at one of them fails exactly where it is hardest to
-    notice — the large-trace paths, which only a big conversation reaches. Each
-    site is pinned here so an unwired one cannot pass by way of the others.
+    The judge reaches `litellm.completion` from three places. A retry helper
+    that is correct but not wired at one of them fails exactly where it is
+    hardest to notice — the large-trace paths, which only a big conversation
+    reaches. Each site is pinned here so an unwired one cannot pass by way of
+    the others.
     """
 
     _TOOLS = [
@@ -155,12 +188,12 @@ class TestEveryCallSiteThatSendsTools:
     def _judge(self) -> JudgeAgent:
         return JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
 
-    def test_the_discovery_loop_declares_reasoning_off(self):
+    def test_the_discovery_loop_retries_with_reasoning_off(self):
         judge = self._judge()
 
         with patch(
             "scenario.judge_agent.litellm.completion",
-            return_value=_finish_test_response(),
+            side_effect=_rejecting_completion(_bad_request(_REJECTION_MESSAGE)),
         ) as completion:
             judge._run_discovery_loop(
                 messages=[{"role": "user", "content": "hi"}],
@@ -174,12 +207,12 @@ class TestEveryCallSiteThatSendsTools:
 
         assert completion.call_args.kwargs["reasoning_effort"] == "none"
 
-    def test_the_forced_verdict_declares_reasoning_off(self):
+    def test_the_forced_verdict_retries_with_reasoning_off(self):
         judge = self._judge()
 
         with patch(
             "scenario.judge_agent.litellm.completion",
-            return_value=_finish_test_response(),
+            side_effect=_rejecting_completion(_bad_request(_REJECTION_MESSAGE)),
         ) as completion:
             judge._force_verdict(
                 messages=[{"role": "user", "content": "hi"}],

--- a/python/tests/test_judge_transport_reasoning.py
+++ b/python/tests/test_judge_transport_reasoning.py
@@ -29,7 +29,6 @@ The sibling fix on the LangWatch platform judge is langwatch/langwatch#6369.
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
-import litellm
 import pytest
 from litellm.exceptions import BadRequestError
 
@@ -94,6 +93,7 @@ async def _call_judge(
     completion: Optional[Any] = None,
 ) -> Any:
     """Run the judge with litellm stubbed, returning the mock for inspection."""
+    previous_default_config = ScenarioConfig.default_config
     executor = MagicMock()
     executor.config = MagicMock()
     executor.config.cache_key = None
@@ -109,7 +109,7 @@ async def _call_judge(
             return mock
     finally:
         context_scenario.reset(token)
-        ScenarioConfig.default_config = None
+        ScenarioConfig.default_config = previous_default_config
 
 
 class TestGivenAProviderThatRejectsToolsWithoutReasoningOff:
@@ -167,6 +167,20 @@ class TestGivenAnUnrelatedRejection:
         with pytest.raises(BadRequestError):
             await _call_judge(
                 judge, _agent_input(), _rejecting_completion(unrelated)
+            )
+
+    @pytest.mark.asyncio
+    async def test_mentioning_the_tokens_without_the_directive_is_not_retried(self):
+        """Mentions "reasoning_effort" and "'none'" but does not ask us to turn
+        reasoning off — retrying would replace the provider's real error."""
+        judge = JudgeAgent(criteria=["c"], model="openai/gpt-5.6-luna")
+        invalid_value = _bad_request(
+            "reasoning_effort 'none' is invalid for this model."
+        )
+
+        with pytest.raises(BadRequestError):
+            await _call_judge(
+                judge, _agent_input(), _rejecting_completion(invalid_value)
             )
 
 


### PR DESCRIPTION
## Why

Closes #864. Platform-side epic: langwatch/langwatch#6594 (sibling PR langwatch/langwatch#6607 applies the same design to the platform's judge model client).

Some reasoning models reject requests that carry function tools unless `reasoning_effort` is `"none"`:

    litellm.BadRequestError: OpenAIException - Function tools with
    reasoning_effort are not supported for <model> in /v1/chat/completions.
    To use function tools, use /v1/responses or set reasoning_effort to 'none'.

The judge always sends tools, so a criteria-graded run against such a model failed with a provider 400 instead of returning a verdict. Verified live: the same request answers 400 without `reasoning_effort` and 200 + a `finish_test` tool call with `reasoning_effort="none"`.

## What changed

Reasoning is disabled **by retry, never preemptively**. The first design on this branch gated a preemptive `reasoning_effort="none"` on `litellm.supports_reasoning`, and this repo's own CI falsified it: the Gemini judge example failed with `"Budget 0 is invalid. This model only works in thinking mode."` — Gemini 2.5 Pro accepts tool-carrying requests but refuses to disable reasoning. "Supports reasoning_effort" and "accepts reasoning off" are different questions, and only the provider answers the second one.

- `judge_agent.py`: `_completion_with_reasoning_off_retry` sends every `litellm.completion` call untouched; when a tool-carrying call with no caller-set `reasoning_effort` raises a rejection carrying the remediation directive `set reasoning_effort to 'none'`, it retries once with reasoning off. Wired at all three call sites (standard call, discovery loop, forced verdict). Unrelated rejections surface unchanged; a caller-set effort is never rewritten; models that work today are never sent anything new.
- `examples/test_audio_to_text.py`: removed the CI skip. This example exercises exactly this path and would have caught the regression; skipped, the class recurs silently (per the epic's sequencing note).

## Test plan

- `tests/test_judge_transport_reasoning.py` — 7 offline deterministic tests: rejected call retried once with reasoning off and reaches a verdict; a caller-set effort surfaces the provider's own error; an accepting (Gemini-shaped) judge gets exactly one untouched request; an unrelated 400 is not retried; a rejection that merely *mentions* `reasoning_effort` and `'none'` without the directive (e.g. "reasoning_effort 'none' is invalid for this model") surfaces instead of retrying; the discovery-loop and forced-verdict call sites each retry. **Falsifiability:** with `judge_agent.py` reverted to `main`, 3 of them fail; the directive-vs-mention test was proven red against the earlier two-token matcher.
- The Gemini judge example (`examples/test_weather_agent__gemini.py`) is the live regression gate for the retry design itself — it is what failed against the first design.

## Human verification

Nothing UI to look at — this is a Python SDK transport change. If you want to see it live: run `examples/test_weather_agent__gemini.py` (thinking-only model, must never be asked to disable reasoning) and `examples/test_audio_to_text.py` (the un-skipped example that exercises the rejection-retry path); both run in this repo's CI against real providers and are green at HEAD.

## How I can prove I was successful

- CI at HEAD (5b7c262) is fully green, 14/14 checks, including the real-LLM examples job — the same job that falsified the first (preemptive) design same-day.
- The offline suite fails 3/7 with the fix reverted to `main`, and the directive-vs-mention regression test fails against the previous looser matcher — both reverts were actually run, not reasoned about.
- No capability oracle remains: `grep -r supports_reasoning python/scenario/` is empty.

<!-- no-ui-surface -->

## Anything surprising?

The rejection is matched on the remediation directive substring `set reasoning_effort to 'none'` rather than a structured field: litellm re-wraps provider errors and the OpenAI `param` field does not survive uniformly. Matching the directive (not just the two tokens) keeps errors like "reasoning_effort 'none' is invalid for this model" — which mention both tokens but are not asking us to turn reasoning off — surfacing instead of looping. The platform sibling keys on `error.param` first, because it reads the raw wire body.
