### PR TITLE
ci(python): give fork PRs something that reads the examples they change (#893)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -95,9 +95,27 @@ jobs:
         run: uv run pyright .
         working-directory: python
 
-      # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
+      # One definition of "this run can read repo secrets", so the live suite
+      # below and its secret-free fallback cannot drift into both running or
+      # neither. Dependabot PRs and fork PRs run without secrets.
+      - name: Resolve secret availability
+        id: secrets
+        env:
+          ACTOR: ${{ github.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+        run: |
+          if [ "$ACTOR" = "dependabot[bot]" ] \
+            || { [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REPO" != "$THIS_REPO" ]; }; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Examples: the live suite, for runs that can read repo secrets.
       - name: Test (Examples)
-        if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: steps.secrets.outputs.available == 'true'
         # Examples hit real LLMs over the network; they can legitimately take
         # well over the 60s per-test timeout that pytest.ini sets for the unit
         # suite. Override to 300s here so slow-but-correct runs don't get
@@ -107,6 +125,18 @@ jobs:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        working-directory: python
+
+      # The same examples, imported rather than run, for the runs the step
+      # above cannot cover. Without this an examples-only change from an
+      # external contributor reaches a green required check with nothing
+      # having read the file it changed: `pytest tests/` never imports
+      # `examples/`, and `pyright` sets `reportMissingImports: false`, so a
+      # module that does not exist type-checks clean. Collection imports every
+      # example module and makes no provider call, so it needs no secrets.
+      - name: Collect (Examples)
+        if: steps.secrets.outputs.available != 'true'
+        run: uv run pytest examples/ --collect-only -q
         working-directory: python
 
   # One required check for the whole workflow. Reports success if every

--- a/scripts/validate-aggregator-workflows.sh
+++ b/scripts/validate-aggregator-workflows.sh
@@ -251,19 +251,10 @@ resolver = [s for s in steps if s.get("id") == "secrets"]
 if len(resolver) != 1:
     print(f"expected exactly one step with id: secrets, found {len(resolver)}")
     sys.exit(1)
-# Both senses, and written where a later step can read them. A resolver that
-# sets some other name, or echoes the right name without the redirect, leaves
-# `steps.secrets.outputs.available` empty: the live suite's `== 'true'` is then
-# never true and the collection's `!= 'true'` always is, so the examples suite
-# silently stops running everywhere while this validator reports PASS.
-resolver_run = resolver[0].get("run", "")
-for value in ("true", "false"):
-    if not any(
-        f"available={value}" in line and "$GITHUB_OUTPUT" in line
-        for line in resolver_run.splitlines()
-    ):
-        print(f"the resolver never writes available={value} to $GITHUB_OUTPUT")
-        sys.exit(1)
+# What the resolver WRITES is checked by running it, in the section below.
+# Reading the shell for it does not work: a substring matches a commented-out
+# line, and whether two writes are mutually exclusive is a control-flow
+# question no amount of string matching answers.
 
 GATE = "steps.secrets.outputs.available"
 examples = [s for s in steps if "examples/" in s.get("run", "")]
@@ -282,17 +273,86 @@ if len(with_secrets) != 1 or len(without_secrets) != 1:
 # Which step does what, not just that two exist. The failure worth catching is
 # the live suite quietly becoming a second collection: both steps would still
 # be present and complementary, and nothing would run the examples again.
-live_run = with_secrets[0].get("run", "")
-collect_run = without_secrets[0].get("run", "")
-if "pytest examples/" not in live_run or "--collect-only" in live_run:
+#
+# Matched as a command rather than a substring, on the executable lines only.
+# `pytest examples/voice/` contains "pytest examples/" while covering a
+# fraction of the tree, and a commented-out command contains it while running
+# nothing at all.
+import re
+
+
+def commands(run: str) -> str:
+    return "\n".join(
+        line for line in run.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+WHOLE_EXAMPLES_TREE = re.compile(r"pytest\s+examples/(?:\s|$)")
+
+live_run = commands(with_secrets[0].get("run", ""))
+collect_run = commands(without_secrets[0].get("run", ""))
+if not WHOLE_EXAMPLES_TREE.search(live_run) or "--collect-only" in live_run:
     print("the secret-enabled step does not run the live suite: " + live_run)
     sys.exit(1)
-if "pytest examples/" not in collect_run or "--collect-only" not in collect_run:
+if (
+    not WHOLE_EXAMPLES_TREE.search(collect_run)
+    or "--collect-only" not in collect_run
+):
     print("the secret-free step does not collect: " + collect_run)
     sys.exit(1)
 EOF
 then pass "python-ci: examples are covered on runs without secrets"
 else fail "python-ci: examples are not covered on runs without secrets"; fi
+
+# The resolver's own decision, by running it rather than reading it. Executing
+# it is no wider a trust boundary than the workflow already is: this is the
+# same script python-ci runs, from the same commit. Every case below is a real
+# event shape, and GitHub takes the LAST write for a key, which is what makes
+# an unconditional pair of writes visible here.
+echo "--- the resolver's decision, over every event shape ---"
+RESOLVER_SH="$(mktemp)"
+trap 'rm -f "$RESOLVER_SH"' EXIT
+if python3 - "$REPO_ROOT/.github/workflows/python-ci.yml" > "$RESOLVER_SH" <<'EOF'
+import yaml, sys
+
+with open(sys.argv[1]) as f:
+    workflow = yaml.safe_load(f)
+
+steps = workflow.get("jobs", {}).get("test", {}).get("steps", [])
+resolver = [s for s in steps if s.get("id") == "secrets"]
+if len(resolver) != 1:
+    sys.exit(1)
+print(resolver[0].get("run", ""))
+EOF
+then
+  BAD=0
+  # <actor> <event> <head repo> <this repo> <expected>
+  check_resolver() {
+    local out
+    out="$(mktemp)"
+    ACTOR="$1" EVENT_NAME="$2" HEAD_REPO="$3" THIS_REPO="$4" GITHUB_OUTPUT="$out" \
+      bash "$RESOLVER_SH" >/dev/null 2>&1 || true
+    local got
+    got="$(grep -o 'available=[a-z]*' "$out" 2>/dev/null | tail -1)"
+    if [ "$got" != "available=$5" ]; then
+      echo "    $2 actor=$1 head=$3 -> ${got:-<nothing written>}, expected available=$5"
+      BAD=1
+    fi
+    rm -f "$out"
+  }
+  check_resolver "dependabot[bot]" pull_request langwatch/scenario langwatch/scenario false
+  check_resolver outsider pull_request outsider/scenario langwatch/scenario false
+  check_resolver maintainer pull_request langwatch/scenario langwatch/scenario true
+  check_resolver maintainer push "" langwatch/scenario true
+  check_resolver maintainer workflow_dispatch "" langwatch/scenario true
+  if [ "$BAD" -eq 0 ]; then
+    pass "python-ci: the resolver answers correctly for every event shape"
+  else
+    fail "python-ci: the resolver answers wrongly for some event shape"
+  fi
+else
+  fail "python-ci: could not extract the secrets resolver to run it"
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/validate-aggregator-workflows.sh
+++ b/scripts/validate-aggregator-workflows.sh
@@ -220,6 +220,64 @@ check_workflow \
   ".github/workflows/docs-ci.yml"
 
 # ---------------------------------------------------------------------------
+# Examples coverage on runs without secrets (see #893)
+#
+# The examples suite needs repo secrets, so it cannot run on a fork PR or a
+# Dependabot PR. Skipping it there is right; leaving nothing in its place is
+# not, because the aggregator counts a skipped step's job as success and an
+# examples-only change from an external contributor then reaches a green
+# required check with nothing having read the file it changed.
+#
+# The invariant is that exactly one of the two examples steps runs on any
+# given run: the live suite when secrets are readable, the secret-free
+# collection when they are not. Both must therefore be gated on the same
+# resolver output, with opposite senses. Complementary conditions written out
+# by hand in two places drift; this is what notices when they do.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Validating examples coverage without secrets ==="
+if python3 - "$REPO_ROOT/.github/workflows/python-ci.yml" <<'EOF'
+import yaml, sys
+
+with open(sys.argv[1]) as f:
+    workflow = yaml.safe_load(f)
+
+steps = workflow.get("jobs", {}).get("test", {}).get("steps", [])
+if not steps:
+    print("python-ci: test job has no steps")
+    sys.exit(1)
+
+resolver = [s for s in steps if s.get("id") == "secrets"]
+if len(resolver) != 1:
+    print(f"expected exactly one step with id: secrets, found {len(resolver)}")
+    sys.exit(1)
+if "$GITHUB_OUTPUT" not in resolver[0].get("run", ""):
+    print("the secrets resolver writes nothing to $GITHUB_OUTPUT")
+    sys.exit(1)
+
+GATE = "steps.secrets.outputs.available"
+examples = [s for s in steps if "examples/" in s.get("run", "")]
+if len(examples) != 2:
+    print(f"expected two steps running examples/, found {len(examples)}")
+    sys.exit(1)
+
+with_secrets = [s for s in examples if s.get("if", "") == f"{GATE} == 'true'"]
+without_secrets = [s for s in examples if s.get("if", "") == f"{GATE} != 'true'"]
+if len(with_secrets) != 1 or len(without_secrets) != 1:
+    print("the two examples steps are not complementary on " + GATE)
+    for s in examples:
+        print(f"  {s.get('name', '<unnamed>')!r}: if: {s.get('if', '<none>')!r}")
+    sys.exit(1)
+
+if "--collect-only" not in without_secrets[0].get("run", ""):
+    print("the secret-free examples step does not collect: "
+          + without_secrets[0].get("run", ""))
+    sys.exit(1)
+EOF
+then pass "python-ci: examples are covered on runs without secrets"
+else fail "python-ci: examples are not covered on runs without secrets"; fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/validate-aggregator-workflows.sh
+++ b/scripts/validate-aggregator-workflows.sh
@@ -251,9 +251,19 @@ resolver = [s for s in steps if s.get("id") == "secrets"]
 if len(resolver) != 1:
     print(f"expected exactly one step with id: secrets, found {len(resolver)}")
     sys.exit(1)
-if "$GITHUB_OUTPUT" not in resolver[0].get("run", ""):
-    print("the secrets resolver writes nothing to $GITHUB_OUTPUT")
-    sys.exit(1)
+# Both senses, and written where a later step can read them. A resolver that
+# sets some other name, or echoes the right name without the redirect, leaves
+# `steps.secrets.outputs.available` empty: the live suite's `== 'true'` is then
+# never true and the collection's `!= 'true'` always is, so the examples suite
+# silently stops running everywhere while this validator reports PASS.
+resolver_run = resolver[0].get("run", "")
+for value in ("true", "false"):
+    if not any(
+        f"available={value}" in line and "$GITHUB_OUTPUT" in line
+        for line in resolver_run.splitlines()
+    ):
+        print(f"the resolver never writes available={value} to $GITHUB_OUTPUT")
+        sys.exit(1)
 
 GATE = "steps.secrets.outputs.available"
 examples = [s for s in steps if "examples/" in s.get("run", "")]
@@ -269,9 +279,16 @@ if len(with_secrets) != 1 or len(without_secrets) != 1:
         print(f"  {s.get('name', '<unnamed>')!r}: if: {s.get('if', '<none>')!r}")
     sys.exit(1)
 
-if "--collect-only" not in without_secrets[0].get("run", ""):
-    print("the secret-free examples step does not collect: "
-          + without_secrets[0].get("run", ""))
+# Which step does what, not just that two exist. The failure worth catching is
+# the live suite quietly becoming a second collection: both steps would still
+# be present and complementary, and nothing would run the examples again.
+live_run = with_secrets[0].get("run", "")
+collect_run = without_secrets[0].get("run", "")
+if "pytest examples/" not in live_run or "--collect-only" in live_run:
+    print("the secret-enabled step does not run the live suite: " + live_run)
+    sys.exit(1)
+if "pytest examples/" not in collect_run or "--collect-only" not in collect_run:
+    print("the secret-free step does not collect: " + collect_run)
     sys.exit(1)
 EOF
 then pass "python-ci: examples are covered on runs without secrets"


### PR DESCRIPTION
## Ticket

Refs #893, deliberately not "Closes": it shuts the gap for the examples that are test modules, and names the part it does not reach.

A fork PR that changes `python/examples/**` reaches a green required check with nothing having read the file it changed. `Test (Examples)` is skipped on fork and Dependabot PRs (they cannot read repo secrets), the `test` job still reports success, and `python-complete` accepts success.

## One correction to the premise

The issue says nothing exercises the change. That is too strong: `pyright` runs unguarded on fork PRs and its config only excludes `examples/frameworks` and `examples/voice/_pipecat_twilio_bot.py`, so it does type-check the rest of `examples/`, including the live case's `examples/voice/_bot/bot.py`.

The real gap is narrower and still worth closing: nothing **imports** the examples. That matters because `pyrightconfig.json` sets `reportMissingImports: false`, so an import of a module that does not exist is clean to the one check that does run. Measured on this branch, with a nonexistent import added to `examples/test_weather_agent.py`:

```
uv run pyright .                        exit 0
pytest examples/ --collect-only -q      exit 2   ImportError while importing test module
```

## Change

`.github/workflows/python-ci.yml`:

- A `Resolve secret availability` step writes one `available` output. Both example steps gate on it, so exactly one runs: the live suite at `== 'true'`, the new `Collect (Examples)` at `!= 'true'`. The previous condition was written out by hand; a second hand-written complement is a drift risk, which is why there is now one definition rather than two.
- `Collect (Examples)` runs `pytest examples/ --collect-only -q`. Collection imports every example test module and makes no provider call, so it runs exactly where the live suite cannot.

`scripts/validate-aggregator-workflows.sh` gains a check that pins the invariant, in the file meta-ci already runs.

## What this covers, and what it does not

Collection reaches the 31 tests in `examples/test_*.py`. It does not reach `examples/voice/**`, which is where the issue's live case (#840, `examples/voice/_bot/bot.py`) sits.

That is not an oversight, and extending it is not the fix. Those files are executable scripts, not importable modules. Importing all 32 of them on this branch:

```
ok=2  hang=0  err=30      every failure SystemExit
```

They exit at import because they parse args and run. `_bot/bot.py` is spawned as a subprocess by `_bot_lifecycle.ensure_pipecat_bot()`, never imported. A `compileall` pass over them would add nothing either, since a syntax error already fails `pyright`. So `examples/voice/**` stays type-checked only, and giving it real fork-safe coverage is a separate piece of work: it needs those scripts to have an importable entry point, or a runner that can drive them without providers.

The issue also notes `scripts/test-voice-pipecat-lifecycle.sh` being invoked by no workflow. That file is not on `main`, so there is nothing to wire up.

## Evidence

The fork-safe step, run with every relevant secret unset, exactly as an external contributor's run would:

```
$ env -u OPENAI_API_KEY -u LANGWATCH_API_KEY -u GEMINI_API_KEY \
      -u OPENAI_BASE_URL -u OPENAI_API_BASE \
      uv run pytest examples/ --collect-only -q
31 tests collected in 3.28s        exit 0
```

The resolver's shell logic, over every input shape the workflow can see:

```
dependabot PR from a branch    available=false
fork PR                        available=false
same-repo branch PR            available=true
push to main                   available=true
workflow_dispatch              available=true
```

The new validator check, mutation-tested. Each mutation is a way this could silently regress:

```
delete the Collect (Examples) step          CAUGHT
both gates == 'true'                        CAUGHT
secret-free step no longer collects         CAUGHT
resolver id renamed (conditions dangle)     CAUGHT
```

Both meta-ci validators pass on the branch (`validate-aggregator-workflows.sh` 29 PASS / 0 FAIL, `validate-pr-auto-approve.sh` exit 0). `actionlint` reports one finding, `SC2086` at line 62 in the pre-existing `Install uv` step, byte-identical on `origin/main`; the added steps contribute none.

## Note on the sibling workflow

`javascript-ci.yml` carries the identical guard on its own `Test (Examples)`. Left alone here because the issue is scoped to Python and the JS examples need their own feasibility check. Worth noting that file already contains the precedent for this change: its `Test (Custom observability probes)` step deliberately carries no fork guard, with the comment "a fork PR that breaks the auto-init contract should go red."

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.
