### PR TITLE
ci: run the two workflow validators that nothing ran (#592)

### DIFF
--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -32,9 +32,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Neither validator runs an authenticated git command, and this job
+          # executes repository-controlled shell on `pull_request`. Without
+          # this, checkout leaves the token in `.git/config` for that shell to
+          # find.
+          persist-credentials: false
 
       - name: Validate pr-auto-approve against the PR-gate checklist
         run: bash scripts/validate-pr-auto-approve.sh
 
+      # Runs even when the step above failed, so one push surfaces both
+      # verdicts. The default `success()` condition would hide the second
+      # validator's findings behind the first one's, costing a round trip to
+      # learn something this run already knew.
       - name: Validate the aggregator workflows' path filters
+        if: ${{ !cancelled() }}
         run: bash scripts/validate-aggregator-workflows.sh

--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -1,0 +1,40 @@
+name: meta-ci
+
+# The repo's two self-validating scripts, actually run.
+#
+# `validate-pr-auto-approve.sh` checks `pr-auto-approve.yml` against the
+# PR-gate AC checklist; `validate-aggregator-workflows.sh` checks that each
+# aggregator workflow's `changes` job carries the path filters its downstream
+# jobs need. Both were written as gates and neither was wired to anything, so
+# they ran only when someone remembered to run them by hand. The first spent an
+# unknown stretch exiting 1 against workflows that had been deleted, and the rot
+# surfaced only when a review happened to run it.
+#
+# Deliberately NOT path-filtered. Both scripts finish in well under a second,
+# and a filter is the failure mode this workflow exists to prevent: a gate that
+# does not fire looks exactly like a gate that passed. `validate-pr-auto-approve`
+# reads four separate files and `validate-aggregator-workflows` reads five, so a
+# correct filter would be nine entries that have to be kept in step with what
+# the scripts happen to read next. Running them always costs a few seconds and
+# cannot silently stop covering anything.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate the workflow gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate pr-auto-approve against the PR-gate checklist
+        run: bash scripts/validate-pr-auto-approve.sh
+
+      - name: Validate the aggregator workflows' path filters
+        run: bash scripts/validate-aggregator-workflows.sh

--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -39,6 +39,24 @@ jobs:
           # find.
           persist-credentials: false
 
+      # Both validators parse YAML with PyYAML. It is present on ubuntu-24.04
+      # today, so this is not fixing a broken run, and a missing module would
+      # not pass silently either: every parsing check reports its own FAIL and
+      # the job exits 1.
+      #
+      # It is the SHAPE of that failure that makes the dependency worth owning.
+      # Measured by making `import yaml` raise: 16 FAILs, reading
+      # "docs-ci: build does not need changes" and fifteen more like it. A run
+      # that says sixteen workflows regressed, when one module is absent, sends
+      # whoever is on it to the wrong file. Pinning also keeps the gate's
+      # verdict from moving with the runner image underneath it.
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: "3.12"
+
+      - name: Install the validators' one dependency
+        run: pip install "PyYAML==6.0.3"
+
       - name: Validate pr-auto-approve against the PR-gate checklist
         run: bash scripts/validate-pr-auto-approve.sh
 


### PR DESCRIPTION
## Ticket

Closes #592, taking option (a), wire it in.

`scripts/validate-pr-auto-approve.sh` validates `pr-auto-approve.yml` against the PR-gate AC checklist and nothing invoked it. The ticket's own story is the argument: it sat exiting 1 against workflows deleted several PRs earlier, and the rot surfaced only when a review happened to run it by hand.

**The sibling has the same gap.** `scripts/validate-aggregator-workflows.sh` checks that each aggregator's `changes` job carries the path filters its downstream jobs need, and a grep across `.github/` returns nothing for it either. Wiring one and leaving the other is the same bug with one fewer instance, so both are wired here.

## Why (a) rather than (b)

Both scripts **pass against main today**:

```
$ bash scripts/validate-pr-auto-approve.sh        ; echo $?
=== ALL CHECKS PASSED ===
0
$ bash scripts/validate-aggregator-workflows.sh   ; echo $?
=== ALL CHECKS PASSED ===
0
```

So wiring them in is a gate that goes green on the first run and starts holding the line, not a backlog to clear first. That is what makes (a) cheap; if either had been red, this would have been a different and larger PR.

## No path filter, deliberately

The ticket suggests filtering on the files each script reads. Not doing that, and the reason is the ticket's own subject: a gate that does not fire looks exactly like a gate that passed. Between them the two scripts read nine files, and a correct filter would have to be kept in step with whatever they read next. Both finish in under a second. Running them always costs a few seconds and cannot silently stop covering anything.

## Evidence

The scripts are unchanged, so what needs proving is that the gate bites. Four mutations against the files they validate, each restored between runs:

| # | Mutation | Result |
|---|---|---|
| M2 | `pr-auto-approve.yml` stops naming the policy doc | CAUGHT (exit 1) |
| M4 | `python-ci.yml`'s `changes` job loses its `'python/**'` filter | CAUGHT (exit 1) |
| M1 | `docs-ci.yml`'s `changes` job loses its `'docs/**'` filter | **ESCAPED** |
| M3 | `.github/LOW_RISK_PULL_REQUESTS.md` is deleted outright | **ESCAPED** |

`actionlint` on the new workflow: exit 0, zero findings.

## The two escapes are real, and they are not this PR's to fix

Wiring the gate up is what exposed them. Both are defects in the validators, not in the wiring:

- **M1.** The path-filter assertion is `grep -q "$filter1" "$wf"` over the whole file, unscoped and substring-matched. For `docs-ci` the needle is `docs/`, which the sibling filter line `'.github/workflows/docs-ci.yml'` satisfies on its own. That check cannot fail, whatever the filters say. `python-ci` escapes the same fate only by luck: its needle `python/**` happens not to appear in `python-ci.yml`.
- **M3.** The script asserts the workflow *references* `.github/LOW_RISK_PULL_REQUESTS.md`; nothing asserts the file exists. Delete the policy doc and the gate stays green.

Filed separately with this evidence rather than folded in, because "wire it in" and "fix what it fails to check" are different changes and the second one edits the validators themselves. A partial gate that runs still beats a complete gate that does not, which is why this PR is worth landing ahead of that one.

## Not made required

The AC asks for required-or-surfaced. This adds the job and surfaces it; making it required is a branch-protection change, which is a human action on the repo settings rather than something in this diff.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.
