### PR TITLE
feat(voice): mint every JavaScript voice session through the gateway

### DIFF
--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -17,8 +17,12 @@ name: javascript-ci
 # The same key, and how to rotate, revoke and cap it, are described at the
 # top of python-ci.yml. Kept in one place so the two do not drift.
 #
-# One exception rides direct, at the examples step below: OpenAI Realtime
-# opens a websocket to api.openai.com, and the gateway proxies HTTP only.
+# The Realtime examples ride it too. Their media websocket still runs to
+# api.openai.com, because the gateway proxies HTTP only, but the credential it
+# opens with is minted first at POST /v1/realtime/client_secrets, which is
+# OpenAI's own path and one the gateway mirrors. So the session is checked
+# against the virtual key's budget and billed there, and no provider key exists
+# in this repository's secrets for it to fall back to.
 env:
   CI: true
   OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
@@ -126,10 +130,6 @@ jobs:
         env:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # Realtime examples open a websocket straight to api.openai.com,
-          # which the gateway cannot proxy, so they need a real OpenAI key
-          # instead of the virtual key held by OPENAI_API_KEY.
-          OPENAI_REALTIME_API_KEY: ${{ secrets.OPENAI_REALTIME_API_KEY }}
         working-directory: javascript
 
   # One required check for the whole workflow. Reports success if every

--- a/.github/workflows/javascript-voice-integration.yml
+++ b/.github/workflows/javascript-voice-integration.yml
@@ -3,12 +3,25 @@ name: javascript-voice-integration
 # All OpenAI-compatible HTTP traffic (judge and user-sim LLMs, TTS, STT)
 # rides the LangWatch AI Gateway: OPENAI_API_KEY holds a LangWatch virtual
 # key, and these base URLs point every client family (openai SDK, litellm,
-# ai-sdk) at the gateway. The OpenAI Realtime websocket connects directly
-# to OpenAI and uses OPENAI_REALTIME_API_KEY (a real provider key) instead.
+# ai-sdk) at the gateway.
+#
+# The two realtime lanes ride it as well. Their media websockets still run to
+# the vendor, because the gateway proxies HTTP only, but the credential each
+# one opens with is minted through the gateway first: OpenAI Realtime at
+# POST /v1/realtime/client_secrets, ElevenLabs ConvAI at
+# GET /v1/convai/conversation/get-signed-url. Both are the vendor's own mint
+# path, and the gateway mirrors them, so each session is checked against the
+# virtual key's budget and session cap and billed as one spend record.
+#
+# ELEVENLABS_BASE_URL carries no /v1: the ElevenLabs SDK appends it, so a base
+# URL that already has one requests /v1/v1/convai/... and 404s. It moves the
+# hosted ConvAI adapter only. The gateway does not front /v1/speech-to-text or
+# /v1/text-to-speech, so the composable ElevenLabs voices keep talking to the
+# vendor and take an explicit baseUrl if they ever need one.
 env:
   OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
   OPENAI_API_BASE: https://gateway.langwatch.ai/v1
-  OPENAI_REALTIME_API_KEY: ${{ secrets.OPENAI_REALTIME_API_KEY }}
+  ELEVENLABS_BASE_URL: https://gateway.langwatch.ai
 
 # On-demand workflow for the JavaScript voice e2e demos that hit live providers
 # (OpenAI Realtime, ElevenLabs, Gemini Live) and the bundled Pipecat stub bot.
@@ -24,10 +37,14 @@ env:
 #     pipecat_ws). Each self-skips when its required key/infra is absent.
 #
 # Secrets required (configure in repo settings):
-#   - OPENAI_API_KEY     — STT, TTS, Realtime API, judge LLM, user-sim TTS
-#   - LANGWATCH_API_KEY  — telemetry export
-#   - GEMINI_API_KEY     — Gemini Live adapter
-#   - ELEVENLABS_API_KEY — ElevenLabs hosted + branded adapters + STT
+#   - OPENAI_API_KEY:     the LangWatch virtual key. Judge LLM, user-sim TTS,
+#                          STT, the OpenAI Realtime mint, and the ElevenLabs
+#                          ConvAI mint all present it.
+#   - LANGWATCH_API_KEY:  telemetry export
+#   - GEMINI_API_KEY:     Gemini Live adapter
+#   - ELEVENLABS_API_KEY: the real vendor key. Agent provisioning, and the
+#                          branded and composable ElevenLabs STT and TTS demos,
+#                          which the gateway does not front.
 #
 # Twilio inbound/outbound demos stay MANUAL (real phone + ngrok tunnel +
 # TWILIO_PHONE_NUMBER_2) and are NOT run here — matching the capability matrix's
@@ -150,6 +167,14 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Two ElevenLabs credentials, because two destinations. The hosted
+          # ConvAI demos mint through the gateway, which authenticates the same
+          # virtual key OPENAI_API_KEY holds: the SDK sends it as `xi-api-key`,
+          # the gateway takes that header as a bearer and resolves the
+          # workspace's own ElevenLabs credential. The composable and branded
+          # demos call /v1/speech-to-text and /v1/text-to-speech, which the
+          # gateway does not front, so they keep the real vendor key.
+          ELEVENLABS_CONVAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           # The bundled Pipecat stub bot was brought up + readiness-polled above,
           # so the bot-gated demos (angry_customer, basic_greeting,

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -27,13 +27,16 @@ name: python-ci
 #               pod caches a key's config for 60 seconds
 #               (LW_GATEWAY_AUTH_CACHE_CONFIG_TTL_SECONDS). Restarting the
 #               gateway deployment clears it at once.
-#   - Cap:      the key carries its own spending budget, currently $10 per
+#   - Cap:      the key carries its own spending budget, currently $15 per
 #               day at virtual-key scope. On a hard breach the gateway
 #               answers HTTP 402 `budget_exceeded` with the scope in
 #               `error.meta.budget_scope`, and every test in this job fails
 #               until the window resets. Size the cap well above a busy
 #               day's spend: one full run costs about $0.09, and the
-#               busiest day seen so far was 31 runs.
+#               busiest day seen so far was 31 runs. The voice-integration
+#               workflows share this key and cost far more per run, because
+#               they mint realtime and ElevenLabs sessions through the
+#               gateway as well. $4 was breached mid-suite on 2026-08-21.
 #   - Fall back: to call the providers directly again, clear the two base
 #               URLs below and GEMINI_API_BASE on the examples step, and put
 #               provider keys back in OPENAI_API_KEY and GEMINI_API_KEY.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,10 +33,15 @@ name: python-ci
 #               `error.meta.budget_scope`, and every test in this job fails
 #               until the window resets. Size the cap well above a busy
 #               day's spend: one full run costs about $0.09, and the
-#               busiest day seen so far was 31 runs. The voice-integration
-#               workflows share this key and cost far more per run, because
-#               they mint realtime and ElevenLabs sessions through the
-#               gateway as well. $4 was breached mid-suite on 2026-08-21.
+#               busiest day seen so far was 31 runs. `javascript-ci.yml` and
+#               `javascript-voice-integration.yml` share this key and cost
+#               far more per run, because they mint the OpenAI Realtime
+#               session through the gateway, and the second mints the
+#               ElevenLabs ConvAI session there too. `voice-integration.yml`,
+#               the Python voice workflow, still dials both vendors directly
+#               with OPENAI_REALTIME_API_KEY and ELEVENLABS_API_KEY, so its
+#               voice traffic does not land on this budget. $4 was breached
+#               mid-suite on 2026-08-21.
 #   - Fall back: to call the providers directly again, clear the two base
 #               URLs below and GEMINI_API_BASE on the examples step, and put
 #               provider keys back in OPENAI_API_KEY and GEMINI_API_KEY.

--- a/docs/docs/pages/voice/adapters/elevenlabs.mdx
+++ b/docs/docs/pages/voice/adapters/elevenlabs.mdx
@@ -42,6 +42,37 @@ const adapter = scenario.elevenLabsAgent({
 
 :::
 
+### Routing through a LangWatch AI Gateway (TypeScript)
+
+`apiKey` is optional. Unset, the adapter reads `ELEVENLABS_CONVAI_API_KEY`, then
+`ELEVENLABS_API_KEY`. `baseUrl` is optional too and falls back to
+`ELEVENLABS_BASE_URL`.
+
+Set both to a gateway and the signed-URL handshake goes there instead of to
+ElevenLabs. The gateway checks the virtual key's budget and open-session cap,
+mints the signed URL, and bills the call as one spend record. The conversation
+websocket the URL names still belongs to ElevenLabs, so the media stream runs
+client to vendor and nothing about latency or the wire protocol changes.
+
+```bash
+# No /v1 on the end: the ElevenLabs SDK appends it, so a base URL that
+# already carries one requests /v1/v1/convai/... and 404s.
+ELEVENLABS_BASE_URL=https://gateway.langwatch.ai
+ELEVENLABS_CONVAI_API_KEY=your-langwatch-virtual-key
+```
+
+Two key variables because there are two destinations. A LangWatch gateway fronts
+the ConvAI mint route and does not front `/v1/speech-to-text` or
+`/v1/text-to-speech`, so `ElevenLabsVoiceAgent`, `ElevenLabsSTTProvider` and the
+`elevenlabs/<voiceId>` TTS voices keep talking to ElevenLabs with
+`ELEVENLABS_API_KEY`. Those three take an explicit `baseUrl` option and do not
+read `ELEVENLABS_BASE_URL`, so setting it for the hosted adapter cannot break
+them.
+
+Leave both new variables unset and every request goes to ElevenLabs as before.
+
+## Per-session options
+
 All per-session options are transmitted in the WebSocket
 `conversation_initiation_client_data` handshake at connect time. ElevenLabs
 applies each one **only if the agent allowlists it** server-side (Agent →

--- a/docs/docs/pages/voice/happy-path-elevenlabs.mdx
+++ b/docs/docs/pages/voice/happy-path-elevenlabs.mdx
@@ -18,6 +18,10 @@ description: Step-by-step guide to test a deployed ElevenLabs Conversational AI 
 
 > **Why an OpenAI key?** Scenario's judge is an LLM, and the user simulator's default TTS is OpenAI. Both are separate from your ElevenLabs agent. A judge is what turns "did the agent sound warm?" into an automated pass/fail.
 
+> **Routing through a LangWatch AI Gateway? (TypeScript)** Set `ELEVENLABS_BASE_URL` to the gateway host with no `/v1` on the end, and `ELEVENLABS_CONVAI_API_KEY` to your virtual key. The adapter then asks the gateway for the signed URL instead of ElevenLabs, so the call is checked against the key's budget and session cap and billed as one spend record. The conversation websocket the signed URL names still belongs to ElevenLabs, so nothing about latency or the wire protocol changes.
+>
+> The gateway fronts the ConvAI mint route only. ElevenLabs speech-to-text and text-to-speech keep talking to ElevenLabs with `ELEVENLABS_API_KEY`, which is why the ConvAI key has a variable of its own. Leave both new variables unset and every request goes to ElevenLabs as before.
+
 ---
 
 ## Step 1 — Install

--- a/docs/docs/pages/voice/happy-path-openai-realtime.mdx
+++ b/docs/docs/pages/voice/happy-path-openai-realtime.mdx
@@ -18,7 +18,11 @@ description: Step-by-step guide to test an OpenAI Realtime voice model with Scen
 
 > **All-in-one key**: unlike the ElevenLabs path, everything here runs on OpenAI: the Realtime model itself, the user simulator TTS, the judge LLM, and the default STT. One key, one provider.
 
-> **Routing through an OpenAI-compatible gateway?** TTS, STT, and the judge LLM follow `OPENAI_BASE_URL` (and `OPENAI_API_BASE` for litellm), so they work with a gateway virtual key. The Realtime websocket always connects directly to OpenAI; set `OPENAI_REALTIME_API_KEY` to a real provider key for it, and the adapter prefers that variable over `OPENAI_API_KEY`.
+> **Routing through an OpenAI-compatible gateway?** TTS, STT, and the judge LLM follow `OPENAI_BASE_URL` (and `OPENAI_API_BASE` for litellm), so they work with a gateway virtual key.
+>
+> In TypeScript the Realtime session follows the same two variables. Before the websocket opens, the adapter posts to `${OPENAI_BASE_URL}/realtime/client_secrets`, which is OpenAI's own mint path, and dials with the ephemeral secret it gets back. Point the variables at OpenAI and OpenAI mints. Point them at a LangWatch AI Gateway and the gateway checks the virtual key's budget and open-session cap, mints the secret, and bills the call. The media websocket still runs to `api.openai.com` either way, so latency and the wire protocol do not change, and no long-lived key ever reaches the socket. If the base URL answers 404 for that path it is not a gateway, so the adapter dials OpenAI directly with `OPENAI_REALTIME_API_KEY` (or `OPENAI_API_KEY`) and logs a warning naming the variable it used. If the mint is refused with any other error status, the adapter raises rather than dialling around the refusal.
+>
+> In Python the Realtime websocket still connects directly to OpenAI. Set `OPENAI_REALTIME_API_KEY` to a real provider key there, and the adapter prefers that variable over `OPENAI_API_KEY`.
 
 ---
 

--- a/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
@@ -11,7 +11,9 @@
  *   ElevenLabs rachel TTS in-process (no socket). Mirrors
  *   `python/examples/voice/elevenlabs_branded.py`.
  *
- * Env-gated on `ELEVENLABS_API_KEY` (+ `ELEVENLABS_AGENT_ID` for hosted) and
+ * Env-gated on `ELEVENLABS_CONVAI_API_KEY` or `ELEVENLABS_API_KEY` (+
+ * `ELEVENLABS_AGENT_ID` for hosted; the branded lane always needs the vendor
+ * key) and
  * `OPENAI_API_KEY` (judge LLM + user-sim TTS). Recordings land in
  * `javascript/examples/vitest/outputs/recordings/elevenlabs_hosted/` and `…/elevenlabs_branded/`.
  */
@@ -30,10 +32,11 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const FEATURE_PATH = resolve(HERE, "..", "..", "..", "..", "..", "specs", "voice-agents.feature");
 
 const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_CONVAI_KEY = voice.resolveElevenLabsConvAIApiKey();
 const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
 
-const hasHostedKey = Boolean(ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && hasOpenAI);
+const hasHostedKey = Boolean(ELEVENLABS_CONVAI_KEY && ELEVENLABS_AGENT_ID && hasOpenAI);
 const hasComposableKey = Boolean(ELEVENLABS_API_KEY && hasOpenAI);
 
 if (hasHostedKey || hasComposableKey) {
@@ -271,7 +274,7 @@ if (hasHostedKey || hasComposableKey) {
   );
 } else {
   describe.skip("ElevenLabs e2e demos (env-gated)", () => {
-    it("requires ELEVENLABS_API_KEY (+ ELEVENLABS_AGENT_ID for hosted) and OPENAI_API_KEY", () => {
+    it("requires an ElevenLabs key (+ ELEVENLABS_AGENT_ID for hosted) and OPENAI_API_KEY", () => {
       expect(true).toBe(true);
     });
   });

--- a/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-hosted.test.ts
@@ -2,7 +2,7 @@
  * ElevenLabs e2e demos — bind the 2 `@e2e @ts-elevenlabs` scenarios from
  * `specs/voice-agents.feature`. Real `scenario.run()`, no mocks.
  *
- * - HOSTED: `scenario.elevenLabsAgent({ agentId, apiKey })` connects to the
+ * - HOSTED: `scenario.elevenLabsAgent({ agentId })` connects to the
  *   live `wss://api.elevenlabs.io/v1/convai/conversation` socket — the hosted
  *   ConvAI agent IS the agent under test. Mirrors
  *   `python/examples/voice/elevenlabs_hosted.py` (lead with `agent()` so the
@@ -67,17 +67,12 @@ if (hasHostedKey || hasComposableKey) {
                 "The greeting plays on connect (real-voice convention), the user " +
                 "asks a question, the agent responds; judge evaluates naturalness.",
               agents: [
+                // The adapter reads ELEVENLABS_BASE_URL itself, so this demo
+                // runs against ElevenLabs or against a gateway in front of it
+                // with no change here, the way OPENAI_BASE_URL already works
+                // for the OpenAI demos.
                 scenario.elevenLabsAgent({
                   agentId: ELEVENLABS_AGENT_ID!,
-                  apiKey: ELEVENLABS_API_KEY!,
-                  // The ElevenLabs SDK reads no base URL variable, so this
-                  // demo reads one itself. It is what lets the same demo run
-                  // against ElevenLabs or against a gateway in front of it,
-                  // the way OPENAI_BASE_URL already does for the OpenAI demo.
-                  // Unset, the SDK talks to ElevenLabs directly.
-                  ...(process.env.ELEVENLABS_BASE_URL
-                    ? { baseUrl: process.env.ELEVENLABS_BASE_URL }
-                    : {}),
                 }),
                 scenario.userSimulatorAgent({ voice: "openai/nova" }),
                 scenario.judgeAgent({

--- a/javascript/examples/vitest/tests/voice/elevenlabs-interruption.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-interruption.test.ts
@@ -88,7 +88,6 @@ describeFeature(
               agents: [
                 scenario.elevenLabsAgent({
                   agentId: ELEVENLABS_AGENT_ID!,
-                  apiKey: ELEVENLABS_API_KEY!,
                   // Verbose per-session prompt so the agent has audio to barge
                   // into (applied via conversation_initiation_client_data; the
                   // shared provisioned test agent stays concise).

--- a/javascript/examples/vitest/tests/voice/elevenlabs-interruption.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-interruption.test.ts
@@ -20,7 +20,7 @@
  * `javascript/examples/vitest/outputs/recordings/elevenlabs_interruption/`.
  *
  * Binds `@e2e @ts-elevenlabs-interruption-demo`. Env-gated on `OPENAI_API_KEY`
- * (judge LLM + user-sim TTS), `ELEVENLABS_API_KEY`, and `ELEVENLABS_AGENT_ID`.
+ * (judge LLM + user-sim TTS), `ELEVENLABS_CONVAI_API_KEY`, and `ELEVENLABS_AGENT_ID`.
  *
  * STATUS — Un-gated after 3/3 consecutive clean live runs (#731). A successful
  * run produces at least one truncated agent segment (barge-in cuts the agent
@@ -36,7 +36,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
-import scenario, { type ScenarioResult } from "@langwatch/scenario";
+import scenario, { voice, type ScenarioResult } from "@langwatch/scenario";
 import { expect } from "vitest";
 
 import { saveDemoRecording } from "./helpers/save-demo-recording";
@@ -53,10 +53,10 @@ const FEATURE_PATH = resolve(
   "voice-agents.feature",
 );
 
-const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_CONVAI_KEY = voice.resolveElevenLabsConvAIApiKey();
 const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
-const RUN_E2E = Boolean(ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && hasOpenAI);
+const RUN_E2E = Boolean(ELEVENLABS_CONVAI_KEY && ELEVENLABS_AGENT_ID && hasOpenAI);
 
 const feature = await loadFeature(FEATURE_PATH);
 

--- a/javascript/examples/vitest/tests/voice/elevenlabs-real-audio-multiturn.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-real-audio-multiturn.test.ts
@@ -36,7 +36,6 @@ const hasHostedKey = Boolean(ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && OPENAI
 function realAudioAgent(): voice.ElevenLabsAgentAdapter {
   return scenario.elevenLabsAgent({
     agentId: ELEVENLABS_AGENT_ID!,
-    apiKey: ELEVENLABS_API_KEY!,
     // The fix: stream REAL PCM for every user turn so EL's STT/VAD/
     // turn-detector run on turns 2+, instead of text-committing them.
   });

--- a/javascript/examples/vitest/tests/voice/elevenlabs-real-audio-multiturn.test.ts
+++ b/javascript/examples/vitest/tests/voice/elevenlabs-real-audio-multiturn.test.ts
@@ -17,7 +17,7 @@
  * returned a non-empty STT `user_transcript` — i.e. audio actually reached the
  * agent.
  *
- * Env-gated on ELEVENLABS_API_KEY + ELEVENLABS_AGENT_ID + OPENAI_API_KEY; self-
+ * Env-gated on ELEVENLABS_CONVAI_API_KEY + ELEVENLABS_AGENT_ID + OPENAI_API_KEY; self-
  * skips otherwise. Runs live via the `javascript-voice-integration.yml`
  * workflow_dispatch (AC5: 3 consecutive clean runs).
  */
@@ -26,11 +26,11 @@ import { describe, it, expect } from "vitest";
 
 import { AGENTS_HEARD_EACH_OTHER } from "./helpers/judge-criteria";
 
-const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_CONVAI_KEY = voice.resolveElevenLabsConvAIApiKey();
 const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
-const hasHostedKey = Boolean(ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY);
+const hasHostedKey = Boolean(ELEVENLABS_CONVAI_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY);
 
 /** Build a fresh hosted-EL adapter (real-audio streaming is the only behavior). */
 function realAudioAgent(): voice.ElevenLabsAgentAdapter {
@@ -84,7 +84,7 @@ function assertRealVoiceMultiTurn(
 
 describe("hosted-EL real voice-in multi-turn (live)", () => {
   if (!hasHostedKey) {
-    it.skip("requires ELEVENLABS_API_KEY + ELEVENLABS_AGENT_ID + OPENAI_API_KEY", () => {});
+    it.skip("requires ELEVENLABS_CONVAI_API_KEY + ELEVENLABS_AGENT_ID + OPENAI_API_KEY", () => {});
     return;
   }
 

--- a/javascript/examples/vitest/tests/voice/proceed-drives-autonomous-realtime-user.test.ts
+++ b/javascript/examples/vitest/tests/voice/proceed-drives-autonomous-realtime-user.test.ts
@@ -126,7 +126,6 @@ describe("repro #705 — proceed(N) drives an autonomous realtime user on hosted
           agents: [
             scenario.elevenLabsAgent({
               agentId: ELEVENLABS_AGENT_ID!,
-              apiKey: ELEVENLABS_API_KEY!,
             }),
             realtimeUser(),
           ],
@@ -211,7 +210,6 @@ describe("repro #705 — proceed(N) drives an autonomous realtime user on hosted
           agents: [
             scenario.elevenLabsAgent({
               agentId: ELEVENLABS_AGENT_ID!,
-              apiKey: ELEVENLABS_API_KEY!,
             }),
             realtimeUser(),
             scenario.judgeAgent({

--- a/javascript/examples/vitest/tests/voice/proceed-drives-autonomous-realtime-user.test.ts
+++ b/javascript/examples/vitest/tests/voice/proceed-drives-autonomous-realtime-user.test.ts
@@ -29,6 +29,7 @@
 // conclusion (memory: voice-e2e-hollow-green — `| tee` swallows the exit code).
 
 import scenario, {
+  voice,
   type ScenarioResult,
 } from "@langwatch/scenario";
 import { describe, it, expect } from "vitest";
@@ -37,12 +38,12 @@ import { AGENTS_HEARD_EACH_OTHER } from "./helpers/judge-criteria";
 import { realtimeUser } from "./helpers/realtime-user";
 import { saveDemoRecording } from "./helpers/save-demo-recording";
 
-const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_CONVAI_KEY = voice.resolveElevenLabsConvAIApiKey();
 const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 const hasHostedKey = Boolean(
-  ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY,
+  ELEVENLABS_CONVAI_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY,
 );
 
 function countSpeakers(result: ScenarioResult): { user: number; agent: number } {

--- a/javascript/examples/vitest/tests/voice/proceed-multiturn-kitchensink.test.ts
+++ b/javascript/examples/vitest/tests/voice/proceed-multiturn-kitchensink.test.ts
@@ -37,12 +37,12 @@ import { AGENTS_HEARD_EACH_OTHER } from "./helpers/judge-criteria";
 import { realtimeUser } from "./helpers/realtime-user";
 import { saveDemoRecording } from "./helpers/save-demo-recording";
 
-const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_CONVAI_KEY = voice.resolveElevenLabsConvAIApiKey();
 const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 const hasHostedKey = Boolean(
-  ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY,
+  ELEVENLABS_CONVAI_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY,
 );
 
 /** Per-turn logger for `proceed(turns, onTurn)` — exercises the callback and

--- a/javascript/examples/vitest/tests/voice/proceed-multiturn-kitchensink.test.ts
+++ b/javascript/examples/vitest/tests/voice/proceed-multiturn-kitchensink.test.ts
@@ -68,7 +68,6 @@ describe("voice kitchen-sink — one scenario, full surface + artifact proof", (
         agents: [
           scenario.elevenLabsAgent({
             agentId: ELEVENLABS_AGENT_ID!,
-            apiKey: ELEVENLABS_API_KEY!,
           }),
           realtimeUser(),
           scenario.judgeAgent({

--- a/javascript/examples/vitest/tests/voice/realtime-user-hosted-el.test.ts
+++ b/javascript/examples/vitest/tests/voice/realtime-user-hosted-el.test.ts
@@ -18,7 +18,7 @@
  * SUCCESS METRIC (Drew's "count utterances"): ≥3 user turns AND ≥3 agent turns
  * where real audio flowed, in one coherent conversation.
  *
- * Env-gated: self-skips without ELEVENLABS_API_KEY + ELEVENLABS_AGENT_ID +
+ * Env-gated: self-skips without ELEVENLABS_CONVAI_API_KEY + ELEVENLABS_AGENT_ID +
  * OPENAI_API_KEY, so CI without the hosted EL secret stays green.
  */
 
@@ -29,11 +29,11 @@ import { AGENTS_HEARD_EACH_OTHER } from "./helpers/judge-criteria";
 
 const { OPENAI_REALTIME_MODEL } = voice;
 
-const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_CONVAI_KEY = voice.resolveElevenLabsConvAIApiKey();
 const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
-const hasHostedKey = Boolean(ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY);
+const hasHostedKey = Boolean(ELEVENLABS_CONVAI_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY);
 
 describe("#705 — realtime user drives hosted EL via scenario.run()", () => {
   it.skipIf(!hasHostedKey)(

--- a/javascript/examples/vitest/tests/voice/realtime-user-hosted-el.test.ts
+++ b/javascript/examples/vitest/tests/voice/realtime-user-hosted-el.test.ts
@@ -48,7 +48,6 @@ describe("#705 — realtime user drives hosted EL via scenario.run()", () => {
         agents: [
           scenario.elevenLabsAgent({
             agentId: ELEVENLABS_AGENT_ID!,
-            apiKey: ELEVENLABS_API_KEY!,
           }),
           // REALTIME user — the model itself speaks, role=USER.
           scenario.openAIRealtimeAgent({

--- a/javascript/examples/vitest/tests/voice/repro-638-hosted-multiturn.test.ts
+++ b/javascript/examples/vitest/tests/voice/repro-638-hosted-multiturn.test.ts
@@ -33,7 +33,6 @@ describe("repro #638 — hosted elevenLabsAgent 2nd scripted user turn", () => {
           agents: [
             scenario.elevenLabsAgent({
               agentId: ELEVENLABS_AGENT_ID!,
-              apiKey: ELEVENLABS_API_KEY!,
             }),
             scenario.userSimulatorAgent({ voice: "openai/nova" }),
             scenario.judgeAgent({

--- a/javascript/examples/vitest/tests/voice/repro-638-hosted-multiturn.test.ts
+++ b/javascript/examples/vitest/tests/voice/repro-638-hosted-multiturn.test.ts
@@ -1,13 +1,13 @@
 // Repro for https://github.com/langwatch/scenario/issues/638 — a 2nd scripted user turn on a hosted elevenLabsAgent should time out with `receiveAudio timed out`. Standalone; does not modify the canonical elevenlabs-hosted.test.ts.
 
-import scenario, { type ScenarioResult } from "@langwatch/scenario";
+import scenario, { voice, type ScenarioResult } from "@langwatch/scenario";
 import { describe, it, expect } from "vitest";
 
-const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_CONVAI_KEY = voice.resolveElevenLabsConvAIApiKey();
 const ELEVENLABS_AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
-const hasHostedKey = Boolean(ELEVENLABS_API_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY);
+const hasHostedKey = Boolean(ELEVENLABS_CONVAI_KEY && ELEVENLABS_AGENT_ID && OPENAI_API_KEY);
 
 describe("repro #638 — hosted elevenLabsAgent 2nd scripted user turn", () => {
   it(

--- a/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
@@ -209,7 +209,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
 
         const recorded: ConnectParams[] = [];
         await expect(makeAdapter(recorded).connect()).rejects.toThrow(
-          new RegExp(`refused this session with HTTP ${status}`),
+          new RegExp(`refused with HTTP ${status}`),
         );
         expect(recorded).toHaveLength(0);
       },

--- a/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
@@ -15,8 +15,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { RealtimeAgentAdapter } from "../realtime/realtime-agent.adapter";
 import { AgentRole } from "../../domain";
+import { RealtimeAgentAdapter } from "../realtime/realtime-agent.adapter";
 
 type ConnectParams = { apiKey?: string };
 
@@ -115,6 +115,24 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
         String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body),
       );
       expect(body.session.model).toBe("gpt-realtime");
+    });
+
+    it("mints for the model connect() was given, which is the one the socket opens with", async () => {
+      // `session.connect({ model })` overrides the session's own model, so a
+      // mint for the session's model would bill something the call never used.
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      await makeAdapter([], {}, "gpt-realtime").connect({
+        model: "gpt-realtime-mini",
+      } as Parameters<RealtimeAgentAdapter["connect"]>[0]);
+
+      const body = JSON.parse(
+        String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body),
+      );
+      expect(body.session.model).toBe("gpt-realtime-mini");
     });
   });
 

--- a/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
@@ -1,23 +1,49 @@
 /**
- * RealtimeAgentAdapter.connect() API-key resolution.
+ * How RealtimeAgentAdapter.connect() obtains the credential it dials with.
  *
- * The Realtime API is a direct websocket to api.openai.com that an
- * OpenAI-compatible gateway cannot proxy. When CI routes OPENAI_API_KEY
- * through a gateway (a LangWatch virtual key), the dedicated
- * OPENAI_REALTIME_API_KEY must win, mirroring OpenAIRealtimeAdapter.
- * Regression: the virtual key leaked into the websocket and OpenAI
- * rejected it with invalid_api_key.
+ * The adapter mints at `${OPENAI_BASE_URL}/realtime/client_secrets`, which is
+ * OpenAI's own path and the one a LangWatch AI Gateway mirrors. The socket then
+ * carries the ephemeral secret the mint returned, so no long-lived key reaches
+ * it. These tests pin the outcomes that decide whether a call is billed:
+ *
+ * - a gateway minted it, so the socket carries the ephemeral secret;
+ * - the route was absent, so the adapter dials directly and says so;
+ * - the mint was refused, so nothing is dialled at all.
+ *
+ * The last two are the money-relevant pair. A refusal that fell back to a
+ * direct provider key would run a call the gateway declined to bill.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { RealtimeAgentAdapter } from "../realtime/realtime-agent.adapter";
 import { AgentRole } from "../../domain";
 
 type ConnectParams = { apiKey?: string };
 
-function makeAdapter(recorded: ConnectParams[]): RealtimeAgentAdapter {
+const ENV_KEYS = [
+  "OPENAI_BASE_URL",
+  "OPENAI_API_KEY",
+  "OPENAI_REALTIME_API_KEY",
+] as const;
+const saved: Record<string, string | undefined> = {};
+
+/** A mint response, with the session-id header only when a gateway answers. */
+function mintResponse(status: number, sessionId?: string): Response {
+  if (status !== 200) return new Response("no", { status });
+  return new Response(JSON.stringify({ value: "ek_minted_secret" }), {
+    status: 200,
+    headers: sessionId ? { "x-langwatch-session-id": sessionId } : {},
+  });
+}
+
+function makeAdapter(
+  recorded: ConnectParams[],
+  overrides: Partial<ConstructorParameters<typeof RealtimeAgentAdapter>[0]> = {},
+  sessionModel?: string,
+): RealtimeAgentAdapter {
   const session = {
     transport: { on: () => undefined, sendEvent: () => undefined },
+    options: sessionModel ? { model: sessionModel } : {},
     connect: async (params: ConnectParams) => {
       recorded.push(params);
     },
@@ -32,58 +58,178 @@ function makeAdapter(recorded: ConnectParams[]): RealtimeAgentAdapter {
     role: AgentRole.AGENT,
     agentName: "Key Resolution Test Agent",
     responseTimeout: 1000,
+    ...overrides,
   });
 }
 
-describe("RealtimeAgentAdapter.connect API-key resolution", () => {
-  const savedRealtimeKey = process.env.OPENAI_REALTIME_API_KEY;
-  const savedOpenAIKey = process.env.OPENAI_API_KEY;
-
+describe("RealtimeAgentAdapter.connect credential resolution", () => {
   beforeEach(() => {
-    delete process.env.OPENAI_REALTIME_API_KEY;
-    delete process.env.OPENAI_API_KEY;
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
-    if (savedRealtimeKey === undefined) {
-      delete process.env.OPENAI_REALTIME_API_KEY;
-    } else {
-      process.env.OPENAI_REALTIME_API_KEY = savedRealtimeKey;
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
     }
-    if (savedOpenAIKey === undefined) {
-      delete process.env.OPENAI_API_KEY;
-    } else {
-      process.env.OPENAI_API_KEY = savedOpenAIKey;
-    }
+    vi.unstubAllGlobals();
+    // spyOn is not undone by unstubAllGlobals, so a silenced console.warn
+    // would outlive this file and mute a later test that asserts on one.
+    vi.restoreAllMocks();
   });
 
-  it("an explicit params.apiKey wins over both env vars", async () => {
-    process.env.OPENAI_REALTIME_API_KEY = "sk-realtime";
-    process.env.OPENAI_API_KEY = "vk-lw-virtual";
-    const recorded: ConnectParams[] = [];
-    await makeAdapter(recorded).connect({ apiKey: "sk-explicit" });
-    expect(recorded[0]?.apiKey).toBe("sk-explicit");
+  describe("when a gateway answers the mint", () => {
+    it("dials with the ephemeral secret and knows the session is billed", async () => {
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
+      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const recorded: ConnectParams[] = [];
+      const adapter = makeAdapter(recorded);
+      await adapter.connect();
+
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+        "https://gateway.example/v1/realtime/client_secrets",
+      );
+      // Neither long-lived key reaches the socket.
+      expect(recorded[0]?.apiKey).toBe("ek_minted_secret");
+      expect(adapter.brokered).toBe(true);
+    });
+
+    it("mints for the model the session was built with", async () => {
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      await makeAdapter([], {}, "gpt-realtime").connect();
+
+      // The gateway prices and budgets against this model, so a default here
+      // would bill a session that opened as something else.
+      const body = JSON.parse(
+        String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body),
+      );
+      expect(body.session.model).toBe("gpt-realtime");
+    });
   });
 
-  it("OPENAI_REALTIME_API_KEY wins over OPENAI_API_KEY", async () => {
-    process.env.OPENAI_REALTIME_API_KEY = "sk-realtime";
-    process.env.OPENAI_API_KEY = "vk-lw-virtual";
-    const recorded: ConnectParams[] = [];
-    await makeAdapter(recorded).connect();
-    expect(recorded[0]?.apiKey).toBe("sk-realtime");
+  describe("when the vendor answers the mint", () => {
+    it("dials with the ephemeral secret but reports no session, because OpenAI names none", async () => {
+      process.env.OPENAI_API_KEY = "sk-provider";
+      const fetchSpy = vi.fn(async () => mintResponse(200));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const recorded: ConnectParams[] = [];
+      const adapter = makeAdapter(recorded);
+      await adapter.connect();
+
+      // Default base URL is OpenAI's own, so no configuration is required.
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+        "https://api.openai.com/v1/realtime/client_secrets",
+      );
+      expect(recorded[0]?.apiKey).toBe("ek_minted_secret");
+      expect(adapter.brokered).toBe(false);
+    });
   });
 
-  it("falls back to OPENAI_API_KEY when no realtime key is set", async () => {
-    process.env.OPENAI_API_KEY = "sk-plain";
-    const recorded: ConnectParams[] = [];
-    await makeAdapter(recorded).connect();
-    expect(recorded[0]?.apiKey).toBe("sk-plain");
+  describe("when the endpoint has no mint route", () => {
+    it("dials the vendor directly with the fallback key, and warns", async () => {
+      process.env.OPENAI_BASE_URL = "https://old-gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => mintResponse(404)),
+      );
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const recorded: ConnectParams[] = [];
+      const adapter = makeAdapter(recorded);
+      await adapter.connect();
+
+      expect(recorded[0]?.apiKey).toBe("sk-direct-provider-key");
+      expect(adapter.brokered).toBe(false);
+      const warned = warn.mock.calls.map(String).join(" ");
+      expect(warned).toMatch(/old-gateway\.example/);
+      expect(warned).toMatch(/OPENAI_REALTIME_API_KEY/);
+      expect(warned).toMatch(/not billed/);
+    });
+
+    it("falls back to OPENAI_API_KEY when no realtime key is set", async () => {
+      process.env.OPENAI_BASE_URL = "https://old-gateway.example/v1";
+      process.env.OPENAI_API_KEY = "sk-plain";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => mintResponse(404)),
+      );
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const recorded: ConnectParams[] = [];
+      await makeAdapter(recorded).connect();
+
+      expect(recorded[0]?.apiKey).toBe("sk-plain");
+      expect(warn.mock.calls.map(String).join(" ")).toMatch(/OPENAI_API_KEY/);
+    });
+  });
+
+  describe("when the mint is refused", () => {
+    it.each([401, 403, 429, 500, 502])(
+      "raises on HTTP %i without connecting, so a declined call cannot run on a provider key",
+      async (status) => {
+        process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+        process.env.OPENAI_API_KEY = "vk-lw-test";
+        process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async () => mintResponse(status)),
+        );
+
+        const recorded: ConnectParams[] = [];
+        await expect(makeAdapter(recorded).connect()).rejects.toThrow(
+          new RegExp(`refused this session with HTTP ${status}`),
+        );
+        expect(recorded).toHaveLength(0);
+      },
+    );
+  });
+
+  describe("when the caller supplies its own credential", () => {
+    it("an explicit params.apiKey skips the mint entirely", async () => {
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "vk-lw-test";
+      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const recorded: ConnectParams[] = [];
+      await makeAdapter(recorded).connect({ apiKey: "sk-explicit" });
+
+      expect(recorded[0]?.apiKey).toBe("sk-explicit");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("`mint: false` dials the vendor directly with no mint attempt", async () => {
+      process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+      process.env.OPENAI_API_KEY = "sk-plain";
+      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const recorded: ConnectParams[] = [];
+      await makeAdapter(recorded, { mint: false }).connect();
+
+      expect(recorded[0]?.apiKey).toBe("sk-plain");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 
   it("throws a clear error when no key is available anywhere", async () => {
     const recorded: ConnectParams[] = [];
     await expect(makeAdapter(recorded).connect()).rejects.toThrow(
-      /OPENAI_REALTIME_API_KEY \/ OPENAI_API_KEY/,
+      /OPENAI_API_KEY/,
     );
     expect(recorded).toHaveLength(0);
   });

--- a/javascript/src/agents/__tests__/realtime-adapter-usage.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-usage.test.ts
@@ -1,0 +1,204 @@
+/**
+ * What RealtimeAgentAdapter reports when a brokered session ends.
+ *
+ * A gateway opens a spend record at the mint, and only a usage report closes
+ * it. Two things decide whether the record is right:
+ *
+ * - the vendor reports usage per response, not per session, so a session that
+ *   keeps only the last `response.done` bills for its last turn. Measured
+ *   against the live Realtime API on 2026-08-21: two turns on one socket
+ *   reported `output_tokens` 4 and 4, not 4 and 8;
+ * - a session that produced no response still has to be closed, or it holds
+ *   one of the key's slots until the gateway's grace expires. The counts are
+ *   stated rather than omitted, because the gateway answers HTTP 400 to a
+ *   usage body carrying neither `input_tokens` nor `output_tokens`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { AgentRole } from "../../domain";
+import { RealtimeAgentAdapter } from "../realtime/realtime-agent.adapter";
+
+const ENV_KEYS = [
+  "OPENAI_BASE_URL",
+  "OPENAI_API_KEY",
+  "OPENAI_REALTIME_API_KEY",
+] as const;
+const saved: Record<string, string | undefined> = {};
+
+/** Every usage body the adapter posted to the gateway, newest last. */
+let reported: Array<Record<string, unknown>> = [];
+/** The raw-event handlers the adapter attached to the transport. */
+let taps: Array<(event: unknown) => void> = [];
+
+function makeAdapter(): RealtimeAgentAdapter {
+  const session = {
+    transport: {
+      on: (event: string, handler: (e: unknown) => void) => {
+        if (event === "*") taps.push(handler);
+      },
+      sendEvent: () => undefined,
+    },
+    options: { model: "gpt-realtime" },
+    connect: async () => undefined,
+    close: () => undefined,
+    sendMessage: () => undefined,
+  } as unknown as ConstructorParameters<
+    typeof RealtimeAgentAdapter
+  >[0]["session"];
+
+  return new RealtimeAgentAdapter({
+    session,
+    role: AgentRole.AGENT,
+    agentName: "Usage Test Agent",
+    responseTimeout: 1000,
+  });
+}
+
+/** One `response.done` frame, as the vendor sends it. */
+function responseDone(usage: Record<string, unknown>): unknown {
+  return { type: "response.done", response: { usage } };
+}
+
+function pushToTaps(event: unknown): void {
+  for (const tap of taps) tap(event);
+}
+
+describe("given a brokered RealtimeAgentAdapter session that ends", () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+    process.env.OPENAI_API_KEY = "vk-lw-test";
+    reported = [];
+    taps = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (String(url).endsWith("/client_secrets")) {
+          return new Response(JSON.stringify({ value: "ek_minted_secret" }), {
+            status: 200,
+            headers: { "x-langwatch-session-id": "req_abc" },
+          });
+        }
+        reported.push(JSON.parse(String(init?.body)));
+        return new Response("{}", { status: 202 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reports every turn, not the last one", async () => {
+    const adapter = makeAdapter();
+    await adapter.connect();
+
+    pushToTaps(
+      responseDone({ input_tokens: 120, output_tokens: 4, total_tokens: 124 }),
+    );
+    pushToTaps(
+      responseDone({ input_tokens: 135, output_tokens: 4, total_tokens: 139 }),
+    );
+    await adapter.disconnect();
+
+    expect(reported).toEqual([
+      {
+        usage: { input_tokens: 255, output_tokens: 8, total_tokens: 263 },
+      },
+    ]);
+  });
+
+  it("sums the nested detail objects a gateway prices separately", async () => {
+    const adapter = makeAdapter();
+    await adapter.connect();
+
+    pushToTaps(
+      responseDone({
+        input_tokens: 10,
+        output_token_details: { audio_tokens: 3, text_tokens: 1 },
+      }),
+    );
+    pushToTaps(
+      responseDone({
+        input_tokens: 5,
+        output_token_details: { audio_tokens: 2, text_tokens: 1 },
+      }),
+    );
+    await adapter.disconnect();
+
+    expect(reported[0]).toEqual({
+      usage: {
+        input_tokens: 15,
+        output_tokens: 0,
+        output_token_details: { audio_tokens: 5, text_tokens: 2 },
+      },
+    });
+  });
+
+  it("closes a session that produced no response at all, at zero", async () => {
+    const adapter = makeAdapter();
+    await adapter.connect();
+    await adapter.disconnect();
+
+    // Stated zeros, not an empty object: the gateway answers HTTP 400 to a
+    // body carrying neither count, which would leave the record open.
+    expect(reported).toEqual([
+      { usage: { input_tokens: 0, output_tokens: 0 } },
+    ]);
+  });
+
+  it("reports once, so a second disconnect cannot bill the session twice", async () => {
+    const adapter = makeAdapter();
+    await adapter.connect();
+    await adapter.disconnect();
+    await adapter.disconnect();
+
+    expect(reported).toHaveLength(1);
+  });
+
+  it("attaches one usage tap across reconnects, so a turn is not counted twice", async () => {
+    const adapter = makeAdapter();
+    await adapter.connect();
+    await adapter.disconnect();
+    await adapter.connect();
+
+    pushToTaps(responseDone({ input_tokens: 10, output_tokens: 2 }));
+    await adapter.disconnect();
+
+    expect(taps).toHaveLength(1);
+    expect(reported[1]).toEqual({
+      usage: { input_tokens: 10, output_tokens: 2 },
+    });
+  });
+
+  it("reports nothing when no gateway minted the session", async () => {
+    // The vendor minted it, so there is no spend record anywhere to close.
+    delete process.env.OPENAI_BASE_URL;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (String(url).endsWith("/client_secrets")) {
+          return new Response(JSON.stringify({ value: "ek_minted_secret" }), {
+            status: 200,
+          });
+        }
+        reported.push(JSON.parse(String(init?.body)));
+        return new Response("{}", { status: 202 });
+      }),
+    );
+
+    const adapter = makeAdapter();
+    await adapter.connect();
+    await adapter.disconnect();
+
+    expect(reported).toEqual([]);
+  });
+});

--- a/javascript/src/agents/__tests__/realtime-adapter-usage.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-usage.test.ts
@@ -30,7 +30,7 @@ let reported: Array<Record<string, unknown>> = [];
 /** The raw-event handlers the adapter attached to the transport. */
 let taps: Array<(event: unknown) => void> = [];
 
-function makeAdapter(): RealtimeAgentAdapter {
+function makeAdapter(connectFails = false): RealtimeAgentAdapter {
   const session = {
     transport: {
       on: (event: string, handler: (e: unknown) => void) => {
@@ -39,7 +39,9 @@ function makeAdapter(): RealtimeAgentAdapter {
       sendEvent: () => undefined,
     },
     options: { model: "gpt-realtime" },
-    connect: async () => undefined,
+    connect: async () => {
+      if (connectFails) throw new Error("socket refused");
+    },
     close: () => undefined,
     sendMessage: () => undefined,
   } as unknown as ConstructorParameters<
@@ -177,6 +179,19 @@ describe("given a brokered RealtimeAgentAdapter session that ends", () => {
     expect(reported[1]).toEqual({
       usage: { input_tokens: 10, output_tokens: 2 },
     });
+  });
+
+  it("closes the session it minted when the socket never opens", async () => {
+    // The mint booked a session and only a report closes it. Left open it
+    // holds one of the key's slots until the gateway's grace expires, and
+    // books a call that never happened.
+    const adapter = makeAdapter(true);
+
+    await expect(adapter.connect()).rejects.toThrow(/socket refused/);
+
+    expect(reported).toEqual([
+      { usage: { input_tokens: 0, output_tokens: 0 } },
+    ]);
   });
 
   it("reports nothing when no gateway minted the session", async () => {

--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -233,10 +233,20 @@ export class RealtimeAgentAdapter extends AgentAdapter {
       this.attachUsageTap();
     }
 
-    await this.session.connect({
-      apiKey: credential.socketKey,
-      ...rest,
-    });
+    try {
+      await this.session.connect({
+        apiKey: credential.socketKey,
+        ...rest,
+      });
+    } catch (error) {
+      // The mint booked a session and the socket never opened, so nothing will
+      // ever report against it. The total is still the zeros seeded above,
+      // which is the truth: an ephemeral credential that opened no socket
+      // consumed nothing. Leaving it would hold one of the key's slots until
+      // the gateway's grace expires, and book a call that never happened.
+      await this.reportUsage();
+      throw error;
+    }
   }
 
   /**

--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -200,7 +200,7 @@ export class RealtimeAgentAdapter extends AgentAdapter {
             : "OPENAI_API_KEY",
       },
       {
-        model: this.mintModel,
+        model: this.mintModel(params?.model),
         noCredentialMessage:
           "RealtimeAgentAdapter.connect requires an API key: pass " +
           "params.apiKey, or set OPENAI_API_KEY so the session can be minted " +
@@ -219,15 +219,22 @@ export class RealtimeAgentAdapter extends AgentAdapter {
   /**
    * The model the mint is asked for.
    *
-   * `RealtimeSession` keeps the model it was built with on its public
-   * `options`, so a session created by the caller's own factory needs no
-   * second declaration here.
+   * `connectModel` is `connect({ model })`, which `session.connect` uses for the
+   * socket, so the mint has to use it too. A gateway prices and budgets the
+   * session against what it was told, and a mint for one model that opens as
+   * another bills the wrong thing.
+   *
+   * Otherwise `RealtimeSession` keeps the model it was built with on its public
+   * `options`, so a session created by the caller's own factory needs no second
+   * declaration here.
    */
-  private get mintModel(): string {
+  private mintModel(connectModel?: string): string {
     const sessionModel = (
       this.session as RealtimeSession & { options?: { model?: string } }
     ).options?.model;
-    return this.config.model ?? sessionModel ?? OPENAI_REALTIME_MODEL;
+    return (
+      connectModel ?? this.config.model ?? sessionModel ?? OPENAI_REALTIME_MODEL
+    );
   }
 
   /**

--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -25,9 +25,13 @@ import type { AgentInput, AgentReturnTypes, AgentRole } from "../../domain";
 import { AgentAdapter } from "../../domain/agents";
 import { Logger } from "../../utils/logger";
 import {
+  accumulateRealtimeUsage,
   acquireRealtimeSocketKey,
+  reportOpenAIRealtimeUsage,
   resolveRealtimeMintEndpoint,
+  zeroRealtimeUsage,
   type RealtimeMintEndpoint,
+  type RealtimeUsage,
 } from "../../voice/broker";
 import { OPENAI_REALTIME_MODEL } from "../../voice/voice-models";
 
@@ -131,6 +135,12 @@ export class RealtimeAgentAdapter extends AgentAdapter {
   private readonly logger = new Logger("RealtimeAgentAdapter");
   /** The gateway's id for the current session, empty unless a gateway minted it. */
   private brokerSessionId = "";
+  /** Where to report the session's usage, set when a gateway minted it. */
+  private mintEndpoint: RealtimeMintEndpoint | null = null;
+  /** Running usage total for the session, sent when it ends. */
+  private sessionUsage: RealtimeUsage | null = null;
+  /** Whether the raw transport tap that accumulates usage is attached. */
+  private usageTapAttached = false;
 
   /**
    * Creates a new RealtimeAgentAdapter instance
@@ -179,6 +189,8 @@ export class RealtimeAgentAdapter extends AgentAdapter {
   ): Promise<void> {
     const { apiKey, ...rest } = params ?? {};
     this.brokerSessionId = "";
+    this.mintEndpoint = null;
+    this.sessionUsage = null;
     if (apiKey) {
       await this.session.connect({ apiKey, ...rest });
       return;
@@ -188,10 +200,12 @@ export class RealtimeAgentAdapter extends AgentAdapter {
     // base URL has no mint route. It is never offered to the mint, because a
     // gateway cannot bill a provider key it did not issue.
     const realtimeKey = process.env.OPENAI_REALTIME_API_KEY;
-    const credential = await acquireRealtimeSocketKey(
+    const endpoint =
       this.config.mint === false
         ? null
-        : resolveRealtimeMintEndpoint(this.config.mint ?? undefined),
+        : resolveRealtimeMintEndpoint(this.config.mint ?? undefined);
+    const credential = await acquireRealtimeSocketKey(
+      endpoint,
       {
         apiKey: realtimeKey ?? process.env.OPENAI_API_KEY ?? "",
         source:
@@ -209,10 +223,73 @@ export class RealtimeAgentAdapter extends AgentAdapter {
       },
     );
     this.brokerSessionId = credential.sessionId;
+    if (this.brokerSessionId) {
+      // A gateway opened a spend record, so this session has to be closed by a
+      // report. The total starts at zero so a session that never completes a
+      // response still closes, instead of holding one of the key's slots until
+      // the gateway's grace expires.
+      this.mintEndpoint = endpoint;
+      this.sessionUsage = zeroRealtimeUsage();
+      this.attachUsageTap();
+    }
 
     await this.session.connect({
       apiKey: credential.socketKey,
       ...rest,
+    });
+  }
+
+  /**
+   * Accumulates what each response reports, through the SDK's raw event tap.
+   *
+   * The vendor reports usage per response rather than per session, so the
+   * numbers are summed: see {@link accumulateRealtimeUsage}. Attached once,
+   * because the transport outlives a single connect and a second listener
+   * would count every response twice.
+   */
+  private attachUsageTap(): void {
+    if (this.usageTapAttached) return;
+    const transport = (
+      this.session as RealtimeSession & {
+        transport?: { on?: (event: string, handler: (e: unknown) => void) => void };
+      }
+    ).transport;
+    if (typeof transport?.on !== "function") return;
+    this.usageTapAttached = true;
+    transport.on("*", (event: unknown) => {
+      if (!this.brokerSessionId || !event || typeof event !== "object") return;
+      const record = event as Record<string, unknown>;
+      if (record.type !== "response.done") return;
+      const response = record.response;
+      if (!response || typeof response !== "object") return;
+      const usage = (response as Record<string, unknown>).usage;
+      if (usage && typeof usage === "object") {
+        this.sessionUsage = accumulateRealtimeUsage(
+          this.sessionUsage,
+          usage as RealtimeUsage,
+        );
+      }
+    });
+  }
+
+  /**
+   * Closes the session's spend record with what the socket measured.
+   *
+   * Clearing the total first is what makes a second disconnect a no-op, so a
+   * session cannot be reported twice.
+   */
+  private async reportUsage(): Promise<void> {
+    if (!this.mintEndpoint || !this.brokerSessionId || !this.sessionUsage) {
+      return;
+    }
+    const usage = this.sessionUsage;
+    const sessionId = this.brokerSessionId;
+    this.sessionUsage = null;
+    await reportOpenAIRealtimeUsage(this.mintEndpoint, {
+      sessionId,
+      usage,
+      onError: (error) =>
+        this.logger.debug("voice broker usage report failed", { error }),
     });
   }
 
@@ -241,6 +318,7 @@ export class RealtimeAgentAdapter extends AgentAdapter {
    * Closes the session connection
    */
   async disconnect(): Promise<void> {
+    await this.reportUsage();
     this.session.close();
   }
 

--- a/javascript/src/agents/realtime/realtime-agent.adapter.ts
+++ b/javascript/src/agents/realtime/realtime-agent.adapter.ts
@@ -1,11 +1,15 @@
 /**
  * Realtime Agent Adapter for Scenario Testing
  *
- * Adapts a connected RealtimeSession to the Scenario framework interface.
- * The session must be created and connected before passing to this adapter.
+ * Adapts a RealtimeSession to the Scenario framework interface. Create the
+ * session with your own session creator, hand it to this adapter, then call
+ * `connect()`.
  *
  * This ensures we test the REAL agent, not a mock, using the same session
- * creation pattern as the browser client.
+ * creation pattern as the browser client. `connect()` mints the session
+ * credential the same way `OpenAIRealtimeAgentAdapter` does, so a run pointed
+ * at a LangWatch AI Gateway is metered there rather than dialing OpenAI with a
+ * long-lived provider key.
  */
 
 import { EventEmitter } from "events";
@@ -20,6 +24,12 @@ import { ResponseFormatter } from "./response-formatter";
 import type { AgentInput, AgentReturnTypes, AgentRole } from "../../domain";
 import { AgentAdapter } from "../../domain/agents";
 import { Logger } from "../../utils/logger";
+import {
+  acquireRealtimeSocketKey,
+  resolveRealtimeMintEndpoint,
+  type RealtimeMintEndpoint,
+} from "../../voice/broker";
+import { OPENAI_REALTIME_MODEL } from "../../voice/voice-models";
 
 /**
  * Configuration for RealtimeAgentAdapter
@@ -31,20 +41,20 @@ export interface RealtimeAgentAdapterConfig {
   role: AgentRole;
 
   /**
-   * A connected RealtimeSession instance
+   * A RealtimeSession instance
    *
-   * The session should be created using your agent's session creator function
-   * and connected before passing to this adapter.
+   * The session should be created using your agent's session creator function.
+   * Connect it through the adapter, which mints the session credential.
    *
    * @example
    * ```typescript
    * const session = createVegetarianRecipeSession();
-   * await session.connect({ apiKey: process.env.OPENAI_API_KEY });
    * const adapter = new RealtimeAgentAdapter({
    *   session,
    *   role: AgentRole.AGENT,
    *   agentName: "Vegetarian Recipe Assistant"
    * });
+   * await adapter.connect();
    * ```
    */
   session: RealtimeSession;
@@ -59,24 +69,45 @@ export interface RealtimeAgentAdapterConfig {
    * @default 30000
    */
   responseTimeout?: number;
+
+  /**
+   * Realtime model id the session credential is minted for.
+   *
+   * Read from the session's own options when omitted, and from
+   * {@link OPENAI_REALTIME_MODEL} when the session names none. The gateway
+   * prices and budgets the session against this value, so it has to match the
+   * model the session actually opens with.
+   */
+  model?: string;
+
+  /**
+   * Where to mint the session credential, overriding `OPENAI_BASE_URL` and
+   * `OPENAI_API_KEY`. `false` skips the mint and dials the vendor directly.
+   *
+   * Same option, same meaning and same default as
+   * `OpenAIRealtimeAgentAdapterInit.mint`.
+   */
+  mint?: Partial<RealtimeMintEndpoint> | false;
 }
 
 /**
  * Adapter that connects Scenario testing framework to OpenAI Realtime API
  *
- * This adapter wraps a connected RealtimeSession to provide the Scenario
- * framework interface. The session must be created and connected externally,
- * ensuring the same session creation pattern is used in both browser and tests.
+ * This adapter wraps a RealtimeSession to provide the Scenario framework
+ * interface. The session is created by your own session creator, so the same
+ * creation pattern runs in both browser and tests. `connect()` mints the
+ * session credential at `OPENAI_BASE_URL`, which is how a run through a
+ * LangWatch AI Gateway gets metered.
  *
  * @example
  * ```typescript
  * // In beforeAll
  * const session = createVegetarianRecipeSession();
- * await session.connect({ apiKey: process.env.OPENAI_API_KEY });
  * const adapter = new RealtimeAgentAdapter({
  *   session,
  *   role: AgentRole.AGENT
  * });
+ * await adapter.connect();
  *
  * // In test
  * await scenario.run({
@@ -98,12 +129,14 @@ export class RealtimeAgentAdapter extends AgentAdapter {
   private responseFormatter = new ResponseFormatter();
   private audioEvents = new EventEmitter();
   private readonly logger = new Logger("RealtimeAgentAdapter");
+  /** The gateway's id for the current session, empty unless a gateway minted it. */
+  private brokerSessionId = "";
 
   /**
    * Creates a new RealtimeAgentAdapter instance
    *
    * The session can be either connected or unconnected.
-   * If unconnected, call connect() with an API key before use.
+   * If unconnected, call connect() before use.
    *
    * @param config - Configuration for the realtime agent adapter
    */
@@ -116,29 +149,85 @@ export class RealtimeAgentAdapter extends AgentAdapter {
   }
 
   /**
-   * Get the connect method from the session
+   * Whether the live session was minted by a gateway rather than the vendor.
+   *
+   * Only true after `connect()`, and only when the mint answered with
+   * `X-LangWatch-Session-Id`. Configuration cannot set it, because the
+   * response is the one thing that cannot be told a lie about what answered.
+   */
+  get brokered(): boolean {
+    return this.brokerSessionId !== "";
+  }
+
+  /**
+   * Open the session, minting its credential the way every other realtime
+   * adapter does.
+   *
+   * The media websocket runs to OpenAI either way. What changes is the bearer
+   * it opens with: `POST ${OPENAI_BASE_URL}/realtime/client_secrets` is
+   * OpenAI's own mint path and a LangWatch AI Gateway mirrors it, so pointing
+   * `OPENAI_BASE_URL` at a gateway makes the same request check the virtual
+   * key's budget and session cap and open one spend record. The socket then
+   * carries the ephemeral secret the mint returned, which the `@openai/agents`
+   * websocket transport was built to take.
+   *
+   * An explicit `params.apiKey` skips the mint: the caller has already said
+   * which credential to dial with.
    */
   async connect(
     params?: Parameters<RealtimeSession["connect"]>[0] | undefined
   ): Promise<void> {
     const { apiKey, ...rest } = params ?? {};
-    // The Realtime API is a direct websocket to api.openai.com that an
-    // OpenAI-compatible gateway cannot proxy. When OPENAI_API_KEY holds a
-    // gateway credential (e.g. a LangWatch virtual key), the dedicated
-    // OPENAI_REALTIME_API_KEY must win, same as OpenAIRealtimeAdapter.
-    const resolvedApiKey =
-      apiKey ??
-      process.env.OPENAI_REALTIME_API_KEY ??
-      process.env.OPENAI_API_KEY;
-    if (!resolvedApiKey) {
-      throw new Error(
-        "RealtimeAgentAdapter.connect requires an API key: pass params.apiKey or set OPENAI_REALTIME_API_KEY / OPENAI_API_KEY.",
-      );
+    this.brokerSessionId = "";
+    if (apiKey) {
+      await this.session.connect({ apiKey, ...rest });
+      return;
     }
+
+    // `OPENAI_REALTIME_API_KEY` is the direct-dial fallback, used only when the
+    // base URL has no mint route. It is never offered to the mint, because a
+    // gateway cannot bill a provider key it did not issue.
+    const realtimeKey = process.env.OPENAI_REALTIME_API_KEY;
+    const credential = await acquireRealtimeSocketKey(
+      this.config.mint === false
+        ? null
+        : resolveRealtimeMintEndpoint(this.config.mint ?? undefined),
+      {
+        apiKey: realtimeKey ?? process.env.OPENAI_API_KEY ?? "",
+        source:
+          realtimeKey !== undefined
+            ? "OPENAI_REALTIME_API_KEY"
+            : "OPENAI_API_KEY",
+      },
+      {
+        model: this.mintModel,
+        noCredentialMessage:
+          "RealtimeAgentAdapter.connect requires an API key: pass " +
+          "params.apiKey, or set OPENAI_API_KEY so the session can be minted " +
+          "at OPENAI_BASE_URL, or set OPENAI_REALTIME_API_KEY to dial OpenAI " +
+          "directly.",
+      },
+    );
+    this.brokerSessionId = credential.sessionId;
+
     await this.session.connect({
-      apiKey: resolvedApiKey,
+      apiKey: credential.socketKey,
       ...rest,
     });
+  }
+
+  /**
+   * The model the mint is asked for.
+   *
+   * `RealtimeSession` keeps the model it was built with on its public
+   * `options`, so a session created by the caller's own factory needs no
+   * second declaration here.
+   */
+  private get mintModel(): string {
+    const sessionModel = (
+      this.session as RealtimeSession & { options?: { model?: string } }
+    ).options?.model;
+    return this.config.model ?? sessionModel ?? OPENAI_REALTIME_MODEL;
   }
 
   /**

--- a/javascript/src/utils/logger.ts
+++ b/javascript/src/utils/logger.ts
@@ -4,8 +4,9 @@ import { LogLevel, LOG_LEVELS } from "../config/log-levels";
 /**
  * Simple logger that respects LOG_LEVEL environment variable.
  *
- * Supports standard log levels: error, warn, info, debug
- * Silent by default (good for library usage)
+ * Supports standard log levels: error, warn, info, debug. `LOG_LEVEL` unset
+ * resolves to `INFO`, so errors, warnings and info all print; set `LOG_LEVEL`
+ * to `error` or `warn` to quiet a library consumer down.
  */
 export class Logger {
   /**
@@ -41,7 +42,6 @@ export class Logger {
     const currentLevelIndex = this.getLogLevelIndexFor(this.LOG_LEVEL);
     const requestedLevelIndex = this.getLogLevelIndexFor(level);
 
-    // If LOG_LEVEL is not set or invalid, don't log (silent by default)
     return currentLevelIndex >= 0 && requestedLevelIndex <= currentLevelIndex;
   }
 

--- a/javascript/src/voice/__tests__/broker.test.ts
+++ b/javascript/src/voice/__tests__/broker.test.ts
@@ -9,6 +9,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  acquireRealtimeSocketKey,
   mintOpenAIRealtimeSession,
   reportOpenAIRealtimeUsage,
   resolveRealtimeMintEndpoint,
@@ -321,5 +322,128 @@ describe("given a usage report at the end of a session", () => {
       }),
     ).resolves.toBeUndefined();
     expect(onError).toHaveBeenCalledOnce();
+  });
+});
+
+/**
+ * The mint-or-dial rule itself, in the one place it is implemented.
+ *
+ * Both realtime adapters call this, so a difference between them cannot exist
+ * without this function saying two things at once.
+ */
+describe("given a socket that needs a credential", () => {
+  const endpoint = { baseUrl: "https://gateway.example/v1", apiKey: "vk-lw" };
+  const fallback = { apiKey: "sk-direct", source: "OPENAI_REALTIME_API_KEY" };
+  const noCredentialMessage = "TestAdapter: no API key.";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("carries the ephemeral secret and the session id when a gateway mints", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ value: "ek_secret" }), {
+          status: 200,
+          headers: { "x-langwatch-session-id": "req_abc" },
+        }),
+    );
+
+    await expect(
+      acquireRealtimeSocketKey(endpoint, fallback, {
+        model: "gpt-realtime",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        noCredentialMessage,
+      }),
+    ).resolves.toEqual({
+      socketKey: "ek_secret",
+      sessionId: "req_abc",
+      minted: true,
+    });
+  });
+
+  it.each([401, 402, 403, 429, 500, 503])(
+    "raises on HTTP %i, so a refused session is never dialled around",
+    async (status) => {
+      // The endpoint answered, so it has the route and declined this call.
+      // Falling back here would spend a provider key on a call the gateway
+      // refused to bill, which is the one thing the broker exists to stop.
+      const fetchImpl = vi.fn(async () => new Response("no", { status }));
+
+      await expect(
+        acquireRealtimeSocketKey(endpoint, fallback, {
+          model: "gpt-realtime",
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          noCredentialMessage,
+        }),
+      ).rejects.toThrow(new RegExp(`refused this session with HTTP ${status}`));
+    },
+  );
+
+  it("falls back on HTTP 404, because an absent route is not a refusal", async () => {
+    // 404 means the base URL is not a LangWatch gateway: a plain OpenAI-
+    // compatible proxy, or a gateway older than this feature. Third-party
+    // setups keep working.
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 404 }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(
+      acquireRealtimeSocketKey(endpoint, fallback, {
+        model: "gpt-realtime",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        noCredentialMessage,
+      }),
+    ).resolves.toEqual({
+      socketKey: "sk-direct",
+      sessionId: "",
+      minted: false,
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("prints the direct-dial warning with LOG_LEVEL unset, so a bypass is visible in CI", async () => {
+    // LOG_LEVEL unset resolves to INFO, which passes WARN. An unbilled run
+    // that logged nothing would read exactly like a billed one.
+    const savedLevel = process.env.LOG_LEVEL;
+    delete process.env.LOG_LEVEL;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await acquireRealtimeSocketKey(endpoint, fallback, {
+        model: "gpt-realtime",
+        fetchImpl: (async () =>
+          new Response("nope", { status: 404 })) as unknown as typeof fetch,
+        noCredentialMessage,
+      });
+    } finally {
+      if (savedLevel === undefined) delete process.env.LOG_LEVEL;
+      else process.env.LOG_LEVEL = savedLevel;
+    }
+
+    expect(warn.mock.calls.map(String).join(" ")).toMatch(/not billed/);
+  });
+
+  it("dials directly with no mint attempt when there is no endpoint", async () => {
+    await expect(
+      acquireRealtimeSocketKey(null, fallback, {
+        model: "gpt-realtime",
+        noCredentialMessage,
+      }),
+    ).resolves.toEqual({
+      socketKey: "sk-direct",
+      sessionId: "",
+      minted: false,
+    });
+  });
+
+  it("raises the caller's own message when nothing is left to dial with", async () => {
+    // The message names the adapter and its variables, so a misconfigured run
+    // says which one to set rather than which function noticed.
+    await expect(
+      acquireRealtimeSocketKey(
+        null,
+        { apiKey: "", source: "OPENAI_API_KEY" },
+        { model: "gpt-realtime", noCredentialMessage },
+      ),
+    ).rejects.toThrow(noCredentialMessage);
   });
 });

--- a/javascript/src/voice/__tests__/broker.test.ts
+++ b/javascript/src/voice/__tests__/broker.test.ts
@@ -9,10 +9,12 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  accumulateRealtimeUsage,
   acquireRealtimeSocketKey,
   mintOpenAIRealtimeSession,
   reportOpenAIRealtimeUsage,
   resolveRealtimeMintEndpoint,
+  zeroRealtimeUsage,
 } from "../broker";
 
 const ENV_KEYS = [
@@ -376,7 +378,7 @@ describe("given a socket that needs a credential", () => {
           fetchImpl: fetchImpl as unknown as typeof fetch,
           noCredentialMessage,
         }),
-      ).rejects.toThrow(new RegExp(`refused this session with HTTP ${status}`));
+      ).rejects.toThrow(new RegExp(`refused with HTTP ${status}`));
     },
   );
 
@@ -445,5 +447,104 @@ describe("given a socket that needs a credential", () => {
         { model: "gpt-realtime", noCredentialMessage },
       ),
     ).rejects.toThrow(noCredentialMessage);
+  });
+});
+
+/**
+ * What a session reports, given what the vendor actually sends.
+ *
+ * OpenAI reports usage per response, not per session. Measured against the
+ * live Realtime API on 2026-08-21, two turns on one socket reported
+ * `input=120 output=4` then `input=135 output=4`. Cumulative would have been
+ * `output=8`. So keeping only the last `response.done` bills a ten-turn call
+ * for its last turn, and that is worse than reporting nothing: an unreported
+ * session settles as cost-unknown at the gateway's grace, while a wrong report
+ * arrives looking authoritative.
+ */
+describe("given the usage a realtime socket reports", () => {
+  it("sums the turns the live API actually sent, rather than keeping the last", () => {
+    const turn0 = { input_tokens: 120, output_tokens: 4, total_tokens: 124 };
+    const turn1 = { input_tokens: 135, output_tokens: 4, total_tokens: 139 };
+
+    const total = accumulateRealtimeUsage(
+      accumulateRealtimeUsage(zeroRealtimeUsage(), turn0),
+      turn1,
+    );
+
+    expect(total).toEqual({
+      input_tokens: 255,
+      output_tokens: 8,
+      total_tokens: 263,
+    });
+  });
+
+  it("sums the nested detail objects a gateway prices separately", () => {
+    // Audio, text and cached splits are priced at different rates, so dropping
+    // them bills the right token count at the wrong price.
+    const first = {
+      input_tokens: 10,
+      input_token_details: {
+        text_tokens: 6,
+        audio_tokens: 4,
+        cached_tokens: 2,
+        cached_tokens_details: { audio_tokens: 1 },
+      },
+      output_token_details: { audio_tokens: 3 },
+    };
+    const second = {
+      input_tokens: 5,
+      input_token_details: {
+        text_tokens: 1,
+        audio_tokens: 4,
+        cached_tokens: 0,
+        cached_tokens_details: { audio_tokens: 1 },
+      },
+      output_token_details: { audio_tokens: 2 },
+    };
+
+    expect(accumulateRealtimeUsage(first, second)).toEqual({
+      input_tokens: 15,
+      input_token_details: {
+        text_tokens: 7,
+        audio_tokens: 8,
+        cached_tokens: 2,
+        cached_tokens_details: { audio_tokens: 2 },
+      },
+      output_token_details: { audio_tokens: 5 },
+    });
+  });
+
+  it("accumulates a count the vendor adds later without being told about it", () => {
+    // No key list, so a new counter adds up on its own instead of being
+    // silently dropped from the record.
+    const total = accumulateRealtimeUsage(
+      { input_tokens: 1, reasoning_tokens: 7 },
+      { input_tokens: 1, reasoning_tokens: 5 },
+    );
+
+    expect(total.reasoning_tokens).toBe(12);
+  });
+
+  it("carries a flag rather than adding it, because a flag is not a count", () => {
+    const total = accumulateRealtimeUsage(
+      { input_tokens: 1, truncated: false },
+      { input_tokens: 1, truncated: true },
+    );
+
+    expect(total.truncated).toBe(true);
+  });
+
+  it("starts a session at stated zeros, because an empty body is refused", () => {
+    // The gateway reads a report by looking for input_tokens or output_tokens
+    // and answers HTTP 400 to a body carrying neither, which leaves the
+    // session open holding one of the key's slots.
+    expect(zeroRealtimeUsage()).toEqual({ input_tokens: 0, output_tokens: 0 });
+  });
+
+  it("hands out a fresh zero each call, so one session cannot bill another", () => {
+    const first = zeroRealtimeUsage();
+    accumulateRealtimeUsage(first, { input_tokens: 99 });
+
+    expect(zeroRealtimeUsage()).toEqual({ input_tokens: 0, output_tokens: 0 });
   });
 });

--- a/javascript/src/voice/__tests__/broker.test.ts
+++ b/javascript/src/voice/__tests__/broker.test.ts
@@ -542,9 +542,13 @@ describe("given the usage a realtime socket reports", () => {
   });
 
   it("hands out a fresh zero each call, so one session cannot bill another", () => {
+    // A shared object would carry one session's counts into the next. The
+    // first is mutated directly, because the accumulator returns a new object
+    // and would leave a shared starting value untouched either way.
     const first = zeroRealtimeUsage();
-    accumulateRealtimeUsage(first, { input_tokens: 99 });
+    const second = zeroRealtimeUsage();
+    first.input_tokens = 99;
 
-    expect(zeroRealtimeUsage()).toEqual({ input_tokens: 0, output_tokens: 0 });
+    expect(second).toEqual({ input_tokens: 0, output_tokens: 0 });
   });
 });

--- a/javascript/src/voice/__tests__/elevenlabs-base-url-scope.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-base-url-scope.test.ts
@@ -130,4 +130,19 @@ describe("given a key for the hosted ConvAI adapter", () => {
 
     expect(resolveElevenLabsConvAIApiKey("sk_explicit")).toBe("sk_explicit");
   });
+
+  it("skips a blank candidate rather than shadowing a real key with a 401", () => {
+    // A variable set to a stray space is truthy. Stopping there would present
+    // whitespace as the credential and fail the mint for no visible reason.
+    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] = "  ";
+    process.env.ELEVENLABS_API_KEY = "sk_vendor";
+
+    expect(resolveElevenLabsConvAIApiKey("")).toBe("sk_vendor");
+  });
+
+  it("reports no key when every candidate is blank", () => {
+    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] = " ";
+
+    expect(resolveElevenLabsConvAIApiKey()).toBe("");
+  });
 });

--- a/javascript/src/voice/__tests__/elevenlabs-base-url-scope.test.ts
+++ b/javascript/src/voice/__tests__/elevenlabs-base-url-scope.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Which ElevenLabs surfaces `ELEVENLABS_BASE_URL` moves, and which it must not.
+ *
+ * A LangWatch AI Gateway fronts one ElevenLabs REST route,
+ * `GET /v1/convai/conversation/get-signed-url`. It answers chi's plain
+ * `404 page not found` for `/v1/speech-to-text` and
+ * `/v1/text-to-speech/{voiceId}` (measured against gateway.langwatch.ai on
+ * 2026-08-21). So the variable that points the hosted ConvAI adapter at a
+ * gateway would break transcription and synthesis in the same process if the
+ * leaves read it too. They take an explicit option instead.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ELEVENLABS_BASE_URL_ENV,
+  ELEVENLABS_CONVAI_API_KEY_ENV,
+  normalizeElevenLabsBaseUrl,
+  resolveElevenLabsBaseUrl,
+  resolveElevenLabsConvAIApiKey,
+} from "../elevenlabs-base-url";
+import { ElevenLabsSTTProvider } from "../stt/elevenlabs-stt";
+import { elevenLabsSynthesizeBytes } from "../tts/elevenlabs-tts";
+
+/** Every base URL a leaf handed to the SDK loader, newest last. */
+const loaded = vi.hoisted(() => [] as Array<string | undefined>);
+
+vi.mock("../elevenlabs-sdk", () => ({
+  loadElevenLabsClient: (_apiKey: string, baseUrl?: string) => {
+    loaded.push(baseUrl);
+    return Promise.resolve({
+      speechToText: { convert: () => Promise.resolve({ text: "hello" }) },
+      textToSpeech: {
+        convert: () =>
+          Promise.resolve(
+            (async function* () {
+              yield new Uint8Array([0, 0]);
+            })(),
+          ),
+      },
+    });
+  },
+}));
+
+const saved = process.env[ELEVENLABS_BASE_URL_ENV];
+
+describe("given ELEVENLABS_BASE_URL is set for the hosted ConvAI demos", () => {
+  beforeEach(() => {
+    loaded.length = 0;
+    process.env[ELEVENLABS_BASE_URL_ENV] = "https://gateway.example";
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ELEVENLABS_BASE_URL_ENV];
+    else process.env[ELEVENLABS_BASE_URL_ENV] = saved;
+  });
+
+  it("moves the surface the gateway fronts", () => {
+    expect(resolveElevenLabsBaseUrl()).toBe("https://gateway.example");
+  });
+
+  it("leaves speech-to-text on ElevenLabs, because the gateway has no route for it", async () => {
+    await new ElevenLabsSTTProvider({ apiKey: "key" }).transcribe({
+      data: Buffer.alloc(2),
+    } as unknown as Parameters<ElevenLabsSTTProvider["transcribe"]>[0]);
+
+    expect(loaded).toEqual([undefined]);
+  });
+
+  it("leaves text-to-speech on ElevenLabs, for the same reason", async () => {
+    await elevenLabsSynthesizeBytes("hi", "voice_1", { apiKey: "key" });
+
+    expect(loaded).toEqual([undefined]);
+  });
+
+  it("still lets a caller point a leaf somewhere explicitly", async () => {
+    await elevenLabsSynthesizeBytes("hi", "voice_1", {
+      apiKey: "key",
+      baseUrl: "https://proxy.example",
+    });
+
+    expect(loaded).toEqual(["https://proxy.example"]);
+  });
+
+  it("checks an explicit leaf base URL the same way, so /v1 is caught once", () => {
+    expect(() => normalizeElevenLabsBaseUrl("https://proxy.example/v1")).toThrow(
+      /must not include \/v1/,
+    );
+  });
+});
+
+/**
+ * Which key each ElevenLabs destination gets.
+ *
+ * The gateway authenticates a LangWatch virtual key, ElevenLabs authenticates
+ * an ElevenLabs key, and one process talks to both. One variable would have to
+ * be both, so the ConvAI lane has its own.
+ */
+describe("given a key for the hosted ConvAI adapter", () => {
+  const savedConvAI = process.env[ELEVENLABS_CONVAI_API_KEY_ENV];
+  const savedVendor = process.env.ELEVENLABS_API_KEY;
+
+  beforeEach(() => {
+    delete process.env[ELEVENLABS_CONVAI_API_KEY_ENV];
+    delete process.env.ELEVENLABS_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedConvAI === undefined) delete process.env[ELEVENLABS_CONVAI_API_KEY_ENV];
+    else process.env[ELEVENLABS_CONVAI_API_KEY_ENV] = savedConvAI;
+    if (savedVendor === undefined) delete process.env.ELEVENLABS_API_KEY;
+    else process.env.ELEVENLABS_API_KEY = savedVendor;
+  });
+
+  it("prefers ELEVENLABS_CONVAI_API_KEY, which is what pairs with a gateway", () => {
+    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] = "vk-lw-test";
+    process.env.ELEVENLABS_API_KEY = "sk_vendor";
+
+    expect(resolveElevenLabsConvAIApiKey()).toBe("vk-lw-test");
+  });
+
+  it("falls back to ELEVENLABS_API_KEY, so an unconfigured run is unchanged", () => {
+    process.env.ELEVENLABS_API_KEY = "sk_vendor";
+
+    expect(resolveElevenLabsConvAIApiKey()).toBe("sk_vendor");
+  });
+
+  it("lets an explicit key win over both", () => {
+    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] = "vk-lw-test";
+
+    expect(resolveElevenLabsConvAIApiKey("sk_explicit")).toBe("sk_explicit");
+  });
+});

--- a/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
+++ b/javascript/src/voice/adapters/__tests__/elevenlabs-base-url.test.ts
@@ -8,12 +8,10 @@
  * real debugging round before this check existed.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  ElevenLabsAgentAdapter,
-  normalizeElevenLabsBaseUrl,
-} from "../elevenlabs";
+import { resolveElevenLabsBaseUrl } from "../../elevenlabs-base-url";
+import { ElevenLabsAgentAdapter } from "../elevenlabs";
 
 /** Options every `ElevenLabsClient` this file builds was constructed with. */
 const clientOptions = vi.hoisted(() => [] as Record<string, unknown>[]);
@@ -46,9 +44,17 @@ function adapterWith(baseUrl?: string): ElevenLabsAgentAdapter {
   });
 }
 
+const savedBaseUrl = process.env.ELEVENLABS_BASE_URL;
+
 describe("given a base URL for the ElevenLabs SDK", () => {
   beforeEach(() => {
     clientOptions.length = 0;
+    delete process.env.ELEVENLABS_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedBaseUrl === undefined) delete process.env.ELEVENLABS_BASE_URL;
+    else process.env.ELEVENLABS_BASE_URL = savedBaseUrl;
   });
 
   describe("when it carries the /v1 prefix", () => {
@@ -83,7 +89,7 @@ describe("given a base URL for the ElevenLabs SDK", () => {
 
   describe("when it names a host root", () => {
     it("keeps it, with any trailing slash removed", () => {
-      expect(normalizeElevenLabsBaseUrl("https://gateway.example/")).toBe(
+      expect(resolveElevenLabsBaseUrl("https://gateway.example/")).toBe(
         "https://gateway.example",
       );
       expect(() => adapterWith("https://gateway.example/")).not.toThrow();
@@ -94,8 +100,24 @@ describe("given a base URL for the ElevenLabs SDK", () => {
     it("leaves the SDK on its own default", () => {
       // Empty is unset, not an error: it is what an unset environment
       // variable spreads into an options object as.
-      expect(normalizeElevenLabsBaseUrl(undefined)).toBeUndefined();
-      expect(normalizeElevenLabsBaseUrl("   ")).toBeUndefined();
+      expect(resolveElevenLabsBaseUrl(undefined)).toBeUndefined();
+      expect(resolveElevenLabsBaseUrl("   ")).toBeUndefined();
+    });
+  });
+
+  describe("when only the environment names one", () => {
+    it("reads ELEVENLABS_BASE_URL, so every call site does not repeat it", () => {
+      // The seven demos that build an adapter would otherwise each need the
+      // same conditional spread, and one of them would be missed.
+      process.env.ELEVENLABS_BASE_URL = "https://gateway.example/";
+      expect(resolveElevenLabsBaseUrl()).toBe("https://gateway.example");
+    });
+
+    it("lets an explicit value win over the environment", () => {
+      process.env.ELEVENLABS_BASE_URL = "https://from-env.example";
+      expect(resolveElevenLabsBaseUrl("https://explicit.example")).toBe(
+        "https://explicit.example",
+      );
     });
   });
 });
@@ -103,6 +125,12 @@ describe("given a base URL for the ElevenLabs SDK", () => {
 describe("given the adapter builds its SDK client", () => {
   beforeEach(() => {
     clientOptions.length = 0;
+    delete process.env.ELEVENLABS_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedBaseUrl === undefined) delete process.env.ELEVENLABS_BASE_URL;
+    else process.env.ELEVENLABS_BASE_URL = savedBaseUrl;
   });
 
   it("hands a configured base URL to the client", async () => {
@@ -112,6 +140,19 @@ describe("given the adapter builds its SDK client", () => {
     ).rejects.toThrow();
 
     expect(clientOptions).toHaveLength(1);
+    expect(clientOptions[0]).toMatchObject({
+      apiKey: "key_test",
+      baseUrl: "https://gateway.example",
+    });
+  });
+
+  it("takes the base URL from the environment when the caller names none", async () => {
+    // This is what lets the ElevenLabs demos ride a gateway with no per-demo
+    // change, the way OPENAI_BASE_URL already does for the OpenAI demos.
+    process.env.ELEVENLABS_BASE_URL = "https://gateway.example";
+
+    await expect(adapterWith(undefined).connect()).rejects.toThrow();
+
     expect(clientOptions[0]).toMatchObject({
       apiKey: "key_test",
       baseUrl: "https://gateway.example",

--- a/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
+++ b/javascript/src/voice/adapters/__tests__/openai-realtime-mint.test.ts
@@ -90,10 +90,13 @@ describe("given an adapter connecting to a realtime session", () => {
       await adapter.connect();
       await adapter.disconnect();
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      // Two requests, and the second one is the point: a gateway session is
+      // opened by the mint and only a report closes it, so a session that ran
+      // no response still has to be closed at zero.
+      expect(fetchSpy.mock.calls.map((call) => String(call[0]))).toEqual([
         "https://gateway.example/v1/realtime/client_secrets",
-      );
+        "https://gateway.example/v1/realtime/sessions/req_abc/usage",
+      ]);
       // The long-lived keys stay off the socket: neither the virtual key nor
       // the direct provider key is what the websocket carries.
       expect(dialledWith).toEqual(["Bearer ek_minted_secret"]);
@@ -189,8 +192,13 @@ describe("given an adapter connecting to a realtime session", () => {
         "https://gateway.example/v1/realtime/sessions/req_abc/usage",
       ]);
       // Zero is the truth here, not a placeholder: an ephemeral credential
-      // that opened no socket consumed nothing at the vendor.
-      expect(calls[1]?.body).toEqual({ usage: {} });
+      // that opened no socket consumed nothing at the vendor. The counts are
+      // stated rather than left out, because the gateway reads a report by
+      // looking for input_tokens or output_tokens and answers 400 to a body
+      // carrying neither, which would leave the session open.
+      expect(calls[1]?.body).toEqual({
+        usage: { input_tokens: 0, output_tokens: 0 },
+      });
     });
   });
 
@@ -206,8 +214,123 @@ describe("given an adapter connecting to a realtime session", () => {
 
       const adapter = adapterAt(server.port());
 
-      await expect(adapter.connect()).rejects.toThrow(/HTTP 402/);
+      await expect(adapter.connect()).rejects.toThrow(/refused with HTTP 402/);
       expect(dialledWith).toEqual([]);
     });
+  });
+});
+
+/**
+ * What the adapter reports when the session ends.
+ *
+ * The vendor reports usage per response, so the number that closes a spend
+ * record has to be the sum of every turn. These tests drive the real
+ * `response.done` frames through the real socket and assert on the body that
+ * reaches the gateway, because the defect lives in the arithmetic between the
+ * frames and the report.
+ */
+describe("given a brokered session that ends", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  /** Every usage body the adapter posted to the gateway, newest last. */
+  let reported: unknown[] = [];
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
+    process.env.OPENAI_API_KEY = "vk-lw-test";
+    reported = [];
+    dialledWith = [];
+    server.arm();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (String(url).endsWith("/client_secrets")) {
+          return mintResponse(200, "req_abc");
+        }
+        reported.push(JSON.parse(String(init?.body)));
+        return new Response("{}", { status: 202 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reports every turn, not the last one", async () => {
+    // The numbers are the two turns measured against the live Realtime API on
+    // 2026-08-21. Keeping the last response would report output_tokens 4.
+    const adapter = adapterAt(server.port());
+    await adapter.connect();
+    await server.socketReady();
+
+    server.push({
+      type: "response.done",
+      response: {
+        usage: {
+          input_tokens: 120,
+          output_tokens: 4,
+          total_tokens: 124,
+          output_token_details: { audio_tokens: 3 },
+        },
+      },
+    });
+    server.push({
+      type: "response.done",
+      response: {
+        usage: {
+          input_tokens: 135,
+          output_tokens: 4,
+          total_tokens: 139,
+          output_token_details: { audio_tokens: 3 },
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await adapter.disconnect();
+
+    expect(reported).toEqual([
+      {
+        usage: {
+          input_tokens: 255,
+          output_tokens: 8,
+          total_tokens: 263,
+          output_token_details: { audio_tokens: 6 },
+        },
+      },
+    ]);
+  });
+
+  it("closes a session that produced no response at all, at zero", async () => {
+    // Connect then disconnect with no response.done. Reporting nothing would
+    // leave the record open, holding one of the key's session slots until the
+    // gateway's grace expires, which surfaces later as a 429 on a fresh mint.
+    const adapter = adapterAt(server.port());
+    await adapter.connect();
+    await server.socketReady();
+    await adapter.disconnect();
+
+    expect(reported).toEqual([
+      { usage: { input_tokens: 0, output_tokens: 0 } },
+    ]);
+  });
+
+  it("reports once, so a second disconnect cannot bill the session twice", async () => {
+    const adapter = adapterAt(server.port());
+    await adapter.connect();
+    await server.socketReady();
+    await adapter.disconnect();
+    await adapter.disconnect();
+
+    expect(reported).toHaveLength(1);
   });
 });

--- a/javascript/src/voice/adapters/elevenlabs.ts
+++ b/javascript/src/voice/adapters/elevenlabs.ts
@@ -77,6 +77,10 @@ import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import { AdapterCapabilities } from "../capabilities";
 import {
+  resolveElevenLabsBaseUrl,
+  resolveElevenLabsConvAIApiKey,
+} from "../elevenlabs-base-url";
+import {
   type ElevenLabsAudioInterface,
   type ElevenLabsAudioInterfaceCtor,
   type ElevenLabsConversation,
@@ -283,23 +287,30 @@ function deepMerge(
 export interface ElevenLabsAgentAdapterOptions {
   /** ID of the ElevenLabs Conversational AI agent (provisioned in the EL dashboard). */
   agentId: string;
-  /** ElevenLabs API key (`xi-api-key`). */
-  apiKey: string;
+  /**
+   * The key sent as `xi-api-key`. Falls back to `ELEVENLABS_CONVAI_API_KEY`,
+   * then `ELEVENLABS_API_KEY`.
+   *
+   * Against a gateway this carries a LangWatch virtual key rather than an
+   * ElevenLabs one, which is why it has its own variable. See
+   * {@link resolveElevenLabsConvAIApiKey}.
+   */
+  apiKey?: string;
   /**
    * Base URL for the ElevenLabs REST API, passed straight to the SDK client's
-   * own `baseUrl` option.
+   * own `baseUrl` option. Falls back to `ELEVENLABS_BASE_URL`.
    *
    * Points the signed-URL handshake at a LangWatch AI Gateway, which mirrors
    * the vendor's own mint path: the gateway checks the virtual key's budget
    * and session cap, mints the signed URL, and bills the call as one spend
    * record. The websocket the URL names still belongs to ElevenLabs, so the
    * media stream runs client to vendor and nothing about latency or the wire
-   * protocol changes. `apiKey` then carries the virtual key.
+   * protocol changes.
    *
-   * There is no environment variable for this, because the ElevenLabs SDK has
-   * none: `ELEVENLABS_API_KEY` is the only variable it reads (checked against
-   * `@elevenlabs/elevenlabs-js` 2.64.0), and the base URL is a constructor
-   * option. Omitted, the SDK talks to ElevenLabs directly as it always has.
+   * Unset here and in the environment, the SDK talks to ElevenLabs directly as
+   * it always has. The variable covers this adapter only; see
+   * {@link resolveElevenLabsBaseUrl} for why the speech-to-text and
+   * text-to-speech leaves take an explicit option instead.
    */
   baseUrl?: string;
   /**
@@ -378,40 +389,6 @@ export interface ElevenLabsAgentAdapterOptions {
  * real-mic cadence, and drain agent audio the SDK pushes via `output()`.
  */
 
-/**
- * Checks a base URL at construction, where the mistake is still readable.
- *
- * The one people make is including `/v1`. `OPENAI_BASE_URL` conventionally
- * does, and the ElevenLabs SDK appends `/v1` itself, so a base URL that
- * carries it produces `/v1/v1/convai/...` and a 404 that names no cause. An
- * empty value means unset, which leaves the SDK on its own default.
- */
-export function normalizeElevenLabsBaseUrl(raw?: string): string | undefined {
-  const trimmed = raw?.trim().replace(/\/+$/, "");
-  if (!trimmed) return undefined;
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    throw new Error(
-      `ElevenLabsAgentAdapter: baseUrl is not a URL: ${trimmed}`,
-    );
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    // `new URL` accepts schemes the SDK cannot make a REST request over, so
-    // parsing alone is not a check.
-    throw new Error(
-      `ElevenLabsAgentAdapter: baseUrl must be http or https: ${trimmed}`,
-    );
-  }
-  if (parsed.pathname.endsWith("/v1")) {
-    throw new Error(
-      `ElevenLabsAgentAdapter: baseUrl must not include /v1 (${trimmed}). ` +
-        `The SDK appends it, so this would request /v1/v1/convai/... and 404.`,
-    );
-  }
-  return trimmed;
-}
 export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
   override role = AgentRole.AGENT;
 
@@ -514,8 +491,8 @@ export class ElevenLabsAgentAdapter extends VoiceAgentAdapter {
   constructor(options: ElevenLabsAgentAdapterOptions) {
     super();
     this.agentId = options.agentId;
-    this.apiKey = options.apiKey;
-    this.baseUrl = normalizeElevenLabsBaseUrl(options.baseUrl);
+    this.apiKey = resolveElevenLabsConvAIApiKey(options.apiKey);
+    this.baseUrl = resolveElevenLabsBaseUrl(options.baseUrl);
     this.systemPromptOverride = options.systemPromptOverride;
     this.firstMessageOverride = options.firstMessageOverride;
     this.dynamicVariables = options.dynamicVariables;

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -33,9 +33,11 @@ import { Logger } from "../../utils/logger";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import {
+  accumulateRealtimeUsage,
   acquireRealtimeSocketKey,
   reportOpenAIRealtimeUsage,
   resolveRealtimeMintEndpoint,
+  zeroRealtimeUsage,
   type RealtimeMintEndpoint,
   type RealtimeUsage,
 } from "../broker";
@@ -200,8 +202,8 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
   private readonly _mint: RealtimeMintEndpoint | null;
   /** The gateway's id for the current session, empty unless a gateway minted it. */
   private _brokerSessionId = "";
-  /** The last usage object the socket reported, sent when the session ends. */
-  private _lastUsage: RealtimeUsage | null = null;
+  /** Running usage total for the session, sent when it ends. */
+  private _sessionUsage: RealtimeUsage | null = null;
   private readonly _wsFactory:
     | ((url: string, authHeader: string) => WebSocket)
     | null;
@@ -320,7 +322,7 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     this._closeReason = null;
 
     this._brokerSessionId = "";
-    this._lastUsage = null;
+    this._sessionUsage = null;
 
     // The socket's bearer is the ephemeral secret the mint returned: a
     // credential for exactly this call, so no long-lived key reaches the
@@ -340,6 +342,12 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     const socketKey = credential.socketKey;
     if (credential.minted) {
       this._brokerSessionId = credential.sessionId;
+      // Start the session's total at zero rather than at nothing. A session
+      // that never completes a response captures no usage, and a total of null
+      // means disconnect() reports nothing at all, which leaves the record open
+      // and holding one of the key's slots until the gateway's grace expires.
+      // Zero is also the truth for a session that did no work.
+      if (this._brokerSessionId) this._sessionUsage = zeroRealtimeUsage();
       setSpanAttributes(currentSpan(), {
         "voice.realtime.brokered": this.brokered,
         "voice.realtime.session_id": credential.sessionId,
@@ -374,7 +382,7 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
       // ephemeral secret that opened no socket used nothing. Leaving it open
       // would hold one of the key's session slots until the gateway's own
       // window expires, and book a call that never happened.
-      await this._closeUnusedSession();
+      await this._reportUsage();
       throw error;
     }
 
@@ -1284,37 +1292,22 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
   }
 
   /**
-   * Closes a session whose socket never opened, at no cost.
-   *
-   * The mint booked it, so only a report can close it; there is no cancel.
-   * Zero is the correct number, not a placeholder: an ephemeral credential
-   * that opened no socket consumed nothing at the vendor. Doing nothing would
-   * leave the session holding a slot against the key's open-session cap until
-   * the gateway's own window expires.
-   */
-  private async _closeUnusedSession(): Promise<void> {
-    if (!this._mint || !this._brokerSessionId) return;
-    const sessionId = this._brokerSessionId;
-    this._brokerSessionId = "";
-    await reportOpenAIRealtimeUsage(this._mint, {
-      sessionId,
-      usage: {},
-      onError: (error) =>
-        logger.debug("voice broker unused-session close failed", { error }),
-    });
-  }
-
-  /**
    * Closes the session's spend record with what the socket measured.
+   *
+   * Also the failure path for a mint that succeeded and a socket that never
+   * opened, because the total starts at zero: the report is the same request
+   * either way, so there is one method rather than two that disagree. Zero is
+   * the truth there, not a placeholder, since an ephemeral credential that
+   * opened no socket consumed nothing at the vendor.
    *
    * Clearing the captured usage first is what makes a second disconnect a
    * no-op, so a session cannot be reported twice.
    */
   private async _reportUsage(): Promise<void> {
-    if (!this._mint || !this._brokerSessionId || !this._lastUsage) return;
-    const usage = this._lastUsage;
+    if (!this._mint || !this._brokerSessionId || !this._sessionUsage) return;
+    const usage = this._sessionUsage;
     const sessionId = this._brokerSessionId;
-    this._lastUsage = null;
+    this._sessionUsage = null;
     await reportOpenAIRealtimeUsage(this._mint, {
       sessionId,
       usage,
@@ -1324,13 +1317,13 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
   }
 
   /**
-   * Keeps the usage OpenAI reports on `response.done`.
+   * Adds the usage OpenAI reports on `response.done` into the session total.
    *
    * Read from the raw message rather than the receive loop because a drain
    * that ends on tail silence never reads the terminal event, and a session
-   * whose usage was never captured bills as cost-unknown. The last response of
-   * a session carries that session's cumulative totals, so keeping the most
-   * recent one is the number to report.
+   * whose usage was never captured bills as cost-unknown. Summed rather than
+   * replaced because the vendor reports per response: see
+   * {@link accumulateRealtimeUsage}.
    */
   private _captureUsage(event: unknown): void {
     if (!this._brokerSessionId || !event || typeof event !== "object") return;
@@ -1340,7 +1333,10 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     if (!response || typeof response !== "object") return;
     const usage = (response as Record<string, unknown>).usage;
     if (usage && typeof usage === "object") {
-      this._lastUsage = usage as RealtimeUsage;
+      this._sessionUsage = accumulateRealtimeUsage(
+        this._sessionUsage,
+        usage as RealtimeUsage,
+      );
     }
   }
 

--- a/javascript/src/voice/adapters/openai-realtime.ts
+++ b/javascript/src/voice/adapters/openai-realtime.ts
@@ -33,10 +33,9 @@ import { Logger } from "../../utils/logger";
 import { VoiceAgentAdapter } from "../adapter";
 import { AudioChunk } from "../audio-chunk";
 import {
-  mintOpenAIRealtimeSession,
+  acquireRealtimeSocketKey,
   reportOpenAIRealtimeUsage,
   resolveRealtimeMintEndpoint,
-  warnDirectDialFallback,
   type RealtimeMintEndpoint,
   type RealtimeUsage,
 } from "../broker";
@@ -326,31 +325,25 @@ export class OpenAIRealtimeAgentAdapter extends VoiceAgentAdapter {
     // The socket's bearer is the ephemeral secret the mint returned: a
     // credential for exactly this call, so no long-lived key reaches the
     // socket. Whether OpenAI or a gateway answers the mint is a property of
-    // OPENAI_BASE_URL, not of this adapter.
-    let socketKey = this._apiKey;
-    if (this._mint) {
-      const result = await mintOpenAIRealtimeSession(this._mint, {
+    // OPENAI_BASE_URL, not of this adapter. `acquireRealtimeSocketKey` holds
+    // the mint-or-dial rule for every adapter that opens a realtime socket.
+    const credential = await acquireRealtimeSocketKey(
+      this._mint,
+      { apiKey: this._apiKey, source: this._apiKeySource },
+      {
         model: this.model,
-      });
-      if (result.minted) {
-        socketKey = result.clientSecret;
-        this._brokerSessionId = result.sessionId;
-        setSpanAttributes(currentSpan(), {
-          "voice.realtime.brokered": this.brokered,
-          "voice.realtime.session_id": result.sessionId,
-        });
-      } else {
-        // No mint route: a gateway older than this feature, or a plain proxy.
-        // Dial the vendor directly, and say so, because an unbilled session
-        // otherwise looks identical to a billed one.
-        warnDirectDialFallback(this._mint.baseUrl, this._apiKeySource);
-      }
-    }
-    if (socketKey === this._apiKey && !this._apiKey) {
-      throw new Error(
-        "OpenAIRealtimeAgentAdapter: no API key. Set OPENAI_API_KEY or " +
+        noCredentialMessage:
+          "OpenAIRealtimeAgentAdapter: no API key. Set OPENAI_API_KEY or " +
           "pass `{ apiKey }` to the constructor.",
-      );
+      },
+    );
+    const socketKey = credential.socketKey;
+    if (credential.minted) {
+      this._brokerSessionId = credential.sessionId;
+      setSpanAttributes(currentSpan(), {
+        "voice.realtime.brokered": this.brokered,
+        "voice.realtime.session_id": credential.sessionId,
+      });
     }
     // No `OpenAI-Beta: realtime=v1` header — that opt-in is the deprecated
     // Beta. The GA endpoint at `/v1/realtime` rejects the header outright

--- a/javascript/src/voice/broker.ts
+++ b/javascript/src/voice/broker.ts
@@ -141,7 +141,10 @@ export async function mintOpenAIRealtimeSession(
     // The endpoint's own message is the useful one: it names the budget, the
     // session cap or the missing provider far more precisely than a status.
     throw new Error(
-      `realtime mint failed with HTTP ${response.status}: ${text.slice(0, 500)}`,
+      `the mint endpoint at ${endpoint.baseUrl}${MINT_PATH} refused this ` +
+        `session with HTTP ${response.status}. A refusal is not an absent ` +
+        `route, so the vendor is not dialed around it and no session opens. ` +
+        `Response: ${text.slice(0, 500)}`,
     );
   }
 
@@ -161,6 +164,69 @@ export async function mintOpenAIRealtimeSession(
     clientSecret,
     sessionId: response.headers.get(SESSION_ID_HEADER) ?? "",
   };
+}
+
+/**
+ * A long-lived key for dialing the vendor directly, and where it came from.
+ *
+ * `source` names the variable rather than describing it, because the
+ * direct-dial warning is read by someone deciding which value to change.
+ */
+export interface DirectDialCredential {
+  apiKey: string;
+  source: string;
+}
+
+/** The bearer a media socket opens with, and the session it belongs to. */
+export interface RealtimeSocketCredential {
+  /** An ephemeral secret when a mint answered, a long-lived key otherwise. */
+  socketKey: string;
+  /** The gateway's id for this session. Empty unless a gateway minted it. */
+  sessionId: string;
+  /** Whether a mint answered at all, by the vendor or by a gateway. */
+  minted: boolean;
+}
+
+/**
+ * Decides what a realtime socket dials with. The one implementation of that
+ * rule, shared by every adapter that opens one.
+ *
+ * Three outcomes, and the difference between the last two is what keeps a
+ * gateway's decision binding:
+ *
+ * - a mint answered, so the socket carries an ephemeral secret for this call;
+ * - the mint route was absent (HTTP 404), so the endpoint is not a LangWatch
+ *   gateway and the vendor is dialed directly with a warning;
+ * - the mint was refused (401, 403, 429, 5xx and every other error status), so
+ *   {@link mintOpenAIRealtimeSession} raises and no socket opens. Dialing the
+ *   vendor around a refusal would run a call the gateway declined to bill,
+ *   which is the whole thing the broker exists to prevent.
+ */
+export async function acquireRealtimeSocketKey(
+  endpoint: RealtimeMintEndpoint | null,
+  fallback: DirectDialCredential,
+  params: {
+    model: string;
+    expiresAfterSeconds?: number;
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;
+    /** Raised when nothing is left to dial with. Names the caller. */
+    noCredentialMessage: string;
+  },
+): Promise<RealtimeSocketCredential> {
+  if (endpoint) {
+    const result = await mintOpenAIRealtimeSession(endpoint, params);
+    if (result.minted) {
+      return {
+        socketKey: result.clientSecret,
+        sessionId: result.sessionId,
+        minted: true,
+      };
+    }
+    warnDirectDialFallback(endpoint.baseUrl, fallback.source);
+  }
+  if (!fallback.apiKey) throw new Error(params.noCredentialMessage);
+  return { socketKey: fallback.apiKey, sessionId: "", minted: false };
 }
 
 /**

--- a/javascript/src/voice/broker.ts
+++ b/javascript/src/voice/broker.ts
@@ -77,6 +77,65 @@ export type RealtimeMintResult =
 export type RealtimeUsage = Record<string, unknown>;
 
 /**
+ * The usage of a session that consumed nothing.
+ *
+ * The counts are stated rather than left out. A gateway reads a usage report by
+ * looking for `input_tokens` or `output_tokens` and refuses a body carrying
+ * neither, so `{}` comes back HTTP 400 and the session stays open until the
+ * gateway's own grace expires. Measured against the live gateway on 2026-08-21.
+ *
+ * A fresh object each call, because it is the running total a session
+ * accumulates into.
+ */
+export function zeroRealtimeUsage(): RealtimeUsage {
+  return { input_tokens: 0, output_tokens: 0 };
+}
+
+/**
+ * Adds one response's usage into a session total.
+ *
+ * OpenAI reports usage per response, not per session. Measured against the live
+ * Realtime API on 2026-08-21, two turns on one socket reported `output_tokens`
+ * 4 and 4 rather than 4 and 8. So a session that keeps only the last
+ * `response.done` bills for its last turn and nothing else, and a wrong report
+ * is worse than none: the gateway settles an unreported session as cost-unknown
+ * at its grace, while a report that arrives looks authoritative.
+ *
+ * Every numeric leaf is summed and nested detail objects are summed key by key,
+ * so the audio, text and cached breakdowns a gateway prices separately add up
+ * alongside the totals. Keys are not listed here: a count the vendor adds later
+ * then accumulates on its own rather than being silently dropped.
+ */
+export function accumulateRealtimeUsage(
+  total: RealtimeUsage | null,
+  usage: RealtimeUsage,
+): RealtimeUsage {
+  const merged: RealtimeUsage = { ...(total ?? {}) };
+  for (const [key, value] of Object.entries(usage)) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      const running = merged[key];
+      merged[key] = value + (typeof running === "number" ? running : 0);
+    } else if (typeof value === "boolean") {
+      // A flag is not a count, and adding two of them would produce a number
+      // that means nothing.
+      merged[key] = value;
+    } else if (isUsageObject(value)) {
+      const running = merged[key];
+      merged[key] = accumulateRealtimeUsage(
+        isUsageObject(running) ? running : null,
+        value,
+      );
+    }
+  }
+  return merged;
+}
+
+/** A nested detail object, as opposed to an array or null. */
+function isUsageObject(value: unknown): value is RealtimeUsage {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
  * Resolves where to mint, or null when there is no key to mint with.
  *
  * `OPENAI_REALTIME_API_KEY` is deliberately not consulted here. That variable
@@ -141,10 +200,9 @@ export async function mintOpenAIRealtimeSession(
     // The endpoint's own message is the useful one: it names the budget, the
     // session cap or the missing provider far more precisely than a status.
     throw new Error(
-      `the mint endpoint at ${endpoint.baseUrl}${MINT_PATH} refused this ` +
-        `session with HTTP ${response.status}. A refusal is not an absent ` +
-        `route, so the vendor is not dialed around it and no session opens. ` +
-        `Response: ${text.slice(0, 500)}`,
+      `realtime mint refused with HTTP ${response.status}: the gateway at ` +
+        `${endpoint.baseUrl} refused the mint, so this session must not fall ` +
+        `back to a direct provider key. ${text.slice(0, 500)}`,
     );
   }
 

--- a/javascript/src/voice/elevenlabs-base-url.ts
+++ b/javascript/src/voice/elevenlabs-base-url.ts
@@ -34,8 +34,11 @@ export const ELEVENLABS_CONVAI_API_KEY_ENV = "ELEVENLABS_CONVAI_API_KEY";
  * `ELEVENLABS_BASE_URL`.
  */
 export function resolveElevenLabsBaseUrl(explicit?: string): string | undefined {
+  // Blank is unset, not a choice: it is what an absent variable spreads into an
+  // options object as, so it falls through to the environment rather than
+  // suppressing it.
   return normalizeElevenLabsBaseUrl(
-    explicit ?? process.env[ELEVENLABS_BASE_URL_ENV],
+    explicit?.trim() || process.env[ELEVENLABS_BASE_URL_ENV],
   );
 }
 
@@ -52,10 +55,12 @@ export function resolveElevenLabsBaseUrl(explicit?: string): string | undefined 
  * the adapter falls back to `ELEVENLABS_API_KEY` and behaves exactly as before.
  */
 export function resolveElevenLabsConvAIApiKey(explicit?: string): string {
+  // Blank is unset at every step, for the same reason as the base URL: a demo
+  // that spreads an absent variable must reach the next candidate, not stop.
   return (
-    explicit ??
-    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] ??
-    process.env.ELEVENLABS_API_KEY ??
+    explicit ||
+    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] ||
+    process.env.ELEVENLABS_API_KEY ||
     ""
   );
 }

--- a/javascript/src/voice/elevenlabs-base-url.ts
+++ b/javascript/src/voice/elevenlabs-base-url.ts
@@ -57,12 +57,14 @@ export function resolveElevenLabsBaseUrl(explicit?: string): string | undefined 
 export function resolveElevenLabsConvAIApiKey(explicit?: string): string {
   // Blank is unset at every step, for the same reason as the base URL: a demo
   // that spreads an absent variable must reach the next candidate, not stop.
-  return (
-    explicit ||
-    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] ||
-    process.env.ELEVENLABS_API_KEY ||
-    ""
-  );
+  // Whitespace counts as blank, because a variable set to a stray space is
+  // truthy and would otherwise shadow a real key with a 401.
+  const candidates = [
+    explicit,
+    process.env[ELEVENLABS_CONVAI_API_KEY_ENV],
+    process.env.ELEVENLABS_API_KEY,
+  ];
+  return candidates.map((c) => c?.trim()).find(Boolean) ?? "";
 }
 
 /**

--- a/javascript/src/voice/elevenlabs-base-url.ts
+++ b/javascript/src/voice/elevenlabs-base-url.ts
@@ -1,0 +1,94 @@
+/**
+ * Where an ElevenLabs request goes, decided in one place.
+ *
+ * `ELEVENLABS_BASE_URL` is scenario's own variable, not the vendor's: the
+ * ElevenLabs SDK reads no base-URL variable at all (checked against
+ * `@elevenlabs/elevenlabs-js` 2.64.0), it takes a `baseUrl` constructor option.
+ * Point it at a LangWatch AI Gateway and the signed-URL mint is checked against
+ * the virtual key's budget and session cap and billed as one spend record, with
+ * `apiKey` then carrying that virtual key. Leave it unset and every request goes
+ * to ElevenLabs exactly as before.
+ *
+ * The conversation websocket the signed URL names still belongs to ElevenLabs,
+ * so the media stream runs client to vendor and nothing about latency or the
+ * wire protocol changes.
+ *
+ * **The variable covers the hosted ConvAI adapter only.** A LangWatch gateway
+ * fronts one ElevenLabs REST route,
+ * `GET /v1/convai/conversation/get-signed-url`, and answers `404 page not
+ * found` for `/v1/speech-to-text` and `/v1/text-to-speech/{voiceId}` (measured
+ * against gateway.langwatch.ai). So the speech-to-text and text-to-speech
+ * leaves take an explicit `baseUrl` option and do not read the environment: a
+ * variable set for the ConvAI demos would otherwise break every composed
+ * ElevenLabs voice in the same process.
+ */
+
+/** The variable the hosted ConvAI adapter reads. Named once so it cannot drift. */
+export const ELEVENLABS_BASE_URL_ENV = "ELEVENLABS_BASE_URL";
+
+/** The key the hosted ConvAI adapter presents, when it is not the vendor's. */
+export const ELEVENLABS_CONVAI_API_KEY_ENV = "ELEVENLABS_CONVAI_API_KEY";
+
+/**
+ * The base URL for a surface the gateway fronts: explicit value, else
+ * `ELEVENLABS_BASE_URL`.
+ */
+export function resolveElevenLabsBaseUrl(explicit?: string): string | undefined {
+  return normalizeElevenLabsBaseUrl(
+    explicit ?? process.env[ELEVENLABS_BASE_URL_ENV],
+  );
+}
+
+/**
+ * The key the hosted ConvAI adapter presents: explicit value, else
+ * `ELEVENLABS_CONVAI_API_KEY`, else `ELEVENLABS_API_KEY`.
+ *
+ * Two variables because a gateway and the vendor want different credentials
+ * and one process runs both. `ELEVENLABS_BASE_URL` moves the ConvAI mint to a
+ * gateway, which authenticates a LangWatch virtual key, while speech-to-text
+ * and text-to-speech keep going to ElevenLabs, which authenticates an
+ * ElevenLabs key. A single variable would have to be both.
+ * `ELEVENLABS_CONVAI_API_KEY` is what pairs with `ELEVENLABS_BASE_URL`; unset,
+ * the adapter falls back to `ELEVENLABS_API_KEY` and behaves exactly as before.
+ */
+export function resolveElevenLabsConvAIApiKey(explicit?: string): string {
+  return (
+    explicit ??
+    process.env[ELEVENLABS_CONVAI_API_KEY_ENV] ??
+    process.env.ELEVENLABS_API_KEY ??
+    ""
+  );
+}
+
+/**
+ * Checks a base URL where the mistake is still readable.
+ *
+ * The one people make is including `/v1`. `OPENAI_BASE_URL` conventionally
+ * does, and the ElevenLabs SDK appends `/v1` itself, so a base URL that carries
+ * it produces `/v1/v1/convai/...` and a 404 that names no cause. An empty value
+ * means unset, which leaves the SDK on its own default.
+ */
+export function normalizeElevenLabsBaseUrl(
+  raw?: string,
+): string | undefined {
+  const trimmed = raw?.trim().replace(/\/+$/, "");
+  if (!trimmed) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`ElevenLabs baseUrl is not a URL: ${trimmed}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    // `new URL` accepts schemes the SDK cannot make a REST request over, so
+    // parsing alone is not a check.
+    throw new Error(`ElevenLabs baseUrl must be http or https: ${trimmed}`);
+  }
+  if (parsed.pathname.endsWith("/v1")) {
+    throw new Error(
+      `ElevenLabs baseUrl must not include /v1 (${trimmed}). ` +
+        `The SDK appends it, so this would request /v1/v1/convai/... and 404.`,
+    );
+  }
+  return trimmed;
+}

--- a/javascript/src/voice/elevenlabs-sdk.ts
+++ b/javascript/src/voice/elevenlabs-sdk.ts
@@ -99,17 +99,29 @@ function missingSdk(cause: unknown): Error {
   );
 }
 
-/** Builds an authenticated client, loading the SDK on first use. */
+/**
+ * Builds an authenticated client, loading the SDK on first use.
+ *
+ * `baseUrl` is the SDK's documented custom-URL option. Undefined leaves the SDK
+ * on its own default host, so an unconfigured caller sends byte-for-byte the
+ * request it sent before.
+ */
 export async function loadElevenLabsClient(
   apiKey: string,
+  baseUrl?: string,
 ): Promise<ElevenLabsClientLike> {
-  let sdk: { ElevenLabsClient: new (o: { apiKey: string }) => unknown };
+  let sdk: {
+    ElevenLabsClient: new (o: { apiKey: string; baseUrl?: string }) => unknown;
+  };
   try {
     sdk = (await import("@elevenlabs/elevenlabs-js")) as unknown as typeof sdk;
   } catch (cause) {
     throw missingSdk(cause);
   }
-  return new sdk.ElevenLabsClient({ apiKey }) as ElevenLabsClientLike;
+  return new sdk.ElevenLabsClient({
+    apiKey,
+    ...(baseUrl ? { baseUrl } : {}),
+  }) as ElevenLabsClientLike;
 }
 
 /**

--- a/javascript/src/voice/index.ts
+++ b/javascript/src/voice/index.ts
@@ -156,6 +156,18 @@ export {
   type TranscribeSegmentsOptions,
 } from "./transcribe";
 
+// Where an ElevenLabs request goes, and which credential it carries. Exported
+// so a caller writing its own gate ("do I have what the hosted adapter needs?")
+// asks the same function the adapter does, instead of restating the fallback
+// order and drifting from it.
+export {
+  ELEVENLABS_BASE_URL_ENV,
+  ELEVENLABS_CONVAI_API_KEY_ENV,
+  normalizeElevenLabsBaseUrl,
+  resolveElevenLabsBaseUrl,
+  resolveElevenLabsConvAIApiKey,
+} from "./elevenlabs-base-url";
+
 // Judge STT pre-pass (EDR §3.3 / §7.7) — automatic transcription of audio
 // `file` parts to text BEFORE the judge's buildTranscriptFromMessages. NOT a
 // "judge requests transcript" tool (no such tool, §7.3); STT is upstream.

--- a/javascript/src/voice/stt/elevenlabs-stt.ts
+++ b/javascript/src/voice/stt/elevenlabs-stt.ts
@@ -13,6 +13,7 @@
  * the branded preset import this leaf.
  */
 import { AudioChunk } from "../audio-chunk";
+import { normalizeElevenLabsBaseUrl } from "../elevenlabs-base-url";
 import {
   type ElevenLabsClientLike,
   loadElevenLabsClient,
@@ -29,6 +30,16 @@ export const ELEVENLABS_STT_ENDPOINT =
 export interface ElevenLabsSTTProviderOptions {
   /** API key; falls back to `process.env.ELEVENLABS_API_KEY`. */
   apiKey?: string;
+  /**
+   * Base URL for the ElevenLabs REST API, passed to the SDK client.
+   *
+   * Explicit only. `ELEVENLABS_BASE_URL` is deliberately not read here: a
+   * LangWatch gateway fronts the ConvAI mint route and not
+   * `/v1/speech-to-text`, so a variable set for the hosted demos would point
+   * transcription at a route that answers 404. See
+   * {@link normalizeElevenLabsBaseUrl}.
+   */
+  baseUrl?: string;
   /** Test seam — override the SDK client constructor. */
   clientFactory?: (apiKey: string) => ElevenLabsClientLike;
 }
@@ -38,10 +49,12 @@ export interface ElevenLabsSTTProviderOptions {
  */
 export class ElevenLabsSTTProvider implements STTProvider {
   private readonly apiKey: string;
+  private readonly baseUrl?: string;
   private readonly clientFactory?: (apiKey: string) => ElevenLabsClientLike;
 
   constructor(options: ElevenLabsSTTProviderOptions = {}) {
     this.apiKey = options.apiKey ?? process.env.ELEVENLABS_API_KEY ?? "";
+    this.baseUrl = normalizeElevenLabsBaseUrl(options.baseUrl);
     this.clientFactory = options.clientFactory;
   }
 
@@ -54,7 +67,7 @@ export class ElevenLabsSTTProvider implements STTProvider {
     // only a run that actually transcribes should pay for them.
     const client = this.clientFactory
       ? this.clientFactory(this.apiKey)
-      : await loadElevenLabsClient(this.apiKey);
+      : await loadElevenLabsClient(this.apiKey, this.baseUrl);
     const wav = pcm16ToWav(audio.data);
     // The SDK accepts Blob/File/ReadStream. Node 20+ supplies Blob globally so
     // we don't need a polyfill.

--- a/javascript/src/voice/tts/elevenlabs-tts.ts
+++ b/javascript/src/voice/tts/elevenlabs-tts.ts
@@ -14,6 +14,7 @@
  */
 import { Buffer } from "node:buffer";
 
+import { normalizeElevenLabsBaseUrl } from "../elevenlabs-base-url";
 import {
   type ElevenLabsClientLike,
   loadElevenLabsClient,
@@ -28,6 +29,16 @@ export type ElevenLabsClientFactory = (apiKey: string) => ElevenLabsClientLike;
 export interface ElevenLabsTtsOptions {
   /** API key for ElevenLabs. Falls back to `process.env.ELEVENLABS_API_KEY`. */
   apiKey?: string;
+  /**
+   * Base URL for the ElevenLabs REST API, passed to the SDK client.
+   *
+   * Explicit only. `ELEVENLABS_BASE_URL` is deliberately not read here: a
+   * LangWatch gateway fronts the ConvAI mint route and not
+   * `/v1/text-to-speech/{voiceId}`, so a variable set for the hosted demos
+   * would point synthesis at a route that answers 404. See
+   * {@link normalizeElevenLabsBaseUrl}.
+   */
+  baseUrl?: string;
   /** Test seam — override the SDK client constructor. */
   clientFactory?: ElevenLabsClientFactory;
 }
@@ -48,7 +59,7 @@ export async function elevenLabsSynthesizeBytes(
   // only a run that actually synthesizes should pay for them.
   const client = options.clientFactory
     ? options.clientFactory(apiKey)
-    : await loadElevenLabsClient(apiKey);
+    : await loadElevenLabsClient(apiKey, normalizeElevenLabsBaseUrl(options.baseUrl));
   const stream = await client.textToSpeech.convert(voiceId, {
     text,
     modelId: ELEVENLABS_TTS_MODEL,


### PR DESCRIPTION
## What this changes

Every JavaScript voice lane now gets its session credential from the LangWatch AI Gateway, and the direct-provider-key bypass is gone from both JavaScript workflows.

### 1. The second realtime adapter had no mint path

`scenario#935` gave the mint to `OpenAIRealtimeAgentAdapter`. There is a second one, `RealtimeAgentAdapter` in `javascript/src/agents/realtime/`, built on the `@openai/agents` SDK. It was never touched. Its `connect()` resolved `OPENAI_REALTIME_API_KEY ?? OPENAI_API_KEY` and passed that straight to `session.connect()`.

That is why `javascript-ci` was red. `tests/scenario-expert-realtime.test.ts` uses that adapter, `OPENAI_REALTIME_API_KEY` is a dead provider key, and run 32476011706 failed with `Incorrect API key provided: sk-proj-***`, `code: invalid_api_key`.

It now mints first and dials with the ephemeral secret. The `@openai/agents` websocket transport was built for `ek_` keys: it sends `Authorization: Bearer <key>` in Node and has an explicit `ek_` branch, so nothing about the transport changes.

### 2. One copy of the mint-or-dial rule

Both adapters now call `acquireRealtimeSocketKey` in `javascript/src/voice/broker.ts`. Three outcomes:

- a mint answered, so the socket carries an ephemeral secret for this call;
- HTTP 404, so the base URL is not a LangWatch gateway. The vendor is dialled directly and a warning names the base URL and the variable the key came from. Third-party proxies and plain OpenAI keep working;
- any other error status (401, 402, 403, 429, 5xx) is a refusal. It raises, and no socket opens.

The refusal rule already lived in `mintOpenAIRealtimeSession`. What is new is that it is now the only copy, so the two adapters cannot drift apart on it.

### 3. ElevenLabs ConvAI rides the gateway

`ElevenLabsAgentAdapter` reads `ELEVENLABS_BASE_URL` and `ELEVENLABS_CONVAI_API_KEY` itself, so the seven demos that build one no longer repeat the wiring.

Two key variables, because there are two destinations. The gateway fronts exactly one ElevenLabs REST route. Measured against `gateway.langwatch.ai`:

| Path | Result |
|---|---|
| `GET /v1/convai/conversation/get-signed-url` | 200, real `wss://` signed URL, `X-Langwatch-Session-Id` |
| `POST /v1/speech-to-text` | `404 page not found` (chi, unrouted) |
| `POST /v1/text-to-speech/{voiceId}` | `404 page not found` (chi, unrouted) |

So `ElevenLabsVoiceAgent`, `ElevenLabsSTTProvider` and the `elevenlabs/<voiceId>` TTS voices keep the vendor key and keep talking to ElevenLabs. They take an explicit `baseUrl` option and deliberately do not read `ELEVENLABS_BASE_URL`, so setting it for the hosted demos cannot break them. A unit test locks that.

### 4. No provider key left to fall back to

`OPENAI_REALTIME_API_KEY` is removed from `javascript-ci.yml` and `javascript-voice-integration.yml`. `voice-integration.yml`, the Python workflow, is untouched: the Python adapter has no broker yet and still dials OpenAI directly.

The adapters still support `OPENAI_REALTIME_API_KEY` as the direct-dial fallback, because a user pointing at a non-gateway base URL needs it. It just no longer exists in this repository's jobs.

## Evidence that voice now routes through the gateway

**`javascript-ci` is green** (run 32513002740, `Test Files 35 passed | 21 skipped`, `tests/scenario-expert-realtime.test.ts (1 test)` passing). The only realtime credential in that job is a `vk-lw-` virtual key, which OpenAI rejects on the websocket. The socket could only have opened with a gateway-minted `ek_`.

**`javascript-voice-integration` is 19 of 22 files green** on the final commit (run 32538623355, `Tests 66 passed | 3 failed`). Every OpenAI Realtime and hosted ElevenLabs demo passes, including all five that exercise the changed `disconnect()` path, with no provider key in the job for either vendor. Across the whole run there are zero occurrences of `usage report failed`, `could not read the usage report`, `HTTP 400` or `budget_exceeded`, so every brokered session closed cleanly. The three failures are live-LLM judge verdicts, described at the end.

**The ElevenLabs SDK received a LangWatch error.** On the first dispatch the virtual key's daily budget was exhausted mid-suite, and `ConversationsClient.getSignedUrl` raised:

```
ElevenLabsError: Status code: 402
{"error":{"type":"budget_exceeded","code":"budget_exceeded",
  "meta":{"budget_id":"...","budget_scope":"virtual_key","budget_window":"day"}, ...}}
  at ConversationsClient.<anonymous> @elevenlabs/elevenlabs-js/.../conversations/client/Client.js:159:31
```

ElevenLabs does not emit LangWatch budget errors. The signed-URL handshake went to the gateway.

**Gateway spend, measured.** Budget snapshot at virtual-key scope, taken either side of the green voice run:

| | spent |
|---|---|
| before | $4.122136131 |
| after | $5.222993328 |
| **booked by the run** | **$1.100857197** |

## Evidence that a refused mint cannot be bypassed

`javascript/src/voice/__tests__/broker.test.ts` and `javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts` both run the refusal case over 401, 402, 403, 429, 500, 502 and 503 and assert that nothing is dialled. The 404 case asserts the opposite: the vendor is dialled and a warning is printed.

## On the logging

The brief for this work said `Logger.warn` is silent unless `LOG_LEVEL` is set, so the direct-dial warning would never appear in CI. That is not what the code does. `LOG_LEVEL` is parsed by `envSchema` with `.default(LogLevel.INFO)`, and `INFO` passes `WARN`, so the warning prints with the variable unset. There is a test that deletes `LOG_LEVEL` and asserts `console.warn` fired. No `LOG_LEVEL` was added to the workflows, because setting it to `warn` would have made CI quieter, not louder. The stale comment in `logger.ts` that claimed silence is corrected.

## Budget

The virtual key's daily cap was $4 and `python-ci.yml` documented $10. The voice workflows share that key and cost far more per run, so a dispatch breached it mid-suite. The cap is now $15 and the comment says what shares it.

## Docs

- `voice/happy-path-openai-realtime.mdx` said the Realtime websocket always connects directly to OpenAI and told readers to set `OPENAI_REALTIME_API_KEY` to a provider key. That instructed people into the bypass. It now describes the mint for TypeScript and keeps the direct-dial note for Python, which is still accurate there.
- The same stale claim in the `javascript-ci.yml` header comment is corrected.
- `voice/happy-path-elevenlabs.mdx` and `voice/adapters/elevenlabs.mdx` now document `ELEVENLABS_BASE_URL` and `ELEVENLABS_CONVAI_API_KEY`, including why the two key variables exist.

## Known failures, not from this change

All three are live LLMs judging live agents, and none touches credentials or usage reporting.

- `tests/voice/interruption-recovery.test.ts` fails on a judge verdict about the Pipecat stub bot's conversational quality. Every mechanical assertion in that demo passes; only the verdict is false.
- `tests/voice/composable-stt-swap.test.ts` fails on `transcribeCalls === 0`: the judge's STT pre-pass never called the swapped provider. Nothing here sits upstream of it, because the pre-pass did not run at all.
- `tests/voice/proceed-multiturn-kitchensink.test.ts` failed only on the last run and passed on the two before it. The hosted ElevenLabs agent answered "I am an AI assistant and do not have personal accounts" to a question about which account to check, and the judge called that a non sequitur. The same verdict records that the audio criterion passed, with live WebSocket audio both ways and nonzero byte counts, so the session itself worked.

The first two failed with identical assertion messages on run 30174712577, 2026-07-25, a month before this branch. This suite carries `--retry.count=1` because the hosted ElevenLabs demos are ambiently flaky.

## `python-ci` is red before this PR

`git diff origin/main...HEAD -- python/` is empty apart from a comment in `python-ci.yml`, so no Python source changed here. Its `Test (Examples)` step is failing on `main` too, on six consecutive pushes, and it is not deterministic: three runs on this branch gave a pass, then `test_running_in_parallel.py::test_vegetarian_recipe_agent`, then `test_lovable_clone.py::test_lovable_clone`. Each is a live LLM judging a live agent, one test out of 30.

## Testing

- 1366 unit tests pass, 109 files.
- `pnpm build:all`, `pnpm smoke:dist`, `pnpm lint:all`, `pnpm lint:lib`, `pnpm typecheck:all` and the docs build all pass locally.
