### PR TITLE
fix(judge): treat an unforced inconclusive finish_test as continue instead of failing the run

### DIFF
--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -1187,5 +1187,52 @@ describe("JudgeAgent", () => {
       expect(result).not.toBeNull();
       expect(result!.success).toBe(false);
     });
+
+    it("forces a verdict when a required large-trace judgment tries to continue", async () => {
+      // Large-trace last-turn/checkpoint escape (#886): discovery relaxes the
+      // pinned finish_test to "required"; if the judge answers continue_test on
+      // a required judgment, the run must NOT dodge into the generic max-turns
+      // failure — it must force a terminal verdict.
+      const largeTrace = createLargeTrace();
+      const collector = createMockSpanCollector(largeTrace);
+      for (const span of largeTrace) {
+        (span.attributes as Record<string, unknown>)["langwatch.thread.id"] =
+          "test-thread";
+      }
+
+      const agent = judgeAgent({
+        criteria: ["Agent requests approval before applying the change"],
+        spanCollector: collector,
+      });
+
+      let callCount = 0;
+      let forcedToolChoice: unknown;
+      agent.invokeLLM = async (params) => {
+        callCount++;
+        if (callCount === 1) {
+          // Discovery step ends on continue_test (a non-final terminal).
+          return mockLLMResult("continue_test", {});
+        }
+        // The forced follow-up call: finish_test is pinned.
+        forcedToolChoice = params.toolChoice;
+        return inconclusiveFinish();
+      };
+
+      // Last turn → judgmentRequired. Before the fix this returned null and the
+      // run continued; now it forces a terminal verdict.
+      const result = await agent.call(
+        createBaseInput({
+          scenarioState: { currentTurn: 4 } as never, // maxTurns 5 → last message
+        })
+      );
+
+      expect(callCount).toBe(2);
+      expect(forcedToolChoice).toEqual({
+        type: "tool",
+        toolName: "finish_test",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+    });
   });
 });

--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -1005,4 +1005,154 @@ describe("JudgeAgent", () => {
       expect(result!.metCriteria).toContain("Inline criterion");
     });
   });
+
+  describe("when the judge finishes with an inconclusive verdict mid-conversation", () => {
+    // Reproduces issue #886: an unforced judge (continue_test freely available)
+    // that calls finish_test with verdict "inconclusive" must be treated as
+    // continue_test — "I can't tell yet" is not a verdict, and ending the run
+    // as FAILED on it makes the conversation look like the user simulator
+    // stopped responding.
+    function createJudge() {
+      const collector = createMockSpanCollector([]);
+      const agent = judgeAgent({
+        criteria: ["Agent requests approval before applying the change"],
+        spanCollector: collector,
+      });
+      return agent;
+    }
+
+    function inconclusiveFinish(): InvokeLLMResult {
+      return mockLLMResult("finish_test", {
+        criteria: {
+          agent_requests_approval_before_applying_the_change: "inconclusive",
+        },
+        reasoning: "Too early to tell — the conversation should continue.",
+        verdict: "inconclusive",
+      });
+    }
+
+    it("treats the finish as continue and returns null", async () => {
+      const agent = createJudge();
+      agent.invokeLLM = async () => inconclusiveFinish();
+
+      // currentTurn 1 of maxTurns 5, no judgmentRequest — nothing forces a verdict.
+      const result = await agent.call(createBaseInput());
+
+      expect(result).toBeNull();
+    });
+
+    it("treats a finish with an omitted verdict as continue too", async () => {
+      const agent = createJudge();
+      agent.invokeLLM = async () =>
+        mockLLMResult("finish_test", {
+          criteria: {
+            agent_requests_approval_before_applying_the_change: "inconclusive",
+          },
+          reasoning: "No verdict field supplied.",
+        });
+
+      const result = await agent.call(createBaseInput());
+
+      expect(result).toBeNull();
+    });
+
+    it("still terminates with failure on the last turn", async () => {
+      const agent = createJudge();
+      agent.invokeLLM = async () => inconclusiveFinish();
+
+      const result = await agent.call(
+        createBaseInput({
+          scenarioState: { currentTurn: 4 } as never, // maxTurns 5 → last message
+        })
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+      expect(result!.unmetCriteria).toContain(
+        "Agent requests approval before applying the change"
+      );
+    });
+
+    it("still terminates with failure when judgment is requested", async () => {
+      const agent = createJudge();
+      agent.invokeLLM = async () => inconclusiveFinish();
+
+      const result = await agent.call(
+        createBaseInput({
+          judgmentRequest: {
+            criteria: ["Agent requests approval before applying the change"],
+          },
+        })
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+    });
+
+    it("continues on an unforced inconclusive finish during large-trace discovery", async () => {
+      const largeTrace = createLargeTrace();
+      const collector = createMockSpanCollector(largeTrace);
+      for (const span of largeTrace) {
+        (span.attributes as Record<string, unknown>)["langwatch.thread.id"] =
+          "test-thread";
+      }
+
+      const agent = judgeAgent({
+        criteria: ["Agent requests approval before applying the change"],
+        spanCollector: collector,
+      });
+      agent.invokeLLM = async () => inconclusiveFinish();
+
+      // Mid-conversation, no judgmentRequest: the discovery loop leaves
+      // continue_test available, so an inconclusive finish must continue.
+      const result = await agent.call(createBaseInput());
+
+      expect(result).toBeNull();
+    });
+
+    it("still terminates when discovery exhaustion forces an inconclusive verdict", async () => {
+      const largeTrace = createLargeTrace();
+      const collector = createMockSpanCollector(largeTrace);
+      for (const span of largeTrace) {
+        (span.attributes as Record<string, unknown>)["langwatch.thread.id"] =
+          "test-thread";
+      }
+
+      const agent = judgeAgent({
+        criteria: ["Agent requests approval before applying the change"],
+        spanCollector: collector,
+        maxDiscoverySteps: 2,
+      });
+
+      let callCount = 0;
+      agent.invokeLLM = async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Discovery exhausted — only discovery tool calls, no terminal.
+          return {
+            text: "",
+            content: [],
+            toolCalls: [
+              {
+                toolName: "expand_trace",
+                input: { span_ids: ["0000000000000000"] },
+                type: "tool-call" as const,
+                toolCallId: "tc-1",
+              },
+            ],
+            toolResults: [],
+          } as unknown as InvokeLLMResult;
+        }
+        // forceVerdict call: the model has no continue escape, so its
+        // inconclusive verdict is legitimate — and terminal.
+        return inconclusiveFinish();
+      };
+
+      const result = await agent.call(createBaseInput());
+
+      expect(callCount).toBe(2);
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+    });
+  });
 });

--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -1110,6 +1110,39 @@ describe("JudgeAgent", () => {
       expect(result).toBeNull();
     });
 
+    it("pins finish_test and stays terminal for a criteria-less last-turn judge", async () => {
+      // A required judgment must not be dodgeable via continue_test even when
+      // the judge has no criteria — otherwise the run falls through to the
+      // generic max-turns failure and the judge's reasoning is lost.
+      const agent = judgeAgent({
+        criteria: [],
+        spanCollector: createMockSpanCollector([]),
+      });
+
+      let capturedToolChoice: unknown;
+      agent.invokeLLM = async (params) => {
+        capturedToolChoice = params.toolChoice;
+        return mockLLMResult("finish_test", {
+          criteria: {},
+          reasoning: "Nothing more to observe.",
+          verdict: "inconclusive",
+        });
+      };
+
+      const result = await agent.call(
+        createBaseInput({
+          scenarioState: { currentTurn: 4 } as never, // maxTurns 5 → last message
+        })
+      );
+
+      expect(capturedToolChoice).toEqual({
+        type: "tool",
+        toolName: "finish_test",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+    });
+
     it("still terminates when discovery exhaustion forces an inconclusive verdict", async () => {
       const largeTrace = createLargeTrace();
       const collector = createMockSpanCollector(largeTrace);

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -576,8 +576,9 @@ export class JudgeAgent extends JudgeAgentAdapter {
     // judgment cannot be dodged via continue_test, criteria or not — the
     // criteria-less enforced case already returned above, and a criteria-less
     // last-turn judge still owes its terminal verdict. Known gap: the
-    // large-trace discovery path relaxes toolChoice to "required" below and
-    // still accepts continue_test there (inherited; tracked in #887).
+    // Standard path pins finish_test; the large-trace path relaxes it to
+    // "required" so the judge can use discovery tools, but still guarantees a
+    // finish_test outcome for a required judgment (see invokeLLMWithDiscovery).
     const toolChoice: ToolChoice<typeof tools> = judgmentRequired
       ? { type: "tool", toolName: "finish_test" }
       : "required";
@@ -598,6 +599,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
       tools,
       toolChoice,
       isLargeTrace,
+      judgmentRequired,
     });
 
     // A verdict is "forced" when this judgment is required to be final: the
@@ -645,14 +647,22 @@ export class JudgeAgent extends JudgeAgentAdapter {
    *
    * When the trace is large, toolChoice is relaxed to "required" so the
    * judge can freely pick discovery tools (expand_trace/grep_trace) before
-   * being forced to a terminal decision.
+   * being forced to a terminal decision. A required judgment (last turn or an
+   * explicit judge() checkpoint) is still guaranteed a finish_test outcome:
+   * if discovery ends on continue_test — or exhausts its steps — we force a
+   * final verdict rather than let the run dodge into the generic max-turns
+   * failure (#886; the large-trace half of the same terminal contract).
    */
   private async invokeLLMWithDiscovery({
     isLargeTrace,
+    judgmentRequired,
     ...params
-  }: InvokeLLMParams & { isLargeTrace: boolean }): Promise<{
+  }: InvokeLLMParams & {
+    isLargeTrace: boolean;
+    judgmentRequired: boolean;
+  }): Promise<{
     completion: InvokeLLMResult;
-    /** True when the discovery loop exhausted and forceVerdict pinned finish_test. */
+    /** True when forceVerdict pinned finish_test (exhaustion, or a dodged required judgment). */
     verdictWasForced: boolean;
   }> {
     if (isLargeTrace) {
@@ -674,11 +684,43 @@ export class JudgeAgent extends JudgeAgentAdapter {
       })),
     });
 
-    if (isLargeTrace && this.discoveryExhausted(completion)) {
-      return { completion: await this.forceVerdict(params), verdictWasForced: true };
+    if (isLargeTrace) {
+      if (this.discoveryExhausted(completion)) {
+        return { completion: await this.forceVerdict(params), verdictWasForced: true };
+      }
+      // A required judgment must not be dodged via continue_test on a large
+      // trace: discovery relaxed the pin, so if the judge continued instead of
+      // finishing, force the final verdict now.
+      if (
+        judgmentRequired &&
+        !this.completionCalledTool(completion, "finish_test")
+      ) {
+        this.logger.debug(
+          "required judgment continued during large-trace discovery - forcing verdict"
+        );
+        return { completion: await this.forceVerdict(params), verdictWasForced: true };
+      }
     }
 
     return { completion, verdictWasForced: false };
+  }
+
+  /**
+   * True when `toolName` was called anywhere in the (possibly multi-step)
+   * completion — the aggregate `steps` array when present, else the final
+   * `toolCalls`. Mirrors how {@link discoveryExhausted} inspects the loop.
+   */
+  private completionCalledTool(
+    completion: InvokeLLMResult,
+    toolName: string
+  ): boolean {
+    const steps = completion.steps;
+    if (steps && steps.length > 0) {
+      return steps.some((step) =>
+        step.toolCalls?.some((tc) => tc.toolName === toolName)
+      );
+    }
+    return Boolean(completion.toolCalls?.some((tc) => tc.toolName === toolName));
   }
 
   /**

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -236,6 +236,7 @@ ${criteriaList}
 <rules>
 - Be strict, do not let the conversation continue if the agent already broke one of the "do not" or "should not" criteria.
 - DO NOT make any judgment calls that are not explicitly listed in the success or failure criteria, withhold judgement if necessary
+- If you do not yet have enough information for a definitive verdict, call the continue_test tool to let the conversation play out - do NOT call finish_test with an "inconclusive" verdict while the conversation can still continue. When a final verdict is explicitly required (the conversation cannot continue), deliver your honest verdict - "inconclusive" is acceptable there
 </rules>
 `.trim();
 }
@@ -563,8 +564,16 @@ export class JudgeAgent extends JudgeAgentAdapter {
       };
     }
 
+    // A final judgment is required when the conversation cannot continue past
+    // this call: the last turn, or an explicit judge() step. Note this is
+    // about the CONTRACT, not the transport — on large traces
+    // invokeLLMWithDiscovery relaxes toolChoice to "required" so the model can
+    // use discovery tools, but a checkpoint/last-turn judgment is still
+    // terminal.
+    const judgmentRequired = isLastMessage || enforceJudgement;
+
     const toolChoice: ToolChoice<typeof tools> =
-      (isLastMessage || enforceJudgement) && hasCriteria
+      judgmentRequired && hasCriteria
         ? { type: "tool", toolName: "finish_test" }
         : "required";
 
@@ -576,7 +585,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
       isLargeTrace,
     });
 
-    const completion = await this.invokeLLMWithDiscovery({
+    const { completion, verdictWasForced } = await this.invokeLLMWithDiscovery({
       model: mergedConfig.model,
       messages,
       temperature: mergedConfig.temperature,
@@ -586,7 +595,16 @@ export class JudgeAgent extends JudgeAgentAdapter {
       isLargeTrace,
     });
 
-    return this.parseToolCalls(completion, criteria);
+    // A verdict is "forced" when this judgment is required to be final: the
+    // last turn, an explicit judge() step, or the discovery loop exhausting
+    // its steps (forceVerdict pinned finish_test). Only a forced judgment may
+    // legitimately end the run on an inconclusive verdict (#886). Deliberately
+    // independent of hasCriteria: a criteria-less judge on the last turn still
+    // delivers its terminal result rather than silently continuing into the
+    // generic max-turns failure.
+    const verdictForced = judgmentRequired || verdictWasForced;
+
+    return this.parseToolCalls(completion, criteria, { verdictForced });
   }
 
   /**
@@ -627,7 +645,11 @@ export class JudgeAgent extends JudgeAgentAdapter {
   private async invokeLLMWithDiscovery({
     isLargeTrace,
     ...params
-  }: InvokeLLMParams & { isLargeTrace: boolean }): Promise<InvokeLLMResult> {
+  }: InvokeLLMParams & { isLargeTrace: boolean }): Promise<{
+    completion: InvokeLLMResult;
+    /** True when the discovery loop exhausted and forceVerdict pinned finish_test. */
+    verdictWasForced: boolean;
+  }> {
     if (isLargeTrace) {
       params.toolChoice = "required";
       params.stopWhen = [
@@ -648,10 +670,10 @@ export class JudgeAgent extends JudgeAgentAdapter {
     });
 
     if (isLargeTrace && this.discoveryExhausted(completion)) {
-      return this.forceVerdict(params);
+      return { completion: await this.forceVerdict(params), verdictWasForced: true };
     }
 
-    return completion;
+    return { completion, verdictWasForced: false };
   }
 
   /**
@@ -739,7 +761,8 @@ export class JudgeAgent extends JudgeAgentAdapter {
 
   private parseToolCalls(
     completion: InvokeLLMResult,
-    criteria: string[]
+    criteria: string[],
+    { verdictForced }: { verdictForced: boolean }
   ): JudgeResult | null {
     let args: FinishTestArgs | undefined;
     if (completion.toolCalls?.length) {
@@ -755,6 +778,20 @@ export class JudgeAgent extends JudgeAgentAdapter {
           args = toolCall.input as FinishTestArgs;
 
           const verdict = args.verdict || "inconclusive";
+
+          // "Can't tell yet" is not a verdict (#886). When nothing forced the
+          // judge to finish — continue_test was freely available — an
+          // inconclusive finish_test used to end the run as FAILED, which in
+          // the UI reads as the user simulator going silent mid-conversation.
+          // Treat it as continue_test and let the conversation play out; a
+          // FORCED judgment (last turn, judge() checkpoint, discovery
+          // exhaustion) keeps its terminal behavior unchanged.
+          if (!verdictForced && verdict === "inconclusive") {
+            this.logger.debug(
+              "finish_test returned an inconclusive verdict without a forced judgment - continuing the conversation"
+            );
+            return null;
+          }
           const reasoning = args.reasoning || "No reasoning provided";
           const criteriaArgs = args.criteria || {};
           const criteriaValues = Object.values(criteriaArgs);

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -572,10 +572,12 @@ export class JudgeAgent extends JudgeAgentAdapter {
     // terminal.
     const judgmentRequired = isLastMessage || enforceJudgement;
 
-    // Pinned on judgmentRequired ALONE: a required judgment must not be
-    // dodgeable via continue_test, criteria or not — the criteria-less
-    // enforced case already returned above, and a criteria-less last-turn
-    // judge still owes its terminal verdict.
+    // Pinned on judgmentRequired ALONE: on the standard path a required
+    // judgment cannot be dodged via continue_test, criteria or not — the
+    // criteria-less enforced case already returned above, and a criteria-less
+    // last-turn judge still owes its terminal verdict. Known gap: the
+    // large-trace discovery path relaxes toolChoice to "required" below and
+    // still accepts continue_test there (inherited; tracked in #887).
     const toolChoice: ToolChoice<typeof tools> = judgmentRequired
       ? { type: "tool", toolName: "finish_test" }
       : "required";

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -572,10 +572,13 @@ export class JudgeAgent extends JudgeAgentAdapter {
     // terminal.
     const judgmentRequired = isLastMessage || enforceJudgement;
 
-    const toolChoice: ToolChoice<typeof tools> =
-      judgmentRequired && hasCriteria
-        ? { type: "tool", toolName: "finish_test" }
-        : "required";
+    // Pinned on judgmentRequired ALONE: a required judgment must not be
+    // dodgeable via continue_test, criteria or not — the criteria-less
+    // enforced case already returned above, and a criteria-less last-turn
+    // judge still owes its terminal verdict.
+    const toolChoice: ToolChoice<typeof tools> = judgmentRequired
+      ? { type: "tool", toolName: "finish_test" }
+      : "required";
 
     this.logger.debug("Calling LLM", {
       model: mergedConfig.model,

--- a/javascript/src/execution/__tests__/judge-inconclusive-continues.test.ts
+++ b/javascript/src/execution/__tests__/judge-inconclusive-continues.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression guard for issue #886: a judge that calls finish_test with
+ * verdict "inconclusive" mid-conversation (nothing forcing a verdict) must
+ * let the conversation CONTINUE, not end the run as FAILED.
+ *
+ * Uses the real judgeAgent with only invokeLLM stubbed, so the test executes
+ * the actual parseToolCalls path that carried the bug — the run used to stop
+ * after turn 1, which in the UI read as "the user simulator stopped
+ * responding".
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { judgeAgent } from "../../agents";
+import { JudgeSpanCollector } from "../../agents/judge/judge-span-collector";
+import type { InvokeLLMResult } from "../../agents/types";
+import {
+  AgentRole,
+  AgentAdapter,
+  type AgentInput,
+  type AgentReturnTypes,
+  UserSimulatorAgentAdapter,
+} from "../../domain";
+import { ScenarioExecution } from "../scenario-execution";
+
+vi.mock("../../config", () => ({
+  getProjectConfig: vi.fn().mockResolvedValue({
+    defaultModel: { model: "openai/gpt-5-mini", temperature: 0 },
+  }),
+}));
+
+class CountingAgent extends AgentAdapter {
+  role = AgentRole.AGENT;
+  calls = 0;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    this.calls += 1;
+    return { role: "assistant" as const, content: `agent reply ${this.calls}` };
+  }
+}
+
+class CountingUserSim extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  calls = 0;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    this.calls += 1;
+    return `user turn ${this.calls}`;
+  }
+}
+
+function finishTestCall(
+  verdict: "success" | "inconclusive",
+  criterionValue: "true" | "inconclusive",
+): InvokeLLMResult {
+  return {
+    text: "",
+    content: [],
+    toolCalls: [
+      {
+        toolName: "finish_test",
+        type: "tool-call" as const,
+        toolCallId: `tc-${verdict}`,
+        input: {
+          criteria: { agent_greets_the_user_politely: criterionValue },
+          reasoning:
+            verdict === "inconclusive"
+              ? "Too early to tell — the conversation should continue."
+              : "The agent greeted the user politely.",
+          verdict,
+        },
+      },
+    ],
+    toolResults: [],
+  } as unknown as InvokeLLMResult;
+}
+
+describe("given a judge that hedges on the first turn (#886)", () => {
+  describe("when finish_test returns verdict inconclusive with turns remaining", () => {
+    it("continues the conversation and reaches the real verdict", async () => {
+      const agentUnderTest = new CountingAgent();
+      const sim = new CountingUserSim();
+
+      const judge = judgeAgent({
+        criteria: ["Agent greets the user politely"],
+        // Explicit collector so the test never couples to the process-global
+        // OTel span collector singleton.
+        spanCollector: new JudgeSpanCollector(),
+      });
+      let judgeLLMCalls = 0;
+      judge.invokeLLM = async () => {
+        judgeLLMCalls += 1;
+        return judgeLLMCalls === 1
+          ? finishTestCall("inconclusive", "inconclusive")
+          : finishTestCall("success", "true");
+      };
+
+      const execution = new ScenarioExecution(
+        {
+          name: "inconclusive continues",
+          description: "judge hedges on turn 1, decides on turn 2",
+          agents: [agentUnderTest, sim, judge],
+        },
+        [
+          async (_state, executor) => {
+            await executor.proceed();
+          },
+        ],
+        "test-batch-id",
+      );
+
+      const result = await execution.execute();
+
+      // Before the fix the run died here: success=false after ONE turn, with
+      // the judge's own reasoning saying the verdict should be inconclusive.
+      expect(judgeLLMCalls).toBe(2);
+      expect(sim.calls).toBe(2);
+      expect(result.success).toBe(true);
+      expect(result.metCriteria).toContain("Agent greets the user politely");
+    });
+  });
+});

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -604,6 +604,7 @@ If you do have enough information, use the finish_test tool to determine if all 
 <rules>
 - Be strict, do not let the conversation continue if the agent already broke one of the "do not" or "should not" criterias.
 - DO NOT make any judgment calls that are not explicitly listed in the success or failure criteria, withhold judgement if necessary
+- If you do not yet have enough information for a definitive verdict, call the continue_test tool to let the conversation play out - do NOT call finish_test with an "inconclusive" verdict while the conversation can still continue. When a final verdict is explicitly required (the conversation cannot continue), deliver your honest verdict - "inconclusive" is acceptable there
 </rules>
 """,
             },
@@ -702,11 +703,26 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 reasoning="TestingAgent was called as a judge, but it has no criteria to judge against",
             )
 
+        # A final judgment is required when the conversation cannot continue
+        # past this call: the last turn, or an explicit judgment_request. This
+        # is about the CONTRACT, not the transport — the discovery loop applies
+        # the pinned tool_choice only on its final step, but a checkpoint/
+        # last-turn judgment is still terminal.
+        judgment_required = is_last_message or enforce_judgment
+
         tool_choice: Any = (
             {"type": "function", "function": {"name": "finish_test"}}
-            if (is_last_message or enforce_judgment) and has_criteria
+            if judgment_required and has_criteria
             else "required"
         )
+
+        # Only a forced judgment may legitimately end the run on an
+        # inconclusive verdict (#886); discovery exhaustion forces separately
+        # in _force_verdict. Deliberately independent of has_criteria: a
+        # criteria-less judge on the last turn still delivers its terminal
+        # result rather than silently continuing into the generic max-turns
+        # failure.
+        verdict_forced = judgment_required
 
         # Multi-step discovery loop for large traces
         if is_large_trace:
@@ -718,6 +734,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 working_messages=working_messages,
                 effective_criteria=effective_criteria,
                 input_messages=input.messages,
+                verdict_forced=verdict_forced,
             )
 
         # Standard single-call path for small traces
@@ -733,7 +750,13 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             **self._extra_params,
         )
 
-        return self._parse_response(response, effective_criteria, messages, input_messages=input.messages)
+        return self._parse_response(
+            response,
+            effective_criteria,
+            messages,
+            input_messages=input.messages,
+            verdict_forced=verdict_forced,
+        )
 
     def _completion_with_reasoning_off_retry(self, **kwargs: Any) -> ModelResponse:
         """
@@ -914,6 +937,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         working_messages: Sequence[ChatCompletionMessageParam],
         effective_criteria: List[str],
         input_messages: Sequence[Any],
+        verdict_forced: bool,
     ) -> AgentReturnTypes:
         """
         Runs the multi-step discovery loop for large traces.
@@ -968,7 +992,13 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             message = cast(Choices, response.choices[0]).message
             if not message.tool_calls:
                 # No tool calls - try to parse as a response
-                return self._parse_response(response, effective_criteria, messages, input_messages=input_messages)
+                return self._parse_response(
+                    response,
+                    effective_criteria,
+                    messages,
+                    input_messages=input_messages,
+                    verdict_forced=verdict_forced,
+                )
 
             # Check for terminal tool call
             terminal_call = next(
@@ -976,7 +1006,13 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 None,
             )
             if terminal_call:
-                return self._parse_response(response, effective_criteria, messages, input_messages=input_messages)
+                return self._parse_response(
+                    response,
+                    effective_criteria,
+                    messages,
+                    input_messages=input_messages,
+                    verdict_forced=verdict_forced,
+                )
 
             # Execute discovery tools and add results to messages
             # Add the assistant message with tool calls
@@ -1063,7 +1099,13 @@ if you don't have enough information to make a verdict, say inconclusive with ma
             **self._extra_params,
         )
         return self._parse_response(
-            forced_response, effective_criteria, rewritten_messages, input_messages=input_messages
+            forced_response,
+            effective_criteria,
+            rewritten_messages,
+            input_messages=input_messages,
+            # The whole point of this call is a pinned finish_test — the model
+            # has no continue escape, so an inconclusive verdict is legitimate.
+            verdict_forced=True,
         )
 
     def _execute_discovery_tool(
@@ -1114,6 +1156,7 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         messages: List[dict],
         *,
         input_messages: Sequence[Any],
+        verdict_forced: bool,
     ) -> AgentReturnTypes:
         """
         Parses a litellm response into the appropriate return type.
@@ -1162,6 +1205,22 @@ if you don't have enough information to make a verdict, say inconclusive with ma
 
             verdict = args.get("verdict", "inconclusive")
             reasoning = args.get("reasoning", "No reasoning provided")
+
+            # "Can't tell yet" is not a verdict (#886). When nothing forced the
+            # judge to finish — continue_test was freely available — an
+            # inconclusive finish_test used to end the run as a failure, which
+            # on a platform surface reads as the simulated user going silent
+            # mid-conversation. Treat it as continue_test and let the
+            # conversation play out; a FORCED judgment (last turn, an explicit
+            # judgment_request, discovery exhaustion) keeps its terminal
+            # behavior unchanged.
+            if not verdict_forced and verdict == "inconclusive":
+                logger.debug(
+                    "finish_test returned an inconclusive verdict without a "
+                    "forced judgment - continuing the conversation"
+                )
+                return []
+
             criteria_verdicts = args.get("criteria", {})
 
             # LLMs sometimes serialise the criteria object as a JSON *string*

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -710,9 +710,13 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         # last-turn judgment is still terminal.
         judgment_required = is_last_message or enforce_judgment
 
+        # Pinned on judgment_required ALONE: a required judgment must not be
+        # dodgeable via continue_test, criteria or not — the criteria-less
+        # enforced case already returned above, and a criteria-less last-turn
+        # judge still owes its terminal verdict.
         tool_choice: Any = (
             {"type": "function", "function": {"name": "finish_test"}}
-            if judgment_required and has_criteria
+            if judgment_required
             else "required"
         )
 

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -710,13 +710,14 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         # last-turn judgment is still terminal.
         judgment_required = is_last_message or enforce_judgment
 
-        # Pinned on judgment_required ALONE: on the standard path a required
-        # judgment cannot be dodged via continue_test, criteria or not — the
-        # criteria-less enforced case already returned above, and a
-        # criteria-less last-turn judge still owes its terminal verdict. Known
-        # gap: the discovery loop applies this pin only on its final step and
-        # still accepts continue_test on earlier steps (inherited; tracked in
-        # #887).
+        # Pinned on judgment_required ALONE: a required judgment cannot be
+        # dodged via continue_test, criteria or not — the criteria-less
+        # enforced case already returned above, and a criteria-less last-turn
+        # judge still owes its terminal verdict. The large-trace discovery loop
+        # relaxes this pin to "required" so the judge can use discovery tools,
+        # but _run_discovery_loop forces a final verdict if a required judgment
+        # answers continue_test there, so the terminal contract holds on both
+        # paths.
         tool_choice: Any = (
             {"type": "function", "function": {"name": "finish_test"}}
             if judgment_required
@@ -1013,6 +1014,24 @@ if you don't have enough information to make a verdict, say inconclusive with ma
                 None,
             )
             if terminal_call:
+                # A required judgment must not be dodged via continue_test on a
+                # large trace: discovery relaxed the pin to "required", so if
+                # the judge continued instead of finishing, force the final
+                # verdict rather than fall through to the generic max-turns
+                # failure (#886; the large-trace half of the terminal contract).
+                if (
+                    verdict_forced
+                    and terminal_call.function.name == "continue_test"
+                ):
+                    logger.debug(
+                        "required judgment continued during discovery - forcing verdict"
+                    )
+                    return self._force_verdict(
+                        messages=messages,
+                        tools=tools,
+                        effective_criteria=effective_criteria,
+                        input_messages=input_messages,
+                    )
                 return self._parse_response(
                     response,
                     effective_criteria,

--- a/python/scenario/judge_agent.py
+++ b/python/scenario/judge_agent.py
@@ -710,10 +710,13 @@ if you don't have enough information to make a verdict, say inconclusive with ma
         # last-turn judgment is still terminal.
         judgment_required = is_last_message or enforce_judgment
 
-        # Pinned on judgment_required ALONE: a required judgment must not be
-        # dodgeable via continue_test, criteria or not — the criteria-less
-        # enforced case already returned above, and a criteria-less last-turn
-        # judge still owes its terminal verdict.
+        # Pinned on judgment_required ALONE: on the standard path a required
+        # judgment cannot be dodged via continue_test, criteria or not — the
+        # criteria-less enforced case already returned above, and a
+        # criteria-less last-turn judge still owes its terminal verdict. Known
+        # gap: the discovery loop applies this pin only on its final step and
+        # still accepts continue_test on earlier steps (inherited; tracked in
+        # #887).
         tool_choice: Any = (
             {"type": "function", "function": {"name": "finish_test"}}
             if judgment_required

--- a/python/tests/test_judge_discovery_exhaustion.py
+++ b/python/tests/test_judge_discovery_exhaustion.py
@@ -1387,3 +1387,77 @@ class TestToolCallReachesJudgeContext:
         print("\n--- AC5 (#630) captured <transcript> slice ---")
         print(transcript)
         print("--- end <transcript> slice ---")
+
+
+class TestInconclusiveVerdictOnDiscoveryPaths:
+    """Issue #886 on the large-trace paths: an inconclusive finish continues
+    when nothing forced the judgment, and stays terminal when discovery
+    exhaustion forced it."""
+
+    @pytest.mark.asyncio
+    async def test_unforced_inconclusive_finish_in_discovery_continues(self):
+        spans = create_nance_agent_trace()
+        collector = _create_collector(spans)
+        judge = JudgeAgent(
+            criteria=["Agent creates a task plan for the workflow"],
+            span_collector=collector,
+            max_discovery_steps=3,
+            token_threshold=100,
+        )
+
+        def mock_completion(**kwargs):
+            # First step already answers finish_test with "can't tell yet" —
+            # continue_test was freely available, so this must continue.
+            return _mock_finish_response(
+                criteria_verdicts={
+                    "agent_creates_a_task_plan_for_the_workflow": "inconclusive",
+                },
+                reasoning="Too early to tell - the conversation should continue.",
+                verdict="inconclusive",
+            )
+
+        with patch(
+            "scenario.judge_agent.litellm.completion", side_effect=mock_completion
+        ):
+            result = await judge.call(_create_input())
+
+        assert result == []  # the judge's continue contract
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_forced_inconclusive_verdict_stays_terminal(self):
+        spans = create_nance_agent_trace()
+        collector = _create_collector(spans)
+        judge = JudgeAgent(
+            criteria=["Agent creates a task plan for the workflow"],
+            span_collector=collector,
+            max_discovery_steps=2,
+            token_threshold=100,
+        )
+
+        call_count = 0
+
+        def mock_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return _mock_discovery_response(
+                    "grep_trace", {"pattern": "workflow"}, f"call_{call_count}"
+                )
+            # Forced verdict after exhaustion: no continue escape, so an
+            # inconclusive verdict is legitimate - and terminal.
+            return _mock_finish_response(
+                criteria_verdicts={
+                    "agent_creates_a_task_plan_for_the_workflow": "inconclusive",
+                },
+                reasoning="Could not determine from the explored trace.",
+                verdict="inconclusive",
+            )
+
+        with patch(
+            "scenario.judge_agent.litellm.completion", side_effect=mock_completion
+        ):
+            result = await judge.call(_create_input())
+
+        assert call_count == 3  # 2 discovery + 1 forced verdict
+        assert isinstance(result, ScenarioResult)
+        assert result.success is False

--- a/python/tests/test_judge_discovery_exhaustion.py
+++ b/python/tests/test_judge_discovery_exhaustion.py
@@ -21,7 +21,7 @@ from scenario._judge.judge_span_digest_formatter import JudgeSpanDigestFormatter
 from scenario._tracing.judge_span_collector import JudgeSpanCollector
 from scenario.cache import context_scenario
 from scenario.config import ScenarioConfig
-from scenario.types import AgentInput, ScenarioResult
+from scenario.types import AgentInput, JudgmentRequest, ScenarioResult
 
 from tests.helpers.create_span import create_mock_span
 
@@ -1459,5 +1459,57 @@ class TestInconclusiveVerdictOnDiscoveryPaths:
             result = await judge.call(_create_input())
 
         assert call_count == 3  # 2 discovery + 1 forced verdict
+        assert isinstance(result, ScenarioResult)
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_required_large_trace_judgment_cannot_continue(self):
+        """Large-trace last-turn/checkpoint escape (#886): if a required
+        judgment answers continue_test during discovery, the run must force a
+        terminal verdict rather than fall through to the max-turns failure."""
+        spans = create_nance_agent_trace()
+        collector = _create_collector(spans)
+        judge = JudgeAgent(
+            criteria=["Agent creates a task plan for the workflow"],
+            span_collector=collector,
+            max_discovery_steps=3,
+            token_threshold=100,
+        )
+
+        tool_choices = []
+        call_count = 0
+
+        def mock_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            tool_choices.append(kwargs.get("tool_choice"))
+            if call_count == 1:
+                # A required judgment tries to dodge via continue_test.
+                resp = MagicMock()
+                resp.choices = [MagicMock()]
+                tc = MagicMock()
+                tc.id = "call_1"
+                tc.function.name = "continue_test"
+                tc.function.arguments = "{}"
+                resp.choices[0].message.tool_calls = [tc]
+                resp.choices[0].message.content = None
+                return resp
+            # Forced verdict call.
+            return _mock_finish_response(
+                criteria_verdicts={
+                    "agent_creates_a_task_plan_for_the_workflow": "inconclusive",
+                },
+                reasoning="Forced final verdict.",
+                verdict="inconclusive",
+            )
+
+        # judgment_request makes the judgment required (verdict_forced).
+        with patch(
+            "scenario.judge_agent.litellm.completion", side_effect=mock_completion
+        ):
+            result = await judge.call(_create_input(judgment_request=JudgmentRequest()))
+
+        assert call_count == 2  # continue_test dodge + forced verdict
+        assert tool_choices[-1] == {"type": "function", "function": {"name": "finish_test"}}
         assert isinstance(result, ScenarioResult)
         assert result.success is False

--- a/python/tests/test_judge_force_verdict_hardening.py
+++ b/python/tests/test_judge_force_verdict_hardening.py
@@ -211,7 +211,11 @@ class TestParseResponseSafetyNet:
             "expand_trace", {"span_ids": ["xx"]}, call_id="tc-leak"
         )
 
-        result = agent._parse_response(leaked, ["A", "B"], messages=[], input_messages=[])
+        # The leak scenario only exists on the force-verdict path, so the
+        # judgment is by definition forced.
+        result = agent._parse_response(
+            leaked, ["A", "B"], messages=[], input_messages=[], verdict_forced=True
+        )
 
         assert isinstance(result, ScenarioResult)
         assert result.success is False

--- a/python/tests/test_judge_inconclusive_continues.py
+++ b/python/tests/test_judge_inconclusive_continues.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #886: an inconclusive finish_test mid-conversation
+must continue the conversation, not end the run as failed.
+
+When nothing forces a verdict (continue_test is freely available), a judge that
+answers finish_test with verdict "inconclusive" is saying "I can't tell yet".
+Treating that as a terminal failure ends the scenario right after the agent's
+last message — which, on a platform surface, reads as the simulated user going
+silent. A FORCED judgment (last turn, an explicit judgment_request, discovery
+exhaustion) keeps its terminal behavior.
+"""
+
+import json
+from typing import Any, Optional
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from scenario import JudgeAgent
+from scenario.config import ScenarioConfig
+from scenario.types import AgentInput, JudgmentRequest, ScenarioResult
+from scenario.cache import context_scenario
+
+
+async def _run_judge(
+    *,
+    verdict: Optional[str],
+    judgment_request: Optional[JudgmentRequest],
+    current_turn: int,
+    max_turns: int = 10,
+) -> Any:
+    """Drive JudgeAgent through a finish_test tool call and return the raw result."""
+    ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
+    criteria = ["Agent requests approval before applying the change"]
+    judge = JudgeAgent(criteria=criteria)
+
+    mock_scenario_state = MagicMock()
+    mock_scenario_state.description = "Test scenario"
+    mock_scenario_state.current_turn = current_turn
+    mock_scenario_state.config.max_turns = max_turns
+
+    agent_input = AgentInput(
+        thread_id="test",
+        messages=[{"role": "user", "content": "Hello"}],
+        new_messages=[],
+        judgment_request=judgment_request,
+        scenario_state=mock_scenario_state,
+    )
+
+    arguments: dict = {
+        "reasoning": "Too early to tell - the conversation should continue.",
+        "criteria": {
+            "agent_requests_approval_before_applying_the_change": "inconclusive"
+        },
+    }
+    if verdict is not None:
+        arguments["verdict"] = verdict
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.tool_calls = [MagicMock()]
+    mock_response.choices[0].message.tool_calls[0].function.name = "finish_test"
+    mock_response.choices[0].message.tool_calls[0].function.arguments = json.dumps(
+        arguments
+    )
+
+    mock_executor = MagicMock()
+    mock_executor.config = MagicMock()
+    mock_executor.config.cache_key = None
+    token = context_scenario.set(mock_executor)
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", return_value=mock_response
+        ):
+            return await judge.call(agent_input)
+    finally:
+        context_scenario.reset(token)
+        ScenarioConfig.default_config = None
+
+
+@pytest.mark.asyncio
+async def test_unforced_inconclusive_finish_continues_the_conversation():
+    """Mid-conversation, no judgment_request: inconclusive means continue."""
+    result = await _run_judge(
+        verdict="inconclusive",
+        judgment_request=None,
+        current_turn=1,
+    )
+
+    assert result == []  # the judge's continue contract
+
+
+@pytest.mark.asyncio
+async def test_unforced_finish_with_missing_verdict_continues_too():
+    """A finish_test without a verdict field defaults to inconclusive - continue."""
+    result = await _run_judge(
+        verdict=None,
+        judgment_request=None,
+        current_turn=1,
+    )
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_forced_by_judgment_request_stays_terminal():
+    """An explicit judgment_request keeps today's terminal behavior."""
+    result = await _run_judge(
+        verdict="inconclusive",
+        judgment_request=JudgmentRequest(),
+        current_turn=1,
+    )
+
+    assert isinstance(result, ScenarioResult)
+    assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_forced_by_last_turn_stays_terminal():
+    """On the last turn the judge must deliver a verdict - inconclusive is terminal."""
+    result = await _run_judge(
+        verdict="inconclusive",
+        judgment_request=None,
+        current_turn=9,
+        max_turns=10,
+    )
+
+    assert isinstance(result, ScenarioResult)
+    assert result.success is False

--- a/python/tests/test_judge_inconclusive_continues.py
+++ b/python/tests/test_judge_inconclusive_continues.py
@@ -117,6 +117,67 @@ async def test_forced_by_judgment_request_stays_terminal():
 
 
 @pytest.mark.asyncio
+async def test_criteria_less_last_turn_judge_pins_finish_test_and_stays_terminal():
+    """A required judgment is not dodgeable via continue_test even with no
+    criteria — otherwise the run falls through to the generic max-turns
+    failure and the judge's reasoning is lost."""
+    ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
+    judge = JudgeAgent(criteria=[])
+
+    mock_scenario_state = MagicMock()
+    mock_scenario_state.description = "Test scenario"
+    mock_scenario_state.current_turn = 9
+    mock_scenario_state.config.max_turns = 10
+
+    agent_input = AgentInput(
+        thread_id="test",
+        messages=[{"role": "user", "content": "Hello"}],
+        new_messages=[],
+        judgment_request=None,
+        scenario_state=mock_scenario_state,
+    )
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.tool_calls = [MagicMock()]
+    mock_response.choices[0].message.tool_calls[0].function.name = "finish_test"
+    mock_response.choices[0].message.tool_calls[0].function.arguments = json.dumps(
+        {
+            "verdict": "inconclusive",
+            "reasoning": "Nothing more to observe.",
+            "criteria": {},
+        }
+    )
+
+    mock_executor = MagicMock()
+    mock_executor.config = MagicMock()
+    mock_executor.config.cache_key = None
+    token = context_scenario.set(mock_executor)
+
+    captured_tool_choice = {}
+
+    def capture_completion(**kwargs):
+        captured_tool_choice["value"] = kwargs.get("tool_choice")
+        return mock_response
+
+    try:
+        with patch(
+            "scenario.judge_agent.litellm.completion", side_effect=capture_completion
+        ):
+            result = await judge.call(agent_input)
+    finally:
+        context_scenario.reset(token)
+        ScenarioConfig.default_config = None
+
+    assert captured_tool_choice["value"] == {
+        "type": "function",
+        "function": {"name": "finish_test"},
+    }
+    assert isinstance(result, ScenarioResult)
+    assert result.success is False
+
+
+@pytest.mark.asyncio
 async def test_forced_by_last_turn_stays_terminal():
     """On the last turn the judge must deliver a verdict - inconclusive is terminal."""
     result = await _run_judge(

--- a/python/tests/test_judge_inconclusive_continues.py
+++ b/python/tests/test_judge_inconclusive_continues.py
@@ -10,14 +10,14 @@ exhaustion) keeps its terminal behavior.
 """
 
 import json
-from typing import Any, Optional
+from typing import Optional
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from scenario import JudgeAgent
 from scenario.config import ScenarioConfig
-from scenario.types import AgentInput, JudgmentRequest, ScenarioResult
+from scenario.types import AgentInput, AgentReturnTypes, JudgmentRequest, ScenarioResult
 from scenario.cache import context_scenario
 
 
@@ -27,8 +27,9 @@ async def _run_judge(
     judgment_request: Optional[JudgmentRequest],
     current_turn: int,
     max_turns: int = 10,
-) -> Any:
+) -> AgentReturnTypes:
     """Drive JudgeAgent through a finish_test tool call and return the raw result."""
+    previous_default_config = ScenarioConfig.default_config
     ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
     criteria = ["Agent requests approval before applying the change"]
     judge = JudgeAgent(criteria=criteria)
@@ -75,7 +76,7 @@ async def _run_judge(
             return await judge.call(agent_input)
     finally:
         context_scenario.reset(token)
-        ScenarioConfig.default_config = None
+        ScenarioConfig.default_config = previous_default_config
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_judge_inconclusive_continues.py
+++ b/python/tests/test_judge_inconclusive_continues.py
@@ -121,6 +121,7 @@ async def test_criteria_less_last_turn_judge_pins_finish_test_and_stays_terminal
     """A required judgment is not dodgeable via continue_test even with no
     criteria — otherwise the run falls through to the generic max-turns
     failure and the judge's reasoning is lost."""
+    previous_default_config = ScenarioConfig.default_config
     ScenarioConfig.default_config = ScenarioConfig(default_model="openai/gpt-4")
     judge = JudgeAgent(criteria=[])
 
@@ -167,7 +168,7 @@ async def test_criteria_less_last_turn_judge_pins_finish_test_and_stays_terminal
             result = await judge.call(agent_input)
     finally:
         context_scenario.reset(token)
-        ScenarioConfig.default_config = None
+        ScenarioConfig.default_config = previous_default_config
 
     assert captured_tool_choice["value"] == {
         "type": "function",

--- a/python/tests/test_judge_transport_reasoning.py
+++ b/python/tests/test_judge_transport_reasoning.py
@@ -218,6 +218,7 @@ class TestEveryCallSiteThatSendsTools:
                 working_messages=[],
                 effective_criteria=["c"],
                 input_messages=[],
+                verdict_forced=False,
             )
 
         assert completion.call_args.kwargs["reasoning_effort"] == "none"


### PR DESCRIPTION
## For humans

When the judge in a simulation isn't sure yet, it sometimes ends the whole run with an "inconclusive" verdict instead of letting the conversation continue. The run then shows as FAILED right after the agent's last message — which looks exactly like the simulated user stopped responding. This PR makes "can't tell yet" mean "keep going": the conversation continues, and the judge only delivers a final verdict when one is actually required. Fixes #886.

## Cause

`parseToolCalls` treated **any** `finish_test` tool call as terminal and mapped every verdict ≠ `"success"` to a failure (`javascript/src/agents/judge/judge-agent.ts:753-776`; Python mirror `python/scenario/judge_agent.py`). The `finish_test` schema offers `"inconclusive"` as a verdict, so a judge model reporting "too early to tell" ended the run as FAILED — with `continue_test` freely available the whole time.

## Fix

- A `finish_test` with `verdict: "inconclusive"` (or a missing verdict, which defaults to inconclusive) is treated as `continue_test` — the judge returns the continue contract (`null` in JS, `[]` in Python) — **unless the judgment was forced**: last turn, an explicit `judge()` checkpoint, or discovery exhaustion. Forced judgments keep their terminal semantics and results.
- One `judgmentRequired` source of truth feeds both the `toolChoice` pinning and the new `verdictForced` flag, in both SDKs, and both are deliberately independent of `hasCriteria` (review round, `6a82e3b2`): a required judgment cannot be dodged via `continue_test`, so a criteria-less judge on the last turn delivers its terminal result instead of silently sliding into the generic max-turns failure. This is the one deliberate behavior change on a forced path vs. main — previously a criteria-less last-turn judge was left unpinned.
- The judge system prompt now says to prefer `continue_test` while the conversation can continue, and explicitly permits an honest inconclusive when a final verdict is required (both SDKs, so JS — which has no last-turn counter-message — doesn't pressure the model into fabricating a definitive verdict).

No event-schema change, no new wire verdict values.

## Failing test first

`javascript/src/agents/judge/__tests__/judge-agent.test.ts` (before the fix):

```
- Expected: null
+ Received: { "metCriteria": [], "success": false,
    "unmetCriteria": ["Agent requests approval before applying the change"] }
```

`javascript/src/execution/__tests__/judge-inconclusive-continues.test.ts` (real `ScenarioExecution` + real judge, only the LLM stubbed):

```
AssertionError: expected 1 to be 2   // judge called once — the run died at turn 1
```

Python `tests/test_judge_inconclusive_continues.py` failed the same way (`ScenarioResult` returned where `[]` was expected).

## After

- JS: 1086 passed (full `src` suite) + typecheck + `lint:all` clean
- Python: 653 passed (full suite minus on-demand voice tiers)
- New coverage: unforced inconclusive → continue (unit + execution level), forced paths pinned terminal (last turn, checkpoint, discovery exhaustion — both SDKs), unforced inconclusive during large-trace discovery → continue, and a required large-trace judgment that answers continue_test is forced to a terminal verdict rather than dodging into the max-turns failure (both SDKs; review round `77ce1dbd`).

## Sweep

Already done exhaustively before this fix — the same tri-state-collapse shape across both SDKs and the platform is mapped and filed as #887 (judge verdict pipeline), #888 (red-team report), and platform-side langwatch/langwatch#6833/#6834/#6835. Deliberately **not** fixed here (separate defect classes, separate reviewers):

- Emitting `INCONCLUSIVE` on forced final verdicts (today it still collapses to FAILURE at the emit boundary) — #887
- JS criteria-payload hardening parity with Python's #161 fix — #887
- Platform fold mapping inconclusive→FAILURE — langwatch/langwatch#6834

## Delivery note

The platform vendors this SDK as a tarball (`vendor/langwatch-scenario-1.0.0.tgz`); a follow-up PR in langwatch/langwatch re-vendors it after this merges — without that, production never sees this fix.


