### PR TITLE
ci: document the gateway key handling, and record what blocks the Gemini lane

### DIFF
--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -10,7 +10,15 @@ name: javascript-ci
 
 # All OpenAI-compatible traffic (judge LLMs, TTS, STT) rides the LangWatch
 # AI Gateway: OPENAI_API_KEY holds a LangWatch virtual key, and these base
-# URLs point every client family (openai SDK, litellm, ai-sdk) at it.
+# URLs point every client family at it. Both families the examples use read
+# OPENAI_BASE_URL: the `openai` package, and `@ai-sdk/openai`, whose
+# `createOpenAI` falls back to that variable before api.openai.com.
+#
+# The same key, and how to rotate, revoke and cap it, are described at the
+# top of python-ci.yml. Kept in one place so the two do not drift.
+#
+# One exception rides direct, at the examples step below: OpenAI Realtime
+# opens a websocket to api.openai.com, and the gateway proxies HTTP only.
 env:
   CI: true
   OPENAI_BASE_URL: https://gateway.langwatch.ai/v1

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,12 +22,18 @@ name: python-ci
 #   - Rotate:   `langwatch virtual-keys rotate <id>` mints a new secret and
 #               keeps the old one working for 24 hours. Put the new secret in
 #               the OPENAI_API_KEY repository secret inside that window.
-#   - Revoke:   `langwatch virtual-keys revoke <id>`. Every job that uses it
-#               fails at once, which is the point of one key over several.
-#   - Cap:      the key carries its own spending budget. When the budget is
-#               reached the gateway refuses with a virtual_key budget error
-#               and this job goes red, so size the cap above a busy day's
-#               spend rather than at it.
+#   - Revoke:   `langwatch virtual-keys revoke <id>`. Allow up to a minute
+#               before the old secret stops working everywhere: each gateway
+#               pod caches a key's config for 60 seconds
+#               (LW_GATEWAY_AUTH_CACHE_CONFIG_TTL_SECONDS). Restarting the
+#               gateway deployment clears it at once.
+#   - Cap:      the key carries its own spending budget, currently $10 per
+#               day at virtual-key scope. On a hard breach the gateway
+#               answers HTTP 402 `budget_exceeded` with the scope in
+#               `error.meta.budget_scope`, and every test in this job fails
+#               until the window resets. Size the cap well above a busy
+#               day's spend: one full run costs about $0.09, and the
+#               busiest day seen so far was 31 runs.
 #   - Fall back: to call the providers directly again, clear the two base
 #               URLs below and GEMINI_API_BASE on the examples step, and put
 #               provider keys back in OPENAI_API_KEY and GEMINI_API_KEY.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -141,10 +141,17 @@ jobs:
           # suite passes that way against a gateway that has a Google
           # credential.
           #
-          # What is missing is the credential: the LangWatch organization
-          # has no Gemini provider on the gateway, so a Gemini request there
-          # cannot be served. Add one and swap these two lines. Until then
-          # the direct key is the only thing that works.
+          # What is missing is the credential, and it takes two steps rather
+          # than one. Add a Gemini provider to the LangWatch organization,
+          # then add that provider to the routing policy this virtual key
+          # is pinned to: a key with a policy reaches only the providers
+          # listed in the policy's modelProviderIds, so an enabled provider
+          # left off the list never joins the chain. Confirm with
+          # `GET /v1/models` on the key, which lists what it can actually
+          # dispatch to, before swapping in these two lines:
+          #
+          #   GEMINI_API_BASE: https://gateway.langwatch.ai/v1beta
+          #   GEMINI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         working-directory: python
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -132,16 +132,20 @@ jobs:
         env:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # The Gemini examples ride the same virtual key. litellm builds
-          # `{GEMINI_API_BASE}/models/{model}:generateContent`, which is the
-          # gateway's own Gemini surface once the base names /v1beta, and it
-          # sends the key as x-goog-api-key, which the gateway accepts.
-          # Set here rather than at the top of the file: this is the only
-          # step that makes live Gemini calls. voice-integration.yml keeps
-          # the direct Google key, because Gemini Live is a websocket API
-          # the gateway does not proxy.
-          GEMINI_API_BASE: https://gateway.langwatch.ai/v1beta
-          GEMINI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # The Gemini examples still call Google directly. The mechanism to
+          # route them is ready and measured: litellm builds
+          # `{GEMINI_API_BASE}/models/{model}:generateContent` and sends the
+          # key as x-goog-api-key, so setting GEMINI_API_BASE to the
+          # gateway's /v1beta surface and GEMINI_API_KEY to the same virtual
+          # key moves them over with no change to any example. The whole
+          # suite passes that way against a gateway that has a Google
+          # credential.
+          #
+          # What is missing is the credential: the LangWatch organization
+          # has no Gemini provider on the gateway, so a Gemini request there
+          # cannot be served. Add one and swap these two lines. Until then
+          # the direct key is the only thing that works.
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         working-directory: python
 
   # One required check for the whole workflow. Reports success if every

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,9 +8,29 @@
 # that branch protection requires.
 name: python-ci
 
-# All OpenAI-compatible traffic (judge LLMs, TTS, STT) rides the LangWatch
-# AI Gateway: OPENAI_API_KEY holds a LangWatch virtual key, and these base
-# URLs point every client family (openai SDK, litellm, ai-sdk) at it.
+# All model traffic rides the LangWatch AI Gateway. One virtual key replaces
+# every provider key: it is metered, capped, and revocable on its own, and no
+# raw provider key sits in this repository's secrets for the examples job.
+#
+# The key lives in the OPENAI_API_KEY secret and is copied into whichever
+# variable each client family reads. The base URLs below point those clients
+# at the gateway: the openai SDK and litellm's openai lane read
+# OPENAI_BASE_URL / OPENAI_API_BASE, and litellm's gemini lane reads
+# GEMINI_API_BASE, set on the examples step.
+#
+# Operating notes:
+#   - Rotate:   `langwatch virtual-keys rotate <id>` mints a new secret and
+#               keeps the old one working for 24 hours. Put the new secret in
+#               the OPENAI_API_KEY repository secret inside that window.
+#   - Revoke:   `langwatch virtual-keys revoke <id>`. Every job that uses it
+#               fails at once, which is the point of one key over several.
+#   - Cap:      the key carries its own spending budget. When the budget is
+#               reached the gateway refuses with a virtual_key budget error
+#               and this job goes red, so size the cap above a busy day's
+#               spend rather than at it.
+#   - Fall back: to call the providers directly again, clear the two base
+#               URLs below and GEMINI_API_BASE on the examples step, and put
+#               provider keys back in OPENAI_API_KEY and GEMINI_API_KEY.
 env:
   CI: true
   OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
@@ -106,7 +126,16 @@ jobs:
         env:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # The Gemini examples ride the same virtual key. litellm builds
+          # `{GEMINI_API_BASE}/models/{model}:generateContent`, which is the
+          # gateway's own Gemini surface once the base names /v1beta, and it
+          # sends the key as x-goog-api-key, which the gateway accepts.
+          # Set here rather than at the top of the file: this is the only
+          # step that makes live Gemini calls. voice-integration.yml keeps
+          # the direct Google key, because Gemini Live is a websocket API
+          # the gateway does not proxy.
+          GEMINI_API_BASE: https://gateway.langwatch.ai/v1beta
+          GEMINI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         working-directory: python
 
   # One required check for the whole workflow. Reports success if every


### PR DESCRIPTION
Finishes the routing work in langwatch/langwatch#7033.

## What is still direct, and why it stays that way for now

The OpenAI-shaped calls in `Test (Examples)` have gone through the LangWatch AI Gateway since #848 in July: the workflow sets `OPENAI_BASE_URL` and the `OPENAI_API_KEY` secret holds a gateway virtual key, not an OpenAI key.

The Gemini examples do not, and this pull request no longer tries to move them. The routing itself works and is measured, but the LangWatch organization has **no Gemini provider configured on the gateway**, so nothing there can serve a Gemini request. Probing production before merging is what caught it. One virtual key, one missing credential, two surfaces, same minute:

```
POST /v1/chat/completions      {"model":"gemini/gemini-2.5-flash"}
400 model_provider_not_bound   "no gemini provider is configured for this key"

POST /v1beta/models/gemini-2.5-flash:generateContent
404  {"meta":{"status":404,"provider":"anthropic"}}
```

So the step keeps the direct Google key, and now records the exact two lines to swap once a Gemini provider exists:

```yaml
GEMINI_API_BASE: https://gateway.langwatch.ai/v1beta
GEMINI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
```

That second response is also langwatch/langwatch#7035 happening on production, which langwatch/langwatch#7049 fixes.

## What this pull request does ship

The header comment now records how to rotate, revoke and cap the key, and how to put provider keys back. The file assumed all of that and said none of it. `javascript-ci.yml` gets the same treatment, pointing at those notes rather than copying them.

## Measured

The whole python examples suite ran against a locally built gateway holding a Google credential, with one virtual key covering both lanes:

```
27 passed, 2 skipped, 0 failed in 160.06s
```

The gateway's own spend table for that key over the run: **128 requests, $0.092808**, of which **12 requests and $0.015182 were the Gemini lane**. So the mechanism is proven; only the production credential is missing. The two skips are the audio examples, which skip themselves when `CI` is set.

## The JavaScript lane needed no change, and that was checked rather than assumed

`javascript-ci.yml` has been fully routed since #848 too. Both client families its examples use read `OPENAI_BASE_URL`: the `openai` package, and `@ai-sdk/openai` 3.0.65, whose `createOpenAI` falls back to that variable before `https://api.openai.com/v1`.

Confirmed end to end, not just by reading: the JavaScript examples suite was run against the same local gateway and produced **171 gateway requests across 8 models**, including `gpt-5-mini`, `gpt-4.1-mini`, `gpt-4o-mini-tts` and `gpt-4o-transcribe`. 29 test files and 56 tests passed. The failures in that local run were all non-gateway paths absent from this machine: the Claude test is `skipIf(!ANTHROPIC_API_KEY)` and CI never sets it, and the Realtime tests got handed the virtual key because the local run had no `OPENAI_REALTIME_API_KEY`.

**One genuine gateway adoption gap, worth naming.** OpenAI Realtime and Gemini Live open websockets, and the gateway proxies HTTP only. That is why `OPENAI_REALTIME_API_KEY` in this workflow and the Gemini Live key in `voice-integration.yml` stay direct. Nothing routes around it here; it is written down at both call sites.

## Before the Gemini lane moves

Three things, in order.

1. Add a Gemini provider to the LangWatch organization. That is the missing credential above.
2. Add that provider to the routing policy the CI virtual key is pinned to. A key with a policy reaches only the providers in the policy's `modelProviderIds`, so step 1 alone leaves the swap failing exactly as it does now. `GET /v1/models` on the key is the check: it lists what the key can dispatch to, not what the organization has configured.
3. Land langwatch/langwatch#7049, so a key that cannot reach Google is refused with a clear 400 instead of the prompt going to another vendor.

## The availability trade

This job already depends on the gateway for every OpenAI-shaped call, so nothing here adds the dependency. It is still worth stating in review, because the trade is the reason the cap below matters.

The trade has already cost one red `main`. On 2026-08-13 the job failed with 26 of 30 tests reporting `The virtual key spending limit (per day) for this request has been reached`. That was not a gateway outage. The key's daily cap was **$1.00**, one full run costs **$0.093**, so the cap covered about **11 runs a day** and the busiest observed day was **31** python-ci runs. It was never going to fail on an anomaly, only on an ordinary heavy day.

**The cap is now $10.00 per day**, still blocking, with the numbers written into the budget's own description. That is about 108 runs, roughly 3.5 times the busiest day seen, and still a hard stop far below anything that would matter if a retry loop ran away.

My judgement, for a reviewer to disagree with: keep the single gateway key. One revocable credential with a meter is worth more than a per-provider fallback nobody would remember to test, and the failure we have actually seen is a cap we set too low, not a gateway that went away. Fix that by sizing the cap, which is done.
