### PR TITLE
ci: fix conventional commits check for external contributors

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,7 +1,7 @@
 name: Conventional Commits
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
The Conventional Commits check fails on every fork PR (e.g. #879) with `Resource not accessible by integration`: on `pull_request` events from forks, `GITHUB_TOKEN` is forced read-only, but `wip: true` in amannn/action-semantic-pull-request needs `statuses: write`.

Fix: trigger on `pull_request_target` instead, per the action's own README recommendation. This is safe because the workflow never checks out or executes PR code — it only reads the PR title.

Failing run: https://github.com/langwatch/scenario/actions/runs/31199238846/job/93416874850?pr=879

🤖 Generated with [Claude Code](https://claude.com/claude-code)