### PR TITLE
fix(voice): align the JS response timeout with Python and split the two receiveAudio timeouts

### DIFF
--- a/docs/docs/pages/voice/troubleshooting.mdx
+++ b/docs/docs/pages/voice/troubleshooting.mdx
@@ -191,6 +191,36 @@ never appended to the internal `VoiceRecording` buffer, so `save_segments()`
 Multi-turn on hosted ElevenLabs works — if you are hitting this on a scripted
 turn 2+, check these in order.
 
+**Read which bound expired.** `receiveAudio` / `recv_audio` arms two deadlines
+and the error says which one fired:
+
+| Bound | Message opens with | What it means |
+|---|---|---|
+| Idle deadline | `The idle deadline of 60s elapsed with no message of any kind from the hosted agent, not even a keepalive ping.` | The socket went completely quiet. Its length is `responseTimeout` / `response_timeout`. |
+| Absolute ceiling | `The absolute ceiling of 60s elapsed while the hosted agent kept the socket alive with keepalive pings but never sent audio.` | The agent was alive the whole time and never spoke. Pings re-arm the idle deadline, so `max(responseTimeout, 45s)` is what bounds this case. |
+
+A silent agent and a pinging one are different problems, so read the bound
+before working through the causes below.
+
+**Raise the timeout for a slow agent.** An agent that runs a tool call, a
+retrieval step, or a long generation before it speaks can pass the default 60
+seconds with nothing wrong. Both SDKs default to 60; raising the knob moves both
+bounds, because the ceiling is `max(responseTimeout, 45s)`.
+
+:::code-group
+
+```python [python]
+adapter = scenario.ElevenLabsAgentAdapter(agent_id=..., api_key=...)
+adapter.response_timeout = 180  # wait up to 3 minutes
+```
+
+```typescript [typescript]
+const agent = scenario.elevenLabsAgent({ agentId, apiKey });
+agent.responseTimeout = 180; // wait up to 3 minutes
+```
+
+:::
+
 **Lead with `agent()`.** The on-connect greeting (`first_message`) has to drain
 before your user audio hits the wire, so the canonical shape is
 `agent() → user("…") → agent() → … → judge()`.
@@ -209,8 +239,9 @@ call. That is now reported on the adapter's `agent_hung_up` / `agentHungUp` flag
 and concludes the scenario rather than timing out.
 
 **Rule out a wedged tool call.** A hosted agent that keeps ping-ing but never
-sends audio (a stuck server tool or RAG lookup) is bounded by a 45s absolute
-ceiling and then surfaces this timeout. Check the agent's tool configuration.
+sends audio (a stuck server tool or RAG lookup) is bounded by the absolute
+ceiling above and then surfaces this timeout. Check the agent's tool
+configuration.
 
 ---
 

--- a/docs/docs/pages/voice/troubleshooting.mdx
+++ b/docs/docs/pages/voice/troubleshooting.mdx
@@ -197,10 +197,10 @@ and the error says which one fired:
 | Bound | Message opens with | What it means |
 |---|---|---|
 | Idle deadline | `The idle deadline of 60s elapsed with no message of any kind from the hosted agent, not even a keepalive ping.` | The socket went completely quiet. Its length is `responseTimeout` / `response_timeout`. |
-| Absolute ceiling | `The absolute ceiling of 60s elapsed while the hosted agent kept the socket alive with keepalive pings but never sent audio.` | The agent was alive the whole time and never spoke. Pings re-arm the idle deadline, so `max(responseTimeout, 45s)` is what bounds this case. |
+| Absolute ceiling | `The absolute ceiling of 60s elapsed while the hosted agent kept sending frames, keepalive pings or transcripts, but never audio.` | The agent was alive the whole time and never spoke. Every inbound frame re-arms the idle deadline, keepalive pings and transcripts alike, so `max(responseTimeout, 45s)` is what bounds this case. |
 
-A silent agent and a pinging one are different problems, so read the bound
-before working through the causes below.
+A silent agent and a talkative-but-speechless one are different problems, so
+read the bound before working through the causes below.
 
 **Raise the timeout for a slow agent.** An agent that runs a tool call, a
 retrieval step, or a long generation before it speaks can pass the default 60

--- a/javascript/src/voice/adapter.runtime.ts
+++ b/javascript/src/voice/adapter.runtime.ts
@@ -111,7 +111,8 @@ export class AgentSpeakingEvent {
   }
 }
 
-const SAFE_DEFAULT_RESPONSE_TIMEOUT_S = 30;
+/** Mirrors `VoiceAgentAdapter.responseTimeout` for an adapter that nulls it out. */
+const SAFE_DEFAULT_RESPONSE_TIMEOUT_S = 60;
 const SAFE_DEFAULT_TAIL_SILENCE_S = 0.6;
 const SAFE_DEFAULT_MAX_DURATION_S = 30;
 /**

--- a/javascript/src/voice/adapter.ts
+++ b/javascript/src/voice/adapter.ts
@@ -79,8 +79,21 @@ export abstract class VoiceAgentAdapter extends AgentAdapter {
     return defaultVoiceCall(this, input);
   }
 
-  /** Seconds to wait for agent audio after sending user audio. */
-  responseTimeout = 30.0;
+  /**
+   * Seconds to wait for agent audio after sending user audio: the STT + LLM +
+   * TTS budget for one agent turn. Kept identical to Python's
+   * `VoiceAgentAdapter.response_timeout` so the same scenario passes or fails
+   * the same way in both SDKs.
+   *
+   * Raise it for an agent that runs a tool call or a retrieval step before it
+   * speaks:
+   *
+   * ```ts
+   * const agent = elevenLabsAgent({ agentId, apiKey });
+   * agent.responseTimeout = 180; // wait up to 3 minutes
+   * ```
+   */
+  responseTimeout = 60.0;
 
   /**
    * Tail silence: once the first agent chunk arrives, keep draining

--- a/javascript/src/voice/adapters/__tests__/elevenlabs-receive-timeout.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs-receive-timeout.test.ts
@@ -10,6 +10,9 @@
  * Keyless: the real SDK `Conversation` runs against the in-memory
  * `FakeWebSocket`, and fake timers stand in for the wall clock, so a 60s budget
  * costs milliseconds.
+ *
+ * Run with `pnpm test src/voice/adapters/__tests__/elevenlabs-receive-timeout.test.ts`
+ * from `javascript/`.
  */
 import { Buffer } from "node:buffer";
 
@@ -136,7 +139,7 @@ describe("receiveAudio timeout budget and diagnosis", () => {
       const message = settled.error()?.message ?? "";
       expect(message).toContain("receiveAudio timed out");
       expect(message).toContain("The absolute ceiling of 60s elapsed");
-      expect(message).toContain("keepalive pings but never sent audio");
+      expect(message).toContain("kept sending frames, keepalive pings or transcripts, but never audio");
       expect(message).toContain("responseTimeout");
       expect(message).toContain(TROUBLESHOOTING_ANCHOR);
       expect(message).not.toContain("The idle deadline");

--- a/javascript/src/voice/adapters/__tests__/elevenlabs-receive-timeout.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs-receive-timeout.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Binds `specs/voice-receive-timeout-diagnosis.feature`.
+ *
+ * `receiveAudio` bounds a turn with two deadlines: an IDLE one of
+ * `responseTimeout` that every inbound frame re-arms, and an ABSOLUTE ceiling of
+ * `max(responseTimeout, 45s)` that nothing re-arms. These tests pin the default
+ * budget (60s, the same number Python uses) and pin each deadline to its own
+ * rejection, so a silent agent and a pinging one stay separate diagnoses.
+ *
+ * Keyless: the real SDK `Conversation` runs against the in-memory
+ * `FakeWebSocket`, and fake timers stand in for the wall clock, so a 60s budget
+ * costs milliseconds.
+ */
+import { Buffer } from "node:buffer";
+
+import { describe, it, expect, vi } from "vitest";
+
+import { ElevenLabsAgentAdapter } from "../index";
+import { FakeWebSocket, makeFakeConv } from "./fixtures/fake-elevenlabs-conversation";
+
+/** Python's `VoiceAgentAdapter.response_timeout`, which JS now matches. */
+const PYTHON_RESPONSE_TIMEOUT_S = 60;
+
+/** `KEEPALIVE_HARD_CEILING_S` in both SDKs. Not exported, so restated here. */
+const KEEPALIVE_HARD_CEILING_S = 45;
+
+const TROUBLESHOOTING_ANCHOR =
+  "https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs";
+
+/** 8 bytes of valid PCM16 (even byte count), base64 as EL sends it. */
+const PCM_B64 = Buffer.from("\x12\x34".repeat(4)).toString("base64");
+
+/** Feed one inbound EL ConvAI frame to the SDK over the fake socket. */
+function emit(socket: FakeWebSocket, event: Record<string, unknown>): void {
+  socket.emit("message", Buffer.from(JSON.stringify(event), "utf-8"));
+}
+
+async function makeConnected(): Promise<{
+  adapter: ElevenLabsAgentAdapter;
+  socket: FakeWebSocket;
+}> {
+  const fake = makeFakeConv();
+  const adapter = new ElevenLabsAgentAdapter({
+    agentId: "agt-receive-timeout",
+    apiKey: "sk-receive-timeout",
+    webSocketFactory: fake.webSocketFactory,
+    conversationClient: fake.conversationClient,
+  });
+  await adapter.connect();
+  return { adapter, socket: fake.socket.current! };
+}
+
+/**
+ * Run `body` against a connected adapter under fake timers, tearing both down
+ * however the body ends. The pump interval and the receive deadlines are the
+ * only clocks involved, so nothing here waits on the real one.
+ */
+async function withFakeClock(
+  body: (ctx: { adapter: ElevenLabsAgentAdapter; socket: FakeWebSocket }) => Promise<void>,
+): Promise<void> {
+  vi.useFakeTimers();
+  let adapter: ElevenLabsAgentAdapter | undefined;
+  try {
+    const connected = await makeConnected();
+    adapter = connected.adapter;
+    await body(connected);
+  } finally {
+    await adapter?.disconnect();
+    vi.useRealTimers();
+  }
+}
+
+/** Settle a receive promise without letting a rejection escape as unhandled. */
+function track(promise: Promise<unknown>): { error: () => Error | undefined } {
+  let error: Error | undefined;
+  promise.catch((err: Error) => {
+    error = err;
+  });
+  return { error: () => error };
+}
+
+describe("receiveAudio timeout budget and diagnosis", () => {
+  it("defaults responseTimeout to the same 60s budget Python uses", () => {
+    const adapter = new ElevenLabsAgentAdapter({ agentId: "agt", apiKey: "sk" });
+    expect(adapter.responseTimeout).toBe(PYTHON_RESPONSE_TIMEOUT_S);
+  });
+
+  it("resolves for an agent that answers after 35s, inside the default budget", async () => {
+    await withFakeClock(async ({ adapter, socket }) => {
+      const recv = adapter.receiveAudio(adapter.responseTimeout);
+      const settled = track(recv);
+
+      // Past the old 30s budget, which rejected here, and short of the 60s one.
+      await vi.advanceTimersByTimeAsync(35_000);
+      expect(settled.error(), "rejected before the agent got its 60s").toBeUndefined();
+
+      emit(socket, { type: "audio", audio_event: { audio_base_64: PCM_B64 } });
+      await vi.advanceTimersByTimeAsync(20);
+
+      const chunk = await recv;
+      expect(chunk.data.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("names the idle deadline when the agent goes completely silent", async () => {
+    await withFakeClock(async ({ adapter }) => {
+      const recv = adapter.receiveAudio(adapter.responseTimeout);
+      const settled = track(recv);
+
+      await vi.advanceTimersByTimeAsync(PYTHON_RESPONSE_TIMEOUT_S * 1000 + 50);
+
+      const message = settled.error()?.message ?? "";
+      expect(message).toContain("receiveAudio timed out");
+      expect(message).toContain("The idle deadline of 60s elapsed");
+      expect(message).toContain("not even a keepalive ping");
+      expect(message).toContain("responseTimeout");
+      expect(message).toContain(TROUBLESHOOTING_ANCHOR);
+      // The silent case is NOT the ceiling case, even though at the default
+      // budget both deadlines land on the same instant.
+      expect(message).not.toContain("absolute ceiling");
+    });
+  });
+
+  it("names the absolute ceiling when the agent pings but never speaks", async () => {
+    await withFakeClock(async ({ adapter, socket }) => {
+      const recv = adapter.receiveAudio(adapter.responseTimeout);
+      const settled = track(recv);
+
+      // A ping every 20s keeps re-arming the 60s idle deadline, so only the
+      // ceiling can end this wait.
+      for (let elapsed = 0; elapsed < 70_000; elapsed += 20_000) {
+        emit(socket, { type: "ping", ping_event: { event_id: elapsed, ping_ms: 5 } });
+        await vi.advanceTimersByTimeAsync(20_000);
+      }
+
+      const message = settled.error()?.message ?? "";
+      expect(message).toContain("receiveAudio timed out");
+      expect(message).toContain("The absolute ceiling of 60s elapsed");
+      expect(message).toContain("keepalive pings but never sent audio");
+      expect(message).toContain("responseTimeout");
+      expect(message).toContain(TROUBLESHOOTING_ANCHOR);
+      expect(message).not.toContain("The idle deadline");
+    });
+  });
+
+  it("honours a raised responseTimeout on the idle path", async () => {
+    await withFakeClock(async ({ adapter }) => {
+      adapter.responseTimeout = 90;
+      const recv = adapter.receiveAudio(adapter.responseTimeout);
+      const settled = track(recv);
+
+      await vi.advanceTimersByTimeAsync(PYTHON_RESPONSE_TIMEOUT_S * 1000 + 50);
+      expect(settled.error(), "rejected at the default instead of the override").toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(settled.error()?.message ?? "").toContain("The idle deadline of 90s elapsed");
+    });
+  });
+
+  it("honours a raised responseTimeout on the ceiling path", async () => {
+    await withFakeClock(async ({ adapter, socket }) => {
+      adapter.responseTimeout = 90;
+      const recv = adapter.receiveAudio(adapter.responseTimeout);
+      const settled = track(recv);
+
+      // Pings every 30s: under the 90s idle deadline, so the ceiling decides.
+      for (let elapsed = 0; elapsed < 100_000; elapsed += 30_000) {
+        emit(socket, { type: "ping", ping_event: { event_id: elapsed, ping_ms: 5 } });
+        if (elapsed === 30_000) {
+          expect(
+            settled.error(),
+            `rejected at the ${KEEPALIVE_HARD_CEILING_S}s floor instead of the raised ceiling`,
+          ).toBeUndefined();
+        }
+        await vi.advanceTimersByTimeAsync(30_000);
+      }
+
+      expect(settled.error()?.message ?? "").toContain("The absolute ceiling of 90s elapsed");
+    });
+  });
+
+  it("keeps a sub-second tail probe on the 45s ceiling floor", async () => {
+    await withFakeClock(async ({ adapter, socket }) => {
+      // The drain's tail probe passes responseTailSilence, not responseTimeout,
+      // so the ceiling floor is what stops a pinging agent wedging the probe.
+      const recv = adapter.receiveAudio(0.6);
+      const settled = track(recv);
+
+      for (let elapsed = 0; elapsed < 46_000; elapsed += 500) {
+        emit(socket, { type: "ping", ping_event: { event_id: elapsed, ping_ms: 5 } });
+        await vi.advanceTimersByTimeAsync(500);
+      }
+
+      expect(settled.error()?.message ?? "").toContain(
+        `The absolute ceiling of ${KEEPALIVE_HARD_CEILING_S}s elapsed`,
+      );
+    });
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-spans.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-spans.test.ts
@@ -349,7 +349,7 @@ describe("OpenAIRealtimeAgentAdapter voice.realtime.* span instrumentation (#770
   it("marks voice.audio.receive ERROR + first_chunk_timeout on a first-chunk failure (AGENT role)", async () => {
     const handle = newHandle();
     const adapter = buildAdapter(handle.port, { apiKey: "test-key", role: AgentRole.AGENT });
-    adapter.responseTimeout = 0.3; // fast — the 30s default would hang the suite
+    adapter.responseTimeout = 0.3; // fast — the 60s default would hang the suite
     await connectAndAwaitSessionUpdate(handle, adapter);
 
     const input = {

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -154,14 +154,14 @@ function idleTimeoutMessage(timeoutS: number): string {
 }
 
 /**
- * Rejection text for the ABSOLUTE ceiling: the agent kept the socket alive with
- * keepalive pings, which re-arm the idle deadline, but never sent audio.
+ * Rejection text for the ABSOLUTE ceiling: the agent kept sending frames, which
+ * re-arm the idle deadline, but never sent audio.
  */
 function ceilingTimeoutMessage(timeoutS: number, ceilingS: number): string {
   return (
     `ElevenLabsAgentAdapter: receiveAudio timed out. The absolute ceiling of ${ceilingS}s ` +
-    "elapsed while the hosted agent kept the socket alive with keepalive pings but " +
-    "never sent audio. Pings re-arm the idle deadline, so this ceiling, " +
+    "elapsed while the hosted agent kept sending frames, keepalive pings or transcripts, " +
+    "but never audio. Every inbound frame re-arms the idle deadline, so this ceiling, " +
     `max(responseTimeout, ${KEEPALIVE_HARD_CEILING_S}s), is what bounds the wait. It usually ` +
     "means a wedged server tool or retrieval call, or an agent that ended or " +
     "transferred its turn. If the agent is only slower than that, raise the adapter's " +

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -129,6 +129,48 @@ const PUMP_INTERVAL_MS = 20;
  */
 const KEEPALIVE_HARD_CEILING_S = 45;
 
+/** Deep link to the section that expands on both receiveAudio timeouts. */
+const RECEIVE_TIMEOUT_DOCS_URL =
+  "https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs";
+
+/**
+ * Rejection text for the IDLE deadline: nothing at all reached the socket, not
+ * even a keepalive ping, for `timeoutS` seconds. A fully silent agent.
+ *
+ * Distinct from {@link ceilingTimeoutMessage} on purpose: silence and
+ * pings-but-no-audio are different diagnoses with different remedies, so one
+ * shared message would send the reader to check the wrong things.
+ */
+function idleTimeoutMessage(timeoutS: number): string {
+  return (
+    `ElevenLabsAgentAdapter: receiveAudio timed out. The idle deadline of ${timeoutS}s ` +
+    "elapsed with no message of any kind from the hosted agent, not even a keepalive " +
+    "ping. For a scripted multi-turn run this usually means the agent ended or " +
+    "transferred its turn (e.g. an escalation/handoff request), or the user turn did " +
+    "not commit. If the agent is only slower than that, raise the adapter's " +
+    `responseTimeout, currently ${timeoutS}s, for example agent.responseTimeout = 180. ` +
+    `See ${RECEIVE_TIMEOUT_DOCS_URL}`
+  );
+}
+
+/**
+ * Rejection text for the ABSOLUTE ceiling: the agent kept the socket alive with
+ * keepalive pings, which re-arm the idle deadline, but never sent audio.
+ */
+function ceilingTimeoutMessage(timeoutS: number, ceilingS: number): string {
+  return (
+    `ElevenLabsAgentAdapter: receiveAudio timed out. The absolute ceiling of ${ceilingS}s ` +
+    "elapsed while the hosted agent kept the socket alive with keepalive pings but " +
+    "never sent audio. Pings re-arm the idle deadline, so this ceiling, " +
+    `max(responseTimeout, ${KEEPALIVE_HARD_CEILING_S}s), is what bounds the wait. It usually ` +
+    "means a wedged server tool or retrieval call, or an agent that ended or " +
+    "transferred its turn. If the agent is only slower than that, raise the adapter's " +
+    `responseTimeout, currently ${timeoutS}s, past ${KEEPALIVE_HARD_CEILING_S}s and the ceiling rises with it, ` +
+    "for example agent.responseTimeout = 180. " +
+    `See ${RECEIVE_TIMEOUT_DOCS_URL}`
+  );
+}
+
 /**
  * EL system tools whose successful invocation means the AGENT ended the call, so
  * the socket close that follows is deliberate rather than a dropped transport
@@ -805,13 +847,19 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
       // and unwedges a pings-but-no-audio receive. Sized as max(timeout, 45s): never
       // below the caller's own idle budget (so it does not pre-empt a legitimately
       // slow-but-responding agent), but at least 45s even for sub-second tail-probe
-      // calls. In the real drain `timeout` is the 30s response budget or the 0.6s
-      // tail probe, so the ceiling is 45s.
+      // calls. In the real drain `timeout` is the 60s response budget or the 0.6s
+      // tail probe, so the ceiling is 60s on the first chunk and 45s on the probes.
       // Must stay `let`: the cleanup() closure below captures hardTimer before
       // it is assigned, so declaration and assignment cannot be merged (const).
       // eslint-disable-next-line prefer-const
       let hardTimer: ReturnType<typeof setTimeout>;
-      const hardCeilingMs = Math.max(timeout, KEEPALIVE_HARD_CEILING_S) * 1000;
+      const ceilingS = Math.max(timeout, KEEPALIVE_HARD_CEILING_S);
+      // Whether ANY inbound frame reached this parked receive. It is what tells the
+      // two rejections apart when both deadlines land on the same instant, which is
+      // the default case: idle 60s, ceiling max(60, 45) = 60s. Nothing received
+      // means the socket was silent throughout, so the idle diagnosis is the true
+      // one however the two timers happen to be ordered.
+      let sawInboundFrame = false;
 
       const cleanup = () => {
         clearTimeout(timer);
@@ -822,19 +870,18 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
         if (waiterIdx >= 0) this.waiters.splice(waiterIdx, 1);
       };
 
-      const onTimeout = () => {
+      const onIdleTimeout = () => {
         cleanup();
-        reject(
-          new Error(
-            "ElevenLabsAgentAdapter: receiveAudio timed out (no agent audio " +
-              "within the deadline — the hosted agent produced no audio, whether " +
-              "fully silent or only keepalive-pinging). For a scripted multi-turn " +
-              "run this usually means the agent ended or transferred its turn " +
-              "(e.g. an escalation/handoff request), or the user turn did not " +
-              "commit. See " +
-              "https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs",
-          ),
-        );
+        reject(new Error(idleTimeoutMessage(timeout)));
+      };
+
+      const onCeilingTimeout = () => {
+        if (!sawInboundFrame) {
+          onIdleTimeout();
+          return;
+        }
+        cleanup();
+        reject(new Error(ceilingTimeoutMessage(timeout, ceilingS)));
       };
 
       // Re-arm the IDLE deadline on every received message (pings included) so a
@@ -842,8 +889,9 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
       // the timer. Matches the Python recv_audio sliding-idle-deadline. The hard
       // ceiling is deliberately NOT reset here.
       const resetTimer = () => {
+        sawInboundFrame = true;
         clearTimeout(timer);
-        timer = setTimeout(onTimeout, timeout * 1000);
+        timer = setTimeout(onIdleTimeout, timeout * 1000);
       };
 
       const waiter = (chunk: AudioChunk) => {
@@ -851,8 +899,8 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
         resolve(chunk);
       };
 
-      timer = setTimeout(onTimeout, timeout * 1000);
-      hardTimer = setTimeout(onTimeout, hardCeilingMs);
+      timer = setTimeout(onIdleTimeout, timeout * 1000);
+      hardTimer = setTimeout(onCeilingTimeout, ceilingS * 1000);
       this.timerResetters.push(resetTimer);
       this.waiters.push(waiter);
     });

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -114,15 +114,16 @@ def _idle_timeout_message(timeout_s: float) -> str:
 
 
 def _ceiling_timeout_message(timeout_s: float, ceiling_s: float) -> str:
-    """Rejection text for the ABSOLUTE ceiling: the agent kept the socket alive
-    with keepalive pings, which re-arm the idle deadline, but never sent audio.
+    """Rejection text for the ABSOLUTE ceiling: the agent kept sending frames,
+    which re-arm the idle deadline, but never sent audio.
     """
     floor = _seconds(KEEPALIVE_HARD_CEILING_S)
     return (
         f"ElevenLabsAgentAdapter: recv_audio timed out. The absolute ceiling of "
-        f"{_seconds(ceiling_s)}s elapsed while the hosted agent kept the socket "
-        f"alive with keepalive pings but never sent audio. Pings re-arm the idle "
-        f"deadline, so this ceiling, max(response_timeout, {floor}s), is what "
+        f"{_seconds(ceiling_s)}s elapsed while the hosted agent kept sending frames, "
+        f"keepalive pings or transcripts, but never audio. Every inbound frame "
+        f"re-arms the idle deadline, so this ceiling, max(response_timeout, "
+        f"{floor}s), is what "
         f"bounds the wait. It usually means a wedged server tool or retrieval call, "
         f"or an agent that ended or transferred its turn. If the agent is only "
         f"slower than that, raise the adapter's response_timeout, currently "

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -80,6 +80,58 @@ SILENCE_TAIL_BYTES = 16000
 #: agent to respond, but finite so a non-responding turn times out cleanly.
 KEEPALIVE_HARD_CEILING_S: Final[float] = 45.0
 
+#: Deep link to the section that expands on both recv_audio timeouts.
+RECEIVE_TIMEOUT_DOCS_URL: Final[str] = (
+    "https://scenario.langwatch.ai/voice/troubleshooting"
+    "#receiveaudio-timed-out-hosted-elevenlabs"
+)
+
+
+def _seconds(value: float) -> str:
+    """Render a seconds value the way the TypeScript adapter's template literal
+    does, so both SDKs print ``60s`` and ``0.6s`` rather than ``60.0s``."""
+    return f"{value:g}"
+
+
+def _idle_timeout_message(timeout_s: float) -> str:
+    """Rejection text for the IDLE deadline: nothing at all reached the socket,
+    not even a keepalive ping, for ``timeout_s`` seconds. A fully silent agent.
+
+    Distinct from :func:`_ceiling_timeout_message` on purpose: silence and
+    pings-but-no-audio are different diagnoses with different remedies, so one
+    shared message would send the reader to check the wrong things.
+    """
+    waited = _seconds(timeout_s)
+    return (
+        f"ElevenLabsAgentAdapter: recv_audio timed out. The idle deadline of "
+        f"{waited}s elapsed with no message of any kind from the hosted agent, "
+        f"not even a keepalive ping. For a scripted multi-turn run this usually "
+        f"means the agent ended or transferred its turn (e.g. an escalation/handoff "
+        f"request), or the user turn did not commit. If the agent is only slower "
+        f"than that, raise the adapter's response_timeout, currently {waited}s, "
+        f"for example adapter.response_timeout = 180. See {RECEIVE_TIMEOUT_DOCS_URL}"
+    )
+
+
+def _ceiling_timeout_message(timeout_s: float, ceiling_s: float) -> str:
+    """Rejection text for the ABSOLUTE ceiling: the agent kept the socket alive
+    with keepalive pings, which re-arm the idle deadline, but never sent audio.
+    """
+    floor = _seconds(KEEPALIVE_HARD_CEILING_S)
+    return (
+        f"ElevenLabsAgentAdapter: recv_audio timed out. The absolute ceiling of "
+        f"{_seconds(ceiling_s)}s elapsed while the hosted agent kept the socket "
+        f"alive with keepalive pings but never sent audio. Pings re-arm the idle "
+        f"deadline, so this ceiling, max(response_timeout, {floor}s), is what "
+        f"bounds the wait. It usually means a wedged server tool or retrieval call, "
+        f"or an agent that ended or transferred its turn. If the agent is only "
+        f"slower than that, raise the adapter's response_timeout, currently "
+        f"{_seconds(timeout_s)}s, past {floor}s and the ceiling rises with it, "
+        f"for example adapter.response_timeout = 180. "
+        f"See {RECEIVE_TIMEOUT_DOCS_URL}"
+    )
+
+
 #: How :meth:`ElevenLabsAgentAdapter.send_audio` signals end-of-turn to EL ConvAI.
 #:
 #: - ``"audio"`` (default): stream the turn's real PCM as 20 ms
@@ -780,15 +832,34 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         # turn); with only the ping-resettable idle ``deadline`` this loop would
         # wedge forever. The ceiling bounds that pings-but-no-audio case. At
         # least ``timeout`` so it never pre-empts the idle deadline.
-        hard_deadline = start + max(timeout, KEEPALIVE_HARD_CEILING_S)
+        ceiling = max(timeout, KEEPALIVE_HARD_CEILING_S)
+        hard_deadline = start + ceiling
+        # Whether ANY inbound frame arrived. It is what tells the two rejections
+        # apart when both bounds land on the same instant, which is the default
+        # case: idle 60s, ceiling max(60, 45) = 60s. Nothing received means the
+        # socket was silent throughout, so the idle diagnosis is the true one.
+        saw_inbound_frame = False
+
+        def timeout_error() -> asyncio.TimeoutError:
+            """The rejection for whichever bound expired. A socket that went
+            completely quiet and one that pings steadily without ever speaking
+            are different problems, so they get different messages."""
+            if saw_inbound_frame and hard_deadline <= deadline:
+                return asyncio.TimeoutError(_ceiling_timeout_message(timeout, ceiling))
+            return asyncio.TimeoutError(_idle_timeout_message(timeout))
+
         while True:
             now = asyncio.get_running_loop().time()
             remaining = min(deadline, hard_deadline) - now
             if remaining <= 0:
-                raise asyncio.TimeoutError("ElevenLabsAgentAdapter: recv_audio timed out")
+                raise timeout_error()
 
             try:
                 raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            except asyncio.TimeoutError as err:
+                # ``wait_for`` raises a bare TimeoutError with an empty message,
+                # which is how both bounds used to reach the caller indistinguishable.
+                raise timeout_error() from err
             except websockets.exceptions.ConnectionClosed:
                 # Issue #648: the hosted agent finished its turn and the server
                 # closed the socket WITHOUT a trailing audio frame (a silent /
@@ -805,6 +876,7 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
             # A received message (ping included) proves the socket is alive, so
             # re-arm the idle deadline. Placed BEFORE json.loads so ANY frame —
             # even a non-JSON/malformed one — counts as a liveness signal.
+            saw_inbound_frame = True
             deadline = asyncio.get_running_loop().time() + timeout
             try:
                 event = json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode())

--- a/python/tests/voice/test_elevenlabs_recv_keepalive.py
+++ b/python/tests/voice/test_elevenlabs_recv_keepalive.py
@@ -311,3 +311,63 @@ async def test_recv_audio_succeeds_when_slow_agent_responds_before_hard_ceiling(
 
     assert isinstance(result, AudioChunk)
     assert result.data == pcm_payload
+
+
+# ---------------------------------------------------------------------------
+# Issue #891: the two bounds must be told apart in the error
+#
+# Both bounds used to raise the same bare "recv_audio timed out", so the reader
+# could not tell a socket that went completely quiet from one that pinged
+# steadily and never spoke. Those are different problems with different fixes,
+# and at the default budget (idle 60s, ceiling max(60, 45) = 60s) they even
+# expire at the same instant, so the text is the only thing separating them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recv_audio_silent_socket_reports_the_idle_deadline():
+    """A socket that never sends anything reports the IDLE deadline, names
+    response_timeout, and links the troubleshooting anchor."""
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+
+    async def fake_recv():
+        await asyncio.sleep(3600)  # never answers
+
+    mock_ws = AsyncMock()
+    mock_ws.recv = fake_recv
+    mock_ws.send = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        with pytest.raises(asyncio.TimeoutError) as excinfo:
+            await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+
+    message = str(excinfo.value)
+    assert f"The idle deadline of {IDLE_TIMEOUT:g}s elapsed" in message
+    assert "not even a keepalive ping" in message
+    assert "response_timeout" in message
+    assert "voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs" in message
+    assert "absolute ceiling" not in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_recv_audio_endless_pings_report_the_absolute_ceiling(monkeypatch):
+    """A socket that pings forever without speaking reports the CEILING, which
+    is the other diagnosis entirely."""
+    monkeypatch.setattr(elevenlabs_module, "KEEPALIVE_HARD_CEILING_S", HARD_CEILING)
+
+    adapter = ElevenLabsAgentAdapter(agent_id="a", api_key="k")
+    mock_ws = _make_endless_pinging_ws()
+
+    with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        await adapter.connect()
+        with pytest.raises(asyncio.TimeoutError) as excinfo:
+            await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+
+    message = str(excinfo.value)
+    assert f"The absolute ceiling of {HARD_CEILING:g}s elapsed" in message
+    assert "keepalive pings but never sent audio" in message
+    assert "response_timeout" in message
+    assert "The idle deadline" not in message

--- a/python/tests/voice/test_elevenlabs_recv_keepalive.py
+++ b/python/tests/voice/test_elevenlabs_recv_keepalive.py
@@ -117,11 +117,14 @@ async def test_recv_audio_tolerates_silent_but_pinging_stretch():
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
-
-        # The pings span ~0.64s; TIMEOUT is 0.30s. A keepalive-aware adapter
-        # stays alive (each gap < TIMEOUT) and returns the audio. The current
-        # adapter exhausts its one-shot budget and raises TimeoutError here.
-        result = await adapter.recv_audio(timeout=TIMEOUT)
+        try:
+            # The pings span ~0.64s; TIMEOUT is 0.30s. A keepalive-aware adapter
+            # stays alive (each gap < TIMEOUT) and returns the audio. The current
+            # adapter exhausts its one-shot budget and raises TimeoutError here.
+            result = await adapter.recv_audio(timeout=TIMEOUT)
+        finally:
+            # connect() started the mic pump; stop it before teardown.
+            await adapter.disconnect()
 
     assert isinstance(result, AudioChunk)
     assert result.data == pcm_payload
@@ -154,8 +157,12 @@ async def test_recv_audio_still_times_out_on_truly_dead_socket():
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
-        with pytest.raises(asyncio.TimeoutError):
-            await adapter.recv_audio(timeout=TIMEOUT)
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await adapter.recv_audio(timeout=TIMEOUT)
+        finally:
+            # connect() started the mic pump; stop it before teardown.
+            await adapter.disconnect()
 
 
 # --------------------------------------------------------------------------- #
@@ -246,9 +253,12 @@ async def test_recv_audio_hard_ceiling_fires_despite_endless_pings(monkeypatch):
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
-
-        with pytest.raises(asyncio.TimeoutError):
-            await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        finally:
+            # connect() started the mic pump; stop it before teardown.
+            await adapter.disconnect()
 
 
 @pytest.mark.asyncio
@@ -307,7 +317,11 @@ async def test_recv_audio_succeeds_when_slow_agent_responds_before_hard_ceiling(
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
-        result = await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        try:
+            result = await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        finally:
+            # connect() started the mic pump; stop it before teardown.
+            await adapter.disconnect()
 
     assert isinstance(result, AudioChunk)
     assert result.data == pcm_payload
@@ -340,8 +354,12 @@ async def test_recv_audio_silent_socket_reports_the_idle_deadline():
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
-        with pytest.raises(asyncio.TimeoutError) as excinfo:
-            await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        try:
+            with pytest.raises(asyncio.TimeoutError) as excinfo:
+                await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        finally:
+            # connect() started the mic pump; stop it before teardown.
+            await adapter.disconnect()
 
     message = str(excinfo.value)
     assert f"The idle deadline of {IDLE_TIMEOUT:g}s elapsed" in message
@@ -363,11 +381,15 @@ async def test_recv_audio_endless_pings_report_the_absolute_ceiling(monkeypatch)
 
     with patch("websockets.connect", new=AsyncMock(return_value=mock_ws)):
         await adapter.connect()
-        with pytest.raises(asyncio.TimeoutError) as excinfo:
-            await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        try:
+            with pytest.raises(asyncio.TimeoutError) as excinfo:
+                await adapter.recv_audio(timeout=IDLE_TIMEOUT)
+        finally:
+            # connect() started the mic pump; stop it before teardown.
+            await adapter.disconnect()
 
     message = str(excinfo.value)
     assert f"The absolute ceiling of {HARD_CEILING:g}s elapsed" in message
-    assert "keepalive pings but never sent audio" in message
+    assert "kept sending frames, keepalive pings or transcripts, but never audio" in message
     assert "response_timeout" in message
     assert "The idle deadline" not in message

--- a/specs/voice-receive-timeout-diagnosis.feature
+++ b/specs/voice-receive-timeout-diagnosis.feature
@@ -1,0 +1,87 @@
+Feature: receiveAudio response-timeout budget and timeout diagnosis
+  As a developer testing a hosted ElevenLabs ConvAI agent
+  I want the same response budget in both SDKs, and a timeout that says which
+  deadline expired and how to move it
+  So that a merely slow agent does not fail in TypeScript while passing in
+  Python, and so the error points at the fix instead of at four checks that are
+  already correct
+
+  Background:
+    Given receiveAudio bounds one turn with an IDLE deadline of responseTimeout,
+      re-armed by every inbound frame including keepalive pings
+    And an ABSOLUTE ceiling of max(responseTimeout, KEEPALIVE_HARD_CEILING_S)
+      that no inbound frame re-arms
+    And the ElevenLabsAgentAdapter is constructed with a webSocketFactory that
+      injects a FakeWebSocket, connected, and driven under fake timers
+
+  # ============================================================
+  # Group: Cross-SDK budget parity
+  # ============================================================
+
+  @unit
+  Scenario: The TypeScript response budget equals the Python one
+    Given VoiceAgentAdapter.response_timeout is 60.0 in Python
+    Then VoiceAgentAdapter.responseTimeout is 60.0 in TypeScript
+    And the runtime fallback used when an adapter nulls the field is also 60
+
+  @unit
+  Scenario: An agent that answers inside the default budget is not failed
+    Given a connected adapter left at its default responseTimeout
+    When receiveAudio is called and no frame arrives for 35 seconds
+    And an audio frame then arrives
+    Then the promise resolves with that audio
+    And no rejection occurred at the former 30 second budget
+
+  # ============================================================
+  # Group: Which deadline expired
+  # ============================================================
+
+  @unit
+  Scenario: A fully silent agent reports the idle deadline
+    Given a connected adapter left at its default responseTimeout
+    When receiveAudio is called and no frame of any kind arrives
+    Then the promise rejects once the idle deadline elapses
+    And the message reports the idle deadline and the seconds it waited
+    And the message states that not even a keepalive ping arrived
+    And the message names responseTimeout as the way to wait longer
+    And the message links the troubleshooting anchor
+      receiveaudio-timed-out-hosted-elevenlabs
+    And the message does not describe the absolute ceiling, even though at the
+      default budget both deadlines land on the same instant
+
+  @unit
+  Scenario: A pinging but speechless agent reports the absolute ceiling
+    Given a connected adapter left at its default responseTimeout
+    When receiveAudio is called and ping frames keep arriving inside the idle
+      deadline while no audio ever does
+    Then the promise rejects once the absolute ceiling elapses
+    And the message reports the absolute ceiling and the seconds it waited
+    And the message explains that pings re-arm the idle deadline
+    And the message names responseTimeout as the way to raise the ceiling
+    And the message does not describe the idle deadline
+
+  # ============================================================
+  # Group: The knob still works
+  # ============================================================
+
+  @unit
+  Scenario: A raised responseTimeout moves the idle deadline
+    Given a connected adapter whose responseTimeout is set to 90
+    When receiveAudio is called and no frame of any kind arrives
+    Then no rejection occurs at 60 seconds
+    And the rejection at 90 seconds reports an idle deadline of 90s
+
+  @unit
+  Scenario: A raised responseTimeout moves the absolute ceiling with it
+    Given a connected adapter whose responseTimeout is set to 90
+    When receiveAudio is called and ping frames keep arriving inside the idle
+      deadline while no audio ever does
+    Then no rejection occurs at the 45 second ceiling floor
+    And the rejection reports an absolute ceiling of 90s
+
+  @unit
+  Scenario: A sub-second tail probe keeps the 45 second ceiling floor
+    Given a connected adapter and a receiveAudio call with the 0.6s tail-probe
+      timeout the drain uses
+    When ping frames keep arriving and no audio ever does
+    Then the rejection reports an absolute ceiling of 45s, not 0.6s


### PR DESCRIPTION
Fixes #891

## What was wrong

`receiveAudio` bounds one agent turn with two deadlines:

- an **idle deadline** of `responseTimeout`, re-armed by every inbound frame, keepalive pings included,
- an **absolute ceiling** of `max(responseTimeout, 45s)`, set once and never re-armed.

Two problems came out of that.

**JS was half as tolerant as Python.** `responseTimeout` defaulted to 30 in TypeScript and 60 in Python. With the ceiling being `max(timeout, 45)`, the real bounds were 30s idle and 45s absolute in JS against 60s and 60s in Python. The same scenario could pass in Python and fail in JS with no difference in the user's code. A hosted agent that runs a tool call or a retrieval step before it speaks passes 30s without much trouble.

**One message for two failures.** Both timers rejected with the same text. It never said which bound fired, never printed the seconds it waited, and never named `responseTimeout`. A fully silent agent and a slow-but-pinging one are different diagnoses, and the message sent both readers to check the same four things, none of which was "the agent is simply slower than the default".

## What changed

**Default.** TypeScript `VoiceAgentAdapter.responseTimeout` is now `60.0`, the same value Python uses. Still overridable per adapter exactly as before. The runtime's fallback for an adapter that nulls the field moved to 60 with it.

**Two messages.** Each deadline now has its own rejection. Both name the bound, the seconds waited, the knob, and the troubleshooting anchor:

Idle:

> ElevenLabsAgentAdapter: receiveAudio timed out. The idle deadline of 60s elapsed with no message of any kind from the hosted agent, not even a keepalive ping. For a scripted multi-turn run this usually means the agent ended or transferred its turn (e.g. an escalation/handoff request), or the user turn did not commit. If the agent is only slower than that, raise the adapter's responseTimeout, currently 60s, for example agent.responseTimeout = 180. See https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs

Ceiling:

> ElevenLabsAgentAdapter: receiveAudio timed out. The absolute ceiling of 60s elapsed while the hosted agent kept the socket alive with keepalive pings but never sent audio. Pings re-arm the idle deadline, so this ceiling, max(responseTimeout, 45s), is what bounds the wait. It usually means a wedged server tool or retrieval call, or an agent that ended or transferred its turn. If the agent is only slower than that, raise the adapter's responseTimeout, currently 60s, past 45s and the ceiling rises with it, for example agent.responseTimeout = 180. See https://scenario.langwatch.ai/voice/troubleshooting#receiveaudio-timed-out-hosted-elevenlabs

At the default both deadlines expire at the same instant, 60s and `max(60, 45)` = 60s, so the split cannot rest on timer ordering. The receive tracks whether any frame arrived at all: nothing received means the socket was silent throughout, which is the idle diagnosis whichever timer happens to fire first.

**Python got the same split.** Its budget does not change, it was already 60/60. The split turned out to be worth doing there anyway: the bound that actually fires in Python is `asyncio.wait_for`, whose bare `TimeoutError` reaches the caller with an empty message. Python now raises the same two texts, with `response_timeout` and `adapter.response_timeout = 180`.

**Docs.** The troubleshooting page now opens the section with a table of the two bounds and what each one means, then gives the slow-agent remedy with a sample in both languages, before the four existing checks. The wedged-tool-call paragraph no longer states a flat 45s ceiling, since the ceiling moves with `responseTimeout`.

## Tests

New `javascript/src/voice/adapters/__tests__/elevenlabs-receive-timeout.test.ts`, 7 cases, keyless. The real ElevenLabs SDK `Conversation` runs against the in-memory `FakeWebSocket` already used by the keepalive tests, with fake timers standing in for the wall clock, so a 60s budget costs milliseconds. All 7 are red on the pre-fix adapter.

- defaults responseTimeout to the same 60s budget Python uses
- resolves for an agent that answers after 35s, inside the default budget
- names the idle deadline when the agent goes completely silent
- names the absolute ceiling when the agent pings but never speaks
- honours a raised responseTimeout on the idle path
- honours a raised responseTimeout on the ceiling path
- keeps a sub-second tail probe on the 45s ceiling floor

Two more in `python/tests/voice/test_elevenlabs_recv_keepalive.py` cover the same split there. Behaviour is pinned in `specs/voice-receive-timeout-diagnosis.feature`.

Suites: JS `vitest run` 1099 passed, 4 skipped. Python `pytest tests/voice -m "not integration"` 582 passed. `lint:all`, `lint:lib`, `typecheck:all` and `pyright` all clean.

## Adjacent, not fixed here

#756, `drainAgentResponse` swallows hard errors from the tail-silence `receiveAudio`, is on this same path and stays open. Its bare `catch { break }` cannot tell a tail-silence timeout from a transport error, so both close the turn quietly. Worth doing next, but it changes the drain's error contract for every voice adapter, so it does not belong in this change.
