### PR TITLE
fix: evaluation score should be passed / total, not passed / failed

### DIFF
--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -1055,7 +1055,10 @@ class ScenarioExecutor:
                         details=agent_response.reasoning,
                         score=(
                             len(agent_response.passed_criteria)
-                            / len(agent_response.failed_criteria)
+                            / (
+                                len(agent_response.passed_criteria)
+                                + len(agent_response.failed_criteria)
+                            )
                             if agent_response.failed_criteria
                             else 1.0
                         ),

--- a/python/tests/test_scenario_executor.py
+++ b/python/tests/test_scenario_executor.py
@@ -290,6 +290,47 @@ class InlineCriteriaMockJudgeAgent(JudgeAgent):
 
 
 @pytest.mark.asyncio
+async def test_evaluation_score_is_fraction_of_criteria_passed(monkeypatch):
+    """The score reported for a judgment is the fraction of its criteria that
+    passed. Dividing by the failure count instead made every verdict with as
+    many passes as failures score 1.0 — identical to a flawless one."""
+    import langwatch.telemetry.span as lwspan
+
+    scores = []
+    monkeypatch.setattr(
+        lwspan.LangWatchSpan,
+        "add_evaluation",
+        lambda self, **kw: scores.append(kw.get("score")),
+    )
+
+    async def score_for(*criteria: str) -> float:
+        scores.clear()
+        await ScenarioExecutor(
+            name="evaluation score",
+            description="test",
+            agents=[
+                MockAgent(),
+                MockUserSimulatorAgent(model="none"),
+                InlineCriteriaMockJudgeAgent(model="none", criteria=list(criteria)),
+            ],
+            script=[user("hello"), agent(), judge()],
+        ).run()
+        return scores[0]
+
+    assert await score_for("a", "b", "c") == 1.0
+    assert await score_for("a", "b", "c", "x fail") == 0.75
+    assert await score_for("a", "b", "c", "x fail", "y fail", "z fail") == 0.5
+    assert await score_for("x fail", "y fail", "z fail") == 0.0
+
+    # The collision this guards: half-failing must not equal flawless.
+    assert await score_for("a", "x fail") != await score_for("a")
+
+    # A judgment with no criteria at all keeps the existing guard — dividing by
+    # the total would be 0/0 here.
+    assert await score_for() == 1.0
+
+
+@pytest.mark.asyncio
 async def test_inline_criteria_checkpoint_pass_continues():
     """When inline criteria pass, the script should continue past the judge step."""
     call_count = {"agent": 0}


### PR DESCRIPTION
## Why

The judgment score reported to LangWatch divides the passed criteria by the
**failed** count instead of the total, so a half-failing verdict gets the same
score as a flawless one.

```
3 passed, 0 failed  ->  score = 1.0
3 passed, 3 failed  ->  score = 1.0     <-- indistinguishable
3 passed, 1 failed  ->  score = 3.0
0 passed, 3 failed  ->  score = 0.0
```

Every verdict where passes equal failures — `(1,1)`, `(2,2)`, `(3,3)` — collapses
onto a perfect 1.0, so the evaluation span can't be used to tell a healthy run
from a half-broken one.

The expression, `scenario_executor.py:1056-1061`:

```python
score=(
    len(agent_response.passed_criteria)
    / len(agent_response.failed_criteria)
    if agent_response.failed_criteria
    else 1.0
),
```

## What changed

- **Denominator is `passed + failed`, not `failed`.** That matches the
  denominator the package already uses for this same ratio elsewhere:
  `pytest_plugin.py:222-225` prints `Passed Criteria: n/total` with
  `total = len(passed_criteria) + len(failed_criteria)`. The span score and the
  terminal report now agree.
- **Kept the existing `if ... failed_criteria else 1.0` guard** rather than
  adding a separate zero-check. It already guarantees a non-zero denominator,
  and a judgment with no criteria at all reaches this line — dividing by the
  total there would be `0/0`. The new test pins that case so the guard can't be
  dropped later.
- **`passed + failed` is exactly the criteria count**, so the new denominator
  can't undercount: `JudgeAgent` puts every criterion in one of the two buckets
  (`judge_agent.py:1344-1352` — a criterion passes only on an explicit `"true"`,
  everything else is a failure).
- `passed=agent_response.success` is untouched and stays correct.

## Test plan

- New `test_evaluation_score_is_fraction_of_criteria_passed` in
  `python/tests/test_scenario_executor.py`. It captures the score by
  `monkeypatch`ing `LangWatchSpan.add_evaluation`, so no network call.
- It asserts three things: the four ratios `1.0 / 0.75 / 0.5 / 0.0`; the
  collision directly (half-failing must not score the same as flawless); and
  the zero-criteria judgment, which is what keeps the guard necessary.
- Confirmed RED on `main` — with the fix reverted and the test kept, it fails at
  `assert 3.0 == 0.75`, i.e. the 3-passed / 1-failed row above.
- `cd python && uv run pytest tests/test_scenario_executor.py` → 13 passed.
- Full suite minus the modules that need live provider credentials
  (`uv run pytest tests --ignore=tests/voice --ignore=tests/test_event_reporter.py`)
  → **668 passed, 10 skipped**. `uv run pyright` clean on both changed files.

## How I can prove I was successful

No playable artifact — this is a metric on the evaluation span. The observable
proof is the captured score itself, before and after, for the same judgments:

| passed | failed | before | after |
|---|---|---|---|
| 3 | 0 | 1.0 | 1.0 |
| 3 | 1 | **3.0** | 0.75 |
| 3 | 3 | **1.0** | 0.5 |
| 0 | 3 | 0.0 | 0.0 |
| 0 | 0 | 1.0 | 1.0 |

The `after` column is exactly what the new test asserts. The `before` column is
what those same assertions produce when the fix is reverted — the two bold cells
are the bug: a 3-of-4 verdict scoring 3.0, and a half-failing verdict scoring a
perfect 1.0.

## Anything surprising?

- **Reports only, never a verdict.** This value goes to the evaluation span and
  nowhere else — one call site, `scenario_executor.py:1051`. It doesn't affect
  `result.success` or any assertion, so no existing test changes behaviour.
- `1 - failed / total` is algebraically the same fix — happy to switch to it if
  you'd prefer that reading.
- The TypeScript package has no equivalent call, so there's no mirror PR to
  send for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
