### PR TITLE
feat(python): export the voice error types from the package root (#723)

### DIFF
--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -135,18 +135,22 @@ from .script import message, user, agent, judge, proceed, succeed, fail
 # what changes is the medium, not the paradigm.
 from .voice import (
     AdapterCapabilities,
+    AgentStreamEndedError,
     AudioChunk,
     AudioSegment,
     ComposableVoiceAgent,
     ElevenLabsAgentAdapter,
     ElevenLabsSTTProvider,
     ElevenLabsVoiceAgent,
+    FirstChunkTimeoutError,
     GeminiLiveAgentAdapter,
     LatencyMetrics,
     LiveKitAgentAdapter,
+    ModalityNegotiationError,
     OpenAIRealtimeAgentAdapter,
     OpenAISTTProvider,
     PipecatAgentAdapter,
+    PipecatRecvError,
     STTProvider,
     TwilioAgentAdapter,
     UnsupportedCapabilityError,
@@ -219,6 +223,13 @@ __all__ = [
     "OpenAISTTProvider",
     "STTProvider",
     "UnsupportedCapabilityError",
+    # Voice errors, catchable from the package root. `raise` sites live in
+    # scenario.voice, but a caller writing `except scenario.<Error>` should
+    # not have to know that.
+    "AgentStreamEndedError",
+    "FirstChunkTimeoutError",
+    "ModalityNegotiationError",
+    "PipecatRecvError",
     "VoiceAgentAdapter",
     "VoiceEvent",
     "VoiceRecording",

--- a/python/tests/test_public_error_exports.py
+++ b/python/tests/test_public_error_exports.py
@@ -6,6 +6,8 @@ errors below were reachable only through the submodule, so catching them by
 type meant importing a second path and knowing which one raised.
 """
 
+import pytest
+
 import scenario
 import scenario.voice as voice
 
@@ -56,10 +58,28 @@ class TestGivenTheVoicePackageGainsANewError:
         """
         declared = [n for n in voice.__all__ if n.endswith("Error")]
         assert declared, "expected scenario.voice to declare at least one error"
-        missing = [n for n in declared if not hasattr(scenario, n)]
-        assert missing == [], (
-            f"{missing} are exported from scenario.voice but not from scenario; "
-            "add them to the root import block and __all__"
+
+        # The same three properties the named list above is held to, applied
+        # to whatever the voice package declares. Reachability alone would let
+        # a future error be rebound to a different class at the root, or be
+        # reachable but unlisted, and still pass here.
+        unreachable = [n for n in declared if not hasattr(scenario, n)]
+        assert unreachable == [], (
+            f"{unreachable} are exported from scenario.voice but not from "
+            "scenario; add them to the root import block and __all__"
+        )
+
+        rebound = [n for n in declared if getattr(scenario, n) is not getattr(voice, n)]
+        assert rebound == [], (
+            f"{rebound} resolve to a different class at the root than the one "
+            "scenario.voice raises, so catching them from the root would miss"
+        )
+
+        unlisted = [n for n in declared if n not in scenario.__all__]
+        assert unlisted == [], (
+            f"{unlisted} are reachable from the root but missing from "
+            "scenario.__all__, so they are exported by accident rather than "
+            "on purpose"
         )
 
 
@@ -74,9 +94,6 @@ class TestGivenAPipecatReceiveFailure:
         """
         assert issubclass(scenario.PipecatRecvError, scenario.AgentStreamEndedError)
 
-        try:
+        with pytest.raises(scenario.AgentStreamEndedError) as caught:
             raise scenario.PipecatRecvError("transport closed")
-        except scenario.AgentStreamEndedError as caught:
-            assert isinstance(caught, scenario.PipecatRecvError)
-        else:  # pragma: no cover - the except above always runs
-            raise AssertionError("PipecatRecvError was not caught as AgentStreamEndedError")
+        assert isinstance(caught.value, scenario.PipecatRecvError)

--- a/python/tests/test_public_error_exports.py
+++ b/python/tests/test_public_error_exports.py
@@ -94,6 +94,11 @@ class TestGivenAPipecatReceiveFailure:
         """
         assert issubclass(scenario.PipecatRecvError, scenario.AgentStreamEndedError)
 
-        with pytest.raises(scenario.AgentStreamEndedError) as caught:
+        # Nothing follows the block on purpose. `pytest.raises(Base)` passes
+        # only when the raised object is an instance of Base, which is the
+        # catchability property itself, since `except` matching in CPython is
+        # isinstance matching. A trailing assertion would add nothing and
+        # reads as unreachable to static analysis, which cannot model the
+        # context manager swallowing the exception.
+        with pytest.raises(scenario.AgentStreamEndedError, match="transport closed"):
             raise scenario.PipecatRecvError("transport closed")
-        assert isinstance(caught.value, scenario.PipecatRecvError)

--- a/python/tests/test_public_error_exports.py
+++ b/python/tests/test_public_error_exports.py
@@ -1,0 +1,82 @@
+"""The package root has to be enough to catch what the library raises.
+
+``scenario.voice`` is where the voice adapters live, but a caller writing
+``except scenario.FirstChunkTimeoutError`` should not have to know that. The
+errors below were reachable only through the submodule, so catching them by
+type meant importing a second path and knowing which one raised.
+"""
+
+import scenario
+import scenario.voice as voice
+
+
+VOICE_ERRORS = [
+    "AgentStreamEndedError",
+    "FirstChunkTimeoutError",
+    "ModalityNegotiationError",
+    "PipecatRecvError",
+    "UnsupportedCapabilityError",
+]
+
+
+class TestGivenAnErrorTheLibraryRaises:
+    def test_reaches_the_package_root(self) -> None:
+        missing = [name for name in VOICE_ERRORS if not hasattr(scenario, name)]
+        assert missing == []
+
+    def test_is_the_same_class_the_submodule_raises(self) -> None:
+        """Identity, not just a name.
+
+        A re-export that rebound the name to a fresh class would satisfy an
+        attribute check and still fail every ``except``, since the object the
+        adapter raises would be a different class from the one caught.
+        """
+        for name in VOICE_ERRORS:
+            assert getattr(scenario, name) is getattr(voice, name), name
+
+    def test_is_listed_in_the_root_public_surface(self) -> None:
+        """``__all__`` is what ``from scenario import *`` and the docs follow.
+
+        An attribute that exists but is unlisted is reachable by accident
+        rather than on purpose, and tooling that reads the surface will not
+        show it.
+        """
+        missing = [name for name in VOICE_ERRORS if name not in scenario.__all__]
+        assert missing == []
+
+
+class TestGivenTheVoicePackageGainsANewError:
+    def test_the_root_gains_it_too(self) -> None:
+        """The list above is a floor, not the contract.
+
+        This is the part that keeps the gap from reopening: it derives the
+        expectation from ``scenario.voice.__all__`` at run time, so an error
+        added there and forgotten here fails without anyone remembering to
+        update a list. That is exactly how these four came to be missing.
+        """
+        declared = [n for n in voice.__all__ if n.endswith("Error")]
+        assert declared, "expected scenario.voice to declare at least one error"
+        missing = [n for n in declared if not hasattr(scenario, n)]
+        assert missing == [], (
+            f"{missing} are exported from scenario.voice but not from scenario; "
+            "add them to the root import block and __all__"
+        )
+
+
+class TestGivenAPipecatReceiveFailure:
+    def test_is_catchable_as_the_general_stream_ended_error(self) -> None:
+        """The subclass relationship has to survive the re-export.
+
+        ``PipecatRecvError`` is documented as a subclass of
+        ``AgentStreamEndedError`` so a caller can catch the general case. Both
+        names now come from the root, and the relationship is only useful if
+        it holds between the objects the root hands out.
+        """
+        assert issubclass(scenario.PipecatRecvError, scenario.AgentStreamEndedError)
+
+        try:
+            raise scenario.PipecatRecvError("transport closed")
+        except scenario.AgentStreamEndedError as caught:
+            assert isinstance(caught, scenario.PipecatRecvError)
+        else:  # pragma: no cover - the except above always runs
+            raise AssertionError("PipecatRecvError was not caught as AgentStreamEndedError")


### PR DESCRIPTION
## Ticket

Closes #723.

`FirstChunkTimeoutError`, `AgentStreamEndedError` and `PipecatRecvError` are exported from `scenario.voice` but not from `scenario`, so a caller cannot catch what the library raises without importing a second path and knowing which module raised it.

## One more than the ticket says

The same check run against the whole module found **four** missing, not three:

```
voice __all__: 42 names; 5 errors:
  AgentStreamEndedError, FirstChunkTimeoutError, PipecatRecvError,
  UnsupportedCapabilityError, ModalityNegotiationError
missing from top-level: AgentStreamEndedError, FirstChunkTimeoutError,
  PipecatRecvError, ModalityNegotiationError
```

`ModalityNegotiationError` postdates the ticket and was missing the same way. `UnsupportedCapabilityError` was already exported, which is what made the gap easy to miss: the root does export a voice error, just not these.

## Change

The four names join the root's existing `from .voice import (...)` block and `__all__`. No new module, no shim, no alias.

## Evidence

**The guard derives its expectation rather than restating it.** The last test reads `scenario.voice.__all__` at run time and asserts every `*Error` in it is reachable from the root. A hand-written list would have to be updated by the same person who forgot the export, which is precisely how all four of these came to be missing.

**Identity is asserted, not just reachability.** A re-export that rebound a name to a fresh class satisfies `hasattr` and still fails every `except`, because the object the adapter raises is then a different class from the one the caller caught. Same reason `PipecatRecvError` subclassing `AgentStreamEndedError` is asserted through the root names.

**Mutation-checked, 4 of 4 caught**, each applied to the shipped source with the files restored between runs:

| # | Mutation | Result |
|---|---|---|
| M1 | four names dropped from the root `__all__` only, attributes still present | CAUGHT |
| M2 | four names dropped from the root import block | CAUGHT |
| M3 | root rebinds `FirstChunkTimeoutError` to a fresh class | CAUGHT |
| M4 | a **new** error joins `scenario.voice.__all__` and nobody updates the root | CAUGHT |

M4 is the one worth reading. It adds an error that does not exist in this PR, which is the exact future case the derived guard exists for, and it fails as intended. Without it the guard could have been vacuously true.

**Suite.** `pytest tests/ -m "not integration"` gives **1233 passed, 10 skipped**, the whole non-integration suite. `pyright` reports 0 errors on both changed files.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.
