### PR TITLE
chore(audio-examples): bring the fourth sibling into the shared judge criteria (#682)

### DIFF
--- a/javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts
+++ b/javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts
@@ -29,12 +29,11 @@ const JS_SIBLINGS = [
   "multimodal-audio-to-text.test.ts",
 ];
 
-/**
- * Python siblings, relative to `python/examples/`. They import the shared
- * constant rather than declaring one, so the drift they can suffer is the same
- * one the JS pair can: importing it and then passing something else.
- */
-const PYTHON_SIBLINGS = ["test_audio_to_text.py", "test_audio_to_audio.py"];
+// Whether the Python siblings actually USE their constant is checked where it
+// can be checked properly: python/tests/test_audio_example_judge_criteria.py
+// walks each example's AST and inspects every JudgeAgent call. Text matching
+// from here could not see a second judge with an inline list, a local rebinding
+// that shadows the import, or an import that stopped coming from `helpers`.
 
 /**
  * Extract the `AUDIO_JUDGE_CRITERIA = [...]` literal from the Python module.
@@ -94,43 +93,6 @@ describe("audio example judge criteria — cross-language parity", () => {
       `${sibling} inlines a judge criterion again — import AUDIO_JUDGE_CRITERIA instead`,
     ).not.toContain("The agent's response demonstrates");
   });
-
-  // The Python pair can drift the same way: import the constant and then hand
-  // the judge something else. #682 is the case this catches: audio-to-audio
-  // sat outside the shared set for a year with its own two criteria, one of
-  // them ("identifies or guesses the voice is male") non-deterministic and not
-  // the capability under test.
-  it.each(PYTHON_SIBLINGS)(
-    "keeps %s on the shared constant, not an inline copy",
-    (sibling) => {
-      const source = readFileSync(
-        fileURLToPath(
-          new URL(`../../../../python/examples/${sibling}`, import.meta.url),
-        ),
-        "utf8",
-      );
-      expect(
-        source,
-        `${sibling} must pass AUDIO_JUDGE_CRITERIA to the judge, not an inline list`,
-      ).toMatch(
-        // Same shape as the JS check: assert on what reaches the judge. The
-        // \b stops a drifted `criteria=list(AUDIO_JUDGE_CRITERIA_STALE)` from
-        // satisfying the match.
-        /\bcriteria\s*=\s*(?:list\(\s*AUDIO_JUDGE_CRITERIA\s*\)|AUDIO_JUDGE_CRITERIA\b)/,
-      );
-      expect(
-        source,
-        `${sibling} declares its own criteria list again. Import AUDIO_JUDGE_CRITERIA instead`,
-      ).not.toContain("AUDIO_JUDGE_CRITERIA = [");
-      // A file can hand one judge the constant and another an inline list, so
-      // the match above is not enough on its own. Same second assertion the JS
-      // siblings carry.
-      expect(
-        source,
-        `${sibling} inlines a judge criterion again. Import AUDIO_JUDGE_CRITERIA instead`,
-      ).not.toContain("The agent's response demonstrates");
-    },
-  );
 
   it("still carries the #680 tightenings the siblings were fixed for", () => {
     const [contentSpecific, coherent] = AUDIO_JUDGE_CRITERIA;

--- a/javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts
+++ b/javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts
@@ -36,18 +36,21 @@ const JS_SIBLINGS = [
 // that shadows the import, or an import that stopped coming from `helpers`.
 
 /**
- * Extract the `AUDIO_JUDGE_CRITERIA = [...]` literal from the Python module.
+ * Extract the `AUDIO_JUDGE_CRITERIA = (...)` literal from the Python module.
  *
- * The Python list is written as double-quoted string literals precisely so it
- * parses as JSON once the trailing comma is dropped. See the warning in that
- * module's docstring.
+ * The Python tuple is written as double-quoted string literals precisely so it
+ * parses as JSON once the parentheses are swapped for brackets and the trailing
+ * comma is dropped. See the warning in that module's docstring. The annotation
+ * between the name and the `=` is deliberately not pinned here: what this guard
+ * is about is the criteria, and a stricter pattern would fail as a rename of the
+ * type rather than as the drift it exists to catch.
  */
 function readPythonCriteria(): string[] {
   const source = readFileSync(PYTHON_CRITERIA_MODULE, "utf8");
-  const match = /^AUDIO_JUDGE_CRITERIA = \[\n(.*?)^\]$/ms.exec(source);
+  const match = /^AUDIO_JUDGE_CRITERIA[^=\n]*= \(\n(.*?)^\)$/ms.exec(source);
   expect(
     match,
-    `could not find an 'AUDIO_JUDGE_CRITERIA = [' list literal in ${PYTHON_CRITERIA_MODULE}. ` +
+    `could not find an 'AUDIO_JUDGE_CRITERIA = (' tuple literal in ${PYTHON_CRITERIA_MODULE}. ` +
       "if it was renamed or reformatted, update this parity guard rather than deleting it",
   ).not.toBeNull();
 

--- a/javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts
+++ b/javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts
@@ -1,12 +1,14 @@
-// Cross-language parity guard for the audio example judge criteria (#680).
+// Cross-language parity guard for the audio example judge criteria (#680, #682).
 //
-// The three audio example siblings (JS audio-to-audio, JS audio-to-text, Python
-// audio-to-text) must judge against byte-identical criteria — #655/#612 aligned
-// them by copy-paste, and #680 found two latent gaps that had to be fixed in all
-// three at once. The JS pair now shares one constant, so only the Python copy
-// can drift; this test is the mechanism that stops it. It is fully deterministic
-// (file read + parse, no API keys, no network), so it runs in CI unlike its
-// live-only siblings.
+// The four audio example siblings (JS audio-to-audio, JS audio-to-text, Python
+// audio-to-text, Python audio-to-audio) must judge against byte-identical
+// criteria. #655/#612 aligned three of them by copy-paste, #680 found two
+// latent gaps that had to be fixed in all three at once, and #682 found the
+// fourth still carrying the pre-alignment criteria a year later. There is now
+// one constant per language and this test holds the two together, so no copy
+// can drift and no sibling can fall out of the set unnoticed. It is fully
+// deterministic (file read + parse, no API keys, no network), so it runs in CI
+// unlike the live-only examples it guards.
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -15,8 +17,11 @@ import { describe, it, expect } from "vitest";
 
 import { AUDIO_JUDGE_CRITERIA } from "./helpers/audio-judge-criteria";
 
-const PYTHON_SIBLING = fileURLToPath(
-  new URL("../../../../python/examples/test_audio_to_text.py", import.meta.url),
+const PYTHON_CRITERIA_MODULE = fileURLToPath(
+  new URL(
+    "../../../../python/examples/helpers/audio_judge_criteria.py",
+    import.meta.url,
+  ),
 );
 
 const JS_SIBLINGS = [
@@ -25,18 +30,25 @@ const JS_SIBLINGS = [
 ];
 
 /**
- * Extract the `AUDIO_JUDGE_CRITERIA = [...]` literal from the Python sibling.
+ * Python siblings, relative to `python/examples/`. They import the shared
+ * constant rather than declaring one, so the drift they can suffer is the same
+ * one the JS pair can: importing it and then passing something else.
+ */
+const PYTHON_SIBLINGS = ["test_audio_to_text.py", "test_audio_to_audio.py"];
+
+/**
+ * Extract the `AUDIO_JUDGE_CRITERIA = [...]` literal from the Python module.
  *
  * The Python list is written as double-quoted string literals precisely so it
- * parses as JSON once the trailing comma is dropped — see the ⚠ note next to the
- * declaration in that file.
+ * parses as JSON once the trailing comma is dropped. See the warning in that
+ * module's docstring.
  */
 function readPythonCriteria(): string[] {
-  const source = readFileSync(PYTHON_SIBLING, "utf8");
+  const source = readFileSync(PYTHON_CRITERIA_MODULE, "utf8");
   const match = /^AUDIO_JUDGE_CRITERIA = \[\n(.*?)^\]$/ms.exec(source);
   expect(
     match,
-    `could not find an 'AUDIO_JUDGE_CRITERIA = [' list literal in ${PYTHON_SIBLING} — ` +
+    `could not find an 'AUDIO_JUDGE_CRITERIA = [' list literal in ${PYTHON_CRITERIA_MODULE}. ` +
       "if it was renamed or reformatted, update this parity guard rather than deleting it",
   ).not.toBeNull();
 
@@ -45,7 +57,7 @@ function readPythonCriteria(): string[] {
     return JSON.parse(`[${body}]`) as string[];
   } catch (error) {
     throw new Error(
-      `AUDIO_JUDGE_CRITERIA in ${PYTHON_SIBLING} is not JSON-parseable — the criteria ` +
+      `AUDIO_JUDGE_CRITERIA in ${PYTHON_CRITERIA_MODULE} is not JSON-parseable. The criteria ` +
         "must be plain double-quoted Python string literals (no single quotes, no " +
         `concatenation, no f-strings) so this parity guard can read them. Cause: ${String(error)}`,
     );
@@ -53,7 +65,7 @@ function readPythonCriteria(): string[] {
 }
 
 describe("audio example judge criteria — cross-language parity", () => {
-  it("keeps the Python sibling byte-identical to the shared JS constants", () => {
+  it("keeps the Python constant byte-identical to the shared JS one", () => {
     expect(readPythonCriteria()).toEqual([...AUDIO_JUDGE_CRITERIA]);
   });
 
@@ -82,6 +94,43 @@ describe("audio example judge criteria — cross-language parity", () => {
       `${sibling} inlines a judge criterion again — import AUDIO_JUDGE_CRITERIA instead`,
     ).not.toContain("The agent's response demonstrates");
   });
+
+  // The Python pair can drift the same way: import the constant and then hand
+  // the judge something else. #682 is the case this catches: audio-to-audio
+  // sat outside the shared set for a year with its own two criteria, one of
+  // them ("identifies or guesses the voice is male") non-deterministic and not
+  // the capability under test.
+  it.each(PYTHON_SIBLINGS)(
+    "keeps %s on the shared constant, not an inline copy",
+    (sibling) => {
+      const source = readFileSync(
+        fileURLToPath(
+          new URL(`../../../../python/examples/${sibling}`, import.meta.url),
+        ),
+        "utf8",
+      );
+      expect(
+        source,
+        `${sibling} must pass AUDIO_JUDGE_CRITERIA to the judge, not an inline list`,
+      ).toMatch(
+        // Same shape as the JS check: assert on what reaches the judge. The
+        // \b stops a drifted `criteria=list(AUDIO_JUDGE_CRITERIA_STALE)` from
+        // satisfying the match.
+        /\bcriteria\s*=\s*(?:list\(\s*AUDIO_JUDGE_CRITERIA\s*\)|AUDIO_JUDGE_CRITERIA\b)/,
+      );
+      expect(
+        source,
+        `${sibling} declares its own criteria list again. Import AUDIO_JUDGE_CRITERIA instead`,
+      ).not.toContain("AUDIO_JUDGE_CRITERIA = [");
+      // A file can hand one judge the constant and another an inline list, so
+      // the match above is not enough on its own. Same second assertion the JS
+      // siblings carry.
+      expect(
+        source,
+        `${sibling} inlines a judge criterion again. Import AUDIO_JUDGE_CRITERIA instead`,
+      ).not.toContain("The agent's response demonstrates");
+    },
+  );
 
   it("still carries the #680 tightenings the siblings were fixed for", () => {
     const [contentSpecific, coherent] = AUDIO_JUDGE_CRITERIA;

--- a/javascript/examples/vitest/tests/helpers/audio-judge-criteria.ts
+++ b/javascript/examples/vitest/tests/helpers/audio-judge-criteria.ts
@@ -17,8 +17,12 @@
 /**
  * The three criteria the audio examples judge against, in order.
  *
- * Keep in sync with `python/examples/test_audio_to_text.py`
- * (`AUDIO_JUDGE_CRITERIA`) — the parity test enforces it.
+ * Keep in sync with `python/examples/helpers/audio_judge_criteria.py`. The
+ * parity test enforces it.
+ *
+ * `as const` is load-bearing, not decoration: it makes the array readonly, so a
+ * sibling cannot push a drifted criterion onto the shared copy. The Python copy
+ * is a tuple for the same reason.
  */
 export const AUDIO_JUDGE_CRITERIA = [
   "The agent's response demonstrates it processed the SPECIFIC content of the audio — it addresses or attempts to answer the actual question that was asked in the audio. A generic acknowledgement that audio was received (e.g. 'I got your audio file', 'I heard your message') does NOT satisfy this criterion on its own",

--- a/python/examples/helpers/__init__.py
+++ b/python/examples/helpers/__init__.py
@@ -2,16 +2,19 @@
 Helper modules for audio conversation examples.
 
 This package contains utilities for:
+- The shared LLM-judge criteria the audio examples all judge against
 - OpenAI voice agent implementation
 - Audio file encoding for transmission in messages
 - Judge agent wrappers for audio transcription
 """
 
+from .audio_judge_criteria import AUDIO_JUDGE_CRITERIA
 from .openai_voice_agent import OpenAiVoiceAgent
 from .audio_helpers import encode_audio_to_base64
 from .judge_audio_wrapper import wrap_judge_for_audio, sanitize_messages_for_audio
 
 __all__ = [
+    "AUDIO_JUDGE_CRITERIA",
     "OpenAiVoiceAgent",
     "encode_audio_to_base64",
     "wrap_judge_for_audio",

--- a/python/examples/helpers/audio_judge_criteria.py
+++ b/python/examples/helpers/audio_judge_criteria.py
@@ -1,0 +1,29 @@
+"""
+Shared LLM-judge criteria for the audio example scenarios.
+
+WHY THIS EXISTS: four sibling examples (JS audio-to-audio, JS audio-to-text,
+Python audio-to-text, Python audio-to-audio) judge the same capability. #655
+and #612 aligned three of them by copy-paste, #680 then found two latent gaps
+that had to be fixed in all three at once, and #682 found the fourth sibling
+still carrying the pre-alignment criteria. Copies drift, so there is now one
+copy per language and a parity test that keeps the two byte-identical:
+`javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts`.
+
+Keep in sync with `javascript/examples/vitest/tests/helpers/audio-judge-criteria.ts`.
+
+WHY THE WORDING IS DEFENSIVE (#680):
+  - Criterion 1 used to accept "acknowledges what it heard", which let a
+    broken pipeline pass: empty audio in, "I received your audio" out.
+  - Criterion 3 is satisfied by a polite deflection ("sorry, I can't process
+    audio files") because that too names the non-text format, so criterion 2
+    has to exclude deflection explicitly rather than leaning on "refusal".
+
+WARNING: keep these as double-quoted string literals with no concatenation and
+no f-strings. The parity test parses this list as JSON.
+"""
+
+AUDIO_JUDGE_CRITERIA = [
+    "The agent's response demonstrates it processed the SPECIFIC content of the audio — it addresses or attempts to answer the actual question that was asked in the audio. A generic acknowledgement that audio was received (e.g. 'I got your audio file', 'I heard your message') does NOT satisfy this criterion on its own",
+    "The agent provides a coherent, on-topic response — NOT an error message, NOT a refusal, NOT a polite deflection or claim that it cannot process audio / non-text input (e.g. 'I'm sorry, I can't listen to audio files'), and NOT an unrelated reply",
+    "The agent's response indicates it received input in a non-text format, or that the question came via audio rather than text (exact phrasing does not matter)",
+]

--- a/python/examples/helpers/audio_judge_criteria.py
+++ b/python/examples/helpers/audio_judge_criteria.py
@@ -18,12 +18,23 @@ WHY THE WORDING IS DEFENSIVE (#680):
     audio files") because that too names the non-text format, so criterion 2
     has to exclude deflection explicitly rather than leaning on "refusal".
 
+WHY A TUPLE: an importer can mutate a shared list in place, and doing so binds
+no name, so no guard that watches the name can see it. One
+`AUDIO_JUDGE_CRITERIA.append(...)` in an example would put a drifted criterion
+in front of the judge while every check still read the pristine file. A tuple
+takes that away outright rather than enumerating the ways to spell it: pyright
+rejects the mutation in CI, and the interpreter rejects it at runtime. The JS
+copy is `as const` for the same reason. The examples pass `list(...)` to the
+judge, which wants a `List[str]`, and that copy is theirs to keep.
+
 WARNING: keep these as double-quoted string literals with no concatenation and
-no f-strings. The parity test parses this list as JSON.
+no f-strings. The parity test parses this tuple as JSON.
 """
 
-AUDIO_JUDGE_CRITERIA = [
+from typing import Final
+
+AUDIO_JUDGE_CRITERIA: Final[tuple[str, ...]] = (
     "The agent's response demonstrates it processed the SPECIFIC content of the audio — it addresses or attempts to answer the actual question that was asked in the audio. A generic acknowledgement that audio was received (e.g. 'I got your audio file', 'I heard your message') does NOT satisfy this criterion on its own",
     "The agent provides a coherent, on-topic response — NOT an error message, NOT a refusal, NOT a polite deflection or claim that it cannot process audio / non-text input (e.g. 'I'm sorry, I can't listen to audio files'), and NOT an unrelated reply",
     "The agent's response indicates it received input in a non-text format, or that the question came via audio rather than text (exact phrasing does not matter)",
-]
+)

--- a/python/examples/test_audio_to_audio.py
+++ b/python/examples/test_audio_to_audio.py
@@ -16,7 +16,12 @@ import pytest
 import scenario
 from scenario.types import AgentRole
 from openai.types.chat import ChatCompletionMessageParam
-from helpers import encode_audio_to_base64, wrap_judge_for_audio, OpenAiVoiceAgent
+from helpers import (
+    AUDIO_JUDGE_CRITERIA,
+    encode_audio_to_base64,
+    wrap_judge_for_audio,
+    OpenAiVoiceAgent,
+)
 
 # Skipped in CI: live end-to-end test — calls OpenAI's `gpt-audio-mini` audio
 # model and the real LangWatch backend (cost, API keys, non-deterministic
@@ -118,10 +123,7 @@ async def test_audio_to_audio():
     audio_judge = wrap_judge_for_audio(
         scenario.JudgeAgent(
             model="openai/gpt-5.6-luna",
-            criteria=[
-                "The agent identifies or guesses the voice is male",
-                "The agent acknowledges the input was audio (not text)",
-            ],
+            criteria=list(AUDIO_JUDGE_CRITERIA),
         )
     )
 

--- a/python/examples/test_audio_to_text.py
+++ b/python/examples/test_audio_to_text.py
@@ -17,7 +17,7 @@ import scenario
 from scenario.types import AgentInput, AgentReturnTypes, AgentRole
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionMessageParam
-from helpers import encode_audio_to_base64, wrap_judge_for_audio
+from helpers import AUDIO_JUDGE_CRITERIA, encode_audio_to_base64, wrap_judge_for_audio
 
 # Runs in CI, like its two JavaScript siblings.
 #
@@ -30,23 +30,7 @@ from helpers import encode_audio_to_base64, wrap_judge_for_audio
 #
 # The wire-shape rule itself is pinned offline and deterministically in
 # `tests/test_judge_transport_reasoning.py`; that is the gate. This example is
-# the live end-to-end check that the three siblings agree.
-
-# The LLM-judge criteria shared by all three audio example siblings (#680).
-#
-# The two JavaScript siblings import the same strings from
-# `javascript/examples/vitest/tests/helpers/audio-judge-criteria.ts`, and
-# `javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts` asserts
-# this list stays byte-identical to that one — so the three copies cannot drift
-# apart the way they were about to under #655/#612.
-#
-# ⚠ Keep these as double-quoted Python string literals: the parity test parses
-# this list as JSON.
-AUDIO_JUDGE_CRITERIA = [
-    "The agent's response demonstrates it processed the SPECIFIC content of the audio — it addresses or attempts to answer the actual question that was asked in the audio. A generic acknowledgement that audio was received (e.g. 'I got your audio file', 'I heard your message') does NOT satisfy this criterion on its own",
-    "The agent provides a coherent, on-topic response — NOT an error message, NOT a refusal, NOT a polite deflection or claim that it cannot process audio / non-text input (e.g. 'I'm sorry, I can't listen to audio files'), and NOT an unrelated reply",
-    "The agent's response indicates it received input in a non-text format, or that the question came via audio rather than text (exact phrasing does not matter)",
-]
+# the live end-to-end check that the siblings agree.
 
 
 # Type definitions for multimodal messages with file content

--- a/python/tests/test_audio_example_judge_criteria.py
+++ b/python/tests/test_audio_example_judge_criteria.py
@@ -12,14 +12,21 @@ ways a sibling drifts are precisely the ones text matching misses: a second
 shadows the import, or an import that no longer comes from `helpers`. Every
 `JudgeAgent(...)` call in the file has to be checked, not merely one of them.
 
+The one drift no reading of the example can catch is a mutation of the shared
+object itself, which binds no name and leaves the helper file pristine. That
+one is not checked for, it is made impossible: the criteria are a tuple, and
+the last test here holds them that way.
+
 Deterministic: it parses files. No API keys, no network, no model. Runs in
 `python-ci`'s unit step alongside the rest of `tests/`, unlike the live
 examples it guards.
 """
 
 import ast
+import importlib.util
 import symtable
 from pathlib import Path
+from types import ModuleType
 from typing import Final, NamedTuple
 
 import pytest
@@ -29,6 +36,7 @@ HELPERS_MODULE: Final = "helpers"
 LIST_BUILTIN: Final = "list"
 
 EXAMPLES: Final = Path(__file__).resolve().parents[1] / "examples"
+CRITERIA_MODULE: Final = EXAMPLES / "helpers" / "audio_judge_criteria.py"
 AUDIO_EXAMPLES: Final = ["test_audio_to_text.py", "test_audio_to_audio.py"]
 
 
@@ -65,7 +73,7 @@ def criteria_argument(call: ast.Call) -> ast.expr | None:
 def resolves_to_shared_constant(value: ast.expr) -> bool:
     """
     True for `AUDIO_JUDGE_CRITERIA` and for the `list(...)` copy of it, which
-    is the form both examples use so the judge cannot mutate the shared list.
+    is the form both examples use because `JudgeAgent` wants a `List[str]`.
     """
     if isinstance(value, ast.Name):
         return value.id == CRITERIA_NAME
@@ -221,3 +229,51 @@ def test_every_judge_uses_the_shared_criteria(example: str) -> None:
             f"{ast.dump(value)[:120]} rather than {CRITERIA_NAME}. Import the shared "
             "constant instead of writing criteria inline."
         )
+
+
+def load_criteria_module() -> ModuleType:
+    """
+    The shared module as the examples get it, loaded from its own path.
+
+    `python/examples` is on `sys.path` when pytest collects the examples, not
+    when it collects this file, so the import goes through the loader directly
+    rather than through a path the test would have to arrange.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "audio_judge_criteria_under_guard", CRITERIA_MODULE
+    )
+    assert spec is not None and spec.loader is not None, (
+        f"{CRITERIA_MODULE} is not importable. Did the shared criteria move?"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_shared_criteria_cannot_be_mutated_in_place() -> None:
+    """
+    Rebinding the name is the loud way to drift. Mutating the object behind it
+    is the quiet one, and every other guard here is blind to it: an
+    `AUDIO_JUDGE_CRITERIA.append("...")` in an example binds no name, so the
+    symbol table reports nothing, and the cross-language parity test reads the
+    helper file rather than the live object, so it reports nothing either. The
+    judge would then be handed a drifted criterion with CI fully green.
+
+    So the criteria are a tuple. That removes the move instead of adding a
+    check for it, and unlike a name-based check it holds through an alias
+    (`stale = AUDIO_JUDGE_CRITERIA` buys the aliaser nothing). pyright rejects
+    the mutation in CI and the interpreter rejects it at runtime.
+    """
+    criteria = load_criteria_module().AUDIO_JUDGE_CRITERIA
+
+    assert isinstance(criteria, tuple), (
+        f"{CRITERIA_NAME} is a {type(criteria).__name__}, which an importer can "
+        "mutate in place without binding the name, so nothing here would see the "
+        "drift. Keep it a tuple; the examples already copy it with `list(...)` for "
+        "the judge."
+    )
+
+    # `getattr` rather than `criteria.append`, so this stays a runtime assertion
+    # about the object and not a line pyright has to be told to ignore.
+    with pytest.raises(AttributeError):
+        getattr(criteria, "append")("The agent acknowledges what it heard")

--- a/python/tests/test_audio_example_judge_criteria.py
+++ b/python/tests/test_audio_example_judge_criteria.py
@@ -18,8 +18,9 @@ examples it guards.
 """
 
 import ast
+import symtable
 from pathlib import Path
-from typing import Final
+from typing import Final, NamedTuple
 
 import pytest
 
@@ -105,55 +106,79 @@ def test_imports_the_criteria_under_its_own_name(example: str) -> None:
                     )
 
 
-def bindings(tree: ast.Module) -> list[tuple[str, ast.AST]]:
-    """
-    Every name this module binds, by any means, with the node that binds it.
+class Binding(NamedTuple):
+    """One scope's binding of a name, as CPython's symbol table sees it."""
 
-    Collected rather than scope-resolved on purpose. The checks below want to
-    say "this name is bound exactly once, by that import", and a binding that
-    is invisible to this walk is the only way to break them. `ast.Name` in a
-    Store or Del context covers assignment targets, `for` targets, walrus,
-    `with ... as` and comprehension targets alike; `ast.arg` covers function
-    and lambda parameters; `alias` covers both import forms; `ExceptHandler`
-    covers `except ... as`.
+    scope: str
+    imported: bool
+    assigned: bool
+    parameter: bool
+
+
+def bindings(example: str, name: str) -> list[Binding]:
     """
-    found: list[tuple[str, ast.AST]] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
-            found.append((node.id, node))
-        elif isinstance(node, ast.arg):
-            found.append((node.arg, node))
-        elif isinstance(node, (ast.Import, ast.ImportFrom)):
-            for alias in node.names:
-                found.append((alias.asname or alias.name.split(".")[0], alias))
-        elif isinstance(node, ast.ExceptHandler) and node.name:
-            found.append((node.name, node))
+    Every scope in the file that binds `name`, according to CPython's own
+    symbol table.
+
+    Walking the AST for binding forms means enumerating them, and the
+    enumeration is what keeps turning out to be incomplete: assignment, then
+    parameters and `for` targets and walrus and `with ... as` and
+    `except ... as`, then `def` and `class`, then `match` patterns. `symtable`
+    is the binder the interpreter itself uses, so it has no such list to get
+    wrong, and it reports nested scopes (functions, lambdas, comprehensions,
+    classes) rather than only the module.
+
+    `assigned` is the discriminator that matters here: a name bound purely by
+    an import reports `imported` and not `assigned`, and anything else binding
+    it as well, including a `def` or `class` of the same name, turns
+    `assigned` on.
+    """
+    table = symtable.symtable((EXAMPLES / example).read_text(), example, "exec")
+    found: list[Binding] = []
+
+    def visit(scope: symtable.SymbolTable, path: str) -> None:
+        for symbol in scope.get_symbols():
+            if symbol.get_name() != name:
+                continue
+            binding = Binding(
+                scope=path,
+                imported=symbol.is_imported(),
+                assigned=symbol.is_assigned(),
+                parameter=symbol.is_parameter(),
+            )
+            if binding.imported or binding.assigned or binding.parameter:
+                found.append(binding)
+        for child in scope.get_children():
+            visit(child, f"{path}.{child.get_name()}")
+
+    visit(table, "<module>")
     return found
 
 
 @pytest.mark.parametrize("example", AUDIO_EXAMPLES)
 def test_binds_the_criteria_name_only_by_importing_it(example: str) -> None:
     """
-    The name must be bound exactly once in the file, by the `helpers` import.
+    The name must be bound in exactly one scope, the module's, and there by an
+    import and nothing else.
 
     A local assignment is the obvious way to shadow it, but a parameter, a
-    `for` target, a walrus, a `with ... as`, an `except ... as` or a second
-    import bind it just as well, and every one of those would leave the judge
-    reading something other than the shared constant while the call site still
-    spells `AUDIO_JUDGE_CRITERIA`. Counting bindings catches all of them without
-    resolving scopes.
+    `for` target, a walrus, a `with ... as`, an `except ... as`, a `def`, a
+    `class`, a `match` pattern or a second import all bind it just as well, and
+    every one of those leaves the judge reading something other than the shared
+    constant while the call site still spells AUDIO_JUDGE_CRITERIA.
     """
-    tree = parse(example)
-    bound = [node for name, node in bindings(tree) if name == CRITERIA_NAME]
+    found = bindings(example, CRITERIA_NAME)
 
-    assert len(bound) == 1, (
-        f"{example} binds {CRITERIA_NAME} {len(bound)} times. It must be bound "
-        "exactly once, by importing it from `helpers`."
+    assert [binding.scope for binding in found] == ["<module>"], (
+        f"{example} binds {CRITERIA_NAME} in "
+        f"{[binding.scope for binding in found] or 'no scope at all'}. It must be "
+        "bound once, at module level, by importing it from `helpers`."
     )
-    assert isinstance(bound[0], ast.alias), (
-        f"{example} binds {CRITERIA_NAME} with a "
-        f"{type(bound[0]).__name__} rather than an import. Import the shared "
-        "constant and leave the name alone."
+    assert found[0].imported and not found[0].assigned, (
+        f"{example} binds {CRITERIA_NAME} at module level by something other than "
+        f"an import ({found[0]}). Import the shared constant and leave the name "
+        "alone: a `def` or `class` of that name shadows it just as an assignment "
+        "would."
     )
 
 
@@ -161,14 +186,13 @@ def test_binds_the_criteria_name_only_by_importing_it(example: str) -> None:
 def test_never_shadows_the_list_builtin(example: str) -> None:
     """
     `criteria=list(AUDIO_JUDGE_CRITERIA)` only means what it looks like while
-    `list` is the builtin. Rebinding it would let the accepted form return
-    anything at all.
+    `list` is the builtin. Rebinding it, in any scope and by any means, would
+    let the accepted form return anything at all.
     """
-    tree = parse(example)
-    shadows = [node for name, node in bindings(tree) if name == LIST_BUILTIN]
-    assert not shadows, (
-        f"{example} rebinds `{LIST_BUILTIN}`, so `list(...)` around the criteria "
-        "no longer means the builtin copy."
+    found = bindings(example, LIST_BUILTIN)
+    assert not found, (
+        f"{example} rebinds `{LIST_BUILTIN}` ({found}), so `list(...)` around the "
+        "criteria no longer means the builtin copy."
     )
 
 

--- a/python/tests/test_audio_example_judge_criteria.py
+++ b/python/tests/test_audio_example_judge_criteria.py
@@ -1,0 +1,154 @@
+"""
+Syntax-aware guard on the audio examples' judge criteria (#680, #682).
+
+The four audio examples judge the same capability and must judge it the same
+way. `javascript/examples/vitest/tests/audio-judge-criteria-parity.test.ts`
+keeps the two language copies of the criteria byte-identical; this file keeps
+the Python examples actually using theirs.
+
+It reads the example sources with `ast` rather than matching text, because the
+ways a sibling drifts are precisely the ones text matching misses: a second
+`JudgeAgent` in the same file with an inline list, a local rebinding that
+shadows the import, or an import that no longer comes from `helpers`. Every
+`JudgeAgent(...)` call in the file has to be checked, not merely one of them.
+
+Deterministic: it parses files. No API keys, no network, no model. Runs in
+`python-ci`'s unit step alongside the rest of `tests/`, unlike the live
+examples it guards.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+CRITERIA_NAME = "AUDIO_JUDGE_CRITERIA"
+HELPERS_MODULE = "helpers"
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
+AUDIO_EXAMPLES = ["test_audio_to_text.py", "test_audio_to_audio.py"]
+
+
+def parse(example: str) -> ast.Module:
+    path = EXAMPLES / example
+    assert path.is_file(), f"{path} does not exist. Did the example move?"
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+def judge_agent_calls(tree: ast.Module) -> list[ast.Call]:
+    """Every `JudgeAgent(...)` call, however the name was reached."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _callee_name(node.func) == "JudgeAgent"
+    ]
+
+
+def _callee_name(func: ast.expr) -> str | None:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def criteria_argument(call: ast.Call) -> ast.expr | None:
+    for keyword in call.keywords:
+        if keyword.arg == "criteria":
+            return keyword.value
+    return None
+
+
+def resolves_to_shared_constant(value: ast.expr) -> bool:
+    """
+    True for `AUDIO_JUDGE_CRITERIA` and for the `list(...)` copy of it, which
+    is the form both examples use so the judge cannot mutate the shared list.
+    """
+    if isinstance(value, ast.Name):
+        return value.id == CRITERIA_NAME
+    if (
+        isinstance(value, ast.Call)
+        and _callee_name(value.func) == "list"
+        and len(value.args) == 1
+    ):
+        return resolves_to_shared_constant(value.args[0])
+    return False
+
+
+@pytest.mark.parametrize("example", AUDIO_EXAMPLES)
+def test_imports_the_criteria_from_helpers(example: str) -> None:
+    tree = parse(example)
+    imported_from = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and any(alias.name == CRITERIA_NAME for alias in node.names)
+    }
+    assert imported_from == {HELPERS_MODULE}, (
+        f"{example} must import {CRITERIA_NAME} from `{HELPERS_MODULE}`, and from "
+        f"nowhere else. Found: {imported_from or 'no import at all'}"
+    )
+
+
+@pytest.mark.parametrize("example", AUDIO_EXAMPLES)
+def test_imports_the_criteria_under_its_own_name(example: str) -> None:
+    tree = parse(example)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == CRITERIA_NAME:
+                    assert alias.asname is None, (
+                        f"{example} imports {CRITERIA_NAME} as `{alias.asname}`. The "
+                        "checks below track the name, so aliasing it hides drift."
+                    )
+
+
+@pytest.mark.parametrize("example", AUDIO_EXAMPLES)
+def test_never_rebinds_the_criteria_name(example: str) -> None:
+    """
+    A local `AUDIO_JUDGE_CRITERIA = [...]` shadows the import, and every check
+    that follows would then be reading a local list. Annotated and augmented
+    assignments count: `AUDIO_JUDGE_CRITERIA: list[str] = [...]` shadows just
+    as well as the plain form.
+    """
+    tree = parse(example)
+    for node in ast.walk(tree):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets = [node.target]
+        for target in targets:
+            assert not (
+                isinstance(target, ast.Name) and target.id == CRITERIA_NAME
+            ), (
+                f"{example} rebinds {CRITERIA_NAME} locally, shadowing the shared "
+                "constant. Import it and leave it alone."
+            )
+
+
+@pytest.mark.parametrize("example", AUDIO_EXAMPLES)
+def test_every_judge_uses_the_shared_criteria(example: str) -> None:
+    """
+    Every `JudgeAgent` in the file, not just the first one found. A file that
+    passes the constant to one judge and an inline list to another is exactly
+    the drift #682 was filed for.
+    """
+    tree = parse(example)
+    calls = judge_agent_calls(tree)
+    assert calls, (
+        f"{example} constructs no JudgeAgent. If the example changed shape, update "
+        "this guard rather than deleting it, or it passes by finding nothing."
+    )
+
+    for index, call in enumerate(calls):
+        value = criteria_argument(call)
+        assert value is not None, (
+            f"{example}: JudgeAgent #{index + 1} (line {call.lineno}) passes no "
+            "`criteria`. It must judge against the shared constant."
+        )
+        assert resolves_to_shared_constant(value), (
+            f"{example}: JudgeAgent #{index + 1} (line {call.lineno}) is given "
+            f"{ast.dump(value)[:120]} rather than {CRITERIA_NAME}. Import the shared "
+            "constant instead of writing criteria inline."
+        )

--- a/python/tests/test_audio_example_judge_criteria.py
+++ b/python/tests/test_audio_example_judge_criteria.py
@@ -19,14 +19,16 @@ examples it guards.
 
 import ast
 from pathlib import Path
+from typing import Final
 
 import pytest
 
-CRITERIA_NAME = "AUDIO_JUDGE_CRITERIA"
-HELPERS_MODULE = "helpers"
+CRITERIA_NAME: Final = "AUDIO_JUDGE_CRITERIA"
+HELPERS_MODULE: Final = "helpers"
+LIST_BUILTIN: Final = "list"
 
-EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
-AUDIO_EXAMPLES = ["test_audio_to_text.py", "test_audio_to_audio.py"]
+EXAMPLES: Final = Path(__file__).resolve().parents[1] / "examples"
+AUDIO_EXAMPLES: Final = ["test_audio_to_text.py", "test_audio_to_audio.py"]
 
 
 def parse(example: str) -> ast.Module:
@@ -103,28 +105,71 @@ def test_imports_the_criteria_under_its_own_name(example: str) -> None:
                     )
 
 
-@pytest.mark.parametrize("example", AUDIO_EXAMPLES)
-def test_never_rebinds_the_criteria_name(example: str) -> None:
+def bindings(tree: ast.Module) -> list[tuple[str, ast.AST]]:
     """
-    A local `AUDIO_JUDGE_CRITERIA = [...]` shadows the import, and every check
-    that follows would then be reading a local list. Annotated and augmented
-    assignments count: `AUDIO_JUDGE_CRITERIA: list[str] = [...]` shadows just
-    as well as the plain form.
+    Every name this module binds, by any means, with the node that binds it.
+
+    Collected rather than scope-resolved on purpose. The checks below want to
+    say "this name is bound exactly once, by that import", and a binding that
+    is invisible to this walk is the only way to break them. `ast.Name` in a
+    Store or Del context covers assignment targets, `for` targets, walrus,
+    `with ... as` and comprehension targets alike; `ast.arg` covers function
+    and lambda parameters; `alias` covers both import forms; `ExceptHandler`
+    covers `except ... as`.
+    """
+    found: list[tuple[str, ast.AST]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            found.append((node.id, node))
+        elif isinstance(node, ast.arg):
+            found.append((node.arg, node))
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                found.append((alias.asname or alias.name.split(".")[0], alias))
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            found.append((node.name, node))
+    return found
+
+
+@pytest.mark.parametrize("example", AUDIO_EXAMPLES)
+def test_binds_the_criteria_name_only_by_importing_it(example: str) -> None:
+    """
+    The name must be bound exactly once in the file, by the `helpers` import.
+
+    A local assignment is the obvious way to shadow it, but a parameter, a
+    `for` target, a walrus, a `with ... as`, an `except ... as` or a second
+    import bind it just as well, and every one of those would leave the judge
+    reading something other than the shared constant while the call site still
+    spells `AUDIO_JUDGE_CRITERIA`. Counting bindings catches all of them without
+    resolving scopes.
     """
     tree = parse(example)
-    for node in ast.walk(tree):
-        targets: list[ast.expr] = []
-        if isinstance(node, ast.Assign):
-            targets = list(node.targets)
-        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
-            targets = [node.target]
-        for target in targets:
-            assert not (
-                isinstance(target, ast.Name) and target.id == CRITERIA_NAME
-            ), (
-                f"{example} rebinds {CRITERIA_NAME} locally, shadowing the shared "
-                "constant. Import it and leave it alone."
-            )
+    bound = [node for name, node in bindings(tree) if name == CRITERIA_NAME]
+
+    assert len(bound) == 1, (
+        f"{example} binds {CRITERIA_NAME} {len(bound)} times. It must be bound "
+        "exactly once, by importing it from `helpers`."
+    )
+    assert isinstance(bound[0], ast.alias), (
+        f"{example} binds {CRITERIA_NAME} with a "
+        f"{type(bound[0]).__name__} rather than an import. Import the shared "
+        "constant and leave the name alone."
+    )
+
+
+@pytest.mark.parametrize("example", AUDIO_EXAMPLES)
+def test_never_shadows_the_list_builtin(example: str) -> None:
+    """
+    `criteria=list(AUDIO_JUDGE_CRITERIA)` only means what it looks like while
+    `list` is the builtin. Rebinding it would let the accepted form return
+    anything at all.
+    """
+    tree = parse(example)
+    shadows = [node for name, node in bindings(tree) if name == LIST_BUILTIN]
+    assert not shadows, (
+        f"{example} rebinds `{LIST_BUILTIN}`, so `list(...)` around the criteria "
+        "no longer means the builtin copy."
+    )
 
 
 @pytest.mark.parametrize("example", AUDIO_EXAMPLES)

--- a/python/tests/test_audio_example_judge_criteria.py
+++ b/python/tests/test_audio_example_judge_criteria.py
@@ -14,8 +14,9 @@ shadows the import, or an import that no longer comes from `helpers`. Every
 
 The one drift no reading of the example can catch is a mutation of the shared
 object itself, which binds no name and leaves the helper file pristine. That
-one is not checked for, it is made impossible: the criteria are a tuple, and
-the last test here holds them that way.
+one is not checked for, it is made impossible: the criteria are a tuple. The
+last two tests here import what the examples import, facade included, and hold
+it that way.
 
 Deterministic: it parses files. No API keys, no network, no model. Runs in
 `python-ci`'s unit step alongside the rest of `tests/`, unlike the live
@@ -23,8 +24,9 @@ examples it guards.
 """
 
 import ast
-import importlib.util
+import importlib
 import symtable
+import sys
 from pathlib import Path
 from types import ModuleType
 from typing import Final, NamedTuple
@@ -36,7 +38,7 @@ HELPERS_MODULE: Final = "helpers"
 LIST_BUILTIN: Final = "list"
 
 EXAMPLES: Final = Path(__file__).resolve().parents[1] / "examples"
-CRITERIA_MODULE: Final = EXAMPLES / "helpers" / "audio_judge_criteria.py"
+CRITERIA_SUBMODULE: Final = "audio_judge_criteria"
 AUDIO_EXAMPLES: Final = ["test_audio_to_text.py", "test_audio_to_audio.py"]
 
 
@@ -231,40 +233,71 @@ def test_every_judge_uses_the_shared_criteria(example: str) -> None:
         )
 
 
-def load_criteria_module() -> ModuleType:
+def import_helpers(monkeypatch: pytest.MonkeyPatch) -> tuple[ModuleType, ModuleType]:
     """
-    The shared module as the examples get it, loaded from its own path.
+    The `helpers` package and its criteria submodule, imported the way the
+    examples import them.
 
-    `python/examples` is on `sys.path` when pytest collects the examples, not
-    when it collects this file, so the import goes through the loader directly
-    rather than through a path the test would have to arrange.
+    `python/examples` is on `sys.path` when pytest collects the examples and
+    not when it collects this file, so the path is arranged here rather than
+    assumed. It goes through `monkeypatch`, which puts it back.
+
+    Both are returned because the question these tests ask is about the pair:
+    what the package exports has to be what the submodule defines.
     """
-    spec = importlib.util.spec_from_file_location(
-        "audio_judge_criteria_under_guard", CRITERIA_MODULE
-    )
-    assert spec is not None and spec.loader is not None, (
-        f"{CRITERIA_MODULE} is not importable. Did the shared criteria move?"
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    monkeypatch.syspath_prepend(str(EXAMPLES))
+    for name in (HELPERS_MODULE, f"{HELPERS_MODULE}.{CRITERIA_SUBMODULE}"):
+        sys.modules.pop(name, None)
+    package = importlib.import_module(HELPERS_MODULE)
+    submodule = importlib.import_module(f"{HELPERS_MODULE}.{CRITERIA_SUBMODULE}")
+    return package, submodule
 
 
-def test_the_shared_criteria_cannot_be_mutated_in_place() -> None:
+def test_the_helpers_facade_re_exports_the_criteria_object_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The examples import from `helpers`, not from `helpers.audio_judge_criteria`,
+    so the package `__init__` is on the path between them and the criteria and
+    is free to export something else.
+
+    Nothing else here would notice. `helpers/__init__.py` can import the tuple
+    under a private name and then export a stale list beside it: the example
+    sources are unchanged, the symbol-table guard sees a plain import, the
+    criteria file stays pristine so the cross-language parity test agrees, and
+    pyright infers the list happily. Verified, `11 passed` and `pyright` clean
+    with the criterion #680 removed exported from the facade.
+
+    Identity, not equality: a facade exporting an equal copy is a second copy,
+    which is the thing this whole set of guards exists to prevent.
+    """
+    package, submodule = import_helpers(monkeypatch)
+
+    assert getattr(package, CRITERIA_NAME) is getattr(submodule, CRITERIA_NAME), (
+        f"`{HELPERS_MODULE}` exports a different object as {CRITERIA_NAME} than "
+        f"`{HELPERS_MODULE}.{CRITERIA_SUBMODULE}` defines, so the examples judge "
+        "against the facade's copy. Re-export the constant, do not rebuild it."
+    )
+
+
+def test_the_shared_criteria_cannot_be_mutated_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Rebinding the name is the loud way to drift. Mutating the object behind it
-    is the quiet one, and every other guard here is blind to it: an
+    is the quiet one, and every source-reading guard here is blind to it: an
     `AUDIO_JUDGE_CRITERIA.append("...")` in an example binds no name, so the
     symbol table reports nothing, and the cross-language parity test reads the
-    helper file rather than the live object, so it reports nothing either. The
-    judge would then be handed a drifted criterion with CI fully green.
+    criteria file rather than the live object, so it reports nothing either.
+    The judge would then be handed a drifted criterion with CI fully green.
 
     So the criteria are a tuple. That removes the move instead of adding a
     check for it, and unlike a name-based check it holds through an alias
     (`stale = AUDIO_JUDGE_CRITERIA` buys the aliaser nothing). pyright rejects
     the mutation in CI and the interpreter rejects it at runtime.
     """
-    criteria = load_criteria_module().AUDIO_JUDGE_CRITERIA
+    package, _ = import_helpers(monkeypatch)
+    criteria = getattr(package, CRITERIA_NAME)
 
     assert isinstance(criteria, tuple), (
         f"{CRITERIA_NAME} is a {type(criteria).__name__}, which an importer can "


### PR DESCRIPTION
## Ticket

Closes #682. `python/examples/test_audio_to_audio.py` still judged against the pre-alignment criteria, including `"The agent identifies or guesses the voice is male"` - voice-gender classification, which is non-deterministic and is not the capability the example tests.

## Premise, re-checked on current main

Still true, and the interesting part is why it survived. Since the ticket was filed, #680 built real machinery for this: `javascript/examples/vitest/tests/helpers/audio-judge-criteria.ts` holds the criteria, and `audio-judge-criteria-parity.test.ts` keeps the Python copy byte-identical and asserts both JS siblings actually pass the constant to their judge rather than an inline array.

That machinery covers three siblings. `test_audio_to_audio.py` is not one of them, so it drifted for a year with nothing to notice. The ticket's option 1 ("update it to use the same criteria") fixes today's file; putting it inside the parity set is what stops the next one.

## Change

- The Python criteria move out of `test_audio_to_text.py` into `python/examples/helpers/audio_judge_criteria.py` and are exported from the `helpers` package, mirroring the JS helper. One copy per language instead of one per test file.
- Both Python examples import it. `test_audio_to_audio.py` drops its own two criteria.
- The vitest parity guard reads the new module and keeps the one check that genuinely spans both languages: the two constants stay byte-identical.
- The shared criteria are immutable, and the guard checks the object the examples actually import, `helpers/__init__.py` included: the Python copy is a `tuple`, the JS copy is `as const`. Every other guard here watches the *name*, and mutating the object binds no name, so an `AUDIO_JUDGE_CRITERIA.append(...)` in an example would have handed the judge a drifted criterion with all of them green. Making the object immutable removes the move rather than enumerating the ways to spell it, and unlike a name-based check it holds through an alias.
- Whether the Python siblings actually *use* theirs is checked in Python, by `python/tests/test_audio_example_judge_criteria.py`, which walks each example's AST. It inspects every `JudgeAgent(...)` call and its `criteria` argument, and requires the criteria name to be bound exactly once in the file and by an import, with `list` never rebound. Text matching could not see a second judge with an inline list, a parameter or `for` target or walrus that shadows the name, or an import that stopped coming from `helpers`. It parses files, so no keys and no network, and it runs in `python-ci`'s unit step.

The criteria strings themselves are unchanged, which the parity test enforces.

The prompt in `test_audio_to_audio.py` stays as it is and reads coherently against the new criteria: it asks the agent to answer the question in the audio (criterion 1) and to mention it received audio (criterion 3). Prompt/criteria coherence in the other three siblings is #681's scope, not this one.

## Evidence

The strongest check is that the extended guard fails on exactly the state the ticket reports. With `test_audio_to_audio.py` restored to its `origin/main` content:

```
FAIL  audio-judge-criteria-parity.test.ts > keeps test_audio_to_audio.py on the shared constant, not an inline copy
AssertionError: test_audio_to_audio.py must pass AUDIO_JUDGE_CRITERIA to the judge, not an inline list
```

With the fix in place:

```
pnpm -F vitest-examples exec vitest run tests/audio-judge-criteria-parity.test.ts
  Test Files  1 passed (1)
       Tests  4 passed (4)

uv run pytest tests/ -m "not integration"
  1328 passed, 10 skipped         # 12 of them the new guard

uv run pytest examples/test_audio_to_audio.py examples/test_audio_to_text.py --collect-only -q
  2 tests collected

uv run pyright examples/test_audio_to_audio.py examples/test_audio_to_text.py examples/helpers/
  0 errors, 0 warnings, 0 informations

eslint tests/audio-judge-criteria-parity.test.ts     clean
```

Resolved at runtime, not just read off the page: importing `helpers` gives 3 criteria, and parsing the JS constant out of `audio-judge-criteria.ts` and comparing gives `byte-identical to JS: True`.

The guard is deterministic (file read plus parse, no API keys, no network), so it runs in CI unlike the live examples it protects.

### Mutation testing

| Mutation | Result |
| --- | --- |
| python constant drifts one word from JS | CAUGHT |
| a second judge in the file gets an inline list | CAUGHT |
| either sibling pastes an inline criteria list back | CAUGHT |
| the judge is given no criteria at all | CAUGHT |
| the constant is re-declared inside a sibling | CAUGHT |
| the import stops coming from `helpers` | CAUGHT |
| the constant is imported under an alias | CAUGHT |
| a parameter shadows the constant | CAUGHT |
| a `for` target shadows the constant | CAUGHT |
| a walrus shadows the constant | CAUGHT |
| a `with ... as` shadows the constant | CAUGHT |
| an `except ... as` shadows the constant | CAUGHT |
| a lambda parameter shadows the constant | CAUGHT |
| a second import rebinds the constant | CAUGHT |
| the `list` builtin is shadowed | CAUGHT |
| the shared constant reverts to a mutable `list` | CAUGHT |
| an example appends to the shared criteria | CAUGHT (pyright) |
| an example aliases the constant, then appends | CAUGHT (pyright) |
| an example assigns to one criterion by index | CAUGHT (pyright) |
| the `helpers` facade exports a stale list beside the tuple | CAUGHT |
| the facade exports a genuine copy, `(*_shared,)` | CAUGHT |
| the facade exports a copy with one criterion drifted | CAUGHT |

The last twelve came out of review. The first version of this guard matched source text, which proves one occurrence rather than the property; a later version checked only assignment-shaped rebindings; and the version after that still watched only the name, so mutating the object behind it escaped (verified: `10 passed` with the exact wording #680 removed appended back on). CPython's own `symtable` answers the binding cases without an enumeration to get wrong, and an immutable object answers the mutation cases without one either.

One near-miss is worth recording, since it looked like an escape and was not. The first copy mutation tried was `AUDIO_JUDGE_CRITERIA = tuple(_shared)`, which passed the identity check. That is CPython returning its argument unchanged: `tuple(t) is t` holds for an exact tuple, as does `t[:] is t`. There was no copy to catch. `(*_shared,)` does build a new tuple, and the check fails on it.

The four `(pyright)` rows are labelled rather than folded in: `pytest tests/` alone does not catch them, `uv run pyright .` does, and `python-ci` runs both in the same job with `examples/` inside pyright's scope. At runtime the interpreter raises `AttributeError` regardless.

### Pre-existing, not from this branch

`javascript-ci` is red on `main` and red here, with the **same file failing in both**, and it is not one this PR touches:

```
main   run 32476011706 (76ee430e)      this branch  run 32480323868 (ab2ae7d9)
  tests/scenario-expert-realtime.test.ts               (same, and the only one)
```

It is a live realtime example. The rest of that job is `34 passed | 21 skipped`, and `audio-judge-criteria-parity.test.ts` is among the passing four-test files. `python-ci`, which runs both `pytest tests/` and `pyright .`, is **green** on this branch, so every guard this PR adds is verified in CI rather than only locally.

Earlier pushes on this branch saw five live files failing, on main and here alike; that set shrank to one on both sides. These examples call real models, so which of them fail varies run to run. What stays constant is that the set matches main's.

Locally `tsc --noEmit` in `examples/vitest` reports `TS2688: Cannot find type definition file for 'yauzl'`. That is this box's install, not the branch: the same error appears with `origin/main`'s copy of the only TypeScript file this PR touches, and CI's own build step passes.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

---
<sub>🤖 **Filed by `tech-debt-fixer` via the create-issue procedure, on behalf of the fleet.** Authored under the owner's GitHub token for API access — the content is the fleet's, not his. Owner-authored and fleet-authored issues are otherwise indistinguishable in this repo; this footer is the only signal.</sub>



