### PR TITLE
feat(javascript): migrate to AI SDK 7

### DIFF
--- a/javascript/examples/vitest/package.json
+++ b/javascript/examples/vitest/package.json
@@ -21,11 +21,11 @@
     "vitest-mock-extended": "5.1.1"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "3.0.41",
-    "@ai-sdk/xai": "3.0.50",
+    "@ai-sdk/anthropic": "4.0.38",
+    "@ai-sdk/xai": "4.0.40",
     "@langwatch/scenario": "workspace:*",
     "@openai/agents": "^0.16.0",
-    "ai": "^6.0.0",
+    "ai": "^7.0.64",
     "express": "^5.1.0",
     "openai": "^6.9.1",
     "vite": "^8.2.1",

--- a/javascript/examples/vitest/tests/00-demo-light.test.ts
+++ b/javascript/examples/vitest/tests/00-demo-light.test.ts
@@ -25,15 +25,10 @@ describe("Demo: Lightweight Scenarios", () => {
     call: async (input) => {
       const response = await generateText({
         model: openai("gpt-5-mini"),
+        instructions: "You can analyze images and respond briefly and helpfully.",
         messages: [
-          {
-            role: "system",
-            content:
-              "You can analyze images and respond briefly and helpfully.",
-          },
           ...input.messages,
         ],
-        experimental_telemetry: { isEnabled: true },
       });
       return response.text;
     },

--- a/javascript/examples/vitest/tests/api-service-mocking.test.ts
+++ b/javascript/examples/vitest/tests/api-service-mocking.test.ts
@@ -48,7 +48,6 @@ const userDataAgent: AgentAdapter = {
       messages: input.messages,
       tools: { fetch_user_data: fetchUserDataTool },
       toolChoice: "auto",
-      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/database-tool-mocking.test.ts
+++ b/javascript/examples/vitest/tests/database-tool-mocking.test.ts
@@ -52,7 +52,6 @@ const databaseAgent: AgentAdapter = {
         find_user: findUserTool,
       },
       toolChoice: "auto",
-      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/false-assumptions.test.ts
+++ b/javascript/examples/vitest/tests/false-assumptions.test.ts
@@ -16,11 +16,10 @@ describe("False Assumptions", () => {
       call: async (input) => {
         const response = await generateText({
           model: openai("gpt-5-mini"),
+          instructions: "You are a helpful assistant",
           messages: [
-            { role: "system", content: "You are a helpful assistant" },
             ...input.messages,
           ],
-          experimental_telemetry: { isEnabled: true },
         });
 
         return response.text;

--- a/javascript/examples/vitest/tests/judge-tool-calls-without-telemetry.test.ts
+++ b/javascript/examples/vitest/tests/judge-tool-calls-without-telemetry.test.ts
@@ -42,7 +42,6 @@ const weatherAgent: AgentAdapter = {
       messages: input.messages,
       tools: { get_weather: getWeatherTool },
       toolChoice: "auto",
-      experimental_telemetry: { isEnabled: true },
     });
 
     if (response.toolCalls && response.toolCalls.length > 0) {

--- a/javascript/examples/vitest/tests/llm-provider-mocking.test.ts
+++ b/javascript/examples/vitest/tests/llm-provider-mocking.test.ts
@@ -39,7 +39,6 @@ const chatAgent: AgentAdapter = {
     const response = await generateText({
       model: openai("gpt-5-mini"),
       messages: input.messages,
-      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },
@@ -51,7 +50,7 @@ describe("LLM Provider Mocking", () => {
     // No actual LLM call will be made
     mockGenerateText.mockResolvedValue({
       text: "I can help you with that request.",
-    } as GenerateTextResult<ToolSet, never>);
+    } as GenerateTextResult<ToolSet, never, never>);
 
     const result = await scenario.run({
       name: "llm mock test",

--- a/javascript/examples/vitest/tests/mocked-weather-agent-tool.test.ts
+++ b/javascript/examples/vitest/tests/mocked-weather-agent-tool.test.ts
@@ -26,19 +26,15 @@ describe("Mocked Weather Agent Tool", () => {
       call: async (input) => {
         const response = await generateText({
           model: openai("gpt-5-mini"),
-          messages: [
-            {
-              role: "system",
-              content: `
+          instructions: `
                 You are a helpful assistant that may help the user with weather information.
                 Do not guess the city if they don't provide it.
               `,
-            },
+          messages: [
             ...input.messages,
           ],
           tools: { get_current_weather: getCurrentWeather },
           toolChoice: "auto",
-          experimental_telemetry: { isEnabled: true },
         });
 
         return response.text;

--- a/javascript/examples/vitest/tests/multilingual-agent.test.ts
+++ b/javascript/examples/vitest/tests/multilingual-agent.test.ts
@@ -16,7 +16,6 @@ const createMultilingualAgent = (): AgentAdapter => ({
     const response = await generateText({
       model: openai("gpt-5-mini"),
       messages: input.messages,
-      experimental_telemetry: { isEnabled: true },
     });
 
     return response.text;

--- a/javascript/examples/vitest/tests/multimodal-images.test.ts
+++ b/javascript/examples/vitest/tests/multimodal-images.test.ts
@@ -35,18 +35,14 @@ describe("Multimodal Images Tests", () => {
     call: async (input) => {
       const response = await generateText({
         model: openai("gpt-5-mini"),
-        messages: [
-          {
-            role: "system",
-            content: `
+        instructions: `
               You are a helpful assistant that can process both text and image input.
               When analyzing images, be descriptive and helpful.
               Respond naturally to user queries about images.
             `,
-          },
+        messages: [
           ...input.messages,
         ],
-        experimental_telemetry: { isEnabled: true },
       });
       return response.text;
     },

--- a/javascript/examples/vitest/tests/running-in-parallel.test.ts
+++ b/javascript/examples/vitest/tests/running-in-parallel.test.ts
@@ -9,18 +9,14 @@ describe("Vegetarian Recipe Agent (Parallel)", () => {
     call: async (input) => {
       const response = await generateText({
         model: openai("gpt-5-mini"),
-        messages: [
-          {
-            role: "system",
-            content: `You are a vegetarian recipe agent. When a user asks for a recipe,
+        instructions: `You are a vegetarian recipe agent. When a user asks for a recipe,
             <rules>
               - You may ask ONLY ONE clarifying question if absolutely necessary (like dietary restrictions or cooking time preference), but then you MUST provide a complete vegetarian recipe.
               - Do not ask multiple follow-up questions.
             </rules>`,
-          },
+        messages: [
           ...input.messages,
         ],
-        experimental_telemetry: { isEnabled: true },
       });
       return response.text;
     },

--- a/javascript/examples/vitest/tests/simple-tool-mocking.test.ts
+++ b/javascript/examples/vitest/tests/simple-tool-mocking.test.ts
@@ -39,7 +39,6 @@ const userDataAgent: AgentAdapter = {
       messages: input.messages,
       tools: { fetch_user_data: fetchUserDataTool },
       toolChoice: "auto",
-      experimental_telemetry: { isEnabled: true },
     });
     return response.text;
   },

--- a/javascript/examples/vitest/tests/span-based-evaluation.test.ts
+++ b/javascript/examples/vitest/tests/span-based-evaluation.test.ts
@@ -68,16 +68,12 @@ const observableAgent: AgentAdapter = {
       // LLM call with tool usage
       const response = await generateText({
         model: openai("gpt-5-mini"),
-        messages: [
-          {
-            role: "system",
-            content: `You are an order processing assistant.
+        instructions: `You are an order processing assistant.
 When asked about products, use the check_inventory tool.`,
-          },
+        messages: [
           ...input.messages,
         ],
         tools: { check_inventory: checkInventoryTool },
-        experimental_telemetry: { isEnabled: true },
         stopWhen: stepCountIs(2),
       });
 

--- a/javascript/examples/vitest/tests/testing-remote-agents-json.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-json.test.ts
@@ -31,21 +31,17 @@ beforeAll(async () => {
           // Use real LLM to generate response
           const result = await generateText({
             model: openai("gpt-5-mini"),
+            /**
+             * Simple system prompt to make the agent pretend like it has access to a weather API and make up the weather so the tests pass.
+             */
+            instructions:
+              "You are a helpful weather assistant. Provide brief, friendly responses about weather. Pretend like you have access to a weather API and make up the weather.",
             messages: [
-              {
-                role: "system",
-                /**
-                 * Simple system prompt to make the agent pretend like it has access to a weather API and make up the weather so the tests pass.
-                 */
-                content:
-                  "You are a helpful weather assistant. Provide brief, friendly responses about weather. Pretend like you have access to a weather API and make up the weather.",
-              },
               {
                 role: "user",
                 content: message,
               },
             ],
-            experimental_telemetry: { isEnabled: true },
           });
 
           res.writeHead(200, { "Content-Type": "application/json" });

--- a/javascript/examples/vitest/tests/testing-remote-agents-sse.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-sse.test.ts
@@ -44,18 +44,13 @@ beforeAll(async () => {
           // Stream response using real LLM
           const result = streamText({
             model: openai("gpt-5-mini"),
+            instructions: "You are a helpful weather assistant. Provide brief, friendly responses. Pretend you have access to weather data. Pretend like you have access to a weather API and make up the weather.",
             messages: [
-              {
-                role: "system",
-                content:
-                  "You are a helpful weather assistant. Provide brief, friendly responses. Pretend you have access to weather data. Pretend like you have access to a weather API and make up the weather.",
-              },
               {
                 role: "user",
                 content,
               },
             ],
-            experimental_telemetry: { isEnabled: true },
           });
 
           // Stream chunks in SSE format

--- a/javascript/examples/vitest/tests/testing-remote-agents-stateful.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-stateful.test.ts
@@ -42,15 +42,10 @@ beforeAll(async () => {
           // Generate response with full history
           const result = await generateText({
             model: openai("gpt-5-mini"),
+            instructions: "You are a helpful travel assistant. Help users plan their trips and provide information about destinations.",
             messages: [
-              {
-                role: "system",
-                content:
-                  "You are a helpful travel assistant. Help users plan their trips and provide information about destinations.",
-              },
               ...history,
             ],
-            experimental_telemetry: { isEnabled: true },
           });
 
           // Add assistant response to history

--- a/javascript/examples/vitest/tests/testing-remote-agents-streaming.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-streaming.test.ts
@@ -42,18 +42,13 @@ beforeAll(async () => {
 
           const result = streamText({
             model: openai("gpt-5-mini"),
+            instructions: "You are a helpful weather assistant. Provide brief, friendly responses, immediately. Pretend like you have access to a weather API and make up the weather.",
             messages: [
-              {
-                role: "system",
-                content:
-                  "You are a helpful weather assistant. Provide brief, friendly responses, immediately. Pretend like you have access to a weather API and make up the weather.",
-              },
               {
                 role: "user",
                 content,
               },
             ],
-            experimental_telemetry: { isEnabled: true },
           });
 
           // Stream chunks to client

--- a/javascript/examples/vitest/tests/testing-remote-agents-traces.test.ts
+++ b/javascript/examples/vitest/tests/testing-remote-agents-traces.test.ts
@@ -60,17 +60,12 @@ beforeAll(async () => {
           const result = await context.with(extracted, () =>
             generateText({
               model: openai("gpt-5-mini"),
+              instructions: "You are an order support assistant. Use the lookup_order_status tool to check orders before answering.",
               messages: [
-                {
-                  role: "system",
-                  content:
-                    "You are an order support assistant. Use the lookup_order_status tool to check orders before answering.",
-                },
                 ...messages,
               ],
               tools: { lookup_order_status: lookupOrderStatus },
               stopWhen: stepCountIs(3),
-              experimental_telemetry: { isEnabled: true },
             })
           );
 

--- a/javascript/examples/vitest/tests/tool-call-role-reversal.test.ts
+++ b/javascript/examples/vitest/tests/tool-call-role-reversal.test.ts
@@ -26,23 +26,23 @@ const toolCallingAgent: AgentAdapter = {
   call: async (input) => {
     const response = await generateText({
       model: openai("gpt-5-mini"),
+      instructions: "You are a helpful shopping assistant. Always use the lookup tool to check product details before responding.",
       messages: [
-        {
-          role: "system",
-          content: "You are a helpful shopping assistant. Always use the lookup tool to check product details before responding.",
-        },
         ...input.messages,
       ],
       tools: { lookup_product: lookupTool },
       toolChoice: "auto",
-      experimental_telemetry: { isEnabled: true },
     });
 
     if (response.toolCalls && response.toolCalls.length > 0) {
       const toolCall = response.toolCalls[0];
       const toolResult = await lookupTool.execute!(
         toolCall.input as { product: string },
-        { toolCallId: toolCall.toolCallId, messages: input.messages }
+        {
+          toolCallId: toolCall.toolCallId,
+          messages: input.messages,
+          context: {},
+        }
       );
       return [
         {

--- a/javascript/examples/vitest/tests/tool-failure-simulation.test.ts
+++ b/javascript/examples/vitest/tests/tool-failure-simulation.test.ts
@@ -45,7 +45,6 @@ const resilientAgent: AgentAdapter = {
       messages: input.messages,
       tools: { call_external_service: callExternalServiceTool },
       toolChoice: "auto",
-      experimental_telemetry: { isEnabled: true },
     });
 
     // Check if the LLM decided to call any tools

--- a/javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts
+++ b/javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts
@@ -9,18 +9,14 @@ describe("Vegetarian Recipe Agent", () => {
     call: async (input) => {
       const response = await generateText({
         model: openai("gpt-5-mini"),
-        messages: [
-          {
-            role: "system",
-            content: `
+        instructions: `
               You are a vegetarian recipe agent.
               Given the user request, ask AT MOST ONE follow-up question,
               then provide a complete recipe. Keep your responses concise and focused.
             `,
-          },
+        messages: [
           ...input.messages,
         ],
-        experimental_telemetry: { isEnabled: true },
       });
       return response.text;
     },

--- a/javascript/examples/vitest/tests/weather-agent.test.ts
+++ b/javascript/examples/vitest/tests/weather-agent.test.ts
@@ -24,19 +24,15 @@ const weatherAgent: AgentAdapter = {
   call: async (input) => {
     const response = await generateText({
       model: openai("gpt-5-mini"),
-      messages: [
-        {
-          role: "system",
-          content: `
+      instructions: `
             You are a helpful assistant that may help the user with weather information.
             Do not guess the city if they don't provide it.
           `,
-        },
+      messages: [
         ...input.messages,
       ],
       tools: { get_current_weather: getCurrentWeather },
       toolChoice: "auto",
-      experimental_telemetry: { isEnabled: true },
     });
 
     if (response.toolCalls && response.toolCalls.length > 0) {
@@ -47,6 +43,7 @@ const weatherAgent: AgentAdapter = {
         {
           toolCallId: toolCall.toolCallId,
           messages: input.messages,
+          context: {},
         }
       );
       return [

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -50,13 +50,14 @@
   "author": "LangWatch",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "pnpm": ">=8"
   },
   "packageManager": "pnpm@10.22.0",
   "dependencies": {
     "@ag-ui/core": "^0.0.58",
-    "@ai-sdk/openai": "^3.0.26",
+    "@ai-sdk/openai": "^4.0.41",
+    "@ai-sdk/otel": "^1.0.64",
     "@elevenlabs/elevenlabs-js": "^2.51.0",
     "@openai/agents": "^0.16.0",
     "@opentelemetry/api": "^1.9.0",
@@ -64,7 +65,7 @@
     "@opentelemetry/sdk-node": "0.221.0",
     "@opentelemetry/sdk-trace-base": "2.10.0",
     "@opentelemetry/sdk-trace-node": "2.10.0",
-    "ai": "^6.0.0",
+    "ai": "^7.0.64",
     "chalk": "^5.6.2",
     "ffmpeg-static": "5.3.0",
     "fft.js": "4.0.4",
@@ -129,7 +130,7 @@
   },
   "peerDependencies": {
     "@google/genai": ">=2.0.0",
-    "ai": ">=6.0.0",
+    "ai": ">=7.0.0",
     "vitest": ">=3.2.4"
   },
   "peerDependenciesMeta": {

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -43,8 +43,11 @@ importers:
         specifier: ^0.0.58
         version: 0.0.58
       '@ai-sdk/openai':
-        specifier: ^3.0.26
-        version: 3.0.65(zod@3.25.76)
+        specifier: ^4.0.41
+        version: 4.0.43(zod@3.25.76)
+      '@ai-sdk/otel':
+        specifier: ^1.0.64
+        version: 1.0.69(zod@3.25.76)
       '@elevenlabs/elevenlabs-js':
         specifier: ^2.51.0
         version: 2.64.0
@@ -67,8 +70,8 @@ importers:
         specifier: 2.10.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
       ai:
-        specifier: ^6.0.0
-        version: 6.0.190(zod@3.25.76)
+        specifier: ^7.0.64
+        version: 7.0.69(zod@3.25.76)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -80,7 +83,7 @@ importers:
         version: 4.0.4
       langwatch:
         specifier: '>=0.16.1 <2.0.0'
-        version: 0.37.0(c5d97d6210f5b7a63432cedc6d1a98ed)
+        version: 0.37.0(0a67e9efc5e61292052eae9cdd19474a)
       open:
         specifier: 11.0.1
         version: 11.0.1
@@ -196,7 +199,7 @@ importers:
     dependencies:
       '@openai/agents':
         specifier: ^0.16.0
-        version: 0.16.0(ws@8.21.3)(zod@3.25.76)
+        version: 0.16.0(ws@8.21.3)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^26.2.0
@@ -314,11 +317,11 @@ importers:
   examples/vitest:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: 3.0.41
-        version: 3.0.41(zod@4.4.3)
+        specifier: 4.0.38
+        version: 4.0.38(zod@4.4.3)
       '@ai-sdk/xai':
-        specifier: 3.0.50
-        version: 3.0.50(zod@4.4.3)
+        specifier: 4.0.40
+        version: 4.0.40(zod@4.4.3)
       '@langwatch/scenario':
         specifier: workspace:*
         version: link:../..
@@ -326,8 +329,8 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0(ws@8.21.3)(zod@4.4.3)
       ai:
-        specifier: ^6.0.0
-        version: 6.0.190(zod@4.4.3)
+        specifier: ^7.0.64
+        version: 7.0.69(zod@4.4.3)
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -365,53 +368,41 @@ packages:
   '@ag-ui/core@0.0.58':
     resolution: {integrity: sha512-XgGb7YmhV+yMBaEmlrpsd5S+nUxq0JgSegss2t4gIFR1j7w3w0ibtKfRgcQHWeMvwZxcT5S28VEEarqtgxYYHw==}
 
-  '@ai-sdk/anthropic@3.0.41':
-    resolution: {integrity: sha512-Wk/YHKyP/MmvQ63MFGRwmm3URM3ey7Tg62y0a7MT+7/8kMVZ40pUYidYO0hB9YB+dHe4z1ks006mNfGYy+wzkA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/anthropic@4.0.38':
+    resolution: {integrity: sha512-esbTb5jq/37dloBJzld3CpYCZskiDWGcI4O8kzst9J/0Km4by7cgQXLTB/gGdjXxBsyjPQUeotVqqRRIrx2zew==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.119':
-    resolution: {integrity: sha512-VAhfRWC+JexZakkVfmjaJKaTj00x7/UHdE8kMWL3NhuQAlf8oXtg9r4dfvFZrByXxchGRBvYE3biEUyibkg0xg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.55':
+    resolution: {integrity: sha512-7WP/nlDz2BkXFlZzwF3w5JgCvktyHC++LP4PZ4mQpbvxrq+M7OdNslevlkuddHhJ+62BZu4oiL/afXlsWOSJZQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.28':
-    resolution: {integrity: sha512-WzDnU0B13FMSSupDtm2lksFZvWGXnOfhG5S0HoPI0pkX5uVkr6N1UTATMyVaxLCG0MRkMhXCjkg4NXgEbb330Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai@4.0.43':
+    resolution: {integrity: sha512-O5t21AmcBwsEg/l8ro91CHzdBjEkxtJRFh6DH9KDjRrWDeTMuqJt7XkaFHIqL8H0nvjFv8H7kck+JwirUWPS2g==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.65':
-    resolution: {integrity: sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/otel@1.0.69':
+    resolution: {integrity: sha512-kDQpc7dK583iKrPOesiI9t9KGLgkvNtr9b/sVDVuzGLpVJc5FxYERtFjUQD4wZqHj7znzUXXy4aep1fpxiK2Ew==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.14':
-    resolution: {integrity: sha512-7bzKd9lgiDeXM7O4U4nQ8iTxguAOkg8LZGD9AfDVZYjO5cKYRwBPwVjboFcVrxncRHu0tYxZtXZtiLKpG4pEng==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
+    engines: {node: '>=22'}
 
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@3.0.10':
-    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/provider@3.0.8':
-    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/xai@3.0.50':
-    resolution: {integrity: sha512-Cy28SydSV5qtmm9GS2BWj6ILnrKTprcE5NZFs1QlGdoOYzFgAteYNGJu1XQ3reY4MJM03C0Scvi1RBf4JB7q2w==}
-    engines: {node: '>=18'}
+  '@ai-sdk/xai@4.0.40':
+    resolution: {integrity: sha512-OzFgYb+CHHfJhYGrXBYCfJsmUZjBpBUAGf0fgnYFZulel9ORD0COBMYwGVILwg/7T3FIz2QalV6BZRblabOTsQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -1668,42 +1659,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.4':
     resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.4':
     resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.4':
     resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.4':
     resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.4':
     resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
@@ -1760,79 +1745,66 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -1917,28 +1889,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -2221,61 +2189,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2368,6 +2326,9 @@ packages:
   '@webgpu/types@0.1.70':
     resolution: {integrity: sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2390,9 +2351,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.190:
-    resolution: {integrity: sha512-T+ixHbWZ6jmHRREpVVJTkFyWJeCekCdzLPan7lp1F32jG5OUw4+odlVYjtMRXVzogU+pWzpMmXdRiHUmdL/q0w==}
-    engines: {node: '>=18'}
+  ai@7.0.69:
+    resolution: {integrity: sha512-gudEqQYt/FuRpQkckLHPYKOh5M5v5ayPmzQAk5xyZOaWkUM0ArNGdXQiBGEuZA7GCwYOjzmWxB44ZW0CyRhHfQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -3118,10 +3079,6 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
-    engines: {node: '>=18.0.0'}
 
   eventsource-parser@3.1.1:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
@@ -4068,56 +4025,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5253,6 +5202,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -5363,7 +5316,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=7.3.2'
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -5573,72 +5526,66 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@3.0.41(zod@4.4.3)':
+  '@ai-sdk/anthropic@4.0.38(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.119(zod@3.25.76)':
+  '@ai-sdk/gateway@4.0.55(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
-  '@ai-sdk/gateway@3.0.119(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.55(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@2.0.28(zod@4.4.3)':
+  '@ai-sdk/openai@4.0.43(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
-      zod: 4.4.3
-
-  '@ai-sdk/openai@3.0.65(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.14(zod@4.4.3)':
+  '@ai-sdk/otel@1.0.69(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.8
-      zod: 4.4.3
+      '@ai-sdk/provider': 4.0.7
+      '@opentelemetry/api': 1.9.1
+      ai: 7.0.69(zod@3.25.76)
+    transitivePeerDependencies:
+      - zod
 
-  '@ai-sdk/provider-utils@4.0.27(zod@3.25.76)':
+  '@ai-sdk/provider-utils@5.0.27(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.8
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.27(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.8
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.10':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@3.0.8':
+  '@ai-sdk/xai@4.0.40(zod@4.4.3)':
     dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/xai@3.0.50(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/openai-compatible': 2.0.28(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
   '@amiceli/vitest-cucumber@7.0.0(vitest@4.1.10)':
@@ -7656,6 +7603,8 @@ snapshots:
 
   '@webgpu/types@0.1.70': {}
 
+  '@workflow/serde@4.1.0': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -7675,20 +7624,18 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.190(zod@3.25.76):
+  ai@7.0.69(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.119(zod@3.25.76)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.55(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@3.25.76)
       zod: 3.25.76
 
-  ai@6.0.190(zod@4.4.3):
+  ai@7.0.69(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.119(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.55(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -8537,10 +8484,7 @@ snapshots:
   eventemitter3@4.0.7:
     optional: true
 
-  eventsource-parser@3.0.8: {}
-
-  eventsource-parser@3.1.1:
-    optional: true
+  eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -9572,7 +9516,7 @@ snapshots:
       ws: 8.21.3
     optional: true
 
-  langwatch@0.37.0(c5d97d6210f5b7a63432cedc6d1a98ed):
+  langwatch@0.37.0(0a67e9efc5e61292052eae9cdd19474a):
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.205.0
@@ -9597,7 +9541,7 @@ snapshots:
       xksuid: 0.0.4
       zod: 4.4.3
     optionalDependencies:
-      '@ai-sdk/openai': 3.0.65(zod@3.25.76)
+      '@ai-sdk/openai': 4.0.43(zod@3.25.76)
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.39.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3)
       '@langchain/langgraph': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.39.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod-to-json-schema@3.25.2(zod@3.25.76))
       '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.39.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3))(ws@8.21.3)
@@ -10854,6 +10798,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@8.3.0: {}
+
+  undici@7.29.0: {}
 
   unpipe@1.0.0: {}
 

--- a/javascript/src/agents/__tests__/user-simulator-voice.test.ts
+++ b/javascript/src/agents/__tests__/user-simulator-voice.test.ts
@@ -285,11 +285,9 @@ describeFeature(
             // Capture system prompt via LLM spy — check persona block present.
             systemPromptCapture = "";
             (sim as unknown as {
-              invokeLLM: (p: { messages: Array<{ role: string; content: string }> }) => Promise<{ text: string; toolCalls: []; steps: [] }>;
-            }).invokeLLM = async ({ messages }) => {
-              // System message is passed unchanged through role reversal.
-              const sysMsg = messages.find((m) => m.role === "system");
-              systemPromptCapture = sysMsg?.content ?? "";
+              invokeLLM: (p: { instructions?: string }) => Promise<{ text: string; toolCalls: []; steps: [] }>;
+            }).invokeLLM = async ({ instructions }) => {
+              systemPromptCapture = instructions ?? "";
               return { text: "I need help please", toolCalls: [], steps: [] };
             };
 

--- a/javascript/src/agents/judge/__tests__/judge-agent.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-agent.test.ts
@@ -244,14 +244,12 @@ describe("JudgeAgent", () => {
 
       await agent.call(createBaseInput());
 
-      const systemMsg = capturedParams!.messages?.find(
-        (m) => "role" in m && m.role === "system"
-      );
-      expect(systemMsg).toBeDefined();
+      const instructions = capturedParams!.instructions;
+      expect(instructions).toBeDefined();
       const content =
-        typeof systemMsg!.content === "string"
-          ? systemMsg!.content
-          : JSON.stringify(systemMsg!.content);
+        typeof instructions === "string"
+          ? instructions
+          : JSON.stringify(instructions);
       expect(content).toContain(customPrompt);
     });
   });

--- a/javascript/src/agents/judge/__tests__/judge-two-phase.unit.test.ts
+++ b/javascript/src/agents/judge/__tests__/judge-two-phase.unit.test.ts
@@ -121,12 +121,7 @@ function schemaShapeKeys(tool: unknown): string[] {
 }
 
 function systemPromptOf(params: InvokeLLMParams | undefined): string {
-  const systemMessage = params?.messages?.find(
-    (m) => "role" in m && m.role === "system"
-  );
-  return typeof systemMessage?.content === "string"
-    ? systemMessage.content
-    : "";
+  return typeof params?.instructions === "string" ? params.instructions : "";
 }
 
 const feature = await loadFeature(FEATURE_PATH);

--- a/javascript/src/agents/judge/__tests__/remote-traces.unit.test.ts
+++ b/javascript/src/agents/judge/__tests__/remote-traces.unit.test.ts
@@ -233,13 +233,11 @@ function userMessageContent(params: InvokeLLMParams | undefined): string {
 }
 
 function systemMessageContent(params: InvokeLLMParams | undefined): string {
-  const systemMessage = params?.messages?.find(
-    (m) => "role" in m && m.role === "system"
-  );
-  if (!systemMessage) throw new Error("Expected a system message in LLM call");
-  return typeof systemMessage.content === "string"
-    ? systemMessage.content
-    : JSON.stringify(systemMessage.content);
+  const instructions = params?.instructions;
+  if (!instructions) throw new Error("Expected instructions in LLM call");
+  return typeof instructions === "string"
+    ? instructions
+    : JSON.stringify(instructions);
 }
 
 // ---------------------------------------------------------------------------

--- a/javascript/src/agents/judge/judge-agent.ts
+++ b/javascript/src/agents/judge/judge-agent.ts
@@ -4,7 +4,7 @@ import {
   ToolSet,
   Tool,
   tool,
-  stepCountIs,
+  isStepCount,
   hasToolCall,
 } from "ai";
 import { z } from "zod/v4";
@@ -858,10 +858,8 @@ export class JudgeAgent extends JudgeAgentAdapter {
 
     const params: InvokeLLMParams = {
       model: mergedConfig.model,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: contentForJudge },
-      ],
+      instructions: systemPrompt,
+      messages: [{ role: "user", content: contentForJudge }],
       temperature: mergedConfig.temperature,
       maxOutputTokens: mergedConfig.maxTokens,
       tools,
@@ -869,7 +867,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
     };
     if (isLargeTrace) {
       params.stopWhen = [
-        stepCountIs(this.maxDiscoverySteps),
+        isStepCount(this.maxDiscoverySteps),
         hasToolCall("continue_test"),
         hasToolCall("make_verdict"),
       ];
@@ -896,8 +894,9 @@ export class JudgeAgent extends JudgeAgentAdapter {
       );
       // generateText never writes back into params.messages, so the discovery
       // cycles live only on the completion steps. Recombine both before
-      // collapsing, then drop the two messages the verdict phase rebuilds by
-      // itself (the system prompt and the criteria block).
+      // collapsing, then drop the criteria block, which the verdict phase
+      // rebuilds by itself. The system prompt travels in `instructions` and
+      // was never part of this array.
       const discoveryHistory: ModelMessage[] = [
         ...(params.messages ?? []),
         ...(completion.steps ?? []).flatMap((step) => [
@@ -906,7 +905,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
       ];
       return {
         decision: "exhausted",
-        discoveryRecap: collapseDiscoveryHistory(discoveryHistory).slice(2),
+        discoveryRecap: collapseDiscoveryHistory(discoveryHistory).slice(1),
       };
     }
     return {
@@ -1042,7 +1041,6 @@ export class JudgeAgent extends JudgeAgentAdapter {
           });
 
       const messages: ModelMessage[] = [
-        { role: "system", content: systemPrompt },
         { role: "user", content: contentForJudge },
       ];
 
@@ -1085,6 +1083,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
 
       const params: InvokeLLMParams = {
         model: mergedConfig.model,
+        instructions: systemPrompt,
         messages,
         temperature: mergedConfig.temperature,
         maxOutputTokens: mergedConfig.maxTokens,
@@ -1096,7 +1095,7 @@ export class JudgeAgent extends JudgeAgentAdapter {
       if (isLargeTrace && !exhaustedEntry) {
         params.toolChoice = "required";
         params.stopWhen = [
-          stepCountIs(this.maxDiscoverySteps),
+          isStepCount(this.maxDiscoverySteps),
           hasToolCall("finish_test"),
           ...(waitExtensionAvailable ? [hasToolCall("wait_for_traces")] : []),
         ];

--- a/javascript/src/agents/llm-invoker.factory.ts
+++ b/javascript/src/agents/llm-invoker.factory.ts
@@ -16,7 +16,7 @@ export const createLLMInvoker = (
     try {
       return await generateText({
         ...params,
-        experimental_telemetry: { isEnabled: true },
+        telemetry: { isEnabled: true },
       });
     } catch (error) {
       logger.error("Error generating text", { error });

--- a/javascript/src/agents/red-team/red-team-agent.ts
+++ b/javascript/src/agents/red-team/red-team-agent.ts
@@ -431,6 +431,10 @@ Reply with exactly this JSON and nothing else:
     const result = await generateText({
       model: this.model,
       messages: this.attackerHistory as ModelMessage[],
+      // H_attacker interleaves system-role [SCORE] and [BACKTRACKED] markers
+      // with the conversation, so they cannot be hoisted to `instructions`
+      // without changing what the attacker model sees.
+      allowSystemInMessages: true,
       temperature: this.temperature,
       maxOutputTokens: this.maxTokens,
     });

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -454,7 +454,6 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
     const strippedMessages = stripAudioContent(preparedMessages);
 
     const messages: ModelMessage[] = [
-      { role: "system", content: systemPrompt },
       { role: "assistant", content: "Hello, how can I help you today" },
       ...strippedMessages,
     ];
@@ -471,6 +470,7 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
 
     const completion = await this.invokeLLM({
       model: mergedConfig.model,
+      instructions: systemPrompt,
       messages: reversedMessages,
       temperature: mergedConfig.temperature,
       maxOutputTokens: mergedConfig.maxTokens,

--- a/javascript/src/tracing/setup.ts
+++ b/javascript/src/tracing/setup.ts
@@ -1,5 +1,7 @@
+import { OpenTelemetry } from "@ai-sdk/otel";
 import { trace } from "@opentelemetry/api";
 import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { registerTelemetry } from "ai";
 import { LangWatchTraceExporter } from "langwatch/observability";
 import { setupObservability } from "langwatch/observability/node";
 import type { SetupObservabilityOptions } from "langwatch/observability/node";
@@ -92,6 +94,11 @@ export function setupScenarioTracing(
     // No existing provider; do a full setup via the langwatch SDK.
     initializeFullSetup(options);
   }
+
+  // AI SDK 7 emits no spans until a telemetry integration is registered, so
+  // without this the judge collector and the LangWatch exporter above would
+  // both receive nothing from the model calls this library makes.
+  registerTelemetry(new OpenTelemetry());
 
   initialized = true;
 }

--- a/javascript/src/voice/adapters/composable.ts
+++ b/javascript/src/voice/adapters/composable.ts
@@ -130,6 +130,7 @@ export class ComposableVoiceAgent extends VoiceAgentAdapter {
   readonly llm: LanguageModel;
   readonly tts: string;
   protected readonly ttsOptions: SynthesizeOptions;
+  protected readonly instructions: string;
   protected readonly history: ModelMessage[];
 
   lastUserTranscript: string | null = null;
@@ -149,12 +150,9 @@ export class ComposableVoiceAgent extends VoiceAgentAdapter {
     this.llm = options.llm;
     this.tts = options.tts;
     this.ttsOptions = options.ttsOptions ?? {};
-    this.history = [
-      {
-        role: "system",
-        content: options.systemPrompt ?? ComposableVoiceAgent.DEFAULT_SYSTEM_PROMPT,
-      },
-    ];
+    this.instructions =
+      options.systemPrompt ?? ComposableVoiceAgent.DEFAULT_SYSTEM_PROMPT;
+    this.history = [];
   }
 
   toString(): string {
@@ -193,6 +191,7 @@ export class ComposableVoiceAgent extends VoiceAgentAdapter {
     const work = (async () => {
       const result = await generateText({
         model: this.llm,
+        instructions: this.instructions,
         messages: this.history,
       });
       const responseText = result.text ?? "";

--- a/javascript/tsup.config.ts
+++ b/javascript/tsup.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts", "src/integrations/vitest/*.ts"],
+  // ai@7 publishes no CommonJS entry point, so the CJS build reaches it through
+  // Node's require(esm), unflagged since Node 22.12 and ai@7 already requires
+  // >=22. `smoke:dist` is what keeps that honest: if a future ai release adds
+  // top-level await anywhere in its graph, require() starts throwing
+  // ERR_REQUIRE_ASYNC_MODULE, and the smoke check fails the build instead of
+  // the consumer's process.
   format: ["cjs", "esm"],
   dts: true,
   clean: true,


### PR DESCRIPTION
Moves `@langwatch/scenario` to AI SDK 7.

**This is not a breaking change.** `package.json`'s module shape is byte-identical to `main` — the dual CJS+ESM build stays exactly as it is, and consumers see no difference. The only changed lines are dependency versions and the Node floor.

## Why CommonJS survives

`ai@7` publishes no `require` condition, which looks like it forces an ESM-only package. It doesn't: Node's `require(esm)` loads it, unflagged since **22.12**, and `ai@7` already requires Node >=22 — so the only consumers this could strand are ones pinned to 22.0–22.11. Verified end to end: the CJS bundle builds and `require('./dist/index.js')` loads it. `@langwatch/web`'s production `server.cjs` already does the same thing eleven times over.

The one real risk is **top-level await**. If a future `ai` release introduces it anywhere in its graph, `require()` starts throwing `ERR_REQUIRE_ASYNC_MODULE`, visible only to CommonJS consumers and only at runtime. `smoke:dist` now covers both formats so that arrives as a failed build instead of a failed consumer process.

## What actually broke, and why tsc didn't catch it

v7 kept deprecated aliases for nearly everything it renamed, so broken code typechecks clean. These were found by running 7.0.64 against a 6.0.217 baseline, not by reading the migration guide.

**System messages are rejected inside `messages`** — v7 throws `InvalidPromptError` where v6 only warned. The judge, the user simulator and the composable voice adapter each led their message array with a system turn; all three now pass it as top-level `instructions`.

The red-team attacker is the deliberate exception and keeps `allowSystemInMessages: true`: its `H_attacker` history interleaves system-role `[SCORE]`, `[BACKTRACKED]` and `[INJECTED]` markers with the conversation, so hoisting would change what the attacker model sees and how it behaves.

Hoisting also shifted one index that was not obvious. `forceVerdict` recaps discovery by collapsing the decision-call history and slicing off *"the two messages the verdict phase rebuilds by itself (the system prompt and the criteria block)"*. With the system prompt no longer in that array the slice drops one, not two — otherwise the first recap entry is eaten and the model loses what the discovery tools returned. One test caught this.

**Telemetry is off until it is registered** — v7 moves OpenTelemetry into `@ai-sdk/otel` and emits *nothing* until `registerTelemetry` runs. Measured: 2 spans on v6, 0 on v7, 3 once registered. Without this the judge span collector and the LangWatch exporter would both have gone silent. `setupScenarioTracing` now registers the integration on both paths — fresh setup and attach-to-existing-provider.

**Renames:** `stepCountIs` → `isStepCount`, `experimental_telemetry` → `telemetry`.

## Examples

The examples are how people learn this library, so they teach the shape that works on v7. Fourteen hoisted their system turn to `instructions`. The OpenAI voice helper keeps its system message — it builds `ChatCompletionMessageParam` for a direct OpenAI API call, not an AI SDK one.

Two v7 type changes needed fixing, both caught by tsc: `ToolExecutionOptions` gained a required `context` field, and `GenerateTextResult` takes three type arguments.

## Verification

- 1273 tests pass
- both dist formats build, and `smoke:dist` loads each
- the two pre-existing `@ag-ui/core` type errors in `event-reporter.ts` are unchanged from `main` and unrelated — confirmed against a pristine `origin/main` worktree

## Release note

This is a **minor**. Please keep the squash message as `feat(javascript): migrate to AI SDK 7` — no `!`, no `BREAKING CHANGE` footer — or Release Please will cut an unwarranted 2.0.0.
