### PR TITLE
perf(vad): frame audio through a Uint8Array view, not a number[] splice (#525)

### DIFF
--- a/javascript/src/voice/__tests__/vad-framing.test.ts
+++ b/javascript/src/voice/__tests__/vad-framing.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Framing and hysteresis behaviour of the SDK-side VAD fallback.
+ *
+ * The ring buffer had no direct coverage: the existing suite drives the
+ * one-shot fallback warning, not what `process()` does with bytes. These
+ * tests were written against the original `number[]` implementation and pass
+ * unchanged against the `Uint8Array` one, which is what makes the swap a
+ * refactor rather than a rewrite.
+ *
+ * Everything below is expressed in whole frames or deliberate fractions of
+ * one, because the only thing that should decide when a frame is classified
+ * is how many bytes have arrived, never how they were chopped into chunks.
+ */
+import { describe, expect, it } from "vitest";
+import { AudioChunk, PCM16_SAMPLE_RATE } from "../audio-chunk";
+import { WebRTCVadFallback } from "../vad";
+
+const FRAME_MS = 30;
+const SAMPLES_PER_FRAME = (PCM16_SAMPLE_RATE * FRAME_MS) / 1000;
+const BYTES_PER_FRAME = SAMPLES_PER_FRAME * 2;
+
+/** PCM16 little-endian bytes for `sampleCount` samples all at `amplitude`. */
+function pcm16(amplitude: number, sampleCount: number): Uint8Array {
+  const bytes = new Uint8Array(sampleCount * 2);
+  for (let i = 0; i < sampleCount; i++) {
+    const value = amplitude < 0 ? amplitude + 0x10000 : amplitude;
+    bytes[i * 2] = value & 0xff;
+    bytes[i * 2 + 1] = (value >> 8) & 0xff;
+  }
+  return bytes;
+}
+
+const chunkOf = (bytes: Uint8Array): AudioChunk =>
+  ({ data: bytes }) as AudioChunk;
+
+/** Loud enough to clear the default RMS threshold of 500. */
+const LOUD = 8000;
+const SILENT = 0;
+
+function makeDetector(options: { hysteresisFrames?: number } = {}) {
+  const starts: number[] = [];
+  const ends: number[] = [];
+  const vad = new WebRTCVadFallback("test-adapter", {
+    ...options,
+    onSpeechStart: () => starts.push(1),
+    onSpeechEnd: () => ends.push(1),
+  });
+  return { vad, starts, ends };
+}
+
+describe("WebRTCVadFallback framing", () => {
+  describe("given fewer bytes than one frame", () => {
+    describe("when the chunk is processed", () => {
+      it("classifies nothing, because a partial frame is not a frame", () => {
+        const { vad, starts } = makeDetector({ hysteresisFrames: 1 });
+
+        vad.process(chunkOf(pcm16(LOUD, SAMPLES_PER_FRAME - 1)));
+
+        expect(vad.isSpeaking).toBe(false);
+        expect(starts).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("given a frame split across two chunks", () => {
+    describe("when the second chunk completes it", () => {
+      it("classifies once the bytes are all in, not once per chunk", () => {
+        const { vad, starts } = makeDetector({ hysteresisFrames: 1 });
+        const frame = pcm16(LOUD, SAMPLES_PER_FRAME);
+
+        vad.process(chunkOf(frame.slice(0, 10)));
+        expect(vad.isSpeaking).toBe(false);
+
+        vad.process(chunkOf(frame.slice(10)));
+
+        expect(vad.isSpeaking).toBe(true);
+        expect(starts).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("given several frames in one chunk", () => {
+    describe("when the chunk is processed", () => {
+      it("classifies each frame, so hysteresis can be satisfied in one call", () => {
+        const { vad, starts } = makeDetector({ hysteresisFrames: 3 });
+
+        vad.process(chunkOf(pcm16(LOUD, SAMPLES_PER_FRAME * 3)));
+
+        expect(vad.isSpeaking).toBe(true);
+        expect(starts).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("given a chunk carrying a whole frame plus a remainder", () => {
+    describe("when a later chunk completes the remainder", () => {
+      it("carries the leftover bytes across calls rather than dropping them", () => {
+        const { vad, starts } = makeDetector({ hysteresisFrames: 2 });
+        const loud = pcm16(LOUD, SAMPLES_PER_FRAME);
+        const half = SAMPLES_PER_FRAME; // in bytes, half a frame
+
+        vad.process(chunkOf(pcm16(LOUD, SAMPLES_PER_FRAME + SAMPLES_PER_FRAME / 2)));
+        expect(vad.isSpeaking).toBe(false);
+
+        // The remaining half frame, which only completes because the leftover
+        // survived the first call.
+        vad.process(chunkOf(loud.slice(0, half)));
+
+        expect(vad.isSpeaking).toBe(true);
+        expect(starts).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("given hysteresis of three frames", () => {
+    describe("when only two loud frames arrive", () => {
+      it("stays silent, because the run has not been held long enough", () => {
+        const { vad, starts } = makeDetector({ hysteresisFrames: 3 });
+
+        vad.process(chunkOf(pcm16(LOUD, SAMPLES_PER_FRAME * 2)));
+
+        expect(vad.isSpeaking).toBe(false);
+        expect(starts).toHaveLength(0);
+      });
+    });
+
+    describe("when speech is followed by enough silence", () => {
+      it("flips back and fires the end callback exactly once", () => {
+        const { vad, starts, ends } = makeDetector({ hysteresisFrames: 3 });
+
+        vad.process(chunkOf(pcm16(LOUD, SAMPLES_PER_FRAME * 3)));
+        expect(vad.isSpeaking).toBe(true);
+
+        vad.process(chunkOf(pcm16(SILENT, SAMPLES_PER_FRAME * 3)));
+
+        expect(vad.isSpeaking).toBe(false);
+        expect(starts).toHaveLength(1);
+        expect(ends).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("given a quiet negative-amplitude frame", () => {
+    describe("when it is classified", () => {
+      it("reads it as silence, which only holds if the sign survives", () => {
+        // -1 is the discriminating fixture, and -8000 is not. Read signed, -1
+        // is an RMS of 1 and silent; read unsigned it is 65535 and the
+        // loudest sample there is. A frame at -8000 is loud under BOTH
+        // readings, so it passes whether or not the sign extension exists.
+        const { vad, starts } = makeDetector({ hysteresisFrames: 1 });
+
+        vad.process(chunkOf(pcm16(-1, SAMPLES_PER_FRAME)));
+
+        expect(vad.isSpeaking).toBe(false);
+        expect(starts).toHaveLength(0);
+      });
+    });
+
+    describe("when it is loud", () => {
+      it("still reads as speech", () => {
+        const { vad } = makeDetector({ hysteresisFrames: 1 });
+
+        vad.process(chunkOf(pcm16(-8000, SAMPLES_PER_FRAME)));
+
+        expect(vad.isSpeaking).toBe(true);
+      });
+    });
+  });
+
+  describe("given consumed bytes", () => {
+    describe("when a later chunk arrives", () => {
+      it("does not classify them a second time", () => {
+        // Uniform audio cannot see this: re-reading history yields the same
+        // verdict, so the run stays green over a buffer that never releases
+        // what it consumed. Alternating frames make the reprocessing visible
+        // as extra transitions, and an unreleased buffer is also a leak.
+        const { vad, starts, ends } = makeDetector({ hysteresisFrames: 1 });
+
+        vad.process(chunkOf(pcm16(LOUD, SAMPLES_PER_FRAME)));
+        vad.process(chunkOf(pcm16(SILENT, SAMPLES_PER_FRAME)));
+        vad.process(chunkOf(pcm16(SILENT, SAMPLES_PER_FRAME)));
+
+        // Re-reading the first frame on the third call would start speech a
+        // second time before ending it again.
+        expect(starts).toHaveLength(1);
+        expect(ends).toHaveLength(1);
+        expect(vad.isSpeaking).toBe(false);
+      });
+    });
+  });
+
+  describe("given a long run of chunks that never align to frames", () => {
+    describe("when they are fed one at a time", () => {
+      it("classifies exactly as many frames as the bytes allow", () => {
+        const { vad, starts } = makeDetector({ hysteresisFrames: 1 });
+        const oddChunk = 101; // bytes, coprime with the frame size
+
+        let sent = 0;
+        while (sent < BYTES_PER_FRAME * 4) {
+          vad.process(chunkOf(pcm16(LOUD, oddChunk)));
+          sent += oddChunk * 2;
+        }
+
+        // Only that the detector settled on speech and fired once: the point
+        // is that misaligned chunking neither loses nor duplicates frames.
+        expect(vad.isSpeaking).toBe(true);
+        expect(starts).toHaveLength(1);
+      });
+    });
+  });
+});

--- a/javascript/src/voice/vad.ts
+++ b/javascript/src/voice/vad.ts
@@ -108,7 +108,19 @@ export class WebRTCVadFallback {
   private readonly onSpeechStart: () => void;
   private readonly onSpeechEnd: () => void;
   private speaking = false;
-  private buf: number[] = [];
+  /**
+   * Incoming bytes awaiting a whole frame.
+   *
+   * A `Uint8Array` with a length, not a `number[]`: the source is already a
+   * `Uint8Array`, so the old buffer was a scatter copy that unpacked every
+   * byte into a boxed slot, and `splice(0, BYTES_PER_FRAME)` then shifted the
+   * whole remainder once PER FRAME. Frames are now read as `subarray` views,
+   * which copy nothing, and the remainder is compacted once per `process()`
+   * call rather than once per frame.
+   */
+  private buf = new Uint8Array(BYTES_PER_FRAME * 2);
+  /** Bytes currently valid in {@link buf}, always starting at index 0. */
+  private bufLen = 0;
   /** Count of consecutive frames in the candidate state (speech or silence). */
   private candidateRun = 0;
   /** The candidate state being voted on by the run counter. */
@@ -134,22 +146,48 @@ export class WebRTCVadFallback {
    */
   process(chunk: AudioChunk): void {
     const data = chunk.data;
-    for (let i = 0; i < data.length; i++) {
-      this.buf.push(data[i]);
+    this.reserve(this.bufLen + data.length);
+    this.buf.set(data, this.bufLen);
+    this.bufLen += data.length;
+
+    // `offset` walks the frames instead of the buffer shrinking under each
+    // one, so a chunk carrying N frames costs one compaction rather than N
+    // shifts of everything behind it.
+    let offset = 0;
+    while (this.bufLen - offset >= BYTES_PER_FRAME) {
+      const frame = this.buf.subarray(offset, offset + BYTES_PER_FRAME);
+      offset += BYTES_PER_FRAME;
+      this.observe(this.classifyFrame(frame));
     }
-    while (this.buf.length >= BYTES_PER_FRAME) {
-      const frame = this.buf.slice(0, BYTES_PER_FRAME);
-      this.buf.splice(0, BYTES_PER_FRAME);
-      const isSpeech = this.classifyFrame(frame);
-      this.observe(isSpeech);
+
+    if (offset > 0) {
+      this.buf.copyWithin(0, offset, this.bufLen);
+      this.bufLen -= offset;
     }
   }
 
   /**
-   * RMS energy classification of a 30 ms PCM16 frame. Pure function over
-   * the byte slice — no IO, no allocation outside the loop.
+   * Ensure {@link buf} can hold `needed` bytes, growing by doubling.
+   *
+   * Only reached when a single chunk is larger than what is already
+   * allocated; the steady state is a transport emitting chunks smaller than
+   * two frames, which never grows.
    */
-  private classifyFrame(frame: number[]): boolean {
+  private reserve(needed: number): void {
+    if (needed <= this.buf.length) return;
+    let capacity = this.buf.length;
+    while (capacity < needed) capacity *= 2;
+    const grown = new Uint8Array(capacity);
+    grown.set(this.buf.subarray(0, this.bufLen));
+    this.buf = grown;
+  }
+
+  /**
+   * RMS energy classification of a 30 ms PCM16 frame. A pure function over
+   * the byte view, with no IO and no allocation at all: the frame is a
+   * `subarray` window onto the ring buffer, not a copy of it.
+   */
+  private classifyFrame(frame: Uint8Array): boolean {
     let sumSquares = 0;
     const sampleCount = frame.length / 2;
     for (let i = 0; i < frame.length; i += 2) {


### PR DESCRIPTION
## Ticket

Closes #525.

`vad.ts:111` held incoming audio in `private buf: number[]`. `process()` unpacked a `Uint8Array` into it one `push` at a time, then took each frame with `slice()` and dropped it with `splice(0, BYTES_PER_FRAME)`, which shifts every remaining element once **per frame**.

## Change

The buffer is a `Uint8Array` with a length. Frames are read as `subarray` views, which copy nothing, and the remainder is compacted once per `process()` call instead of once per frame. `classifyFrame` takes a `Uint8Array`; its arithmetic is untouched, since a `Uint8Array` element is already the 0-255 byte the old code read.

Capacity starts at two frames and doubles only if a single chunk exceeds it, which the steady state never does.

## Measurement

The ticket asks for before and after on a representative clip. 60 seconds of 24 kHz PCM16 delivered in 20 ms chunks, which is the shape a realtime transport actually emits and deliberately does not divide the 30 ms frame, so the buffer always carries a remainder. Median of 7 runs, same machine, same process:

| | median |
|---|---|
| `number[]` + `splice` | **18.2 ms** |
| `Uint8Array` + offset | **3.3 ms** |

Runs before: 17.9, 18.0, 18.2, 18.2, 19.4, 20.3, 23.7. After: 3.1, 3.2, 3.2, 3.3, 3.4, 4.0, 5.1.

## Evidence

**The framing had no direct coverage.** The existing `vad-fallback.test.ts` drives the one-shot fallback warning, not what `process()` does with bytes. So ten tests were written **against the original `number[]` implementation** and pass unchanged against this one. That is what makes this a refactor rather than a rewrite, and it is checkable: the test file applies cleanly to `main`.

**Five mutations, five caught:**

| # | Mutation | Fails |
|---|---|---|
| M1 | never compact, so consumed bytes are re-read | the re-classification test |
| M2 | drop the leftover instead of carrying it | the split-frame test |
| M3 | off-by-one on the frame boundary (`>` for `>=`) | five tests |
| M4 | drop the PCM16 sign extension | the quiet-negative test |
| M5 | `reserve` never grows the buffer | two tests |

**Two of those escaped on the first pass, and the tests were wrong, not the mutations.** Worth stating because both were tests I had written believing they covered exactly the thing they did not:

- The sign-extension test used amplitude `-8000`. Read signed that is loud; read unsigned as `57536` it is also loud. It passed with or without the sign extension. The discriminating fixture is `-1`: signed it is an RMS of 1 and silent, unsigned it is `65535` and the loudest sample there is. The test now uses `-1` and asserts silence.
- Every framing test used uniform audio, so re-reading consumed bytes produced the same verdict and M1 passed. Alternating loud and silent frames makes the reprocessing observable as extra speech transitions, which is also what an uncompacted buffer would leak.

**Tests.** 487 pass across `src/voice` (49 files, 1 skipped).

**Types.** `tsc --noEmit` reports 1 error on this branch and 1 on `main`, measured in a clean `main` worktree against the same `node_modules`. It is `TS2688 Cannot find type definition file for 'yauzl'` on both, and names no file in this diff.

**Lint.** `eslint` exits 0 on both changed files.

## Deployment impact

None. Internal buffering of an SDK-side detector; the public surface (`process(chunk)`, `onSpeechStart` / `onSpeechEnd`, `isSpeaking`) and the detection thresholds are unchanged.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.
