### PR TITLE
feat(voice): let the realtime adapters mint through a voice gateway

### DIFF
--- a/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
@@ -70,6 +70,14 @@ if (hasHostedKey || hasComposableKey) {
                 scenario.elevenLabsAgent({
                   agentId: ELEVENLABS_AGENT_ID!,
                   apiKey: ELEVENLABS_API_KEY!,
+                  // The ElevenLabs SDK reads no base URL variable, so this
+                  // demo reads one itself. It is what lets the same demo run
+                  // against ElevenLabs or against a gateway in front of it,
+                  // the way OPENAI_BASE_URL already does for the OpenAI demo.
+                  // Unset, the SDK talks to ElevenLabs directly.
+                  ...(process.env.ELEVENLABS_BASE_URL
+                    ? { baseUrl: process.env.ELEVENLABS_BASE_URL }
+                    : {}),
                 }),
                 scenario.userSimulatorAgent({ voice: "openai/nova" }),
                 scenario.judgeAgent({

--- a/javascript/src/voice/__tests__/broker.test.ts
+++ b/javascript/src/voice/__tests__/broker.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Brokered realtime voice sessions.
+ *
+ * The subject is the contract between an adapter and a voice gateway: what
+ * turns brokering on, which key mints, what the socket then dials with, and
+ * what closes the session's spend record. Money depends on all four, so each
+ * is asserted rather than inferred from a connection succeeding.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mintOpenAIRealtimeSession,
+  reportOpenAIRealtimeUsage,
+  resolveVoiceBroker,
+} from "../broker";
+
+const ENV_KEYS = [
+  "LANGWATCH_VOICE_BROKER_URL",
+  "LANGWATCH_VOICE_BROKER_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_REALTIME_API_KEY",
+] as const;
+
+describe("given a voice broker configuration", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  describe("when nothing is configured", () => {
+    it("reports no broker, so the adapter connects directly", () => {
+      expect(resolveVoiceBroker()).toBeNull();
+    });
+
+    it("still reports no broker when only a key is present", () => {
+      // A key with no address is not a broker anyone configured. Treating it
+      // as one would silently redirect every session.
+      process.env.LANGWATCH_VOICE_BROKER_KEY = "vk-lw-test";
+      expect(resolveVoiceBroker()).toBeNull();
+    });
+  });
+
+  describe("when a broker URL is set", () => {
+    it("falls back to OPENAI_API_KEY, where a gateway user keeps the virtual key", () => {
+      process.env.LANGWATCH_VOICE_BROKER_URL = "https://gateway.example/";
+      process.env.OPENAI_API_KEY = "vk-lw-from-openai-var";
+
+      const broker = resolveVoiceBroker();
+
+      expect(broker).toEqual({
+        baseUrl: "https://gateway.example",
+        apiKey: "vk-lw-from-openai-var",
+      });
+    });
+
+    it("never mints with OPENAI_REALTIME_API_KEY", () => {
+      // That variable holds a direct provider key. Minting with it would
+      // present a credential the gateway does not issue and cannot bill, and
+      // the failure would look like a broker outage.
+      process.env.LANGWATCH_VOICE_BROKER_URL = "https://gateway.example";
+      process.env.OPENAI_REALTIME_API_KEY = "sk-real-provider-key";
+
+      expect(() => resolveVoiceBroker()).toThrow(/no key/i);
+    });
+
+    it("prefers an explicit configuration over the environment", () => {
+      process.env.LANGWATCH_VOICE_BROKER_URL = "https://from-env.example";
+      process.env.OPENAI_API_KEY = "vk-from-env";
+
+      expect(
+        resolveVoiceBroker({ baseUrl: "https://explicit.example", apiKey: "vk-explicit" }),
+      ).toEqual({ baseUrl: "https://explicit.example", apiKey: "vk-explicit" });
+    });
+  });
+});
+
+describe("given a mint through the gateway", () => {
+  const broker = { baseUrl: "https://gateway.example", apiKey: "vk-lw-test" };
+
+  it("sends the virtual key and reads back the vendor secret and session id", async () => {
+    const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe("https://gateway.example/v1/realtime/client_secrets");
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer vk-lw-test",
+      );
+      expect(JSON.parse(init.body as string)).toEqual({
+        session: { type: "realtime", model: "gpt-realtime" },
+      });
+      return new Response(JSON.stringify({ value: "ek_abc", expires_at: 1 }), {
+        status: 200,
+        headers: { "x-langwatch-session-id": "req_123" },
+      });
+    });
+
+    const minted = await mintOpenAIRealtimeSession(broker, {
+      model: "gpt-realtime",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(minted).toEqual({ clientSecret: "ek_abc", sessionId: "req_123" });
+  });
+
+  it("reads the session id from the body when the header is absent", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            value: "ek_abc",
+            langwatch: { session_id: "req_from_body" },
+          }),
+          { status: 200 },
+        ),
+    );
+
+    const minted = await mintOpenAIRealtimeSession(broker, {
+      model: "gpt-realtime",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(minted.sessionId).toBe("req_from_body");
+  });
+
+  it("surfaces the gateway's own refusal message", async () => {
+    // The gateway names the cause: a budget, a session cap, a missing
+    // provider. A bare status would send the reader to the wrong place.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "realtime_session_limit",
+              message: "this virtual key already holds the most voice sessions",
+            },
+          }),
+          { status: 429 },
+        ),
+    );
+
+    await expect(
+      mintOpenAIRealtimeSession(broker, {
+        model: "gpt-realtime",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/realtime_session_limit/);
+  });
+
+  it("refuses a mint that returned no credential", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ expires_at: 1 }), { status: 200 }),
+    );
+
+    await expect(
+      mintOpenAIRealtimeSession(broker, {
+        model: "gpt-realtime",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/no client secret/i);
+  });
+});
+
+describe("given a usage report at the end of a session", () => {
+  const broker = { baseUrl: "https://gateway.example", apiKey: "vk-lw-test" };
+
+  it("posts the vendor's usage object against the session id", async () => {
+    const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe(
+        "https://gateway.example/v1/realtime/sessions/req_123/usage",
+      );
+      expect(JSON.parse(init.body as string)).toEqual({
+        usage: { input_tokens: 15, output_tokens: 43 },
+      });
+      return new Response("{}", { status: 202 });
+    });
+
+    await reportOpenAIRealtimeUsage(broker, {
+      sessionId: "req_123",
+      usage: { input_tokens: 15, output_tokens: 43 },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("sends nothing when the mint never named a session", async () => {
+    const fetchImpl = vi.fn();
+    await reportOpenAIRealtimeUsage(broker, {
+      sessionId: "",
+      usage: { input_tokens: 1 },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("never throws, because a billing report must not fail the test it measures", async () => {
+    // The session still settles: the gateway closes an unreported admission
+    // as cost-unknown once its grace expires.
+    const onError = vi.fn();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("gateway unreachable");
+    });
+
+    await expect(
+      reportOpenAIRealtimeUsage(broker, {
+        sessionId: "req_123",
+        usage: { input_tokens: 1 },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        onError,
+      }),
+    ).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledOnce();
+  });
+});

--- a/javascript/src/voice/__tests__/broker.test.ts
+++ b/javascript/src/voice/__tests__/broker.test.ts
@@ -1,26 +1,26 @@
 /**
- * Brokered realtime voice sessions.
+ * Minting a realtime voice session.
  *
- * The subject is the contract between an adapter and a voice gateway: what
- * turns brokering on, which key mints, what the socket then dials with, and
- * what closes the session's spend record. Money depends on all four, so each
- * is asserted rather than inferred from a connection succeeding.
+ * The subject is the contract between an adapter and whatever answers
+ * `OPENAI_BASE_URL`: which key mints, what the socket then dials with, how the
+ * adapter learns a gateway brokered the call, and what closes the spend
+ * record. Money depends on all four, so each is asserted rather than inferred
+ * from a connection succeeding.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mintOpenAIRealtimeSession,
   reportOpenAIRealtimeUsage,
-  resolveVoiceBroker,
+  resolveRealtimeMintEndpoint,
 } from "../broker";
 
 const ENV_KEYS = [
-  "LANGWATCH_VOICE_BROKER_URL",
-  "LANGWATCH_VOICE_BROKER_KEY",
+  "OPENAI_BASE_URL",
   "OPENAI_API_KEY",
   "OPENAI_REALTIME_API_KEY",
 ] as const;
 
-describe("given a voice broker configuration", () => {
+describe("given the environment scenario already uses for chat", () => {
   const saved: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -37,57 +37,64 @@ describe("given a voice broker configuration", () => {
     }
   });
 
-  describe("when nothing is configured", () => {
-    it("reports no broker, so the adapter connects directly", () => {
-      expect(resolveVoiceBroker()).toBeNull();
-    });
+  describe("when OPENAI_BASE_URL is unset", () => {
+    it("mints at OpenAI, because the path is OpenAI's own", () => {
+      process.env.OPENAI_API_KEY = "sk-provider";
 
-    it("still reports no broker when only a key is present", () => {
-      // A key with no address is not a broker anyone configured. Treating it
-      // as one would silently redirect every session.
-      process.env.LANGWATCH_VOICE_BROKER_KEY = "vk-lw-test";
-      expect(resolveVoiceBroker()).toBeNull();
+      expect(resolveRealtimeMintEndpoint()).toEqual({
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "sk-provider",
+      });
     });
   });
 
-  describe("when a broker URL is set", () => {
-    it("falls back to OPENAI_API_KEY, where a gateway user keeps the virtual key", () => {
-      process.env.LANGWATCH_VOICE_BROKER_URL = "https://gateway.example/";
-      process.env.OPENAI_API_KEY = "vk-lw-from-openai-var";
+  describe("when OPENAI_BASE_URL points at a gateway", () => {
+    it("mints there with the same key chat uses, and needs nothing else", () => {
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1/";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
 
-      const broker = resolveVoiceBroker();
-
-      expect(broker).toEqual({
-        baseUrl: "https://gateway.example",
-        apiKey: "vk-lw-from-openai-var",
+      expect(resolveRealtimeMintEndpoint()).toEqual({
+        baseUrl: "https://gateway.example/v1",
+        apiKey: "vk-lw-test",
       });
     });
 
-    it("never mints with OPENAI_REALTIME_API_KEY", () => {
-      // That variable holds a direct provider key. Minting with it would
-      // present a credential the gateway does not issue and cannot bill, and
-      // the failure would look like a broker outage.
-      process.env.LANGWATCH_VOICE_BROKER_URL = "https://gateway.example";
-      process.env.OPENAI_REALTIME_API_KEY = "sk-real-provider-key";
-
-      expect(() => resolveVoiceBroker()).toThrow(/no key/i);
-    });
-
-    it("prefers an explicit configuration over the environment", () => {
-      process.env.LANGWATCH_VOICE_BROKER_URL = "https://from-env.example";
+    it("prefers an explicit endpoint over the environment", () => {
+      process.env.OPENAI_BASE_URL = "https://from-env.example/v1";
       process.env.OPENAI_API_KEY = "vk-from-env";
 
       expect(
-        resolveVoiceBroker({ baseUrl: "https://explicit.example", apiKey: "vk-explicit" }),
-      ).toEqual({ baseUrl: "https://explicit.example", apiKey: "vk-explicit" });
+        resolveRealtimeMintEndpoint({
+          baseUrl: "https://explicit.example/v1",
+          apiKey: "vk-explicit",
+        }),
+      ).toEqual({
+        baseUrl: "https://explicit.example/v1",
+        apiKey: "vk-explicit",
+      });
+    });
+  });
+
+  describe("when only OPENAI_REALTIME_API_KEY is set", () => {
+    it("does not mint with it, so the adapter dials the vendor directly", () => {
+      // That variable holds a direct provider key. Minting with it would
+      // present a gateway a credential it did not issue and cannot bill, and
+      // the refusal would read as a gateway outage.
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_REALTIME_API_KEY = "sk-real-provider-key";
+
+      expect(resolveRealtimeMintEndpoint()).toBeNull();
     });
   });
 });
 
-describe("given a mint through the gateway", () => {
-  const broker = { baseUrl: "https://gateway.example", apiKey: "vk-lw-test" };
+describe("given a mint request", () => {
+  const endpoint = {
+    baseUrl: "https://gateway.example/v1",
+    apiKey: "vk-lw-test",
+  };
 
-  it("sends the virtual key and reads back the vendor secret and session id", async () => {
+  it("sends the key and reads back the vendor secret and the session id", async () => {
     const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
       expect(url).toBe("https://gateway.example/v1/realtime/client_secrets");
       expect((init.headers as Record<string, string>).Authorization).toBe(
@@ -102,37 +109,58 @@ describe("given a mint through the gateway", () => {
       });
     });
 
-    const minted = await mintOpenAIRealtimeSession(broker, {
+    const result = await mintOpenAIRealtimeSession(endpoint, {
       model: "gpt-realtime",
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    expect(minted).toEqual({ clientSecret: "ek_abc", sessionId: "req_123" });
+    expect(result).toEqual({
+      minted: true,
+      clientSecret: "ek_abc",
+      sessionId: "req_123",
+    });
   });
 
-  it("reads the session id from the body when the header is absent", async () => {
+  it("reports no session id when the vendor answered, because only a gateway names one", async () => {
+    // This is how the adapter learns what it is talking to. OpenAI's own mint
+    // carries no such header, so there is nothing to report usage to and
+    // nothing that would accept a report.
     const fetchImpl = vi.fn(
       async () =>
-        new Response(
-          JSON.stringify({
-            value: "ek_abc",
-            langwatch: { session_id: "req_from_body" },
-          }),
-          { status: 200 },
-        ),
+        new Response(JSON.stringify({ value: "ek_from_openai" }), {
+          status: 200,
+        }),
     );
 
-    const minted = await mintOpenAIRealtimeSession(broker, {
+    const result = await mintOpenAIRealtimeSession(endpoint, {
       model: "gpt-realtime",
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    expect(minted.sessionId).toBe("req_from_body");
+    expect(result).toEqual({
+      minted: true,
+      clientSecret: "ek_from_openai",
+      sessionId: "",
+    });
   });
 
-  it("surfaces the gateway's own refusal message", async () => {
-    // The gateway names the cause: a budget, a session cap, a missing
-    // provider. A bare status would send the reader to the wrong place.
+  it("reports an absent mint route rather than raising, so the caller can dial directly", async () => {
+    // A LangWatch gateway older than this feature answers 404 here. That is an
+    // absence, not a refusal, and the adapter falls back to a direct dial.
+    const fetchImpl = vi.fn(async () => new Response("not found", { status: 404 }));
+
+    const result = await mintOpenAIRealtimeSession(endpoint, {
+      model: "gpt-realtime",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({ minted: false, status: 404 });
+  });
+
+  it("raises on a refusal, so a declined session never falls back to a provider key", async () => {
+    // The endpoint's own message names the cause: a budget, a session cap, a
+    // missing provider. Falling back here would run a call the gateway just
+    // declined to bill.
     const fetchImpl = vi.fn(
       async () =>
         new Response(
@@ -147,7 +175,7 @@ describe("given a mint through the gateway", () => {
     );
 
     await expect(
-      mintOpenAIRealtimeSession(broker, {
+      mintOpenAIRealtimeSession(endpoint, {
         model: "gpt-realtime",
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
@@ -160,7 +188,7 @@ describe("given a mint through the gateway", () => {
     );
 
     await expect(
-      mintOpenAIRealtimeSession(broker, {
+      mintOpenAIRealtimeSession(endpoint, {
         model: "gpt-realtime",
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
@@ -169,7 +197,10 @@ describe("given a mint through the gateway", () => {
 });
 
 describe("given a usage report at the end of a session", () => {
-  const broker = { baseUrl: "https://gateway.example", apiKey: "vk-lw-test" };
+  const endpoint = {
+    baseUrl: "https://gateway.example/v1",
+    apiKey: "vk-lw-test",
+  };
 
   it("posts the vendor's usage object against the session id", async () => {
     const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
@@ -182,7 +213,7 @@ describe("given a usage report at the end of a session", () => {
       return new Response("{}", { status: 202 });
     });
 
-    await reportOpenAIRealtimeUsage(broker, {
+    await reportOpenAIRealtimeUsage(endpoint, {
       sessionId: "req_123",
       usage: { input_tokens: 15, output_tokens: 43 },
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -191,9 +222,9 @@ describe("given a usage report at the end of a session", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
-  it("sends nothing when the mint never named a session", async () => {
+  it("sends nothing when the vendor minted the session", async () => {
     const fetchImpl = vi.fn();
-    await reportOpenAIRealtimeUsage(broker, {
+    await reportOpenAIRealtimeUsage(endpoint, {
       sessionId: "",
       usage: { input_tokens: 1 },
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -202,15 +233,15 @@ describe("given a usage report at the end of a session", () => {
   });
 
   it("never throws, because a billing report must not fail the test it measures", async () => {
-    // The session still settles: the gateway closes an unreported admission
-    // as cost-unknown once its grace expires.
+    // The session still settles: the gateway closes an unreported admission as
+    // cost-unknown once its grace expires.
     const onError = vi.fn();
     const fetchImpl = vi.fn(async () => {
       throw new Error("gateway unreachable");
     });
 
     await expect(
-      reportOpenAIRealtimeUsage(broker, {
+      reportOpenAIRealtimeUsage(endpoint, {
         sessionId: "req_123",
         usage: { input_tokens: 1 },
         fetchImpl: fetchImpl as unknown as typeof fetch,

--- a/javascript/src/voice/__tests__/broker.test.ts
+++ b/javascript/src/voice/__tests__/broker.test.ts
@@ -88,6 +88,15 @@ describe("given the environment scenario already uses for chat", () => {
   });
 });
 
+/** A fetch that never answers, and rejects only when its signal aborts. */
+function stallUntilAborted(_url: string, init?: RequestInit): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    init?.signal?.addEventListener("abort", () =>
+      reject(init.signal?.reason ?? new Error("aborted")),
+    );
+  });
+}
+
 describe("given a mint request", () => {
   const endpoint = {
     baseUrl: "https://gateway.example/v1",
@@ -182,6 +191,27 @@ describe("given a mint request", () => {
     ).rejects.toThrow(/realtime_session_limit/);
   });
 
+  it("gives up on a stalled endpoint rather than leaving connect pending", async () => {
+    // connect() waits for the mint before it opens the socket, so an
+    // unbounded request leaves connection setup pending forever and the
+    // caller never learns why.
+    const fetchImpl = vi.fn(stallUntilAborted);
+
+    await expect(
+      mintOpenAIRealtimeSession(endpoint, {
+        model: "gpt-realtime",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow();
+
+    // The bound came from the signal the mint attached, not from the test
+    // giving up first.
+    expect(
+      (fetchImpl.mock.calls[0]?.[1] as RequestInit | undefined)?.signal,
+    ).toBeInstanceOf(AbortSignal);
+  });
+
   it("refuses a mint that returned no credential", async () => {
     const fetchImpl = vi.fn(
       async () => new Response(JSON.stringify({ expires_at: 1 }), { status: 200 }),
@@ -254,21 +284,15 @@ describe("given a usage report at the end of a session", () => {
   it("gives up on a stalled gateway rather than holding the socket open", async () => {
     // disconnect() awaits this, so an unbounded request keeps the websocket
     // open and the test that owns it never finishes.
+    const timeoutMs = 20;
     const onError = vi.fn();
-    const fetchImpl = vi.fn(
-      (_url: string, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () =>
-            reject(init.signal?.reason ?? new Error("aborted")),
-          );
-        }),
-    );
+    const fetchImpl = vi.fn(stallUntilAborted);
 
     await reportOpenAIRealtimeUsage(endpoint, {
       sessionId: "req_123",
       usage: { input_tokens: 1 },
       fetchImpl: fetchImpl as unknown as typeof fetch,
-      timeoutMs: 20,
+      timeoutMs,
       onError,
     });
 

--- a/javascript/src/voice/__tests__/broker.test.ts
+++ b/javascript/src/voice/__tests__/broker.test.ts
@@ -232,6 +232,54 @@ describe("given a usage report at the end of a session", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("reports a refusal, because a rejected report is not a delivered one", async () => {
+    // A 404 for an unknown session or a 401 for a rotated key answers, so
+    // nothing throws. Reading only the thrown case would treat both as a
+    // report that landed, and the session would settle as cost-unknown with
+    // nobody told why.
+    const onError = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response("no", { status: 404 }));
+
+    await reportOpenAIRealtimeUsage(endpoint, {
+      sessionId: "req_123",
+      usage: { input_tokens: 1 },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(String(onError.mock.calls[0]?.[0])).toMatch(/HTTP 404/);
+  });
+
+  it("gives up on a stalled gateway rather than holding the socket open", async () => {
+    // disconnect() awaits this, so an unbounded request keeps the websocket
+    // open and the test that owns it never finishes.
+    const onError = vi.fn();
+    const fetchImpl = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(init.signal?.reason ?? new Error("aborted")),
+          );
+        }),
+    );
+
+    await reportOpenAIRealtimeUsage(endpoint, {
+      sessionId: "req_123",
+      usage: { input_tokens: 1 },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      timeoutMs: 20,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledOnce();
+    // The bound came from the signal the helper attached, not from the test
+    // giving up first.
+    expect(
+      (fetchImpl.mock.calls[0]?.[1] as RequestInit | undefined)?.signal,
+    ).toBeInstanceOf(AbortSignal);
+  });
+
   it("never throws, because a billing report must not fail the test it measures", async () => {
     // The session still settles: the gateway closes an unreported admission as
     // cost-unknown once its grace expires.

--- a/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The base URL the ElevenLabs adapter hands to the SDK.
+ *
+ * It is checked at construction rather than at connect, because the mistake
+ * people make produces a 404 from the vendor that names no cause: the SDK
+ * appends `/v1` itself, and `OPENAI_BASE_URL` conventionally includes one, so
+ * a base URL copied from that habit requests `/v1/v1/convai/...`. That cost a
+ * real debugging round before this check existed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ElevenLabsAgentAdapter,
+  normalizeElevenLabsBaseUrl,
+} from "../elevenlabs";
+
+function adapterWith(baseUrl?: string): ElevenLabsAgentAdapter {
+  return new ElevenLabsAgentAdapter({
+    agentId: "agent_test",
+    apiKey: "key_test",
+    baseUrl,
+  });
+}
+
+describe("given a base URL for the ElevenLabs SDK", () => {
+  describe("when it carries the /v1 prefix", () => {
+    it("refuses it, naming the doubling it would produce", () => {
+      expect(() => adapterWith("https://gateway.example/v1")).toThrow(/\/v1\/v1/);
+    });
+
+    it("refuses it with a trailing slash too", () => {
+      expect(() => adapterWith("https://gateway.example/v1/")).toThrow(
+        /must not include \/v1/,
+      );
+    });
+  });
+
+  describe("when it is not a URL", () => {
+    it("refuses it at construction rather than at the first request", () => {
+      expect(() => adapterWith("gateway.example")).toThrow(/is not a URL/);
+    });
+  });
+
+  describe("when it names a host root", () => {
+    it("keeps it, with any trailing slash removed", () => {
+      expect(normalizeElevenLabsBaseUrl("https://gateway.example/")).toBe(
+        "https://gateway.example",
+      );
+      expect(() => adapterWith("https://gateway.example/")).not.toThrow();
+    });
+  });
+
+  describe("when it is absent or empty", () => {
+    it("leaves the SDK on its own default", () => {
+      // Empty is unset, not an error: it is what an unset environment
+      // variable spreads into an options object as.
+      expect(normalizeElevenLabsBaseUrl(undefined)).toBeUndefined();
+      expect(normalizeElevenLabsBaseUrl("   ")).toBeUndefined();
+    });
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
@@ -8,12 +8,35 @@
  * real debugging round before this check existed.
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   ElevenLabsAgentAdapter,
   normalizeElevenLabsBaseUrl,
 } from "../elevenlabs";
+
+/** Options every `ElevenLabsClient` this file builds was constructed with. */
+const clientOptions = vi.hoisted(() => [] as Record<string, unknown>[]);
+
+// The SDK runtime is replaced so the client's own construction is observable.
+// `connect()` is then allowed to fail at the Conversation, because what is
+// under test is the option bag the client received, not a live session.
+vi.mock("../../elevenlabs-sdk", () => ({
+  loadElevenLabsConversationRuntime: () =>
+    Promise.resolve({
+      AudioInterface: class {},
+      Conversation: class {
+        constructor() {
+          throw new Error("stop after the client is built");
+        }
+      },
+      ElevenLabsClient: class {
+        constructor(options: Record<string, unknown>) {
+          clientOptions.push(options);
+        }
+      },
+    }),
+}));
 
 function adapterWith(baseUrl?: string): ElevenLabsAgentAdapter {
   return new ElevenLabsAgentAdapter({
@@ -24,6 +47,10 @@ function adapterWith(baseUrl?: string): ElevenLabsAgentAdapter {
 }
 
 describe("given a base URL for the ElevenLabs SDK", () => {
+  beforeEach(() => {
+    clientOptions.length = 0;
+  });
+
   describe("when it carries the /v1 prefix", () => {
     it("refuses it, naming the doubling it would produce", () => {
       expect(() => adapterWith("https://gateway.example/v1")).toThrow(/\/v1\/v1/);
@@ -70,5 +97,36 @@ describe("given a base URL for the ElevenLabs SDK", () => {
       expect(normalizeElevenLabsBaseUrl(undefined)).toBeUndefined();
       expect(normalizeElevenLabsBaseUrl("   ")).toBeUndefined();
     });
+  });
+});
+
+describe("given the adapter builds its SDK client", () => {
+  beforeEach(() => {
+    clientOptions.length = 0;
+  });
+
+  it("hands a configured base URL to the client", async () => {
+    // Normalizing a value it never passes on would be a check with no effect.
+    await expect(
+      adapterWith("https://gateway.example").connect(),
+    ).rejects.toThrow();
+
+    expect(clientOptions).toHaveLength(1);
+    expect(clientOptions[0]).toMatchObject({
+      apiKey: "key_test",
+      baseUrl: "https://gateway.example",
+    });
+  });
+
+  it("omits the option entirely when no base URL is set", async () => {
+    // Passing `baseUrl: undefined` is not the same as omitting it: an
+    // unconfigured adapter must send byte-for-byte what it sent before.
+    await expect(adapterWith(undefined).connect()).rejects.toThrow();
+
+    expect(clientOptions).toHaveLength(1);
+    // Keys, not toEqual: an undefined property is invisible to toEqual, so
+    // that assertion would pass on `baseUrl: undefined` too, which is the
+    // exact thing this test exists to rule out.
+    expect(Object.keys(clientOptions[0] ?? {})).toEqual(["apiKey"]);
   });
 });

--- a/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
@@ -42,6 +42,18 @@ describe("given a base URL for the ElevenLabs SDK", () => {
     });
   });
 
+  describe("when its scheme is not http or https", () => {
+    it("refuses it, because the SDK cannot make a REST request over it", () => {
+      // `new URL` parses these, so parsing alone is not a check.
+      expect(() => adapterWith("ftp://gateway.example")).toThrow(
+        /must be http or https/,
+      );
+      expect(() => adapterWith("file:///tmp/gateway")).toThrow(
+        /must be http or https/,
+      );
+    });
+  });
+
   describe("when it names a host root", () => {
     it("keeps it, with any trailing slash removed", () => {
       expect(normalizeElevenLabsBaseUrl("https://gateway.example/")).toBe(

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
@@ -152,6 +152,48 @@ describe("given an adapter connecting to a realtime session", () => {
     });
   });
 
+  describe("when the socket never opens", () => {
+    it("closes the session it minted, at zero, rather than leaving it open", async () => {
+      // The mint booked a session and only a report can close it. Left open
+      // it holds one of the key's session slots until the gateway's window
+      // expires, and books a call that never happened.
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      const calls: Array<{ url: string; body: unknown }> = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string, init?: RequestInit) => {
+          calls.push({
+            url,
+            body: init?.body ? JSON.parse(String(init.body)) : null,
+          });
+          return url.endsWith("/client_secrets")
+            ? mintResponse(200, "req_abc")
+            : new Response("{}", { status: 202 });
+        }),
+      );
+
+      const adapter = new OpenAIRealtimeAgentAdapter({
+        url: "ws://127.0.0.1:1/realtime",
+        wsFactory: (url, authHeader) => {
+          dialledWith.push(authHeader);
+          // Nothing listens on port 1, so this errors before it opens.
+          return new WebSocket(url);
+        },
+      });
+
+      await expect(adapter.connect()).rejects.toThrow();
+
+      expect(calls.map((c) => c.url)).toEqual([
+        "https://gateway.example/v1/realtime/client_secrets",
+        "https://gateway.example/v1/realtime/sessions/req_abc/usage",
+      ]);
+      // Zero is the truth here, not a placeholder: an ephemeral credential
+      // that opened no socket consumed nothing at the vendor.
+      expect(calls[1]?.body).toEqual({ usage: {} });
+    });
+  });
+
   describe("when the mint is refused", () => {
     it("raises without opening a socket, so a declined call cannot run on a provider key", async () => {
       process.env.OPENAI_BASE_URL = "https://gateway.example/v1";

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
@@ -1,0 +1,161 @@
+/**
+ * How OpenAIRealtimeAgentAdapter obtains the credential it dials with.
+ *
+ * The adapter mints at `${OPENAI_BASE_URL}/realtime/client_secrets`, which is
+ * OpenAI's own path and the one a LangWatch AI Gateway mirrors. These tests
+ * pin the four outcomes that decide whether a call is billed, and what the
+ * socket ends up carrying:
+ *
+ * - a gateway minted it, so usage is reported back and the socket carries the
+ *   ephemeral secret;
+ * - the vendor minted it, so there is no session to report to;
+ * - the route was absent, so the adapter dials directly and says so;
+ * - the mint was refused, so nothing is dialled at all.
+ *
+ * The last two are the money-relevant pair. A refusal that fell back to a
+ * direct provider key would run a call the gateway declined to bill, and a
+ * silent fallback would make an unbilled run look like a billed one.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+
+import { OpenAIRealtimeAgentAdapter } from "../../index";
+import { setupMockRealtimeServer } from "./fixtures/mock-realtime-server";
+
+const server = setupMockRealtimeServer(() => {});
+
+const ENV_KEYS = [
+  "OPENAI_BASE_URL",
+  "OPENAI_API_KEY",
+  "OPENAI_REALTIME_API_KEY",
+  "OPENAI_REALTIME_URL",
+] as const;
+const saved: Record<string, string | undefined> = {};
+
+/** Auth headers the adapter presented to the socket, newest last. */
+let dialledWith: string[] = [];
+
+function adapterAt(port: number): OpenAIRealtimeAgentAdapter {
+  return new OpenAIRealtimeAgentAdapter({
+    url: `ws://127.0.0.1:${port}/realtime`,
+    wsFactory: (url, authHeader) => {
+      dialledWith.push(authHeader);
+      return new WebSocket(url, { headers: { Authorization: authHeader } });
+    },
+  });
+}
+
+/** A mint response, with the session-id header only when a gateway answers. */
+function mintResponse(status: number, sessionId?: string): Response {
+  if (status !== 200) return new Response("no", { status });
+  return new Response(JSON.stringify({ value: "ek_minted_secret" }), {
+    status: 200,
+    headers: sessionId ? { "x-langwatch-session-id": sessionId } : {},
+  });
+}
+
+describe("given an adapter connecting to a realtime session", () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    dialledWith = [];
+    server.arm();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    vi.unstubAllGlobals();
+  });
+
+  describe("when a gateway answers the mint", () => {
+    it("dials with the ephemeral secret and knows the session is billed", async () => {
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
+      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const adapter = adapterAt(server.port());
+      await adapter.connect();
+      await adapter.disconnect();
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+        "https://gateway.example/v1/realtime/client_secrets",
+      );
+      // The long-lived keys stay off the socket: neither the virtual key nor
+      // the direct provider key is what the websocket carries.
+      expect(dialledWith).toEqual(["Bearer ek_minted_secret"]);
+      expect(adapter.brokered).toBe(true);
+    });
+  });
+
+  describe("when the vendor answers the mint", () => {
+    it("dials with the ephemeral secret but reports no session, because OpenAI names none", async () => {
+      process.env.OPENAI_API_KEY = "sk-provider";
+      const fetchSpy = vi.fn(async () => mintResponse(200));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const adapter = adapterAt(server.port());
+      await adapter.connect();
+      await adapter.disconnect();
+
+      // Default base URL is OpenAI's own, so no configuration is required for
+      // this path and none is read.
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+        "https://api.openai.com/v1/realtime/client_secrets",
+      );
+      expect(dialledWith).toEqual(["Bearer ek_minted_secret"]);
+      expect(adapter.brokered).toBe(false);
+    });
+  });
+
+  describe("when the endpoint has no mint route", () => {
+    it("dials the vendor directly with the fallback key, and warns", async () => {
+      // A LangWatch gateway older than this feature answers 404. That is an
+      // absence, not a refusal, so the call still runs; the warning is what
+      // stops an unbilled run from reading as a billed one.
+      process.env.OPENAI_BASE_URL = "https://old-gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => mintResponse(404)),
+      );
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const adapter = adapterAt(server.port());
+      await adapter.connect();
+      await adapter.disconnect();
+
+      expect(dialledWith).toEqual(["Bearer sk-direct-provider-key"]);
+      expect(adapter.brokered).toBe(false);
+      expect(warn.mock.calls.map(String).join(" ")).toMatch(
+        /old-gateway\.example.*not billed|not billed.*old-gateway\.example/s,
+      );
+    });
+  });
+
+  describe("when the mint is refused", () => {
+    it("raises without opening a socket, so a declined call cannot run on a provider key", async () => {
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => mintResponse(402)),
+      );
+
+      const adapter = adapterAt(server.port());
+
+      await expect(adapter.connect()).rejects.toThrow(/HTTP 402/);
+      expect(dialledWith).toEqual([]);
+    });
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
@@ -71,6 +71,9 @@ describe("given an adapter connecting to a realtime session", () => {
       else process.env[key] = saved[key];
     }
     vi.unstubAllGlobals();
+    // spyOn is not undone by unstubAllGlobals, so a silenced console.warn
+    // would outlive this file and mute a later test that asserts on one.
+    vi.restoreAllMocks();
   });
 
   describe("when a gateway answers the mint", () => {
@@ -78,7 +81,9 @@ describe("given an adapter connecting to a realtime session", () => {
       process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
       process.env.OPENAI_API_KEY = "vk-lw-test";
       process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
-      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) =>
+        mintResponse(200, "req_abc"),
+      );
       vi.stubGlobal("fetch", fetchSpy);
 
       const adapter = adapterAt(server.port());
@@ -99,7 +104,9 @@ describe("given an adapter connecting to a realtime session", () => {
   describe("when the vendor answers the mint", () => {
     it("dials with the ephemeral secret but reports no session, because OpenAI names none", async () => {
       process.env.OPENAI_API_KEY = "sk-provider";
-      const fetchSpy = vi.fn(async () => mintResponse(200));
+      const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) =>
+        mintResponse(200),
+      );
       vi.stubGlobal("fetch", fetchSpy);
 
       const adapter = adapterAt(server.port());
@@ -136,9 +143,12 @@ describe("given an adapter connecting to a realtime session", () => {
 
       expect(dialledWith).toEqual(["Bearer sk-direct-provider-key"]);
       expect(adapter.brokered).toBe(false);
-      expect(warn.mock.calls.map(String).join(" ")).toMatch(
-        /old-gateway\.example.*not billed|not billed.*old-gateway\.example/s,
-      );
+      // The warning names the variable the key actually came from. Naming a
+      // fixed one would send a reader to a variable that is not set.
+      const warned = warn.mock.calls.map(String).join(" ");
+      expect(warned).toMatch(/old-gateway\.example/);
+      expect(warned).toMatch(/OPENAI_REALTIME_API_KEY/);
+      expect(warned).toMatch(/not billed/);
     });
   });
 

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -286,17 +286,20 @@ export interface ElevenLabsAgentAdapterOptions {
   /** ElevenLabs API key (`xi-api-key`). */
   apiKey: string;
   /**
-   * Base URL for the ElevenLabs REST API, passed straight to the SDK client.
+   * Base URL for the ElevenLabs REST API, passed straight to the SDK client's
+   * own `baseUrl` option.
    *
-   * Points the signed-URL handshake at a LangWatch voice gateway, which
-   * mirrors the vendor's own mint path: the gateway checks the virtual key's
-   * budget and session cap, mints the signed URL, and bills the call as one
-   * spend record. The websocket the URL names still belongs to ElevenLabs,
-   * so the media stream runs client to vendor and nothing about latency or
-   * the wire protocol changes. `apiKey` then carries the virtual key.
+   * Points the signed-URL handshake at a LangWatch AI Gateway, which mirrors
+   * the vendor's own mint path: the gateway checks the virtual key's budget
+   * and session cap, mints the signed URL, and bills the call as one spend
+   * record. The websocket the URL names still belongs to ElevenLabs, so the
+   * media stream runs client to vendor and nothing about latency or the wire
+   * protocol changes. `apiKey` then carries the virtual key.
    *
-   * Omitted, this follows `LANGWATCH_VOICE_BROKER_URL`, and with that unset
-   * the SDK talks to ElevenLabs directly as it always has.
+   * There is no environment variable for this, because the ElevenLabs SDK has
+   * none: `ELEVENLABS_API_KEY` is the only variable it reads (checked against
+   * `@elevenlabs/elevenlabs-js` 2.64.0), and the base URL is a constructor
+   * option. Omitted, the SDK talks to ElevenLabs directly as it always has.
    */
   baseUrl?: string;
   /**
@@ -477,7 +480,7 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     super();
     this.agentId = options.agentId;
     this.apiKey = options.apiKey;
-    this.baseUrl = options.baseUrl ?? process.env.LANGWATCH_VOICE_BROKER_URL;
+    this.baseUrl = options.baseUrl;
     this.systemPromptOverride = options.systemPromptOverride;
     this.firstMessageOverride = options.firstMessageOverride;
     this.dynamicVariables = options.dynamicVariables;

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -377,6 +377,34 @@ export interface ElevenLabsAgentAdapterOptions {
  * {@link AudioInterface} and start the session), stream PCM16 audio chunks at
  * real-mic cadence, and drain agent audio the SDK pushes via `output()`.
  */
+
+/**
+ * Checks a base URL at construction, where the mistake is still readable.
+ *
+ * The one people make is including `/v1`. `OPENAI_BASE_URL` conventionally
+ * does, and the ElevenLabs SDK appends `/v1` itself, so a base URL that
+ * carries it produces `/v1/v1/convai/...` and a 404 that names no cause. An
+ * empty value means unset, which leaves the SDK on its own default.
+ */
+export function normalizeElevenLabsBaseUrl(raw?: string): string | undefined {
+  const trimmed = raw?.trim().replace(/\/+$/, "");
+  if (!trimmed) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(
+      `ElevenLabsAgentAdapter: baseUrl is not a URL: ${trimmed}`,
+    );
+  }
+  if (parsed.pathname.endsWith("/v1")) {
+    throw new Error(
+      `ElevenLabsAgentAdapter: baseUrl must not include /v1 (${trimmed}). ` +
+        `The SDK appends it, so this would request /v1/v1/convai/... and 404.`,
+    );
+  }
+  return trimmed;
+}
 export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
   override role = AgentRole.AGENT;
 
@@ -480,7 +508,7 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     super();
     this.agentId = options.agentId;
     this.apiKey = options.apiKey;
-    this.baseUrl = options.baseUrl;
+    this.baseUrl = normalizeElevenLabsBaseUrl(options.baseUrl);
     this.systemPromptOverride = options.systemPromptOverride;
     this.firstMessageOverride = options.firstMessageOverride;
     this.dynamicVariables = options.dynamicVariables;

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -397,6 +397,13 @@ export function normalizeElevenLabsBaseUrl(raw?: string): string | undefined {
       `ElevenLabsAgentAdapter: baseUrl is not a URL: ${trimmed}`,
     );
   }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    // `new URL` accepts schemes the SDK cannot make a REST request over, so
+    // parsing alone is not a check.
+    throw new Error(
+      `ElevenLabsAgentAdapter: baseUrl must be http or https: ${trimmed}`,
+    );
+  }
   if (parsed.pathname.endsWith("/v1")) {
     throw new Error(
       `ElevenLabsAgentAdapter: baseUrl must not include /v1 (${trimmed}). ` +

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -286,6 +286,20 @@ export interface ElevenLabsAgentAdapterOptions {
   /** ElevenLabs API key (`xi-api-key`). */
   apiKey: string;
   /**
+   * Base URL for the ElevenLabs REST API, passed straight to the SDK client.
+   *
+   * Points the signed-URL handshake at a LangWatch voice gateway, which
+   * mirrors the vendor's own mint path: the gateway checks the virtual key's
+   * budget and session cap, mints the signed URL, and bills the call as one
+   * spend record. The websocket the URL names still belongs to ElevenLabs,
+   * so the media stream runs client to vendor and nothing about latency or
+   * the wire protocol changes. `apiKey` then carries the virtual key.
+   *
+   * Omitted, this follows `LANGWATCH_VOICE_BROKER_URL`, and with that unset
+   * the SDK talks to ElevenLabs directly as it always has.
+   */
+  baseUrl?: string;
+  /**
    * Per-session system prompt override applied via the SDK's
    * `conversationConfigOverride.agent.prompt.prompt`. Lets demos use a different
    * prompt shape without mutating the shared test agent.
@@ -373,6 +387,7 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
 
   readonly agentId: string;
   private readonly apiKey: string;
+  private readonly baseUrl?: string;
   private readonly systemPromptOverride?: string;
   private readonly firstMessageOverride?: string;
   private readonly dynamicVariables?: Record<string, string | number | boolean>;
@@ -462,6 +477,7 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     super();
     this.agentId = options.agentId;
     this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl ?? process.env.LANGWATCH_VOICE_BROKER_URL;
     this.systemPromptOverride = options.systemPromptOverride;
     this.firstMessageOverride = options.firstMessageOverride;
     this.dynamicVariables = options.dynamicVariables;
@@ -487,7 +503,13 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
     });
     const { AudioInterface, Conversation, ElevenLabsClient } =
       await loadElevenLabsConversationRuntime();
-    const client = new ElevenLabsClient({ apiKey: this.apiKey });
+    // `baseUrl` is the SDK's documented custom-URL option. Undefined leaves
+    // the SDK on its own default host, so an unconfigured adapter is
+    // byte-for-byte the request it sent before.
+    const client = new ElevenLabsClient({
+      apiKey: this.apiKey,
+      ...(this.baseUrl ? { baseUrl: this.baseUrl } : {}),
+    });
 
     // The adapter's NARROW prompt/first-message knobs build an `agent` override
     // that is always sent (an empty `agent` object is a no-op) so the handshake

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -195,6 +195,7 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
   lastAgentTranscript: string | null = null;
 
   private readonly _apiKey: string;
+  private readonly _apiKeySource: string;
   private readonly _urlOverride: string | null;
   /** Where to mint, or null when there is no key to mint with. */
   private readonly _mint: RealtimeMintEndpoint | null;
@@ -262,6 +263,15 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
       process.env.OPENAI_REALTIME_API_KEY ??
       process.env.OPENAI_API_KEY ??
       "";
+    // Which of the three the key came from. Only used to name it in the
+    // direct-dial warning, where naming the wrong one sends the reader to a
+    // variable that is not set.
+    this._apiKeySource =
+      init.apiKey !== undefined
+        ? "the apiKey passed to the adapter"
+        : process.env.OPENAI_REALTIME_API_KEY !== undefined
+          ? "OPENAI_REALTIME_API_KEY"
+          : "OPENAI_API_KEY";
     this._urlOverride = init.url ?? null;
     this._wsFactory = init.wsFactory ?? null;
     this._mint =
@@ -333,7 +343,7 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
         // No mint route: a gateway older than this feature, or a plain proxy.
         // Dial the vendor directly, and say so, because an unbilled session
         // otherwise looks identical to a billed one.
-        warnDirectDialFallback(this._mint.baseUrl);
+        warnDirectDialFallback(this._mint.baseUrl, this._apiKeySource);
       }
     }
     if (socketKey === this._apiKey && !this._apiKey) {

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -35,9 +35,10 @@ import { AudioChunk } from "../audio-chunk";
 import {
   mintOpenAIRealtimeSession,
   reportOpenAIRealtimeUsage,
-  resolveVoiceBroker,
+  resolveRealtimeMintEndpoint,
+  warnDirectDialFallback,
+  type RealtimeMintEndpoint,
   type RealtimeUsage,
-  type VoiceBrokerConfig,
 } from "../broker";
 import { AdapterCapabilities } from "../capabilities";
 import { createAudioMessage, extractAudio } from "../messages";
@@ -113,10 +114,11 @@ export interface OpenAIRealtimeAgentAdapterInit {
   /** Tool definitions passed straight through to the Realtime session. */
   tools?: RealtimeToolDef[];
   /**
-   * Explicit API key; falls back to `process.env.OPENAI_REALTIME_API_KEY`,
-   * then `process.env.OPENAI_API_KEY`. Realtime always connects directly to
-   * OpenAI, so keep a real provider key here when `OPENAI_API_KEY` holds a
-   * gateway virtual key.
+   * Explicit API key for dialing the vendor directly; falls back to
+   * `process.env.OPENAI_REALTIME_API_KEY`, then `process.env.OPENAI_API_KEY`.
+   *
+   * This key is only used when the session is not minted, so it matters when
+   * `OPENAI_BASE_URL` points at an endpoint with no mint route. See `mint`.
    */
   apiKey?: string;
   /**
@@ -139,19 +141,20 @@ export interface OpenAIRealtimeAgentAdapterInit {
    */
   wsFactory?: (url: string, authHeader: string) => WebSocket;
   /**
-   * Mint this session through a LangWatch voice gateway instead of
-   * authenticating with a provider key.
+   * Where to mint the session credential, overriding `OPENAI_BASE_URL` and
+   * `OPENAI_API_KEY`. `false` skips the mint and dials the vendor directly.
    *
-   * The gateway checks the key's budget and session cap, mints OpenAI's own
-   * ephemeral client secret, and bills the call as one spend record; the
-   * media socket still runs straight to OpenAI, so nothing about latency or
-   * the wire protocol changes. `false` disables brokering even when the
-   * environment configures it.
+   * `POST /v1/realtime/client_secrets` is OpenAI's own path, and a LangWatch
+   * AI Gateway mirrors it, so the same request works against either. Against
+   * OpenAI it returns an ephemeral client secret. Against a gateway it also
+   * checks the virtual key's budget and open-session cap and opens one spend
+   * record, naming the session on the `X-LangWatch-Session-Id` response
+   * header. Usage is reported back only when that header is present.
    *
-   * Omitted, brokering follows `LANGWATCH_VOICE_BROKER_URL`, and with that
-   * unset the adapter connects directly to OpenAI as it always has.
+   * The media socket runs to the vendor either way, so latency and the wire
+   * protocol do not change.
    */
-  broker?: Partial<VoiceBrokerConfig> | false;
+  mint?: Partial<RealtimeMintEndpoint> | false;
 }
 
 /**
@@ -193,9 +196,9 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
 
   private readonly _apiKey: string;
   private readonly _urlOverride: string | null;
-  /** Broker configuration, or null when connecting straight to OpenAI. */
-  private readonly _broker: VoiceBrokerConfig | null;
-  /** The gateway's id for the current session, set at mint. */
+  /** Where to mint, or null when there is no key to mint with. */
+  private readonly _mint: RealtimeMintEndpoint | null;
+  /** The gateway's id for the current session, empty unless a gateway minted it. */
   private _brokerSessionId = "";
   /** The last usage object the socket reported, sent when the session ends. */
   private _lastUsage: RealtimeUsage | null = null;
@@ -246,14 +249,14 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     this.instructions = init.instructions ?? "";
     this.tools = init.tools ?? [];
     this.role = init.role ?? AgentRole.AGENT;
-    // The provider key for a direct connection: explicit param, then
+    // The fallback key for dialing the vendor directly: explicit param, then
     // OPENAI_REALTIME_API_KEY, then OPENAI_API_KEY. OPENAI_REALTIME_API_KEY
-    // exists so a deployment whose OPENAI_API_KEY is a gateway virtual key
-    // can still hold a real provider key for this socket.
+    // exists so a deployment whose OPENAI_API_KEY is a virtual key can still
+    // hold a real provider key for this socket.
     //
-    // A brokered adapter uses none of these on the socket. It mints OpenAI's
-    // own ephemeral secret through the gateway and dials with that, so the
-    // provider key stays server side. See `broker`.
+    // A minted session uses none of these on the socket. It dials with the
+    // ephemeral secret the mint returned, so a long-lived key never reaches
+    // the socket. See `mint`.
     this._apiKey =
       init.apiKey ??
       process.env.OPENAI_REALTIME_API_KEY ??
@@ -261,19 +264,25 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
       "";
     this._urlOverride = init.url ?? null;
     this._wsFactory = init.wsFactory ?? null;
-    this._broker =
-      init.broker === false
+    this._mint =
+      init.mint === false
         ? null
-        : resolveVoiceBroker(init.broker ?? undefined);
+        : resolveRealtimeMintEndpoint(init.mint ?? undefined);
   }
 
   get url(): string {
     return resolveRealtimeUrl(this._urlOverride, this.model);
   }
 
-  /** Whether this adapter mints through a gateway rather than using a provider key. */
+  /**
+   * Whether the live session was minted by a gateway rather than the vendor.
+   *
+   * Only true after `connect()`, and only when the mint answered with
+   * `X-LangWatch-Session-Id`. Configuration cannot set it, because the
+   * response is the one thing that cannot be told a lie about what answered.
+   */
   get brokered(): boolean {
-    return this._broker !== null;
+    return this._brokerSessionId !== "";
   }
 
   /** Hide the API key when this object lands in error messages or logs. */
@@ -304,22 +313,30 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     this._brokerSessionId = "";
     this._lastUsage = null;
 
-    // Brokered, the socket's bearer is the vendor's own ephemeral secret,
-    // minted for this session against the virtual key's budget and cap. It
-    // is a short-lived credential for exactly this call, so the long-lived
-    // provider key never reaches the client or the socket.
+    // The socket's bearer is the ephemeral secret the mint returned: a
+    // credential for exactly this call, so no long-lived key reaches the
+    // socket. Whether OpenAI or a gateway answers the mint is a property of
+    // OPENAI_BASE_URL, not of this adapter.
     let socketKey = this._apiKey;
-    if (this._broker) {
-      const minted = await mintOpenAIRealtimeSession(this._broker, {
+    if (this._mint) {
+      const result = await mintOpenAIRealtimeSession(this._mint, {
         model: this.model,
       });
-      socketKey = minted.clientSecret;
-      this._brokerSessionId = minted.sessionId;
-      setSpanAttributes(currentSpan(), {
-        "voice.realtime.brokered": true,
-        "voice.realtime.session_id": minted.sessionId,
-      });
-    } else if (!this._apiKey) {
+      if (result.minted) {
+        socketKey = result.clientSecret;
+        this._brokerSessionId = result.sessionId;
+        setSpanAttributes(currentSpan(), {
+          "voice.realtime.brokered": this.brokered,
+          "voice.realtime.session_id": result.sessionId,
+        });
+      } else {
+        // No mint route: a gateway older than this feature, or a plain proxy.
+        // Dial the vendor directly, and say so, because an unbilled session
+        // otherwise looks identical to a billed one.
+        warnDirectDialFallback(this._mint.baseUrl);
+      }
+    }
+    if (socketKey === this._apiKey && !this._apiKey) {
       throw new Error(
         "OpenAIRealtimeAgentAdapter: no API key. Set OPENAI_API_KEY or " +
           "pass `{ apiKey }` to the constructor.",
@@ -1254,22 +1271,17 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
   }
 
   /**
-   * Keeps the usage OpenAI reports on `response.done`.
+   * Closes the session's spend record with what the socket measured.
    *
-   * Read from the raw message rather than the receive loop because a drain
-   * that ends on tail silence never reads the terminal event, and a session
-   * whose usage was never captured bills as cost-unknown. The last response
-   * of a session carries that session's cumulative totals, so keeping the
-   * most recent one is what the gateway wants.
+   * Clearing the captured usage first is what makes a second disconnect a
+   * no-op, so a session cannot be reported twice.
    */
-  /** Closes the session's spend record with what the socket measured. */
   private async _reportUsage(): Promise<void> {
-    if (!this._broker || !this._brokerSessionId || !this._lastUsage) return;
+    if (!this._mint || !this._brokerSessionId || !this._lastUsage) return;
     const usage = this._lastUsage;
     const sessionId = this._brokerSessionId;
     this._lastUsage = null;
-    this._brokerSessionId = "";
-    await reportOpenAIRealtimeUsage(this._broker, {
+    await reportOpenAIRealtimeUsage(this._mint, {
       sessionId,
       usage,
       onError: (error) =>
@@ -1277,8 +1289,17 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     });
   }
 
+  /**
+   * Keeps the usage OpenAI reports on `response.done`.
+   *
+   * Read from the raw message rather than the receive loop because a drain
+   * that ends on tail silence never reads the terminal event, and a session
+   * whose usage was never captured bills as cost-unknown. The last response of
+   * a session carries that session's cumulative totals, so keeping the most
+   * recent one is the number to report.
+   */
   private _captureUsage(event: unknown): void {
-    if (!this._broker || !event || typeof event !== "object") return;
+    if (!this._brokerSessionId || !event || typeof event !== "object") return;
     const record = event as Record<string, unknown>;
     if (record.type !== "response.done") return;
     const response = record.response;

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -32,6 +32,13 @@ import { AgentRole } from "../../domain/agents";
 import { Logger } from "../../utils/logger";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
+import {
+  mintOpenAIRealtimeSession,
+  reportOpenAIRealtimeUsage,
+  resolveVoiceBroker,
+  type RealtimeUsage,
+  type VoiceBrokerConfig,
+} from "../broker";
 import { AdapterCapabilities } from "../capabilities";
 import { createAudioMessage, extractAudio } from "../messages";
 import { currentSpan, setSpanAttributes, voiceSpan } from "../telemetry";
@@ -64,7 +71,24 @@ interface CompletedToolCall {
   arguments: string;
 }
 
+/**
+ * The vendor's own realtime endpoint.
+ *
+ * Overridable per adapter (`url`) and per environment
+ * (`OPENAI_REALTIME_URL`), because the media socket is not always dialled at
+ * OpenAI directly: a proxy in front of it, or a loopback server in a test,
+ * both need a different address while everything else stays the same.
+ */
 const REALTIME_URL_TEMPLATE = "wss://api.openai.com/v1/realtime?model={model}";
+
+/** Resolves the realtime endpoint from an override, the environment, or the vendor default. */
+function resolveRealtimeUrl(override: string | null, model: string): string {
+  const configured = override ?? process.env.OPENAI_REALTIME_URL ?? null;
+  if (!configured) return REALTIME_URL_TEMPLATE.replace("{model}", model);
+  return configured.includes("{model}")
+    ? configured.replace("{model}", model)
+    : configured;
+}
 
 /**
  * Realtime tool definition — structural shape passed through to the
@@ -114,6 +138,20 @@ export interface OpenAIRealtimeAgentAdapterInit {
    * Authorization header value.
    */
   wsFactory?: (url: string, authHeader: string) => WebSocket;
+  /**
+   * Mint this session through a LangWatch voice gateway instead of
+   * authenticating with a provider key.
+   *
+   * The gateway checks the key's budget and session cap, mints OpenAI's own
+   * ephemeral client secret, and bills the call as one spend record; the
+   * media socket still runs straight to OpenAI, so nothing about latency or
+   * the wire protocol changes. `false` disables brokering even when the
+   * environment configures it.
+   *
+   * Omitted, brokering follows `LANGWATCH_VOICE_BROKER_URL`, and with that
+   * unset the adapter connects directly to OpenAI as it always has.
+   */
+  broker?: Partial<VoiceBrokerConfig> | false;
 }
 
 /**
@@ -155,6 +193,12 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
 
   private readonly _apiKey: string;
   private readonly _urlOverride: string | null;
+  /** Broker configuration, or null when connecting straight to OpenAI. */
+  private readonly _broker: VoiceBrokerConfig | null;
+  /** The gateway's id for the current session, set at mint. */
+  private _brokerSessionId = "";
+  /** The last usage object the socket reported, sent when the session ends. */
+  private _lastUsage: RealtimeUsage | null = null;
   private readonly _wsFactory:
     | ((url: string, authHeader: string) => WebSocket)
     | null;
@@ -202,11 +246,14 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     this.instructions = init.instructions ?? "";
     this.tools = init.tools ?? [];
     this.role = init.role ?? AgentRole.AGENT;
-    // Explicit param, then OPENAI_REALTIME_API_KEY, then OPENAI_API_KEY.
-    // Realtime connects DIRECTLY to OpenAI's websocket (gateways that proxy
-    // the HTTP audio endpoints do not proxy realtime), so when
-    // OPENAI_API_KEY holds a gateway virtual key, OPENAI_REALTIME_API_KEY
-    // carries the real provider key.
+    // The provider key for a direct connection: explicit param, then
+    // OPENAI_REALTIME_API_KEY, then OPENAI_API_KEY. OPENAI_REALTIME_API_KEY
+    // exists so a deployment whose OPENAI_API_KEY is a gateway virtual key
+    // can still hold a real provider key for this socket.
+    //
+    // A brokered adapter uses none of these on the socket. It mints OpenAI's
+    // own ephemeral secret through the gateway and dials with that, so the
+    // provider key stays server side. See `broker`.
     this._apiKey =
       init.apiKey ??
       process.env.OPENAI_REALTIME_API_KEY ??
@@ -214,12 +261,19 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
       "";
     this._urlOverride = init.url ?? null;
     this._wsFactory = init.wsFactory ?? null;
+    this._broker =
+      init.broker === false
+        ? null
+        : resolveVoiceBroker(init.broker ?? undefined);
   }
 
   get url(): string {
-    return (
-      this._urlOverride ?? REALTIME_URL_TEMPLATE.replace("{model}", this.model)
-    );
+    return resolveRealtimeUrl(this._urlOverride, this.model);
+  }
+
+  /** Whether this adapter mints through a gateway rather than using a provider key. */
+  get brokered(): boolean {
+    return this._broker !== null;
   }
 
   /** Hide the API key when this object lands in error messages or logs. */
@@ -247,7 +301,25 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     this._deferredResponseCreate = false;
     this._closeReason = null;
 
-    if (!this._apiKey) {
+    this._brokerSessionId = "";
+    this._lastUsage = null;
+
+    // Brokered, the socket's bearer is the vendor's own ephemeral secret,
+    // minted for this session against the virtual key's budget and cap. It
+    // is a short-lived credential for exactly this call, so the long-lived
+    // provider key never reaches the client or the socket.
+    let socketKey = this._apiKey;
+    if (this._broker) {
+      const minted = await mintOpenAIRealtimeSession(this._broker, {
+        model: this.model,
+      });
+      socketKey = minted.clientSecret;
+      this._brokerSessionId = minted.sessionId;
+      setSpanAttributes(currentSpan(), {
+        "voice.realtime.brokered": true,
+        "voice.realtime.session_id": minted.sessionId,
+      });
+    } else if (!this._apiKey) {
       throw new Error(
         "OpenAIRealtimeAgentAdapter: no API key. Set OPENAI_API_KEY or " +
           "pass `{ apiKey }` to the constructor.",
@@ -258,7 +330,7 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     // with "The Realtime Beta API is no longer supported." (observed in
     // CI 2026-05-22). Python parity is intentionally broken here; track
     // for back-port.
-    const authHeader = `Bearer ${this._apiKey}`;
+    const authHeader = `Bearer ${socketKey}`;
     const ws = this._wsFactory
       ? this._wsFactory(this.url, authHeader)
       : new WebSocket(this.url, { headers: { Authorization: authHeader } });
@@ -354,6 +426,11 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     const ws = this._ws;
     if (!ws) return;
     this._ws = null;
+    // Report before tearing the socket down. OpenAI reports usage over that
+    // socket, so this is the only path by which the numbers reach the
+    // gateway; a session that never reports settles as cost-unknown on the
+    // gateway's grace rather than being lost.
+    await this._reportUsage();
     // Issue #662: clear response-lifecycle guard state on teardown so a
     // reused adapter instance does not carry a stale active/deferred flag
     // into its next connection.
@@ -1172,7 +1249,44 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
       // Non-JSON frame — match Python adapter behavior and drop it.
       return;
     }
+    this._captureUsage(event);
     this._enqueueEvent(event);
+  }
+
+  /**
+   * Keeps the usage OpenAI reports on `response.done`.
+   *
+   * Read from the raw message rather than the receive loop because a drain
+   * that ends on tail silence never reads the terminal event, and a session
+   * whose usage was never captured bills as cost-unknown. The last response
+   * of a session carries that session's cumulative totals, so keeping the
+   * most recent one is what the gateway wants.
+   */
+  /** Closes the session's spend record with what the socket measured. */
+  private async _reportUsage(): Promise<void> {
+    if (!this._broker || !this._brokerSessionId || !this._lastUsage) return;
+    const usage = this._lastUsage;
+    const sessionId = this._brokerSessionId;
+    this._lastUsage = null;
+    this._brokerSessionId = "";
+    await reportOpenAIRealtimeUsage(this._broker, {
+      sessionId,
+      usage,
+      onError: (error) =>
+        logger.debug("voice broker usage report failed", { error }),
+    });
+  }
+
+  private _captureUsage(event: unknown): void {
+    if (!this._broker || !event || typeof event !== "object") return;
+    const record = event as Record<string, unknown>;
+    if (record.type !== "response.done") return;
+    const response = record.response;
+    if (!response || typeof response !== "object") return;
+    const usage = (response as Record<string, unknown>).usage;
+    if (usage && typeof usage === "object") {
+      this._lastUsage = usage as RealtimeUsage;
+    }
   }
 
   private _enqueueEvent(event: unknown): void {

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -362,18 +362,28 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
       ? this._wsFactory(this.url, authHeader)
       : new WebSocket(this.url, { headers: { Authorization: authHeader } });
 
-    await new Promise<void>((resolve, reject) => {
-      const onOpen = () => {
-        ws.off("error", onError);
-        resolve();
-      };
-      const onError = (err: Error) => {
-        ws.off("open", onOpen);
-        reject(err);
-      };
-      ws.once("open", onOpen);
-      ws.once("error", onError);
-    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onOpen = () => {
+          ws.off("error", onError);
+          resolve();
+        };
+        const onError = (err: Error) => {
+          ws.off("open", onOpen);
+          reject(err);
+        };
+        ws.once("open", onOpen);
+        ws.once("error", onError);
+      });
+    } catch (error) {
+      // The mint booked a session and the socket never opened, so nothing
+      // will ever report against it. Closing it at zero is the truth: an
+      // ephemeral secret that opened no socket used nothing. Leaving it open
+      // would hold one of the key's session slots until the gateway's own
+      // window expires, and book a call that never happened.
+      await this._closeUnusedSession();
+      throw error;
+    }
 
     ws.on("message", (raw: RawData) => this._handleMessage(raw));
     ws.on("close", () => {
@@ -1278,6 +1288,27 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     }
     this._captureUsage(event);
     this._enqueueEvent(event);
+  }
+
+  /**
+   * Closes a session whose socket never opened, at no cost.
+   *
+   * The mint booked it, so only a report can close it; there is no cancel.
+   * Zero is the correct number, not a placeholder: an ephemeral credential
+   * that opened no socket consumed nothing at the vendor. Doing nothing would
+   * leave the session holding a slot against the key's open-session cap until
+   * the gateway's own window expires.
+   */
+  private async _closeUnusedSession(): Promise<void> {
+    if (!this._mint || !this._brokerSessionId) return;
+    const sessionId = this._brokerSessionId;
+    this._brokerSessionId = "";
+    await reportOpenAIRealtimeUsage(this._mint, {
+      sessionId,
+      usage: {},
+      onError: (error) =>
+        logger.debug("voice broker unused-session close failed", { error }),
+    });
   }
 
   /**

--- a/javascript/src/voice/broker.ts
+++ b/javascript/src/voice/broker.ts
@@ -1,101 +1,98 @@
 /**
- * Brokered realtime voice sessions.
+ * Minting a realtime voice session, at OpenAI or at a gateway in front of it.
  *
- * A voice gateway can broker a realtime session instead of relaying it: the
- * client presents a virtual key, the gateway checks the budget and mints the
- * vendor's own short-lived session credential, and the media socket then runs
- * client to vendor directly. Audio never crosses the gateway, so latency is
- * unchanged, and the session still lands on one spend record.
+ * `POST /v1/realtime/client_secrets` is OpenAI's own path. A LangWatch AI
+ * Gateway mirrors it: it checks the virtual key's budget and its open-session
+ * cap, mints OpenAI's ephemeral client secret, and opens one spend record for
+ * the call. The media socket still runs client to vendor in both cases, so
+ * latency and the wire protocol are unchanged.
  *
- * Two vendors reach a broker differently, which is why only OpenAI needs this
- * module:
+ * That symmetry is the whole design. The adapter reads `OPENAI_BASE_URL` and
+ * `OPENAI_API_KEY`, the two variables scenario already reads for chat, and
+ * mints at `${OPENAI_BASE_URL}/realtime/client_secrets`. Point those at OpenAI
+ * and the mint happens at OpenAI with a provider key. Point them at a gateway
+ * and the mint happens through the broker with a virtual key. There is no
+ * third URL, no third key, and no branch on who is answering. Anyone already
+ * routing chat through a gateway gets voice with no new configuration.
  *
- * - ElevenLabs mints through its own REST path, so pointing the official SDK
- *   at the gateway's base URL is the whole change (see `baseUrl` on
- *   {@link ElevenLabsAgentAdapterOptions}).
- * - OpenAI Realtime dials a websocket with a bearer token and has no mint step
- *   of its own, so the caller performs the mint, dials with the credential it
- *   returns, and reports what the socket measured when the session ends.
- *
- * Brokering is opt-in. With no broker configured every adapter connects
- * straight to its vendor exactly as before.
+ * ElevenLabs needs nothing from this module: it mints over its own REST path,
+ * so its official SDK reaches a gateway through the `baseUrl` option the SDK
+ * already exposes.
  */
 
-/** Where to mint, and the key to mint with. */
-export interface VoiceBrokerConfig {
-  /** Gateway base URL, without a trailing slash. */
+import { Logger } from "../utils/logger";
+
+const logger = new Logger("scenario.voice.broker");
+
+/** Where the mint request goes, and the key it carries. */
+export interface RealtimeMintEndpoint {
+  /** OpenAI-compatible base URL, including `/v1`, without a trailing slash. */
   baseUrl: string;
-  /** The virtual key the gateway authenticates and bills. */
+  /** The key the endpoint authenticates: a provider key, or a virtual key. */
   apiKey: string;
 }
 
-/** A minted session: the vendor credential, and the id the gateway bills. */
-export interface BrokeredRealtimeSession {
-  /** The vendor's own short-lived credential, used as the socket's bearer. */
-  clientSecret: string;
-  /**
-   * The gateway's id for this session, or "" when it did not name one. Usage
-   * is reported against it, so an empty id means the session cannot be
-   * closed by report and settles on the gateway's own grace instead.
-   */
-  sessionId: string;
-}
+/** The vendor's default, used when `OPENAI_BASE_URL` is unset. */
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
+
+const MINT_PATH = "/realtime/client_secrets";
+const usagePath = (sessionId: string) =>
+  `/realtime/sessions/${encodeURIComponent(sessionId)}/usage`;
+
+/** A gateway names the session it opened on this response header. OpenAI does not. */
+const SESSION_ID_HEADER = "x-langwatch-session-id";
+
+/**
+ * What a mint attempt produced.
+ *
+ * `sessionId` is empty unless a gateway answered, because only a gateway
+ * carries {@link SESSION_ID_HEADER}. An empty id therefore means the vendor
+ * minted the credential itself and there is no session to report usage to.
+ */
+export type RealtimeMintResult =
+  | { minted: true; clientSecret: string; sessionId: string }
+  | { minted: false; status: number };
 
 /** Token counts a realtime socket reported, in the vendor's own shape. */
 export type RealtimeUsage = Record<string, unknown>;
 
-const MINT_PATH = "/v1/realtime/client_secrets";
-const USAGE_PATH = (sessionId: string) =>
-  `/v1/realtime/sessions/${encodeURIComponent(sessionId)}/usage`;
-
-/** The gateway names the session it billed on this response header. */
-const SESSION_ID_HEADER = "x-langwatch-session-id";
-
 /**
- * Resolves broker configuration, or null when brokering is off.
+ * Resolves where to mint, or null when there is no key to mint with.
  *
- * The base URL is what turns brokering on; there is no separate flag, because
- * a broker with no address is not a configuration anyone meant. The key falls
- * back to `OPENAI_API_KEY` because a gateway user already puts their virtual
- * key there.
- *
- * `OPENAI_REALTIME_API_KEY` is deliberately NOT consulted. That variable
- * exists to hold a direct provider key, so reading it here would mint with a
- * credential the gateway does not issue and cannot bill.
+ * `OPENAI_REALTIME_API_KEY` is deliberately not consulted here. That variable
+ * holds a direct provider key for the socket, and presenting it to a gateway
+ * would offer a credential the gateway did not issue and cannot bill. It stays
+ * what it already was: the fallback for dialing the vendor directly.
  */
-export function resolveVoiceBroker(
-  explicit?: Partial<VoiceBrokerConfig>,
-): VoiceBrokerConfig | null {
+export function resolveRealtimeMintEndpoint(
+  explicit?: Partial<RealtimeMintEndpoint>,
+): RealtimeMintEndpoint | null {
+  const apiKey = explicit?.apiKey ?? process.env.OPENAI_API_KEY ?? "";
+  if (!apiKey) return null;
   const baseUrl =
-    explicit?.baseUrl ?? process.env.LANGWATCH_VOICE_BROKER_URL ?? "";
-  if (!baseUrl) return null;
-  const apiKey =
-    explicit?.apiKey ??
-    process.env.LANGWATCH_VOICE_BROKER_KEY ??
-    process.env.OPENAI_API_KEY ??
-    "";
-  if (!apiKey) {
-    throw new Error(
-      "voice broker: a base URL is set but no key. Set " +
-        "LANGWATCH_VOICE_BROKER_KEY (or OPENAI_API_KEY) to the virtual key " +
-        "the gateway should bill.",
-    );
-  }
+    explicit?.baseUrl ?? process.env.OPENAI_BASE_URL ?? OPENAI_DEFAULT_BASE_URL;
   return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey };
 }
 
 /**
- * Mints an OpenAI realtime session through the gateway.
+ * Mints a realtime session, and reports whether the route existed.
  *
- * The body is OpenAI's own, so the gateway forwards it as written apart from
- * resolving the model against the key's allowlist. What comes back is
- * OpenAI's ephemeral client secret, which authenticates a server-side
- * websocket as a bearer token.
+ * A 404 means the base URL points at something with no mint route, which is
+ * what a LangWatch gateway older than this feature answers. That is an absence,
+ * so the caller may fall back to dialing the vendor directly. Any other error
+ * status is a refusal by an endpoint that does have the route, such as an
+ * exhausted budget or a rejected model, and it raises. Falling back on a
+ * refusal would spend a direct provider key on a call the gateway just
+ * declined to bill.
  */
 export async function mintOpenAIRealtimeSession(
-  broker: VoiceBrokerConfig,
-  params: { model: string; expiresAfterSeconds?: number; fetchImpl?: typeof fetch },
-): Promise<BrokeredRealtimeSession> {
+  endpoint: RealtimeMintEndpoint,
+  params: {
+    model: string;
+    expiresAfterSeconds?: number;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<RealtimeMintResult> {
   const doFetch = params.fetchImpl ?? fetch;
   const body: Record<string, unknown> = {
     session: { type: "realtime", model: params.model },
@@ -107,21 +104,22 @@ export async function mintOpenAIRealtimeSession(
     };
   }
 
-  const response = await doFetch(`${broker.baseUrl}${MINT_PATH}`, {
+  const response = await doFetch(`${endpoint.baseUrl}${MINT_PATH}`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${broker.apiKey}`,
+      Authorization: `Bearer ${endpoint.apiKey}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
   });
 
   const text = await response.text();
+  if (response.status === 404) return { minted: false, status: 404 };
   if (!response.ok) {
-    // The gateway's own message is the useful one: it names a budget, a
-    // session cap or a missing provider far more precisely than a status.
+    // The endpoint's own message is the useful one: it names the budget, the
+    // session cap or the missing provider far more precisely than a status.
     throw new Error(
-      `voice broker: mint failed with HTTP ${response.status}: ${text.slice(0, 500)}`,
+      `realtime mint failed with HTTP ${response.status}: ${text.slice(0, 500)}`,
     );
   }
 
@@ -129,17 +127,17 @@ export async function mintOpenAIRealtimeSession(
   try {
     parsed = JSON.parse(text) as Record<string, unknown>;
   } catch {
-    throw new Error("voice broker: mint returned a body that is not JSON");
+    throw new Error("realtime mint returned a body that is not JSON");
   }
 
   const clientSecret = readClientSecret(parsed);
   if (!clientSecret) {
-    throw new Error("voice broker: mint returned no client secret");
+    throw new Error("realtime mint returned no client secret");
   }
   return {
+    minted: true,
     clientSecret,
-    sessionId:
-      response.headers.get(SESSION_ID_HEADER) ?? readEchoedSessionId(parsed),
+    sessionId: response.headers.get(SESSION_ID_HEADER) ?? "",
   };
 }
 
@@ -147,15 +145,15 @@ export async function mintOpenAIRealtimeSession(
  * Reports what the socket measured, closing the session's spend record.
  *
  * OpenAI reports usage over the socket, in `response.done`, and that socket
- * runs client to vendor, so this is the only path by which those numbers
- * reach the gateway. A session that never reports is not lost: the gateway
- * settles it as cost-unknown once its grace expires.
+ * runs client to vendor, so this is the only path by which those numbers reach
+ * a gateway. A session that never reports is not lost: the gateway settles it
+ * as cost-unknown once its grace expires.
  *
- * Never throws. A failed report costs accuracy on one session, and raising
- * here would fail a test whose subject is the agent, not the billing.
+ * Never throws. A failed report costs accuracy on one session, and raising here
+ * would fail a test whose subject is the agent, not the billing.
  */
 export async function reportOpenAIRealtimeUsage(
-  broker: VoiceBrokerConfig,
+  endpoint: RealtimeMintEndpoint,
   params: {
     sessionId: string;
     usage: RealtimeUsage;
@@ -163,13 +161,15 @@ export async function reportOpenAIRealtimeUsage(
     onError?: (error: unknown) => void;
   },
 ): Promise<void> {
+  // No session id means the vendor minted this credential, so there is no
+  // spend record anywhere to close.
   if (!params.sessionId) return;
   const doFetch = params.fetchImpl ?? fetch;
   try {
-    await doFetch(`${broker.baseUrl}${USAGE_PATH(params.sessionId)}`, {
+    await doFetch(`${endpoint.baseUrl}${usagePath(params.sessionId)}`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${broker.apiKey}`,
+        Authorization: `Bearer ${endpoint.apiKey}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ usage: params.usage }),
@@ -180,11 +180,26 @@ export async function reportOpenAIRealtimeUsage(
 }
 
 /**
+ * Warns that a mint route was absent and a direct provider key is in use.
+ *
+ * Loud on purpose. A silent fall back to a direct key looks exactly like a
+ * successful brokered run while producing no spend record at all, so a test
+ * run that proved nothing would read as a run that proved everything.
+ */
+export function warnDirectDialFallback(baseUrl: string): void {
+  logger.warn(
+    `realtime mint route not found at ${baseUrl}${MINT_PATH}; dialing the ` +
+      `vendor directly with OPENAI_REALTIME_API_KEY. This session is not ` +
+      `billed or budgeted by the gateway at ${baseUrl}.`,
+  );
+}
+
+/**
  * The credential, wherever the mint put it.
  *
- * OpenAI returns `{ value }` at the top level today and has previously
- * nested it under `client_secret`, so both are read rather than pinning the
- * adapter to one release's shape.
+ * OpenAI returns `{ value }` at the top level today and has previously nested
+ * it under `client_secret`, so both are read rather than pinning the adapter to
+ * one release's shape.
  */
 function readClientSecret(body: Record<string, unknown>): string {
   if (typeof body.value === "string" && body.value) return body.value;
@@ -195,19 +210,6 @@ function readClientSecret(body: Record<string, unknown>): string {
     typeof (nested as Record<string, unknown>).value === "string"
   ) {
     return (nested as Record<string, unknown>).value as string;
-  }
-  return "";
-}
-
-/** The session id the gateway echoes into the body, for clients that read it there. */
-function readEchoedSessionId(body: Record<string, unknown>): string {
-  const langwatch = body.langwatch;
-  if (
-    langwatch &&
-    typeof langwatch === "object" &&
-    typeof (langwatch as Record<string, unknown>).session_id === "string"
-  ) {
-    return (langwatch as Record<string, unknown>).session_id as string;
   }
   return "";
 }

--- a/javascript/src/voice/broker.ts
+++ b/javascript/src/voice/broker.ts
@@ -43,6 +43,16 @@ const usagePath = (sessionId: string) =>
 const SESSION_ID_HEADER = "x-langwatch-session-id";
 
 /**
+ * How long a usage report may take before it is abandoned.
+ *
+ * `disconnect()` awaits the report, so an unbounded request holds the socket
+ * open and the test that owns it never finishes. A report is worth a few
+ * seconds and never worth a hang: the session still settles on the gateway's
+ * own grace if it never arrives.
+ */
+const USAGE_REPORT_TIMEOUT_MS = 5_000;
+
+/**
  * What a mint attempt produced.
  *
  * `sessionId` is empty unless a gateway answered, because only a gateway
@@ -158,6 +168,7 @@ export async function reportOpenAIRealtimeUsage(
     sessionId: string;
     usage: RealtimeUsage;
     fetchImpl?: typeof fetch;
+    timeoutMs?: number;
     onError?: (error: unknown) => void;
   },
 ): Promise<void> {
@@ -166,14 +177,29 @@ export async function reportOpenAIRealtimeUsage(
   if (!params.sessionId) return;
   const doFetch = params.fetchImpl ?? fetch;
   try {
-    await doFetch(`${endpoint.baseUrl}${usagePath(params.sessionId)}`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${endpoint.apiKey}`,
-        "Content-Type": "application/json",
+    const response = await doFetch(
+      `${endpoint.baseUrl}${usagePath(params.sessionId)}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${endpoint.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ usage: params.usage }),
+        signal: AbortSignal.timeout(
+          params.timeoutMs ?? USAGE_REPORT_TIMEOUT_MS,
+        ),
       },
-      body: JSON.stringify({ usage: params.usage }),
-    });
+    );
+    // A refused report is a failure that answers. Reading only the thrown
+    // case would treat a 404 for an unknown session, or a 401 for a rotated
+    // key, as a report that landed, and the session would settle as
+    // cost-unknown with nobody told why.
+    if (!response.ok) {
+      params.onError?.(
+        new Error(`realtime usage report refused with HTTP ${response.status}`),
+      );
+    }
   } catch (error) {
     params.onError?.(error);
   }
@@ -185,11 +211,18 @@ export async function reportOpenAIRealtimeUsage(
  * Loud on purpose. A silent fall back to a direct key looks exactly like a
  * successful brokered run while producing no spend record at all, so a test
  * run that proved nothing would read as a run that proved everything.
+ *
+ * `credentialSource` names where the key being dialled came from, because the
+ * adapter reads three in order and naming a fixed one sends the reader to a
+ * variable that is not set.
  */
-export function warnDirectDialFallback(baseUrl: string): void {
+export function warnDirectDialFallback(
+  baseUrl: string,
+  credentialSource: string,
+): void {
   logger.warn(
     `realtime mint route not found at ${baseUrl}${MINT_PATH}; dialing the ` +
-      `vendor directly with OPENAI_REALTIME_API_KEY. This session is not ` +
+      `vendor directly with ${credentialSource}. This session is not ` +
       `billed or budgeted by the gateway at ${baseUrl}.`,
   );
 }

--- a/javascript/src/voice/broker.ts
+++ b/javascript/src/voice/broker.ts
@@ -1,0 +1,213 @@
+/**
+ * Brokered realtime voice sessions.
+ *
+ * A voice gateway can broker a realtime session instead of relaying it: the
+ * client presents a virtual key, the gateway checks the budget and mints the
+ * vendor's own short-lived session credential, and the media socket then runs
+ * client to vendor directly. Audio never crosses the gateway, so latency is
+ * unchanged, and the session still lands on one spend record.
+ *
+ * Two vendors reach a broker differently, which is why only OpenAI needs this
+ * module:
+ *
+ * - ElevenLabs mints through its own REST path, so pointing the official SDK
+ *   at the gateway's base URL is the whole change (see `baseUrl` on
+ *   {@link ElevenLabsAgentAdapterOptions}).
+ * - OpenAI Realtime dials a websocket with a bearer token and has no mint step
+ *   of its own, so the caller performs the mint, dials with the credential it
+ *   returns, and reports what the socket measured when the session ends.
+ *
+ * Brokering is opt-in. With no broker configured every adapter connects
+ * straight to its vendor exactly as before.
+ */
+
+/** Where to mint, and the key to mint with. */
+export interface VoiceBrokerConfig {
+  /** Gateway base URL, without a trailing slash. */
+  baseUrl: string;
+  /** The virtual key the gateway authenticates and bills. */
+  apiKey: string;
+}
+
+/** A minted session: the vendor credential, and the id the gateway bills. */
+export interface BrokeredRealtimeSession {
+  /** The vendor's own short-lived credential, used as the socket's bearer. */
+  clientSecret: string;
+  /**
+   * The gateway's id for this session, or "" when it did not name one. Usage
+   * is reported against it, so an empty id means the session cannot be
+   * closed by report and settles on the gateway's own grace instead.
+   */
+  sessionId: string;
+}
+
+/** Token counts a realtime socket reported, in the vendor's own shape. */
+export type RealtimeUsage = Record<string, unknown>;
+
+const MINT_PATH = "/v1/realtime/client_secrets";
+const USAGE_PATH = (sessionId: string) =>
+  `/v1/realtime/sessions/${encodeURIComponent(sessionId)}/usage`;
+
+/** The gateway names the session it billed on this response header. */
+const SESSION_ID_HEADER = "x-langwatch-session-id";
+
+/**
+ * Resolves broker configuration, or null when brokering is off.
+ *
+ * The base URL is what turns brokering on; there is no separate flag, because
+ * a broker with no address is not a configuration anyone meant. The key falls
+ * back to `OPENAI_API_KEY` because a gateway user already puts their virtual
+ * key there.
+ *
+ * `OPENAI_REALTIME_API_KEY` is deliberately NOT consulted. That variable
+ * exists to hold a direct provider key, so reading it here would mint with a
+ * credential the gateway does not issue and cannot bill.
+ */
+export function resolveVoiceBroker(
+  explicit?: Partial<VoiceBrokerConfig>,
+): VoiceBrokerConfig | null {
+  const baseUrl =
+    explicit?.baseUrl ?? process.env.LANGWATCH_VOICE_BROKER_URL ?? "";
+  if (!baseUrl) return null;
+  const apiKey =
+    explicit?.apiKey ??
+    process.env.LANGWATCH_VOICE_BROKER_KEY ??
+    process.env.OPENAI_API_KEY ??
+    "";
+  if (!apiKey) {
+    throw new Error(
+      "voice broker: a base URL is set but no key. Set " +
+        "LANGWATCH_VOICE_BROKER_KEY (or OPENAI_API_KEY) to the virtual key " +
+        "the gateway should bill.",
+    );
+  }
+  return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey };
+}
+
+/**
+ * Mints an OpenAI realtime session through the gateway.
+ *
+ * The body is OpenAI's own, so the gateway forwards it as written apart from
+ * resolving the model against the key's allowlist. What comes back is
+ * OpenAI's ephemeral client secret, which authenticates a server-side
+ * websocket as a bearer token.
+ */
+export async function mintOpenAIRealtimeSession(
+  broker: VoiceBrokerConfig,
+  params: { model: string; expiresAfterSeconds?: number; fetchImpl?: typeof fetch },
+): Promise<BrokeredRealtimeSession> {
+  const doFetch = params.fetchImpl ?? fetch;
+  const body: Record<string, unknown> = {
+    session: { type: "realtime", model: params.model },
+  };
+  if (params.expiresAfterSeconds !== undefined) {
+    body.expires_after = {
+      anchor: "created_at",
+      seconds: params.expiresAfterSeconds,
+    };
+  }
+
+  const response = await doFetch(`${broker.baseUrl}${MINT_PATH}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${broker.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    // The gateway's own message is the useful one: it names a budget, a
+    // session cap or a missing provider far more precisely than a status.
+    throw new Error(
+      `voice broker: mint failed with HTTP ${response.status}: ${text.slice(0, 500)}`,
+    );
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    throw new Error("voice broker: mint returned a body that is not JSON");
+  }
+
+  const clientSecret = readClientSecret(parsed);
+  if (!clientSecret) {
+    throw new Error("voice broker: mint returned no client secret");
+  }
+  return {
+    clientSecret,
+    sessionId:
+      response.headers.get(SESSION_ID_HEADER) ?? readEchoedSessionId(parsed),
+  };
+}
+
+/**
+ * Reports what the socket measured, closing the session's spend record.
+ *
+ * OpenAI reports usage over the socket, in `response.done`, and that socket
+ * runs client to vendor, so this is the only path by which those numbers
+ * reach the gateway. A session that never reports is not lost: the gateway
+ * settles it as cost-unknown once its grace expires.
+ *
+ * Never throws. A failed report costs accuracy on one session, and raising
+ * here would fail a test whose subject is the agent, not the billing.
+ */
+export async function reportOpenAIRealtimeUsage(
+  broker: VoiceBrokerConfig,
+  params: {
+    sessionId: string;
+    usage: RealtimeUsage;
+    fetchImpl?: typeof fetch;
+    onError?: (error: unknown) => void;
+  },
+): Promise<void> {
+  if (!params.sessionId) return;
+  const doFetch = params.fetchImpl ?? fetch;
+  try {
+    await doFetch(`${broker.baseUrl}${USAGE_PATH(params.sessionId)}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${broker.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ usage: params.usage }),
+    });
+  } catch (error) {
+    params.onError?.(error);
+  }
+}
+
+/**
+ * The credential, wherever the mint put it.
+ *
+ * OpenAI returns `{ value }` at the top level today and has previously
+ * nested it under `client_secret`, so both are read rather than pinning the
+ * adapter to one release's shape.
+ */
+function readClientSecret(body: Record<string, unknown>): string {
+  if (typeof body.value === "string" && body.value) return body.value;
+  const nested = body.client_secret;
+  if (
+    nested &&
+    typeof nested === "object" &&
+    typeof (nested as Record<string, unknown>).value === "string"
+  ) {
+    return (nested as Record<string, unknown>).value as string;
+  }
+  return "";
+}
+
+/** The session id the gateway echoes into the body, for clients that read it there. */
+function readEchoedSessionId(body: Record<string, unknown>): string {
+  const langwatch = body.langwatch;
+  if (
+    langwatch &&
+    typeof langwatch === "object" &&
+    typeof (langwatch as Record<string, unknown>).session_id === "string"
+  ) {
+    return (langwatch as Record<string, unknown>).session_id as string;
+  }
+  return "";
+}

--- a/javascript/src/voice/broker.ts
+++ b/javascript/src/voice/broker.ts
@@ -53,6 +53,16 @@ const SESSION_ID_HEADER = "x-langwatch-session-id";
 const USAGE_REPORT_TIMEOUT_MS = 5_000;
 
 /**
+ * How long a mint may take before it is abandoned.
+ *
+ * `connect()` waits for this before it opens the socket, so an unbounded
+ * request leaves connection setup pending forever against a stalled endpoint.
+ * Generous rather than tight: a mint is a real round trip to a vendor, and a
+ * session refused for slowness costs a call that would have worked.
+ */
+const MINT_TIMEOUT_MS = 15_000;
+
+/**
  * What a mint attempt produced.
  *
  * `sessionId` is empty unless a gateway answered, because only a gateway
@@ -101,6 +111,7 @@ export async function mintOpenAIRealtimeSession(
     model: string;
     expiresAfterSeconds?: number;
     fetchImpl?: typeof fetch;
+    timeoutMs?: number;
   },
 ): Promise<RealtimeMintResult> {
   const doFetch = params.fetchImpl ?? fetch;
@@ -121,6 +132,7 @@ export async function mintOpenAIRealtimeSession(
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(params.timeoutMs ?? MINT_TIMEOUT_MS),
   });
 
   const text = await response.text();


### PR DESCRIPTION
## What this does

The two realtime voice adapters can now mint their session credential through an OpenAI-compatible endpoint instead of dialing the vendor with a long-lived provider key.

`POST /v1/realtime/client_secrets` is OpenAI's own path. The LangWatch AI Gateway mirrors it. So the same request works against either, and the adapter does not care which one answers:

- Point `OPENAI_BASE_URL` at OpenAI and the vendor mints an ephemeral client secret.
- Point it at a gateway and the gateway checks the virtual key's budget and its open-session cap, mints the vendor's secret, and opens one spend record for the call.

The media socket runs client to vendor in both cases. Audio never crosses the gateway, so latency and the wire protocol do not change.

## No LangWatch-specific configuration

The adapters read only what each vendor's own SDK reads.

| Vendor | Credential | Endpoint |
| --- | --- | --- |
| OpenAI Realtime | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
| ElevenLabs | `ELEVENLABS_API_KEY` | the SDK's own `baseUrl` option |

There is no third URL and no third key. Someone already routing chat through the gateway gets voice with no new configuration at all, which is the same property that made the chat migration a zero-code-change win.

ElevenLabs has no environment variable for the base URL because the SDK has none. `@elevenlabs/elevenlabs-js` 2.64.0 reads exactly one variable, `ELEVENLABS_API_KEY`, and takes the base URL as a constructor option. Inventing one inside the adapter would have been the LangWatch-specific configuration this change removes.

The ElevenLabs demo under `examples/vitest` reads `ELEVENLABS_BASE_URL` itself and passes it to that option, so both demos can be pointed at a gateway with environment alone. That is the demo's own choice, not the adapter's contract.

One usage note that costs a confused hour: the SDK's `baseUrl` is the host root, not the `/v1` prefix. The SDK appends `/v1/...` itself, so a base URL ending in `/v1` produces `/v1/v1/convai/...` and a 404. `OPENAI_BASE_URL` is the opposite and does include `/v1`.

## How the adapter knows a gateway answered

From the response, not from a flag. The gateway names the session it opened on the `X-LangWatch-Session-Id` header and OpenAI does not. If the header is present the adapter posts the socket's usage back to `${OPENAI_BASE_URL}/realtime/sessions/{id}/usage` at disconnect. If it is absent there is no session to report to, so it sends nothing.

Configuration can be wrong about what it is pointed at. A response cannot.

## The two failure paths, which are not the same

**Absence.** A base URL with no mint route answers 404. A LangWatch gateway older than this feature does exactly that. The adapter then dials the vendor directly with `OPENAI_REALTIME_API_KEY` and logs a warning that names the base URL and says the session is not billed. The warning is the point: a silent fallback makes an unbilled run look exactly like a billed one, so a test run that proved nothing would read as a run that proved everything.

**Refusal.** Any other error status comes from an endpoint that does have the route, such as an exhausted budget or a rejected model. That raises. Falling back there would spend a direct provider key on a call the gateway just declined to bill.

`OPENAI_REALTIME_API_KEY` stays what it already was: the fallback credential for a direct dial. It is never used to mint, because presenting it to a gateway offers a credential the gateway did not issue and cannot bill.

## Compatibility

Existing users change nothing.

- Only `OPENAI_REALTIME_API_KEY` set: no key to mint with, so the adapter dials directly as before.
- `OPENAI_API_KEY` set and no base URL: mints at OpenAI, dials with the ephemeral secret. Shorter-lived credential on the socket, same call.
- Both set against an old gateway: 404, direct dial, warning.

## Tests

16 new tests across two files.

- `src/voice/__tests__/broker.test.ts` covers resolution, the mint contract, the 404-versus-refusal split, and that a usage report never throws.
- `src/voice/adapters/__tests__/openai-realtime-mint.test.ts` drives the real adapter against an in-process websocket server and asserts what the socket carried in each of the four outcomes. The gateway case proves neither long-lived key reaches the socket. The refusal case proves no socket is opened at all.

Full suite: 1304 passed, 58 skipped.

## Dogfood

Both vendors ran green through the gateway with direct provider keys stripped from the environment, against the gateway change in langwatch/langwatch#7066.

- ElevenLabs hosted agent: 4 of 4 green, a real conversation, websocket reaching `wss://api.elevenlabs.io`. Billed $0.034666667.
- OpenAI Realtime: 3 of 3 green. Billed $0.0052766.

Both figures agree with what the gateway's own Usage page shows for the same key, to the cent and past it.

The composable ElevenLabs scenario failed with `401 Invalid API key`, which is the control: it is the one path that still wants a direct vendor key, and its failure is what proves the keys were genuinely stripped rather than silently reused.

## Note on the realtime CI lane

`javascript-ci` runs `Test (Examples)` with a direct provider key in `OPENAI_REALTIME_API_KEY`. That key is currently dead and has broken the job on `main` four runs in a row with `Incorrect API key provided`. This is not caused by this PR and this PR does not change it.

The adapter support here is what makes pointing that lane at the gateway possible, the same way the chat lane already runs through it. Doing so is a separate change and a call for the repo owner, so this only states it.

The irony is worth one sentence: the lane that tests voice is the last one still carrying a raw provider key.
