### PR TITLE
fix: don't merge checkpoint criteria twice into ScenarioResult

### DIFF
--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1739,15 +1739,18 @@ class ScenarioExecutor:
                     # Checkpoint passed: continue script
                     return None
                 else:
-                    # Checkpoint failed: compile all results into the failing result.
-                    compiled_passed, compiled_failed = self._compiled_checkpoints
-                    result.passed_criteria = compiled_passed
+                    # Checkpoint failed: compile the failed criteria into the
+                    # failing result. This checkpoint's own passes are already
+                    # in _compiled_checkpoints (recorded just above), and run()
+                    # prepends those to every ScenarioResult a script step
+                    # returns — so anything left here would be reported twice.
+                    _, compiled_failed = self._compiled_checkpoints
+                    result.passed_criteria = []
                     result.failed_criteria = compiled_failed
                     return result
             else:
-                # Final judge evaluation — merge prior checkpoint criteria
-                compiled_passed, _ = self._compiled_checkpoints
-                result.passed_criteria = compiled_passed + result.passed_criteria
+                # Final judge evaluation. Prior checkpoint criteria are merged
+                # by run(), not here.
                 return result
 
     # Event handling methods

--- a/python/tests/test_scenario_executor.py
+++ b/python/tests/test_scenario_executor.py
@@ -460,6 +460,53 @@ async def test_inline_criteria_fail_includes_accumulated():
     assert "this will fail" in result.failed_criteria
 
 
+@pytest.mark.asyncio
+async def test_accumulated_criteria_are_not_duplicated():
+    """Checkpoint criteria are merged by run(); _script_call_agent must not
+    merge them a second time. Membership assertions cannot see a duplicate,
+    so this asserts the exact list."""
+    def build(final_step):
+        return ScenarioExecutor(
+            name="test no duplicates", description="test",
+            agents=[
+                MockAgent(),
+                MockUserSimulatorAgent(model="none"),
+                InlineCriteriaMockJudgeAgent(model="none", criteria=["final criterion passes"]),
+            ],
+            script=[
+                user("hello"), agent(), judge(criteria=["criterion A passes"]),
+                user("more"), agent(), final_step,
+            ],
+        )
+
+    # Checkpoint-failure path.
+    result = await build(judge(criteria=["this will fail"])).run()
+    assert not result.success
+    assert result.passed_criteria == ["criterion A passes"]
+    assert result.failed_criteria == ["this will fail"]
+
+    # Checkpoint-failure path where the failing checkpoint also passed a
+    # criterion — that one is already compiled, so it must not come back twice.
+    result = await build(
+        judge(criteria=["criterion B passes", "this will fail"])
+    ).run()
+    assert not result.success
+    assert result.passed_criteria == ["criterion A passes", "criterion B passes"]
+    assert result.failed_criteria == ["this will fail"]
+
+    # Final-judge path — a *passing* result must be clean too.
+    result = await build(judge()).run()
+    assert result.success, result.reasoning
+    assert result.passed_criteria == ["criterion A passes", "final criterion passes"]
+
+    # succeed() returns to run() without passing through _script_call_agent, so
+    # run() has to stay the merge point — dropping its merge instead would lose
+    # these criteria entirely rather than duplicate them.
+    result = await build(succeed("done")).run()
+    assert result.success, result.reasoning
+    assert result.passed_criteria == ["criterion A passes"]
+
+
 # --------------------------------------------------------------------- #
 # Voice disconnect logging — issue #488                                  #
 # --------------------------------------------------------------------- #

--- a/python/tests/test_scenario_executor.py
+++ b/python/tests/test_scenario_executor.py
@@ -4,7 +4,7 @@ import pytest
 import scenario
 from scenario import JudgeAgent, UserSimulatorAgent
 from scenario.agent_adapter import AgentAdapter
-from scenario.types import AgentInput, AgentReturnTypes, AgentRole, JudgmentRequest, ScenarioResult
+from scenario.types import AgentInput, AgentReturnTypes, AgentRole, JudgmentRequest, ScenarioResult, ScriptStep
 from scenario.script import user, agent, judge, succeed
 
 from scenario.scenario_executor import ScenarioExecutor
@@ -465,7 +465,7 @@ async def test_accumulated_criteria_are_not_duplicated():
     """Checkpoint criteria are merged by run(); _script_call_agent must not
     merge them a second time. Membership assertions cannot see a duplicate,
     so this asserts the exact list."""
-    def build(final_step):
+    def build(final_step: ScriptStep) -> ScenarioExecutor:
         return ScenarioExecutor(
             name="test no duplicates", description="test",
             agents=[


### PR DESCRIPTION

## Why

Every criterion that passes an inline `scenario.judge(criteria=[...])`
checkpoint is reported **twice** in `ScenarioResult.passed_criteria`.

```python
script=[
    user("hello"), agent(), judge(criteria=["criterion A passes"]),
    user("more"),  agent(), judge(criteria=["criterion B passes"]),
    user("more"),  agent(), judge(criteria=["this will fail"]),
]
# actual:   ['criterion A passes', 'criterion B passes',
#            'criterion A passes', 'criterion B passes']
# expected: ['criterion A passes', 'criterion B passes']
```

Successful runs too — a script ending in a final `judge()` reports
`['criterion A passes', 'criterion A passes', 'final criterion passes']`.

The compiled checkpoint passes are merged in two places: `_script_call_agent`
merges them into the result it returns (`scenario_executor.py:1744` on the
checkpoint-fail branch, `:1750` on the final-judge branch), and `run()` merges
them again into any `ScenarioResult` a script step returns (`:646`).

Users see it as a wrong `Passed Criteria: N/M` from the pytest reporter
(`pytest_plugin.py:222`), and as duplicated `met_criteria` on the run-finished
event and in saved reports.

## What changed

`run()` becomes the single merge point. The final-judge branch no longer
merges; the checkpoint-fail branch **clears** `result.passed_criteria` rather
than overwriting it with the compiled list — that checkpoint's own result is
appended to `_checkpoint_results` just above, so its passes are already
compiled, and anything left on the result comes back a second time.

It has to be that way round: `succeed()`, `fail()` and the max-turns exit reach
`run()` **without** going through `_script_call_agent`, so dropping `run()`'s
merge would lose their criteria instead. `failed_criteria` is untouched —
`run()` merges only the passes.

Deduping at the merge would hide the symptom but leave both merge sites in
place, and would collapse two checkpoints that each genuinely declare the same
criterion into a single entry.

## Test plan

- New `test_accumulated_criteria_are_not_duplicated` covers four paths:
  checkpoint failure, a failing checkpoint that **also** passed a criterion,
  the final judge, and `succeed()` after a checkpoint — the last one pins the
  direction of the fix. Confirmed RED on `main`:
  `Left contains one more item: 'criterion A passes'`.
- The existing tests can't catch this: every assertion is
  `assert "criterion A passes" in result.passed_criteria`, and `in` is blind to
  duplication. The new test asserts the exact list.
- Full non-voice suite: 620 passed, pre-existing failures unchanged.

`result.success` is correct in every case — this only affects the reported
criteria and metrics derived from them, never a scenario's verdict.

The TypeScript port has the same double merge
(`scenario-execution.ts:622-623`, `:2339-2341`, `:2347-2349`) and reproduces on
the same paths; its tests miss it because they assert with `toContain`. Kept
out of this PR to keep the diff reviewable — happy to send the mirror if you'd
like them to land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
