### PR TITLE
fix(py): include keyword arguments in cache keys

### DIFF
--- a/python/scenario/cache.py
+++ b/python/scenario/cache.py
@@ -114,11 +114,9 @@ def scenario_cache(ignore=[]):
             return wrapped(*args, **kwargs)
 
         sig = inspect.signature(wrapped)
-        parameters = list(sig.parameters.values())
-
-        all_args = {
-            str(parameter.name): value for parameter, value in zip(parameters, args)
-        }
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        all_args = dict(bound_args.arguments)
         for arg in ["self"] + ignore:
             if arg in all_args:
                 del all_args[arg]

--- a/python/tests/test_arun_cache.py
+++ b/python/tests/test_arun_cache.py
@@ -65,7 +65,7 @@ class _Agent(AgentAdapter):
 
 
 class _KeywordAgent(AgentAdapter):
-    def __init__(self):
+    def __init__(self) -> None:
         self.values: list[str] = []
 
     async def call(self, input: AgentInput) -> AgentReturnTypes:
@@ -77,7 +77,7 @@ class _KeywordAgent(AgentAdapter):
 
 
 class _NormalizedAgent(AgentAdapter):
-    def __init__(self):
+    def __init__(self) -> None:
         self.values: list[str] = []
 
     async def call(self, input: AgentInput) -> AgentReturnTypes:

--- a/python/tests/test_arun_cache.py
+++ b/python/tests/test_arun_cache.py
@@ -30,12 +30,28 @@ os.environ["SCENARIO_CACHE_DIR"] = _TMP_CACHE.name
 
 
 _call_count = 0
+_keyword_call_count = 0
+_normalized_call_count = 0
 
 
 @scenario.cache()
 async def expensive(arg: str) -> str:
     global _call_count
     _call_count += 1
+    return f"computed-{arg}"
+
+
+@scenario.cache()
+async def expensive_keyword(*, arg: str) -> str:
+    global _keyword_call_count
+    _keyword_call_count += 1
+    return f"computed-{arg}"
+
+
+@scenario.cache()
+async def expensive_normalized(arg: str = "default") -> str:
+    global _normalized_call_count
+    _normalized_call_count += 1
     return f"computed-{arg}"
 
 
@@ -46,6 +62,32 @@ class _Agent(AgentAdapter):
     async def call(self, input: AgentInput) -> AgentReturnTypes:
         val = await expensive("shared-arg")
         return {"role": "assistant", "content": f"{self._tag}:{val}"}
+
+
+class _KeywordAgent(AgentAdapter):
+    def __init__(self):
+        self.values: list[str] = []
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        self.values = [
+            await expensive_keyword(arg="first"),
+            await expensive_keyword(arg="second"),
+        ]
+        return {"role": "assistant", "content": "|".join(self.values)}
+
+
+class _NormalizedAgent(AgentAdapter):
+    def __init__(self):
+        self.values: list[str] = []
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        self.values = [
+            await expensive_normalized("same"),
+            await expensive_normalized(arg="same"),
+            await expensive_normalized(),
+            await expensive_normalized(arg="default"),
+        ]
+        return {"role": "assistant", "content": "|".join(self.values)}
 
 
 class _User(AgentAdapter):
@@ -94,3 +136,54 @@ async def test_scenario_cache_works_under_concurrent_arun():
         f"cache under arun failed to deduplicate — expensive() ran "
         f"{_call_count} times across 5 identical invocations"
     )
+
+
+@pytest.mark.asyncio
+async def test_scenario_cache_distinguishes_keyword_arguments():
+    global _keyword_call_count
+    _keyword_call_count = 0
+    agent = _KeywordAgent()
+
+    result = await scenario.arun(
+        name="cache-keyword-arguments",
+        description="cached calls with distinct keyword arguments",
+        cache_key="arun-cache-keyword-arguments-v1",
+        agents=[agent, _User(), _Judge()],
+        script=[
+            scenario.user("hi"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+
+    assert result.success
+    assert agent.values == ["computed-first", "computed-second"]
+    assert _keyword_call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_scenario_cache_normalizes_calling_conventions_and_defaults():
+    global _normalized_call_count
+    _normalized_call_count = 0
+    agent = _NormalizedAgent()
+
+    result = await scenario.arun(
+        name="cache-normalized-arguments",
+        description="equivalent cached calls share an entry",
+        cache_key="arun-cache-normalized-arguments-v1",
+        agents=[agent, _User(), _Judge()],
+        script=[
+            scenario.user("hi"),
+            scenario.agent(),
+            scenario.judge(),
+        ],
+    )
+
+    assert result.success
+    assert agent.values == [
+        "computed-same",
+        "computed-same",
+        "computed-default",
+        "computed-default",
+    ]
+    assert _normalized_call_count == 2


### PR DESCRIPTION
## Summary

Fix the Python `@scenario.cache()` decorator so its cache key includes the complete bound function invocation, including keyword arguments and default values.

Fixes #926.

## Root cause

The decorator previously constructed `all_args` by zipping the function parameters with positional `args`. Values supplied through `kwargs` were omitted, so distinct calls such as `cached(arg="first")` and `cached(arg="second")` could collide and return stale results.

## Changes

- bind `args` and `kwargs` with `inspect.signature(wrapped).bind(...)`;
- apply parameter defaults before constructing the cache key;
- preserve existing ignored-argument and `AgentInput` handling;
- add integration coverage for:
  - distinct keyword argument values;
  - equivalent positional and keyword calls;
  - omitted and explicitly supplied default values.

## Impact

Agent and RAG evaluation calls that use keyword arguments now produce deterministic cache entries for their actual inputs. Calls that omit default values may experience a one-time cold cache miss after upgrading because the cache-key material is now normalized.

## Validation

Passed:

- focused reproducer against the real `scenario/cache.py` implementation;
- `python -m py_compile scenario/cache.py tests/test_arun_cache.py`;
- `git diff --check HEAD^ HEAD`.

The project test file could not be collected in the local partial environment because the full uv dependency set was unavailable (`ModuleNotFoundError: litellm`). The added test is included for the repository CI environment.