### PR TITLE
test(voice): resolve the feature path once instead of in 22 suites (#521)

### DIFF
--- a/javascript/src/__tests__/features.test.ts
+++ b/javascript/src/__tests__/features.test.ts
@@ -7,7 +7,7 @@
  * long way from "the specs directory moved".
  */
 import { existsSync, readFileSync } from "node:fs";
-import { basename, isAbsolute } from "node:path";
+import { basename, isAbsolute, sep } from "node:path";
 
 import { describe, it, expect } from "vitest";
 
@@ -31,7 +31,7 @@ describe("given the shared feature-path helper", () => {
       // The hop count is the thing that was duplicated 22 times and the thing
       // most likely to go wrong. specs/ sits at the repository root, above
       // javascript/, so a path still inside the package means one hop short.
-      expect(VOICE_AGENTS_FEATURE).not.toContain("/javascript/");
+      expect(VOICE_AGENTS_FEATURE.split(sep)).not.toContain("javascript");
     });
   });
 });

--- a/javascript/src/__tests__/features.test.ts
+++ b/javascript/src/__tests__/features.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Guards the shared feature-path resolution.
+ *
+ * Twenty-two cucumber-bound suites now import their feature path from one
+ * module, so a wrong answer here breaks all of them at once. It would break
+ * them loudly, but as a parse error naming a path nobody wrote, which is a
+ * long way from "the specs directory moved".
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { basename, isAbsolute } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import { VOICE_AGENTS_FEATURE } from "./features";
+
+describe("given the shared feature-path helper", () => {
+  describe("when a suite asks for the voice-agents feature", () => {
+    it("resolves an absolute path that exists on disk", () => {
+      expect(isAbsolute(VOICE_AGENTS_FEATURE)).toBe(true);
+      expect(existsSync(VOICE_AGENTS_FEATURE)).toBe(true);
+    });
+
+    it("points at the repository's own voice-agents spec", () => {
+      // Existence alone would be satisfied by any file the hops happen to
+      // land on. Read it and check it is the feature the suites bind to.
+      expect(basename(VOICE_AGENTS_FEATURE)).toBe("voice-agents.feature");
+      expect(readFileSync(VOICE_AGENTS_FEATURE, "utf8")).toContain("Feature:");
+    });
+
+    it("resolves out of the javascript package, not inside it", () => {
+      // The hop count is the thing that was duplicated 22 times and the thing
+      // most likely to go wrong. specs/ sits at the repository root, above
+      // javascript/, so a path still inside the package means one hop short.
+      expect(VOICE_AGENTS_FEATURE).not.toContain("/javascript/");
+    });
+  });
+});

--- a/javascript/src/__tests__/features.ts
+++ b/javascript/src/__tests__/features.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared resolution of the repository's `.feature` files for vitest-cucumber.
+ *
+ * Every cucumber-bound test needs an absolute path to the same feature file,
+ * and each one used to count its own hops back to the repository root. The
+ * count depends on how deep the test sits, so `src/voice/__tests__` needed four
+ * and `src/agents/judge/__tests__` needed five, and 22 files each carried their
+ * own copy of an answer that is only correct for where they happen to live.
+ *
+ * Anchoring on this module's location instead makes the depth a property of one
+ * file. Moving a test no longer silently breaks its path, and moving `specs/`
+ * is a single edit here.
+ */
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Repository root, three levels above `javascript/src/__tests__`. */
+const REPO_ROOT = resolve(HERE, "..", "..", "..");
+
+function featurePath(name: string): string {
+  const path = resolve(REPO_ROOT, "specs", name);
+  if (!existsSync(path)) {
+    // loadFeature fails on a missing file with a parse error naming a path
+    // nobody wrote, because it is assembled from hops. Say which file is
+    // missing and where this looked, so a moved spec reads as a moved spec.
+    throw new Error(
+      `Feature file not found: ${path} (resolved from ${HERE} against specs/${name})`
+    );
+  }
+  return path;
+}
+
+export const VOICE_AGENTS_FEATURE = featurePath("voice-agents.feature");

--- a/javascript/src/agents/__tests__/user-simulator-voice.test.ts
+++ b/javascript/src/agents/__tests__/user-simulator-voice.test.ts
@@ -17,17 +17,15 @@
  * `script/__tests__/interrupt-after-and-user-overrides.test.ts`.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect, vi } from "vitest";
 
-import { AudioChunk } from "../../voice/audio-chunk";
 import { makeChunk } from "./fixtures/make-chunk";
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
+import type { AgentInput } from "../../domain";
+import { AudioChunk } from "../../voice/audio-chunk";
 import { extractAudio, messageHasAudio } from "../../voice/messages";
 import { userSimulatorAgent, type UserSimulatorAgentConfig } from "../user-simulator-agent";
-import type { AgentInput } from "../../domain";
 
 // Mock getProjectConfig to avoid filesystem dependency in unit tests.
 vi.mock("../../config", () => ({
@@ -36,21 +34,9 @@ vi.mock("../../config", () => ({
   }),
 }));
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature"
-);
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
 
 /**
  * Build a minimal {@link AgentInput} stub sufficient for user simulator tests.
@@ -110,7 +96,7 @@ function stubSynth(
     fn ?? defaultFn;
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/agents/__tests__/voice-assistant-role.test.ts
+++ b/javascript/src/agents/__tests__/voice-assistant-role.test.ts
@@ -17,30 +17,16 @@
  * Tag convention: `@ts-assistant-role` (per-subject) — see issue #523.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect } from "vitest";
 
-import { AudioChunk } from "../../voice/audio-chunk";
 import { makeChunk } from "./fixtures/make-chunk";
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
+import { AudioChunk } from "../../voice/audio-chunk";
 import { createAudioMessage, extractAudio, messageHasAudio } from "../../voice/messages";
 import { JudgeAgent } from "../judge/judge-agent";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature"
-);
-
-
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/agents/judge/__tests__/judge-voice.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-voice.test.ts
@@ -14,32 +14,17 @@
  * Tag convention: `@ts-judge` (per-subject) — see issue #523.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { describe, expect, it } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import { createAudioMessage } from "../../../voice/messages";
 import { makeChunk } from "../../__tests__/fixtures/make-chunk";
 import { judgeAgent, JudgeAgent, type JudgeAgentConfig } from "../judge-agent";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature"
-);
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
 
 /** Build a message-bus message containing audio content. */
 function audioMessage(
@@ -153,7 +138,7 @@ describe("effectiveIncludeAudio — explicit override edge cases", () => {
 // Bound feature-file scenarios
 // ---------------------------------------------------------------------------
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/script/__tests__/voice-steps.test.ts
+++ b/javascript/src/script/__tests__/voice-steps.test.ts
@@ -11,13 +11,13 @@
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import type { ModelMessage } from "ai";
 import { expect } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 import { AgentRole } from "../../domain/agents";
 import {
   AdapterCapabilities,
@@ -35,9 +35,6 @@ import {
   sleep,
   voiceAgent,
 } from "../index";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
 
 /**
  * Minimal voice-aware adapter used by these scenarios. Each instance
@@ -147,7 +144,7 @@ function makeStateStub() {
   return {} as never;
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
+++ b/javascript/src/voice/__tests__/adapter-lifecycle.test.ts
@@ -20,9 +20,6 @@
  * "multi-adapter", or "disconnect error" scenario near line 138).
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect, it } from "vitest";
 
@@ -32,20 +29,10 @@ import {
   type AgentReturnTypes,
   UserSimulatorAgentAdapter,
 } from "../../domain";
-import { agent, fail, succeed, user } from "../../script";
-import { ScenarioExecution } from "../../execution/scenario-execution";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
+import { ScenarioExecution } from "../../execution/scenario-execution";
+import { agent, fail, succeed, user } from "../../script";
 
 class TextUserSimulator extends UserSimulatorAgentAdapter {
   role = AgentRole.USER;
@@ -138,7 +125,7 @@ it("disconnect errors are swallowed so cleanup never masks the scenario result",
 // Bound scenario — the spec-named happy-path contract.
 // -------------------------------------------------------------------------
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/hooks.test.ts
+++ b/javascript/src/voice/__tests__/hooks.test.ts
@@ -15,29 +15,17 @@
  * it() below — it is an implementation-level guarantee, not a named feature
  * scenario. Option (a) chosen: no spec scenario exists for this behavior.
  */
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect, it } from "vitest";
 
-import { agent, succeed, user } from "../../script";
 import { ScenarioExecution } from "../../execution/scenario-execution";
+import { agent, succeed, user } from "../../script";
 import { AudioChunk, silentChunk } from "../audio-chunk";
 import type { VoiceEvent } from "../recording.types";
 import { AudioUserSimulator } from "./fixtures/audio-user-simulator";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 
 /**
  * Build a synthetic-but-non-silent PCM16 chunk so the recorder treats it
@@ -85,7 +73,7 @@ it("throwing on_voice_event hook does not break the scenario", async () => {
   expect(voiceEventCalls).toBeGreaterThan(0);
 });
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/interruption.test.ts
+++ b/javascript/src/voice/__tests__/interruption.test.ts
@@ -8,22 +8,17 @@
  * `sampleDelay` invariants.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { describe, expect, it } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 import {
   CANNED_PHRASES,
   CONTEXTUAL_PROMPT,
   InterruptionConfig,
 } from "../interruption";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
-
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/result-extensions.test.ts
+++ b/javascript/src/voice/__tests__/result-extensions.test.ts
@@ -8,12 +8,12 @@
 
 import { mkdtempSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 import type { ScenarioResult } from "../../domain";
 import {
   computeLatencyMetrics,
@@ -25,8 +25,6 @@ import type {
   VoiceEvent,
 } from "../recording.types";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
 const SAMPLE_RATE = 24000;
 
 function pcmSegment(
@@ -78,7 +76,7 @@ function makeVoiceResult(overrides: {
   };
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/transcribe.test.ts
+++ b/javascript/src/voice/__tests__/transcribe.test.ts
@@ -8,19 +8,15 @@
  * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
  * the suite if any bound scenario is missing a step binding.
  */
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect, vi } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 import type { AudioChunk } from "../audio-chunk";
+import type { AudioSegment, VoiceRecording } from "../recording.types";
 import { type STTProvider } from "../stt";
 import { transcribeSegments } from "../transcribe";
-import type { AudioSegment, VoiceRecording } from "../recording.types";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
 
 const PCM_BYTES = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -40,7 +36,7 @@ function makeRecording(
   };
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/tts.test.ts
+++ b/javascript/src/voice/__tests__/tts.test.ts
@@ -8,12 +8,11 @@
  * the suite if any bound scenario is missing a step binding.
  */
 import { createHash } from "node:crypto";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect, vi } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 import { AudioChunk } from "../audio-chunk";
 import {
   clearTtsCache,
@@ -23,12 +22,9 @@ import {
   type TTSCallable,
 } from "../tts";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
-
 const TEST_PREFIX = "test-tts";
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/vad-fallback.test.ts
+++ b/javascript/src/voice/__tests__/vad-fallback.test.ts
@@ -13,30 +13,18 @@
  * Loaded via @amiceli/vitest-cucumber which reads the feature file and fails
  * the suite if any bound scenario is missing a step binding.
  */
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { beforeEach, expect, vi, type MockInstance } from "vitest";
 
-import { agent, succeed, user } from "../../script";
 import { ScenarioExecution } from "../../execution/scenario-execution";
+import { agent, succeed, user } from "../../script";
 import { AudioChunk } from "../audio-chunk";
 import type { VoiceEvent } from "../recording.types";
 import { WebRTCVadFallback } from "../vad";
 import { AudioUserSimulator } from "./fixtures/audio-user-simulator";
 import { FakeVoiceAdapter } from "./fixtures/fake-adapter";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 
 function speechChunk(durationSeconds: number): AudioChunk {
   // Loud sine-ish shape: alternate ±20000 samples — RMS ≈ 20000, comfortably
@@ -60,7 +48,7 @@ beforeEach(() => {
   WebRTCVadFallback.resetWarnings();
 });
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/voice-contract-surface.test.ts
+++ b/javascript/src/voice/__tests__/voice-contract-surface.test.ts
@@ -9,12 +9,10 @@
  * the suite if any bound scenario is missing a step binding.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 import { AgentAdapter, AgentRole } from "../../domain/agents";
 import {
   AdapterCapabilities,
@@ -26,9 +24,6 @@ import {
   VoiceAgentAdapter,
   silentChunk,
 } from "../index";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
 
 /**
  * Stub adapter used by several scenarios. Keeps the same shape as the
@@ -66,7 +61,7 @@ class StubVoiceAdapter extends VoiceAgentAdapter {
   }
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/__tests__/voice-docs.test.ts
+++ b/javascript/src/voice/__tests__/voice-docs.test.ts
@@ -16,9 +16,9 @@ import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect } from "vitest";
+import { VOICE_AGENTS_FEATURE } from "../../__tests__/features";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "specs", "voice-agents.feature");
 // Capability matrix is sourced from the published docs page (single
 // source-of-truth across Python + TS). The wrapper page documents the
 // adapters; the per-capability table itself is auto-generated from the
@@ -49,7 +49,7 @@ const GENERATED_MATRIX_PATH = resolve(
   "capability-matrix.mdx",
 );
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/adapters/__tests__/elevenlabs.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs.test.ts
@@ -14,18 +14,17 @@
  * uses `includeTags: ["ts-bound"]`. Per-subject tagging matches the
  * established per-subject tag-convention decision.
  */
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
-import type { LanguageModel } from "ai";
 import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import type { LanguageModel } from "ai";
 import { afterEach, describe, it, expect, vi } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import { AgentRole } from "../../../domain/agents";
-import { AudioChunk, silentChunk } from "../../audio-chunk";
 import { VoiceAgentAdapter } from "../../adapter";
-import { ELEVENLABS_DEFAULT_VOICE_ID } from "../../voice-models";
+import { AudioChunk, silentChunk } from "../../audio-chunk";
 import { elevenLabsAgent } from "../../factories";
+import { ELEVENLABS_DEFAULT_VOICE_ID } from "../../voice-models";
 import {
   ComposableVoiceAgent,
   ElevenLabsAgentAdapter,
@@ -35,18 +34,6 @@ import {
   type STTProvider,
 } from "../index";
 import { FakeWebSocket, makeFakeConv } from "./fixtures/fake-elevenlabs-conversation";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
 
 /** Feed one inbound EL ConvAI frame to the SDK over the fake socket. */
 function emit(socket: FakeWebSocket, event: Record<string, unknown>): void {
@@ -97,7 +84,7 @@ function makeFakeLanguageModel(text: string): {
   return { model, calls };
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/adapters/__tests__/gemini-live.test.ts
+++ b/javascript/src/voice/adapters/__tests__/gemini-live.test.ts
@@ -19,12 +19,11 @@
  */
 
 import { Buffer } from "node:buffer";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { vi, expect, describe, it, beforeEach } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import { AdapterCapabilities } from "../../capabilities";
 import { GeminiLiveAgentAdapter } from "../gemini-live";
 
@@ -67,19 +66,7 @@ vi.mock("@google/genai", () => {
   };
 });
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
-
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/adapters/__tests__/openai-realtime.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime.test.ts
@@ -10,9 +10,6 @@
  * response.cancel on interrupt) without hitting a network.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { expect } from "vitest";
 
@@ -26,18 +23,7 @@ import {
   silentChunk,
 } from "../../index";
 import { setupMockRealtimeServer } from "./fixtures/mock-realtime-server";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 
 interface ServerEvent {
   type: string;
@@ -99,7 +85,7 @@ function buildAdapter(
   });
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/adapters/__tests__/pipecat.test.ts
+++ b/javascript/src/voice/adapters/__tests__/pipecat.test.ts
@@ -18,12 +18,11 @@
  */
 
 import { Buffer } from "node:buffer";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import {
   AudioChunk,
   PendingTransportError,
@@ -31,18 +30,6 @@ import {
   type PipecatWebSocketLike,
 } from "../../index";
 import { pcm16ToMulaw } from "../twilio-shared";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
 
 /**
  * Test double for `ws.WebSocket`. Captures every outbound frame, exposes
@@ -141,7 +128,7 @@ afterEach(() => {
   sockets = [];
 });
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/adapters/__tests__/twilio-server.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-server.test.ts
@@ -8,19 +8,14 @@
  * the transport level (no real Twilio account, no tunnel).
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
 import { afterAll, expect } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import { TwilioAgentAdapter } from "../twilio";
 import { TwilioRESTHelper } from "../twilio-shared";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
-
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 const trackedAdapters: TwilioAgentAdapter[] = [];
 

--- a/javascript/src/voice/adapters/__tests__/twilio-shared-codec.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-shared-codec.test.ts
@@ -11,12 +11,10 @@
  * silently degrades.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { describe, expect, it } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import { PCM16_SAMPLE_RATE } from "../../audio-chunk";
 import {
   TWILIO_FRAME_BYTES,
@@ -28,18 +26,6 @@ import {
   pcm16ToMulaw,
   resamplePcm16,
 } from "../twilio-shared";
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(
-  HERE,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "specs",
-  "voice-agents.feature",
-);
 
 /**
  * Synthesise a sine wave in PCM16 little-endian bytes. Amplitude ≤ 30000
@@ -90,7 +76,7 @@ function mean(samples: number[]): number {
   return sum / samples.length;
 }
 
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 describeFeature(
   feature,

--- a/javascript/src/voice/adapters/__tests__/twilio-tunnel.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio-tunnel.test.ts
@@ -8,20 +8,15 @@
  * locally.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
 import { afterAll, describe, expect, it } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import { TwilioAgentAdapter } from "../twilio";
 import { TwilioRESTHelper } from "../twilio-shared";
 import { openTwilioTunnel, type OpenedTunnel } from "../twilio-tunnel";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
-
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 const TUNNEL_ENABLED = !!process.env.NGROK_AUTHTOKEN;
 

--- a/javascript/src/voice/adapters/__tests__/twilio.test.ts
+++ b/javascript/src/voice/adapters/__tests__/twilio.test.ts
@@ -8,12 +8,11 @@
  */
 
 import { Buffer } from "node:buffer";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import { AudioChunk } from "../../audio-chunk";
 import { TwilioAgentAdapter } from "../twilio";
 import type { MediaStreamWebSocket } from "../twilio-server";
@@ -28,10 +27,7 @@ import {
   verifyTwilioSignature,
 } from "../twilio-shared";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
-
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 /** Build an adapter wired to a stubbed REST helper so connect() can run. */
 function makeAdapter(opts?: {

--- a/javascript/src/voice/effects/__tests__/effects.test.ts
+++ b/javascript/src/voice/effects/__tests__/effects.test.ts
@@ -10,14 +10,12 @@
  * binding conflicts from issue #523.
  */
 
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { describe, expect, it } from "vitest";
 
 import * as voiceNs from "../..";
 
+import { VOICE_AGENTS_FEATURE } from "../../../__tests__/features";
 import * as effectsModule from "../index";
 import {
   backgroundNoise,
@@ -37,10 +35,7 @@ import {
 // `static` is a reserved keyword — import via alias
 import { static_ as staticEffect } from "../noise";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
-
-const feature = await loadFeature(FEATURE_PATH);
+const feature = await loadFeature(VOICE_AGENTS_FEATURE);
 
 // ---------------------------------------------------------------------------
 // Fixture helpers


### PR DESCRIPTION
## Ticket

Closes #521.

## Change

Every cucumber-bound suite resolved `specs/voice-agents.feature` by counting hops back to the repository root. The count depends on how deep the suite sits, so `src/voice/__tests__` needed four `".."` and `src/agents/judge/__tests__` needed five, and each file carried its own copy of an answer that is only correct where that file happens to live. Moving a test breaks its path; moving `specs/` means finding every copy.

`javascript/src/__tests__/features.ts` now anchors on its own location and exports `VOICE_AGENTS_FEATURE`, so the depth is a property of one file. The 22 suites import it and drop their `HERE` constant and their `node:path` / `node:url` imports where nothing else used them.

The helper also refuses a path that is not there. `loadFeature` on a missing file fails with a parse error quoting a path assembled from hops, which reads like a corrupt feature file rather than a moved one; the guard says which file is missing and where it looked.

The ticket counted four such files when it was filed. It is 22 now, which is the argument for doing it rather than against.

## Scope note

Two things in the diff beyond the mechanical swap, both worth knowing before reading it:

- **`javascript/src/__tests__/` is new.** The ticket suggested `javascript/src/voice/__tests__/_helpers.ts`, but the consumers are not all under `voice/` (there are suites in `agents/`, `agents/judge/` and `script/`), so the helper sits where all of them can reach it. `tsup` builds from explicit entries, so nothing here enters the published package.
- **11 pre-existing `import/order` violations got fixed.** `eslint --fix` was run on the touched files to clear the ordering the new import introduced, and it also tidied violations already on `main` in those same files. That is why a few diffs move imports the change did not otherwise touch.

## Evidence

**Full suite green.** `vitest run`: **1082 passed | 4 skipped (1086)**, 93 files. Every one of the 22 rewritten suites still loads and binds its scenarios.

**No new lint.** Compared rule-by-rule and file-by-file against `origin/main` using `eslint -f json`:

```
main:   209 problems
branch: 198 problems
NEW:      0
REMOVED: 11   (import/order, all pre-existing, in files this PR already touches)
```

**Typecheck unchanged.** `tsc --noEmit` output is byte-identical to `main`'s: both exit 2 on the same pre-existing `TS2688: Cannot find type definition file for 'yauzl'`, which this change neither causes nor fixes.

**Mutation-checked.** Four mutations of the new helper, restoring the file between runs:

| # | Mutation | Result |
|---|---|---|
| M1 | one hop short, resolves inside `javascript/` | CAUGHT (guard throws on import) |
| M2 | one hop long, resolves above the repository | CAUGHT (guard throws on import) |
| M3 | one hop short **and** the guard deleted | CAUGHT (3 failed) |
| M4 | resolves a different, real spec file | CAUGHT (1 failed) |

M3 is the one that earns the third assertion. With the guard gone the path simply points at a file that is not there, and it is `expect(VOICE_AGENTS_FEATURE).not.toContain("/javascript/")` that names the cause as "one hop short" rather than "missing file".

One harness note, since it changes how the table should be read: my first run reported M3 as ESCAPED. It had not escaped. The parser only matched a vitest summary containing the word `passed`, and M3 fails all three tests, so the line reads `Tests  3 failed (3)` and matched nothing, which scored as zero failures. Fixed to parse failed and passed independently and to report an unparseable run as INVALID rather than as a pass.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.
