### PR TITLE
ci: make two workflow-validator checks able to fail (#903)

### DIFF
--- a/scripts/validate-aggregator-workflows.sh
+++ b/scripts/validate-aggregator-workflows.sh
@@ -122,7 +122,11 @@ wanted = sys.argv[2:]
 changes = d.get('jobs', {}).get('changes', {})
 declared = None
 for step in changes.get('steps', []) or []:
-    if 'detect-changes' in str(step.get('uses', '')):
+    # Exact reference, not a substring: any action whose name merely contains
+    # "detect-changes" could supply a matching `filters` input and satisfy this
+    # while the job never uses the local one. That is the same shape of hole
+    # this check was written to close, one level up.
+    if step.get('uses') == './.github/actions/detect-changes':
         declared = (step.get('with') or {}).get('filters')
         break
 if declared is None:

--- a/scripts/validate-aggregator-workflows.sh
+++ b/scripts/validate-aggregator-workflows.sh
@@ -106,11 +106,39 @@ EOF
   then pass "$name: cancel-in-progress: true"; else fail "$name: cancel-in-progress not set to true"; fi
 
   echo "--- path filters in changes job ---"
-  if grep -q "$filter1" "$wf" && grep -q "$filter2" "$wf"; then
-    pass "$name: path filters ($filter1, $filter2) present"
-  else
-    fail "$name: path filters missing (expected $filter1 and $filter2)"
-  fi
+  # Membership of the `relevant` list the detect-changes step actually
+  # declares, not a substring of the file. An unscoped grep passed on any line
+  # that happened to contain the needle: `docs/` is satisfied by the sibling
+  # entry '.github/workflows/docs-ci.yml' AND by the build job's
+  # cache-dependency-path, so deleting the real filter left this check saying
+  # PASS. python-ci escaped only because `python/**` happens to appear nowhere
+  # else in its file, which is luck rather than a check. This parses the YAML
+  # the way every other check in this script already does.
+  if python3 - "$wf" "$filter1" "$filter2" <<'EOF'
+import yaml, sys
+with open(sys.argv[1]) as f:
+    d = yaml.safe_load(f)
+wanted = sys.argv[2:]
+changes = d.get('jobs', {}).get('changes', {})
+declared = None
+for step in changes.get('steps', []) or []:
+    if 'detect-changes' in str(step.get('uses', '')):
+        declared = (step.get('with') or {}).get('filters')
+        break
+if declared is None:
+    print("changes job declares no detect-changes step with filters")
+    sys.exit(1)
+# `filters` is a block scalar carrying its own YAML document.
+patterns = (yaml.safe_load(declared) or {}).get('relevant')
+if not isinstance(patterns, list):
+    print(f"the relevant filter is not a list: {patterns!r}")
+    sys.exit(1)
+missing = [w for w in wanted if w not in patterns]
+if missing:
+    print(f"missing from the relevant filter: {missing}; declared: {patterns}")
+    sys.exit(1)
+EOF
+  then pass "$name: path filters ($filter1, $filter2) present"; else fail "$name: path filters missing (expected $filter1 and $filter2)"; fi
 
   echo "--- $inner_job needs changes ---"
   if python3 - "$wf" "$inner_job" <<'EOF'
@@ -168,24 +196,24 @@ check_workflow \
   "python-ci" \
   "test" \
   "python-complete" \
-  "python/" \
-  "python-ci.yml"
+  "python/**" \
+  ".github/workflows/python-ci.yml"
 
 check_workflow \
   "$REPO_ROOT/.github/workflows/javascript-ci.yml" \
   "javascript-ci" \
   "ci-checks" \
   "javascript-complete" \
-  "javascript/" \
-  "javascript-ci.yml"
+  "javascript/**" \
+  ".github/workflows/javascript-ci.yml"
 
 check_workflow \
   "$REPO_ROOT/.github/workflows/docs-ci.yml" \
   "docs-ci" \
   "build" \
   "docs-complete" \
-  "docs/" \
-  "docs-ci.yml"
+  "docs/**" \
+  ".github/workflows/docs-ci.yml"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/validate-pr-auto-approve.sh
+++ b/scripts/validate-pr-auto-approve.sh
@@ -291,6 +291,16 @@ else
   fail "policy path wrong — expected 'cat .github/LOW_RISK_PULL_REQUESTS.md'"
 fi
 
+# The checks either side of this one read the REFERENCE. None of them read the
+# file, so deleting the policy outright left every check green and the
+# workflow `cat`-ing a path that is not there: the same staleness this script
+# exists to catch, one level down.
+if [ -f "$REPO_ROOT/.github/LOW_RISK_PULL_REQUESTS.md" ]; then
+  pass "the policy document the workflow reads exists"
+else
+  fail "policy document missing at .github/LOW_RISK_PULL_REQUESTS.md (the workflow cats it at run time)"
+fi
+
 if grep -q 'dev/docs/' "$WF"; then
   fail "old dev/docs/ path still present"
 else

--- a/scripts/validate-pr-auto-approve.sh
+++ b/scripts/validate-pr-auto-approve.sh
@@ -295,10 +295,13 @@ fi
 # file, so deleting the policy outright left every check green and the
 # workflow `cat`-ing a path that is not there: the same staleness this script
 # exists to catch, one level down.
-if [ -f "$REPO_ROOT/.github/LOW_RISK_PULL_REQUESTS.md" ]; then
-  pass "the policy document the workflow reads exists"
+# `-s`, not `-f`, to match what the workflow itself enforces: it refuses an
+# empty policy at run time (`[ ! -s ... ]`), so a check that accepted one would
+# report green over a state the workflow rejects.
+if [ -s "$REPO_ROOT/.github/LOW_RISK_PULL_REQUESTS.md" ]; then
+  pass "the policy document the workflow reads exists and is not empty"
 else
-  fail "policy document missing at .github/LOW_RISK_PULL_REQUESTS.md (the workflow cats it at run time)"
+  fail "policy document missing or empty at .github/LOW_RISK_PULL_REQUESTS.md (the workflow cats it at run time)"
 fi
 
 if grep -q 'dev/docs/' "$WF"; then


### PR DESCRIPTION
## Ticket

Closes #903.

Two checks in the repo's workflow validators could not fail. Until #592 those scripts ran only by hand, so a vacuous check cost nothing. Wired into CI it is worse than no check, because it reports coverage that does not exist.

## 1. The path-filter check was satisfied by lines that were not the filter

`check_workflow` asserted the `changes` job's path filters with an unscoped substring grep over the whole file:

```bash
if grep -q "$filter1" "$wf" && grep -q "$filter2" "$wf"; then
```

For `docs-ci` the needle was `docs/`. Two unrelated lines contain it: the sibling filter entry `'.github/workflows/docs-ci.yml'`, and the build job's `cache-dependency-path: "docs/pnpm-lock.yaml"`. The issue named the first; the second turned up while reproducing it, which means removing the sibling entry would not have been enough to make the check bite either.

Reproduced on `main` before changing anything, deleting `- 'docs/**'` from the `changes` job:

```
PASS: docs-ci: path filters (docs/, docs-ci.yml) present
exit=0
```

`python-ci` and `javascript-ci` escaped only because their needles happen to occur nowhere else in their own files. That is luck, not a check, and it expires the first time someone adds a cache path.

The assertion now reads the `relevant` list that the `detect-changes` step actually declares, parsing the block scalar as the YAML document it is, and tests membership against the exact patterns. That also closes the smaller half of the issue: a filter written in a comment, or in a different job, no longer satisfies it.

The call sites move from substrings to the real patterns, `docs/**` and `.github/workflows/docs-ci.yml`, so what the script prints on failure is what a fixer has to add back.

## 2. Nothing asserted the policy document exists

`validate-pr-auto-approve.sh` checks that the workflow references `.github/LOW_RISK_PULL_REQUESTS.md` and that the reference uses the canonical path. Both read the reference. Neither reads the file, so deleting it left the run green over a workflow that `cat`s a path that is not there, which is the same staleness #592 is about, one level down.

There is now an existence check next to the path checks.

## Evidence

Every mutation applied to the shipped tree, restored between runs, exit code taken directly.

| # | Mutation | Before | After |
|---|---|---|---|
| M1 | drop `- 'docs/**'` from `docs-ci` | **0, PASS** | 1, FAIL |
| M2 | drop `- 'python/**'` from `python-ci` | 1 | 1 |
| M3 | drop `- 'javascript/**'` from `javascript-ci` | 1 | 1 |
| M4 | drop `- '.github/workflows/docs-ci.yml'` from `docs-ci` | **0** | 1 |
| M5 | delete `.github/LOW_RISK_PULL_REQUESTS.md` | **0, ALL CHECKS PASSED** | 1 |
| M6 | point the `changes` job at a look-alike action that still supplies `filters` | 0 | 1 |
| M7 | truncate the policy document to zero bytes | 0 | 1 |

M6 and M7 came from review and are the same defect class as the two the issue named, so they are folded in rather than deferred. M7 is the sharper of the pair: `pr-auto-approve.yml:347` already refuses an empty policy at run time with `[ ! -s ... ]`, so the first version of this check would have reported green over a state the workflow itself rejects.

M1 and M5 are the two acceptance criteria. M4 is the case neither the issue nor I expected at first: the workflow-self filter was equally unprotected for `docs-ci`, and only shows up once you ask which lines were satisfying the needle. M2 and M3 are there because a fix that made the check strict in the wrong place would break the two families that already worked, and they confirm it did not.

Baseline on a clean tree after the change: both validators exit 0.

`shellcheck` reports the same two SC2016 infos as `main`, on lines this PR does not touch. Both are deliberate single-quoting of literal `${{ }}` GitHub expressions.

## Relationship to #902

Independent, and no file overlap. #902 wires these scripts into CI; this makes two of their checks real. Either can merge first. If both land, the gate #902 adds is running the versions this PR fixes.

## Deployment impact

None. Two developer-facing validation scripts; no workflow behaviour, no runtime code, no configuration.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.