### PR TITLE
feat(voice): let the python realtime adapters mint through a voice gateway

### DIFF
--- a/.github/workflows/voice-integration.yml
+++ b/.github/workflows/voice-integration.yml
@@ -1,14 +1,25 @@
 name: voice-integration
 
-# All OpenAI-compatible HTTP traffic (judge and user-sim LLMs, TTS, STT)
-# rides the LangWatch AI Gateway: OPENAI_API_KEY holds a LangWatch virtual
-# key, and these base URLs point every client family (openai SDK, litellm,
-# ai-sdk) at the gateway. The OpenAI Realtime websocket connects directly
-# to OpenAI and uses OPENAI_REALTIME_API_KEY (a real provider key) instead.
+# All OpenAI traffic rides the LangWatch AI Gateway, the realtime voice
+# sessions included. OPENAI_API_KEY holds a LangWatch virtual key, and these
+# base URLs point every client family (openai SDK, litellm, ai-sdk) at the
+# gateway.
+#
+# The realtime lane used to be the exception: the websocket dialled OpenAI
+# with OPENAI_REALTIME_API_KEY, a real provider key, so the one part of the
+# suite that spends the most money was the one part the gateway could not
+# meter. The adapter now mints at POST {OPENAI_BASE_URL}/realtime/client_secrets
+# and dials with the ephemeral secret that mint returns, so the session is
+# budgeted and billed while the media socket still runs client to vendor.
+#
+# OPENAI_REALTIME_API_KEY is deliberately absent. With no provider key in the
+# job there is nothing to fall back to, so a run that reached OpenAI directly
+# could not pass. That is the same proof the python-ci examples lane already
+# relies on: routing is demonstrated by the absence of an alternative, not
+# asserted in a comment.
 env:
   OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
   OPENAI_API_BASE: https://gateway.langwatch.ai/v1
-  OPENAI_REALTIME_API_KEY: ${{ secrets.OPENAI_REALTIME_API_KEY }}
 
 # On-demand workflow for voice tests that hit live providers (OpenAI Realtime,
 # Twilio, ElevenLabs, Gemini Live). These tests cost real API money and/or
@@ -24,13 +35,30 @@ env:
 #     `integration` by tests/voice/conftest.py).
 #
 # Secrets required (configure in repo settings):
-#   - OPENAI_API_KEY     — STT, TTS, Realtime API
+#   - OPENAI_API_KEY     : the LangWatch virtual key. STT, TTS, Realtime mint
 #   - LANGWATCH_API_KEY  — telemetry export
 #   - GEMINI_API_KEY     — Gemini Live adapter
-#   - ELEVENLABS_API_KEY — ElevenLabs adapter + STT
+#   - ELEVENLABS_API_KEY : ElevenLabs adapter, STT, and agent provisioning
 #   - TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER,
 #     TWILIO_PHONE_NUMBER_2 — two Twilio-owned numbers for fully automated
 #     inbound/outbound demos
+#
+# The ElevenLabs ConvAI lane still mints at the vendor. The adapter can mint
+# through the gateway instead, at
+# GET {ELEVENLABS_BASE_URL}/v1/convai/conversation/get-signed-url, and the
+# route is live. What blocks it here is the credential, not the code. The
+# gateway resolves whatever arrives in xi-api-key as a LangWatch virtual key,
+# so brokering needs ELEVENLABS_API_KEY to hold the virtual key. In this job
+# that one variable also authenticates ElevenLabs speech-to-text and the
+# agent-provisioning step, and the gateway fronts neither, so changing it
+# would break both. Enable the lane by giving ElevenLabs STT and provisioning
+# their own credential, then adding:
+#
+#   ELEVENLABS_BASE_URL: https://gateway.langwatch.ai
+#   ELEVENLABS_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+#
+# ELEVENLABS_BASE_URL must NOT carry /v1: the adapter appends it, so a value
+# that includes it would request /v1/v1/convai/... and 404.
 #
 # If a secret is absent the relevant tests FAIL with a clear diagnosis message
 # (`_require_env` -> pytest.fail, deliberately: "e2e tests fail on missing
@@ -63,6 +91,13 @@ jobs:
     env:
       CI: true
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+      # A voice adapter that cannot find a mint route warns and dials the
+      # vendor directly. That is right for a library, and wrong here: an
+      # unbilled session looks exactly like a billed one in the log, so a run
+      # that proved nothing would read as a run that proved everything. This
+      # filter turns the warning into a test failure, so a job can only go
+      # green if every voice session was actually minted.
+      FALLBACK_IS_A_FAILURE: error::scenario.voice.broker.VoiceGatewayFallbackWarning
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -158,7 +193,7 @@ jobs:
           # `--reruns 1` (pytest-rerunfailures, already a dep): absorb a single
           # ambient hosted-EL flake (#708) while a genuine failure that fails
           # both attempts still propagates.
-          uv run pytest tests/voice -m "integration and not voice_multiturn" -v --tb=short --reruns 1 --timeout=540 || rc=$?
+          uv run pytest tests/voice -m "integration and not voice_multiturn" -v --tb=short --reruns 1 --timeout=540 -W "$FALLBACK_IS_A_FAILURE" || rc=$?
           if [ "$rc" -eq 5 ]; then
             echo "No integration-marked tests collected — treating as pass."
             exit 0
@@ -192,7 +227,7 @@ jobs:
           # `--reruns 1` (pytest-rerunfailures): absorb a single ambient
           # hosted-EL flake (#708); a genuine failure that fails both attempts
           # still propagates through `pipefail` and fails the step.
-          uv run pytest tests/voice/ -m "not voice_multiturn" -v --tb=short -q --reruns 1 --timeout=540 2>&1 | tee /tmp/e2e-voice-results.log
+          uv run pytest tests/voice/ -m "not voice_multiturn" -v --tb=short -q --reruns 1 --timeout=540 -W "$FALLBACK_IS_A_FAILURE" 2>&1 | tee /tmp/e2e-voice-results.log
         working-directory: python
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -273,7 +308,7 @@ jobs:
             # Outer (`timeout 600`): hard backstop for a hang pytest cannot
             # interrupt at all, capping one bad demo at 10 min rather than letting
             # it ride the job timeout.
-            timeout 600 uv run pytest -p no:cacheprovider -x "$f" -v --tb=short --timeout=540 || rc=1
+            timeout 600 uv run pytest -p no:cacheprovider -x "$f" -v --tb=short --timeout=540 -W "$FALLBACK_IS_A_FAILURE" || rc=1
             echo "::endgroup::"
           done
           exit $rc

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import pytest
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
     """Refuse ``flaky`` on a test that ``asyncio_concurrent`` owns.
 
     pytest-asyncio-concurrent takes grouped async tests out of the normal
@@ -26,7 +28,7 @@ def pytest_collection_modifyitems(config, items):
     ``reruns=4``, failed on its first attempt, and was reported as a hard
     failure. Failing collection is the cheapest place to say so.
     """
-    offenders = []
+    offenders: list[str] = []
     for item in items:
         if item.get_closest_marker("flaky") and item.get_closest_marker(
             "asyncio_concurrent"

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -1,0 +1,43 @@
+"""
+Repository-wide collection guards.
+
+Nothing here configures a test. The one job is to refuse a combination of
+markers that reads as protection and provides none.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    """Refuse ``flaky`` on a test that ``asyncio_concurrent`` owns.
+
+    pytest-asyncio-concurrent takes grouped async tests out of the normal
+    protocol: it collects them into an ``AsyncioConcurrentGroup`` and runs
+    them from its own ``pytest_runtest_protocol_async_group`` hook.
+    pytest-rerunfailures implements reruns in ``pytest_runtest_protocol``,
+    which that group never calls, so ``@pytest.mark.flaky(reruns=N)`` on a
+    concurrent test is inert. It does not warn, and the run summary counts no
+    reruns, so the only way to notice is to read a failure log line by line
+    and see the rerun that never happened.
+
+    That combination cost a red CI lane: a live-LLM example carried
+    ``reruns=4``, failed on its first attempt, and was reported as a hard
+    failure. Failing collection is the cheapest place to say so.
+    """
+    offenders = []
+    for item in items:
+        if item.get_closest_marker("flaky") and item.get_closest_marker(
+            "asyncio_concurrent"
+        ):
+            offenders.append(item.nodeid)
+    if offenders:
+        raise pytest.UsageError(
+            "flaky reruns do not run under asyncio_concurrent: "
+            "pytest-rerunfailures hooks pytest_runtest_protocol, which the "
+            "concurrent group protocol never calls, so these markers protect "
+            "nothing. Make the test deterministic, or drop the group so the "
+            "test runs under the normal protocol:\n  "
+            + "\n  ".join(offenders)
+        )

--- a/python/examples/lovable_clone/lovable_agent.py
+++ b/python/examples/lovable_clone/lovable_agent.py
@@ -26,7 +26,7 @@ class LovableAgent:
 
         You will be given a basic React, TypeScript, Vite, Tailwind and Radix UI template and will work on top of that. Use the components from the "@/components/ui" folder.
 
-        On the first user request for building the application, start by the src/index.css and tailwind.config.ts files to define the colors and general application style.
+        On the first user request for building the application, read src/index.css and tailwind.config.ts, then UPDATE src/index.css with the colors and general application style for this site. Do that before you create any page. A site that keeps the template's default palette is not finished work.
         Then, start building the website, you can call tools in sequence as much as you want.
 
         You will be given tools to read file, create file and update file to carry on your work.
@@ -35,8 +35,9 @@ class LovableAgent:
 
         <execution_flow>
         1. Call the read_file tool to understand the current files before updating them or creating new ones
-        2. Start building the website, you can call tools in sequence as much as you want
-        3. Ask the user for next steps
+        2. Call update_file on src/index.css to set this site's colors and style
+        3. Start building the website, you can call tools in sequence as much as you want
+        4. Ask the user for next steps
         </execution_flow>
 
         <files>

--- a/python/examples/test_running_in_parallel.py
+++ b/python/examples/test_running_in_parallel.py
@@ -46,10 +46,10 @@ class VegetarianRecipeAgentAdapter(AgentAdapter):
         return [cast(ChatCompletionMessageParam, message)]
 
 
-@pytest.mark.flaky(reruns=4)
 @pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent")
 async def test_vegetarian_recipe_agent():
-    # Define the scenario
+    # No ``flaky`` marker: reruns declared on a test that
+    # pytest-asyncio-concurrent owns never happen. See test_user_is_hungry.
     result = await scenario.run(
         name="dinner idea",
         description="User is looking for a dinner idea",
@@ -62,7 +62,7 @@ async def test_vegetarian_recipe_agent():
                     "Recipe includes a list of ingredients",
                     "Recipe includes step-by-step cooking instructions",
                     "The recipe is vegetarian and does not include meat",
-                    "The should NOT ask more than two follow-up questions",
+                    "The agent should NOT ask more than two follow-up questions",
                 ]
             ),
         ],
@@ -76,9 +76,18 @@ async def test_vegetarian_recipe_agent():
 
 @pytest.mark.agent_test
 @pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent")
-@pytest.mark.flaky(reruns=4)
 async def test_user_is_hungry():
-    # Define the scenario
+    # Follow-up prompts are fixed strings rather than free-form
+    # ``scenario.user()`` calls, matching test_running_in_parallel_with_arun.
+    # A free-form simulator wandered into asking for meat, the agent's hard
+    # rule made it decline, and the judge then failed the three criteria that
+    # ask for an actual recipe. Two agent turns are also enough: with three,
+    # the agent had room to ask the third follow-up that criterion 5 forbids.
+    #
+    # No ``flaky`` marker: pytest-asyncio-concurrent runs a group through its
+    # own protocol hook, which pytest-rerunfailures never sees, so reruns
+    # declared here would silently never happen. The conftest guard fails
+    # collection if one is added back.
     result = await scenario.run(
         name="hungry user",
         description="User is very very hungry and wants a big, filling meal",
@@ -98,9 +107,7 @@ async def test_user_is_hungry():
         script=[
             scenario.user("I'm starving! I need something really filling for dinner tonight"),
             scenario.agent(),
-            scenario.user(),
-            scenario.agent(),
-            scenario.user(),
+            scenario.user("That sounds great, can you share the recipe?"),
             scenario.agent(),
             scenario.judge(),
         ],

--- a/python/examples/test_running_in_parallel_with_arun.py
+++ b/python/examples/test_running_in_parallel_with_arun.py
@@ -57,9 +57,11 @@ class VegetarianRecipeAgentAdapter(AgentAdapter):
         return [cast(ChatCompletionMessageParam, message)]
 
 
-@pytest.mark.flaky(reruns=2)
 @pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent_arun")
 async def test_vegetarian_recipe_agent_via_arun():
+    # No ``flaky`` marker: reruns declared on a test that
+    # pytest-asyncio-concurrent owns never happen, because the group protocol
+    # never calls the hook pytest-rerunfailures implements.
     result = await scenario.arun(
         name="dinner idea (arun)",
         description="User is looking for a dinner idea",
@@ -84,12 +86,13 @@ async def test_vegetarian_recipe_agent_via_arun():
 
 @pytest.mark.agent_test
 @pytest.mark.asyncio_concurrent(group="vegetarian_recipe_agent_arun")
-@pytest.mark.flaky(reruns=3)
 async def test_user_is_hungry_via_arun():
     # Follow-up prompts are fixed strings rather than free-form
     # ``scenario.user()`` calls so the UserSimulator's LLM noise
     # can't pivot the conversation away from vegetarian criteria
-    # the judge checks.
+    # the judge checks. That determinism is what keeps this test stable,
+    # not the ``flaky`` marker that used to sit here: reruns never run on a
+    # test that pytest-asyncio-concurrent owns.
     result = await scenario.arun(
         name="hungry user (arun)",
         description="User is very very hungry and wants a big, filling meal",

--- a/python/examples/voice/_recording_helper.py
+++ b/python/examples/voice/_recording_helper.py
@@ -13,6 +13,17 @@ from scenario.voice.recording import VoiceRecording
 _RECORDINGS_ROOT = Path(__file__).resolve().parent.parent.parent / "outputs" / "recordings"
 
 
+def demo_recording_dir(demo_name: str) -> Path:
+    """Where a demo's recording lands.
+
+    Public so a test can find the files without restating the layout. Two
+    copies of that join drift apart silently: a test that looked for a name
+    the writer stopped using would report a missing recording as an import
+    error, which is what happened before this existed.
+    """
+    return _RECORDINGS_ROOT / demo_name
+
+
 def save_demo_recording(
     audio: Optional[VoiceRecording],
     demo_name: Optional[str] = None,
@@ -33,6 +44,6 @@ def save_demo_recording(
     if demo_name is None:
         caller_frame = inspect.stack()[1]
         demo_name = Path(caller_frame.filename).stem
-    target = _RECORDINGS_ROOT / demo_name
+    target = demo_recording_dir(demo_name)
     audio.save_segments(target, manifest=True)
     return target

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -8,4 +8,5 @@ timeout = 60
 timeout_method = thread
 markers =
     integration: hits live providers / external services — requires API keys, run via the on-demand voice-integration workflow, not on every PR.
+    voice_gateway_mint: exercises the voice gateway mint endpoint resolution itself, so the unit-suite network guard in tests/voice/conftest.py leaves that resolution alone.
     voice_multiturn: multi-turn voice @e2e demo that must run in its own pytest process. Several of these wedge the process if run together in one suite (see issue #491 / TESTING.md "Voice @e2e suite — isolation requirement"). The voice-integration workflow deselects them from the bulk run and runs each in a fresh process.

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -425,7 +425,7 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
                 warn_direct_dial_fallback(
                     self._mint.base_url,
                     ELEVENLABS_SIGNED_URL_PATH,
-                    "ELEVENLABS_API_KEY",
+                    "the api_key passed to the adapter",
                 )
 
         self._ws = await websockets.connect(

--- a/python/scenario/voice/adapters/elevenlabs.py
+++ b/python/scenario/voice/adapters/elevenlabs.py
@@ -46,10 +46,17 @@ import base64
 import json
 import logging
 from collections import deque
-from typing import Any, ClassVar, Deque, Final, Literal, Optional
+from typing import Any, ClassVar, Deque, Final, Literal, Optional, Union
 
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
+from ..broker import (
+    ELEVENLABS_SIGNED_URL_PATH,
+    ElevenLabsMintEndpoint,
+    mint_elevenlabs_signed_url,
+    resolve_elevenlabs_mint_endpoint,
+    warn_direct_dial_fallback,
+)
 from ..capabilities import AdapterCapabilities
 
 
@@ -260,6 +267,8 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         agent_id: str,
         api_key: str,
         *,
+        base_url: Optional[str] = None,
+        mint: Union[ElevenLabsMintEndpoint, bool, None] = None,
         system_prompt_override: Optional[str] = None,
         first_message_override: Optional[str] = None,
         dynamic_variables: Optional[dict[str, Any]] = None,
@@ -270,6 +279,28 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         super().__init__()
         self.agent_id = agent_id
         self._api_key = api_key
+        # Where to mint the session's signed URL. ``False`` skips the mint and
+        # dials the vendor's own websocket directly with ``xi-api-key``, which
+        # is what an unconfigured adapter has always done. An explicit
+        # endpoint, ``base_url=``, or ELEVENLABS_BASE_URL points the mint at a
+        # LangWatch AI Gateway, which mirrors the vendor's signed-URL path:
+        # the gateway checks the virtual key's budget and session cap, mints
+        # the signed URL, and bills the call as one spend record. The
+        # websocket that URL names still belongs to ElevenLabs, so the media
+        # stream runs client to vendor and nothing about latency or the wire
+        # protocol changes. ``api_key`` then carries the virtual key.
+        self._mint: Optional[ElevenLabsMintEndpoint]
+        if mint is False:
+            self._mint = None
+        elif isinstance(mint, ElevenLabsMintEndpoint):
+            self._mint = mint
+        else:
+            self._mint = resolve_elevenlabs_mint_endpoint(
+                base_url=base_url, api_key=api_key
+            )
+        #: The gateway's id for the current session, empty unless a gateway
+        #: minted it.
+        self._broker_session_id: str = ""
         # Per-session overrides applied via conversation_initiation_client_data
         # at the start of every WS connect. Used by demos that need a
         # different prompt shape (e.g. verbose for interrupt demos) without
@@ -343,6 +374,17 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
     def url(self) -> str:
         return CONVAI_URL_TEMPLATE.format(agent_id=self.agent_id)
 
+    @property
+    def brokered(self) -> bool:
+        """Whether the live session was minted by a gateway, not the vendor.
+
+        Only true after ``connect()``, and only when the mint answered with
+        ``X-LangWatch-Session-Id``. Configuration cannot set it, because the
+        response is the one thing that cannot be told a lie about what
+        answered.
+        """
+        return self._broker_session_id != ""
+
     def __repr__(self) -> str:  # redact credentials
         return f"ElevenLabsAgentAdapter(agent_id={self.agent_id!r}, api_key='***')"  # noqa: S105
 
@@ -361,11 +403,36 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
         """
         import websockets
 
+        self._broker_session_id = ""
+
+        # A minted signed URL already carries the session's authentication in
+        # its query string, so no key travels on the socket. Without a mint
+        # endpoint the adapter dials the vendor's own websocket with
+        # ``xi-api-key``, exactly as it always has.
+        target_url = self.url
+        headers = {"xi-api-key": self._api_key}
+        if self._mint is not None:
+            result = await mint_elevenlabs_signed_url(self._mint, self.agent_id)
+            if result.minted:
+                target_url = result.credential
+                headers = {}
+                self._broker_session_id = result.session_id
+            else:
+                # No mint route: a plain proxy, or a gateway older than this
+                # feature. Dial the vendor directly, and say so, because an
+                # unbilled session otherwise looks identical to a billed one.
+                # A refusal never reaches here: it raises inside the mint.
+                warn_direct_dial_fallback(
+                    self._mint.base_url,
+                    ELEVENLABS_SIGNED_URL_PATH,
+                    "ELEVENLABS_API_KEY",
+                )
+
         self._ws = await websockets.connect(
-            self.url,
-            additional_headers={"xi-api-key": self._api_key},
+            target_url,
+            additional_headers=headers,
         )
-        logger.debug("ElevenLabsAgentAdapter: connected to %s", self.url)
+        logger.debug("ElevenLabsAgentAdapter: connected (brokered=%s)", self.brokered)
 
         # Stamp EL-specific attrs onto the active ``voice.adapter.connect`` span
         # (opened by the executor connect loop). Base spans are name-owned; the
@@ -375,7 +442,11 @@ class ElevenLabsAgentAdapter(VoiceAgentAdapter):
 
         set_span_attributes(
             _otel_trace.get_current_span(),
-            {"voice.elevenlabs.agent_id": self.agent_id},
+            {
+                "voice.elevenlabs.agent_id": self.agent_id,
+                "voice.elevenlabs.brokered": self.brokered,
+                "voice.elevenlabs.session_id": self._broker_session_id or None,
+            },
         )
 
         # The NARROW prompt/first-message knobs build an `agent` override that is

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -29,7 +29,7 @@ import base64
 import json
 import logging
 import os
-from typing import Any, ClassVar, List, Optional, cast
+from typing import Any, ClassVar, Dict, List, Optional, Union, cast
 
 from openai.types.chat import ChatCompletionMessageParam
 
@@ -37,6 +37,14 @@ from ...config.voice_models import OPENAI_REALTIME_MODEL, OPENAI_STT_MODEL
 from ...types import AgentInput, AgentReturnTypes, AgentRole
 from ..adapter import VoiceAgentAdapter
 from ..audio_chunk import AudioChunk
+from ..broker import (
+    REALTIME_MINT_PATH,
+    RealtimeMintEndpoint,
+    mint_openai_realtime_session,
+    report_openai_realtime_usage,
+    resolve_realtime_mint_endpoint,
+    warn_direct_dial_fallback,
+)
 from ..capabilities import AdapterCapabilities
 
 
@@ -93,6 +101,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         api_key: Optional[str] = None,
         role: AgentRole = AgentRole.AGENT,
         speaks_first: bool = False,
+        mint: Union[RealtimeMintEndpoint, bool, None] = None,
     ):
         super().__init__()
         self.model = model
@@ -100,16 +109,55 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         self.instructions = instructions
         self.tools = tools or []
         self.role = role  # type: ignore[misc]
-        # Resolve API key: explicit param, then OPENAI_REALTIME_API_KEY, then
-        # OPENAI_API_KEY. The Realtime API connects DIRECTLY to OpenAI's
-        # websocket (gateways that proxy the HTTP audio endpoints do not
-        # proxy realtime), so when OPENAI_API_KEY holds a gateway virtual
-        # key, OPENAI_REALTIME_API_KEY carries the real provider key.
+        # The fallback key for dialling the vendor directly: explicit param,
+        # then OPENAI_REALTIME_API_KEY, then OPENAI_API_KEY.
+        # OPENAI_REALTIME_API_KEY exists so a deployment whose OPENAI_API_KEY
+        # is a virtual key can still hold a real provider key for this socket.
+        #
+        # A minted session uses none of these on the socket. It dials with the
+        # ephemeral secret the mint returned, so a long-lived key never
+        # reaches the socket. See ``mint``.
         self._api_key: str = (
             api_key
             or os.environ.get("OPENAI_REALTIME_API_KEY")
             or os.environ.get("OPENAI_API_KEY", "")
         )
+        # Which of the three the key came from. Only used to name it in the
+        # direct-dial warning, where naming the wrong one sends the reader to
+        # a variable that is not set.
+        self._api_key_source: str = (
+            "the api_key passed to the adapter"
+            if api_key is not None
+            else (
+                "OPENAI_REALTIME_API_KEY"
+                if os.environ.get("OPENAI_REALTIME_API_KEY")
+                else "OPENAI_API_KEY"
+            )
+        )
+        # Where to mint the session credential. ``False`` skips the mint and
+        # dials the vendor directly; an explicit endpoint overrides
+        # OPENAI_BASE_URL and OPENAI_API_KEY; ``None`` resolves from those two.
+        #
+        # ``POST /v1/realtime/client_secrets`` is OpenAI's own path, and a
+        # LangWatch AI Gateway mirrors it, so the same request works against
+        # either. Against OpenAI it returns an ephemeral client secret.
+        # Against a gateway it also checks the virtual key's budget and
+        # open-session cap and opens one spend record, naming the session on
+        # the ``X-LangWatch-Session-Id`` response header. Usage is reported
+        # back only when that header is present.
+        self._mint: Optional[RealtimeMintEndpoint]
+        if mint is False:
+            self._mint = None
+        elif isinstance(mint, RealtimeMintEndpoint):
+            self._mint = mint
+        else:
+            self._mint = resolve_realtime_mint_endpoint()
+        #: The gateway's id for the current session, empty unless a gateway
+        #: minted it.
+        self._broker_session_id: str = ""
+        #: The last usage object the socket reported, sent when the session
+        #: ends.
+        self._last_usage: Optional[Dict[str, Any]] = None
         self._ws: Any = None
 
         # Transcript observability — updated on incoming transcript events.
@@ -180,6 +228,17 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
     @property
     def url(self) -> str:
         return REALTIME_URL_TEMPLATE.format(model=self.model)
+
+    @property
+    def brokered(self) -> bool:
+        """Whether the live session was minted by a gateway, not the vendor.
+
+        Only true after ``connect()``, and only when the mint answered with
+        ``X-LangWatch-Session-Id``. Configuration cannot set it, because the
+        response is the one thing that cannot be told a lie about what
+        answered.
+        """
+        return self._broker_session_id != ""
 
     def __repr__(self) -> str:  # redact credentials
         return (
@@ -323,12 +382,49 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         self._response_active = False
         self._deferred_response_create = False
 
-        self._ws = await websockets.connect(
-            self.url,
-            additional_headers={
-                "Authorization": f"Bearer {self._api_key}",
-            },
-        )
+        self._broker_session_id = ""
+        self._last_usage = None
+
+        # The socket's bearer is the ephemeral secret the mint returned: a
+        # credential for exactly this call, so no long-lived key reaches the
+        # socket. Whether OpenAI or a gateway answers the mint is a property
+        # of OPENAI_BASE_URL, not of this adapter.
+        socket_key = self._api_key
+        if self._mint is not None:
+            result = await mint_openai_realtime_session(self._mint, self.model)
+            if result.minted:
+                socket_key = result.credential
+                self._broker_session_id = result.session_id
+            else:
+                # No mint route: a plain proxy, or a gateway older than this
+                # feature. Dial the vendor directly, and say so, because an
+                # unbilled session otherwise looks identical to a billed one.
+                # A refusal never reaches here: it raises inside the mint.
+                warn_direct_dial_fallback(
+                    self._mint.base_url, REALTIME_MINT_PATH, self._api_key_source
+                )
+        if socket_key == self._api_key and not self._api_key:
+            raise RuntimeError(
+                "OpenAIRealtimeAgentAdapter: no API key. Set OPENAI_API_KEY or "
+                "pass `api_key=` to the constructor."
+            )
+
+        try:
+            self._ws = await websockets.connect(
+                self.url,
+                additional_headers={
+                    "Authorization": f"Bearer {socket_key}",
+                },
+            )
+        except BaseException:
+            # The mint booked a session and the socket never opened, so
+            # nothing will ever report against it. Closing it at zero is the
+            # truth: an ephemeral secret that opened no socket used nothing.
+            # Leaving it open would hold one of the key's session slots until
+            # the gateway's own window expires, and book a call that never
+            # happened.
+            await self._close_unused_session()
+            raise
         logger.debug("OpenAIRealtimeAgentAdapter: connected to %s", self.url)
 
         # Configure session: audio formats, voice, instructions, tools.
@@ -373,11 +469,70 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 "voice.realtime.voice": self.voice,
                 "voice.realtime.session_type": "realtime",
                 "voice.realtime.tool_count": len(self.tools),
+                "voice.realtime.brokered": self.brokered,
+                "voice.realtime.session_id": self._broker_session_id or None,
             },
         )
 
+    def _capture_usage(self, event: dict[str, Any]) -> None:
+        """Keep the usage OpenAI reports on ``response.done``.
+
+        Read from every inbound event rather than from the audio branch,
+        because a drain that ends on tail silence never reaches the terminal
+        event and a session whose usage was never captured bills as
+        cost-unknown. The last response of a session carries that session's
+        cumulative totals, so keeping the most recent one is the number to
+        report.
+        """
+        if not self._broker_session_id:
+            return
+        if event.get("type") != "response.done":
+            return
+        response = event.get("response")
+        if not isinstance(response, dict):
+            return
+        usage = response.get("usage")
+        if isinstance(usage, dict):
+            self._last_usage = usage
+
+    async def _close_unused_session(self) -> None:
+        """Close a session whose socket never opened.
+
+        The mint booked it, so only a report can close it; there is no
+        cancel. Zero is the correct number, not a placeholder: an ephemeral
+        credential that opened no socket consumed nothing at the vendor.
+        """
+        if self._mint is None or not self._broker_session_id:
+            return
+        session_id = self._broker_session_id
+        self._broker_session_id = ""
+        error = await report_openai_realtime_usage(self._mint, session_id, {})
+        if error is not None:
+            logger.debug(
+                "OpenAIRealtimeAgentAdapter: unused-session close failed: %r",
+                error,
+            )
+
+    async def _report_usage(self) -> None:
+        """Close the session's spend record with what the socket measured.
+
+        Clearing the captured usage first is what makes a second disconnect a
+        no-op, so a session cannot be reported twice.
+        """
+        if self._mint is None or not self._broker_session_id or not self._last_usage:
+            return
+        usage = self._last_usage
+        session_id = self._broker_session_id
+        self._last_usage = None
+        error = await report_openai_realtime_usage(self._mint, session_id, usage)
+        if error is not None:
+            logger.debug(
+                "OpenAIRealtimeAgentAdapter: usage report failed: %r", error
+            )
+
     async def disconnect(self) -> None:
-        """Close the WebSocket if open."""
+        """Close the WebSocket if open, then close the session's spend record."""
+        await self._report_usage()
         if self._ws is not None:
             try:
                 await self._ws.close()
@@ -519,6 +674,9 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 continue
 
             etype = event.get("type", "")
+            # Every inbound event passes here, which is why the usage capture
+            # lives here and not in the terminal branch below.
+            self._capture_usage(event)
 
             if etype in ("response.output_audio.delta", "response.audio.delta"):
                 # Accept both the GA event name and its retired beta alias —

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -40,6 +40,7 @@ from ..audio_chunk import AudioChunk
 from ..broker import (
     REALTIME_MINT_PATH,
     RealtimeMintEndpoint,
+    accumulate_realtime_usage,
     close_unused_realtime_session,
     mint_openai_realtime_session,
     report_openai_realtime_usage,
@@ -156,9 +157,9 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         #: The gateway's id for the current session, empty unless a gateway
         #: minted it.
         self._broker_session_id: str = ""
-        #: The last usage object the socket reported, sent when the session
-        #: ends.
-        self._last_usage: Optional[Dict[str, Any]] = None
+        #: What the socket has reported so far this session, summed across
+        #: responses and sent when the session ends.
+        self._session_usage: Optional[Dict[str, Any]] = None
         self._ws: Any = None
 
         # Transcript observability — updated on incoming transcript events.
@@ -384,7 +385,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         self._deferred_response_create = False
 
         self._broker_session_id = ""
-        self._last_usage = None
+        self._session_usage = None
 
         # The socket's bearer is the ephemeral secret the mint returned: a
         # credential for exactly this call, so no long-lived key reaches the
@@ -476,14 +477,16 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         )
 
     def _capture_usage(self, event: dict[str, Any]) -> None:
-        """Keep the usage OpenAI reports on ``response.done``.
+        """Add the usage OpenAI reports on ``response.done`` to the session.
 
         Read from every inbound event rather than from the audio branch,
         because a drain that ends on tail silence never reaches the terminal
         event and a session whose usage was never captured bills as
-        cost-unknown. The last response of a session carries that session's
-        cumulative totals, so keeping the most recent one is the number to
-        report.
+        cost-unknown.
+
+        Summed rather than replaced. OpenAI reports usage per response, so a
+        session that kept only the last ``response.done`` would bill for its
+        last turn and nothing else.
         """
         if not self._broker_session_id:
             return
@@ -494,7 +497,9 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             return
         usage = response.get("usage")
         if isinstance(usage, dict):
-            self._last_usage = usage
+            self._session_usage = accumulate_realtime_usage(
+                self._session_usage, usage
+            )
 
     async def _close_unused_session(self) -> None:
         """Close a session whose socket never opened.
@@ -520,11 +525,15 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
         Clearing the captured usage first is what makes a second disconnect a
         no-op, so a session cannot be reported twice.
         """
-        if self._mint is None or not self._broker_session_id or not self._last_usage:
+        if (
+            self._mint is None
+            or not self._broker_session_id
+            or not self._session_usage
+        ):
             return
-        usage = self._last_usage
+        usage = self._session_usage
         session_id = self._broker_session_id
-        self._last_usage = None
+        self._session_usage = None
         error = await report_openai_realtime_usage(self._mint, session_id, usage)
         if error is not None:
             logger.debug(

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -41,11 +41,11 @@ from ..broker import (
     REALTIME_MINT_PATH,
     RealtimeMintEndpoint,
     accumulate_realtime_usage,
-    close_unused_realtime_session,
     mint_openai_realtime_session,
     report_openai_realtime_usage,
     resolve_realtime_mint_endpoint,
     warn_direct_dial_fallback,
+    zero_realtime_usage,
 )
 from ..capabilities import AdapterCapabilities
 
@@ -397,6 +397,14 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             if result.minted:
                 socket_key = result.credential
                 self._broker_session_id = result.session_id
+                # Start the session's total at zero rather than at nothing.
+                # A session that never completes a response captures no usage,
+                # and a total of None means disconnect() reports nothing at
+                # all, which leaves the record open and holding one of the
+                # key's slots until the gateway's grace expires. Zero is also
+                # the truth for a session that did no work.
+                if self._broker_session_id:
+                    self._session_usage = zero_realtime_usage()
             else:
                 # No mint route: a plain proxy, or a gateway older than this
                 # feature. Dial the vendor directly, and say so, because an
@@ -425,7 +433,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             # Leaving it open would hold one of the key's session slots until
             # the gateway's own window expires, and book a call that never
             # happened.
-            await self._close_unused_session()
+            await self._report_usage()
             raise
         logger.debug("OpenAIRealtimeAgentAdapter: connected to %s", self.url)
 
@@ -501,26 +509,13 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
                 self._session_usage, usage
             )
 
-    async def _close_unused_session(self) -> None:
-        """Close a session whose socket never opened.
-
-        The mint booked it, so only a report can close it; there is no
-        cancel. Zero is the correct number, not a placeholder: an ephemeral
-        credential that opened no socket consumed nothing at the vendor.
-        """
-        if self._mint is None or not self._broker_session_id:
-            return
-        session_id = self._broker_session_id
-        self._broker_session_id = ""
-        error = await close_unused_realtime_session(self._mint, session_id)
-        if error is not None:
-            logger.debug(
-                "OpenAIRealtimeAgentAdapter: unused-session close failed: %r",
-                error,
-            )
-
     async def _report_usage(self) -> None:
         """Close the session's spend record with what the socket measured.
+
+        Also the failure path for a mint that succeeded and a socket that
+        never opened, because the total starts at zero: the report is the same
+        request either way, so there is one method rather than two that
+        disagree.
 
         Clearing the captured usage first is what makes a second disconnect a
         no-op, so a session cannot be reported twice.

--- a/python/scenario/voice/adapters/openai_realtime.py
+++ b/python/scenario/voice/adapters/openai_realtime.py
@@ -40,6 +40,7 @@ from ..audio_chunk import AudioChunk
 from ..broker import (
     REALTIME_MINT_PATH,
     RealtimeMintEndpoint,
+    close_unused_realtime_session,
     mint_openai_realtime_session,
     report_openai_realtime_usage,
     resolve_realtime_mint_endpoint,
@@ -506,7 +507,7 @@ class OpenAIRealtimeAgentAdapter(VoiceAgentAdapter):
             return
         session_id = self._broker_session_id
         self._broker_session_id = ""
-        error = await report_openai_realtime_usage(self._mint, session_id, {})
+        error = await close_unused_realtime_session(self._mint, session_id)
         if error is not None:
             logger.debug(
                 "OpenAIRealtimeAgentAdapter: unused-session close failed: %r",

--- a/python/scenario/voice/broker.py
+++ b/python/scenario/voice/broker.py
@@ -352,6 +352,43 @@ async def report_openai_realtime_usage(
     return None
 
 
+def accumulate_realtime_usage(
+    total: Optional[Dict[str, Any]], usage: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Add one response's usage into a session total.
+
+    OpenAI reports usage per response, not per session: measured against the
+    live API on 2026-08-21, two turns on one socket reported
+    ``output_tokens`` 4 and 4 rather than 4 and 8. So a session that keeps
+    only the last ``response.done`` bills for its last turn and nothing else.
+
+    Every numeric leaf is summed, and nested detail objects are summed
+    key by key, so the audio, text and cached breakdowns a gateway prices
+    separately add up alongside the totals. Keys are not listed here: a count
+    the vendor adds later then accumulates on its own rather than being
+    silently dropped.
+    """
+    merged: Dict[str, Any] = dict(total or {})
+    for key, value in usage.items():
+        if isinstance(value, bool):
+            # A flag is not a count, and adding two of them would produce a
+            # number that means nothing.
+            merged[key] = value
+        elif isinstance(value, (int, float)):
+            running = merged.get(key)
+            merged[key] = value + (
+                running
+                if isinstance(running, (int, float)) and not isinstance(running, bool)
+                else 0
+            )
+        elif isinstance(value, dict):
+            running = merged.get(key)
+            merged[key] = accumulate_realtime_usage(
+                running if isinstance(running, dict) else None, value
+            )
+    return merged
+
+
 async def close_unused_realtime_session(
     endpoint: RealtimeMintEndpoint,
     session_id: str,

--- a/python/scenario/voice/broker.py
+++ b/python/scenario/voice/broker.py
@@ -304,7 +304,7 @@ async def report_openai_realtime_usage(
     *,
     transport: Optional[httpx.AsyncBaseTransport] = None,
     timeout_s: Optional[float] = None,
-) -> Optional[BaseException]:
+) -> Optional[Exception]:
     """Report what the socket measured, closing the session's spend record.
 
     OpenAI reports usage over the socket, in ``response.done``, and that
@@ -336,7 +336,10 @@ async def report_openai_realtime_usage(
                 timeout_s if timeout_s is not None else USAGE_REPORT_TIMEOUT_S
             ),
         )
-    except BaseException as error:  # noqa: BLE001 - reported, never raised
+    except Exception as error:  # noqa: BLE001 - reported, never raised
+        # Deliberately not BaseException: asyncio.CancelledError is one, and
+        # returning it here instead of letting it through would swallow the
+        # cancellation of whatever task owns this disconnect.
         return error
     # A refused report is a failure that answers. Reading only the raised case
     # would treat a 404 for an unknown session, or a 401 for a rotated key, as

--- a/python/scenario/voice/broker.py
+++ b/python/scenario/voice/broker.py
@@ -1,0 +1,452 @@
+"""
+Minting a voice session, at the vendor or at a gateway in front of it.
+
+``POST /v1/realtime/client_secrets`` is OpenAI's own path, and
+``GET /v1/convai/conversation/get-signed-url`` is ElevenLabs'. A LangWatch AI
+Gateway mirrors both: it checks the virtual key's budget and its open-session
+cap, mints the vendor's own short-lived credential, and opens one spend record
+for the call. The media socket still runs client to vendor in both cases, so
+latency and the wire protocol are unchanged.
+
+That symmetry is the whole design. Each adapter reads the variables its vendor
+already defines and mints at the same path either way. Point them at the vendor
+and the mint happens at the vendor with a provider key. Point them at a gateway
+and the mint happens through the broker with a virtual key. There is no third
+URL, no third key, and no branch on who is answering.
+
+Port of ``javascript/src/voice/broker.ts``; the two SDKs keep the same
+semantics on purpose.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import warnings
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import quote, urlparse
+
+import httpx
+
+
+logger = logging.getLogger("scenario.voice.broker")
+
+#: The vendor's default, used when ``OPENAI_BASE_URL`` is unset.
+OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+#: The vendor's default, used when ``ELEVENLABS_BASE_URL`` is unset.
+ELEVENLABS_DEFAULT_BASE_URL = "https://api.elevenlabs.io"
+
+REALTIME_MINT_PATH = "/realtime/client_secrets"
+ELEVENLABS_SIGNED_URL_PATH = "/v1/convai/conversation/get-signed-url"
+
+#: A gateway names the session it opened on this response header. The vendors
+#: do not, which is how an adapter learns what answered.
+SESSION_ID_HEADER = "x-langwatch-session-id"
+
+#: How long a mint may take before it is abandoned.
+#:
+#: ``connect()`` waits for this before it opens the socket, so an unbounded
+#: request leaves connection setup pending forever against a stalled endpoint.
+#: Generous rather than tight: a mint is a real round trip to a vendor, and a
+#: session refused for slowness costs a call that would have worked.
+MINT_TIMEOUT_S = 15.0
+
+#: How long a usage report may take before it is abandoned.
+#:
+#: ``disconnect()`` awaits the report, so an unbounded request holds the socket
+#: open and the test that owns it never finishes. A report is worth a few
+#: seconds and never worth a hang: the session still settles on the gateway's
+#: own grace if it never arrives.
+USAGE_REPORT_TIMEOUT_S = 5.0
+
+
+class VoiceGatewayFallbackWarning(RuntimeWarning):
+    """A mint route was absent, so the adapter dialled the vendor directly.
+
+    Raised as a warning rather than logged only, because pytest prints its
+    warnings summary on every run while it hides log records of passing tests.
+    A run that fell back produced no spend record at all, so the difference
+    has to reach the CI log.
+    """
+
+
+class VoiceGatewayMintError(RuntimeError):
+    """The endpoint has a mint route and refused to mint.
+
+    Distinct from an absent route on purpose. An absence may be dialled
+    around; a refusal may not, because dialling the vendor with a direct
+    provider key would run exactly the call the gateway declined to bill.
+    """
+
+
+@dataclass(frozen=True)
+class RealtimeMintEndpoint:
+    """Where an OpenAI Realtime mint request goes, and the key it carries."""
+
+    #: OpenAI-compatible base URL, including ``/v1``, without a trailing slash.
+    base_url: str
+    #: The key the endpoint authenticates: a provider key, or a virtual key.
+    api_key: str
+
+
+@dataclass(frozen=True)
+class ElevenLabsMintEndpoint:
+    """Where an ElevenLabs signed-URL request goes, and the key it carries."""
+
+    #: ElevenLabs-compatible base URL, WITHOUT ``/v1``, no trailing slash.
+    base_url: str
+    #: The key the endpoint authenticates: a provider key, or a virtual key.
+    api_key: str
+
+
+@dataclass(frozen=True)
+class MintResult:
+    """What a mint attempt produced.
+
+    ``session_id`` is empty unless a gateway answered, because only a gateway
+    carries :data:`SESSION_ID_HEADER`. An empty id therefore means the vendor
+    minted the credential itself and there is no session to report usage to.
+
+    ``status`` is meaningful only when ``minted`` is false, where it is always
+    404: every other refusal raises rather than returning.
+    """
+
+    minted: bool
+    #: The vendor credential: an ``ek_...`` client secret, or a ``wss://``
+    #: signed URL. Empty when ``minted`` is false.
+    credential: str = ""
+    session_id: str = ""
+    status: int = 0
+
+
+def resolve_realtime_mint_endpoint(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[RealtimeMintEndpoint]:
+    """Resolve where to mint an OpenAI Realtime session, or ``None``.
+
+    ``None`` means there is no key to mint with, so the caller dials the
+    vendor directly.
+
+    ``OPENAI_REALTIME_API_KEY`` is deliberately not consulted here. That
+    variable holds a direct provider key for the socket, and presenting it to
+    a gateway would offer a credential the gateway did not issue and cannot
+    bill. It stays what it already was: the fallback for dialling the vendor
+    directly.
+    """
+    key = api_key or os.environ.get("OPENAI_API_KEY") or ""
+    if not key:
+        return None
+    resolved_base = (
+        base_url or os.environ.get("OPENAI_BASE_URL") or OPENAI_DEFAULT_BASE_URL
+    )
+    return RealtimeMintEndpoint(base_url=resolved_base.rstrip("/"), api_key=key)
+
+
+def normalize_elevenlabs_base_url(raw: Optional[str]) -> Optional[str]:
+    """Check an ElevenLabs base URL at construction, where the mistake is
+    still readable.
+
+    The one people make is including ``/v1``. ``OPENAI_BASE_URL``
+    conventionally does, and this module appends ``/v1`` itself, so a base URL
+    that carries it would request ``/v1/v1/convai/...`` and return a 404 that
+    names no cause. An empty value means unset.
+    """
+    trimmed = (raw or "").strip().rstrip("/")
+    if not trimmed:
+        return None
+    parsed = urlparse(trimmed)
+    if parsed.scheme not in ("http", "https"):
+        # A value that parses is not therefore a value a REST request can be
+        # made over, so parsing alone is not a check.
+        raise ValueError(
+            f"ElevenLabs base URL must be http or https: {trimmed}"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"ElevenLabs base URL is not a URL: {trimmed}")
+    if parsed.path.endswith("/v1"):
+        raise ValueError(
+            f"ElevenLabs base URL must not include /v1 ({trimmed}). "
+            "The adapter appends it, so this would request "
+            "/v1/v1/convai/... and 404."
+        )
+    return trimmed
+
+
+def resolve_elevenlabs_mint_endpoint(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[ElevenLabsMintEndpoint]:
+    """Resolve where to mint an ElevenLabs signed URL, or ``None``.
+
+    ``None`` means no base URL is configured, which leaves the adapter on its
+    existing direct dial to the vendor's own websocket. The base URL IS the
+    configuration here: ElevenLabs defines no environment variable for it, so
+    ``ELEVENLABS_BASE_URL`` is scenario's own name for the same option the
+    official SDKs expose as a client argument.
+    """
+    resolved_base = normalize_elevenlabs_base_url(
+        base_url if base_url is not None else os.environ.get("ELEVENLABS_BASE_URL")
+    )
+    if not resolved_base:
+        return None
+    key = api_key or os.environ.get("ELEVENLABS_API_KEY") or ""
+    if not key:
+        return None
+    return ElevenLabsMintEndpoint(base_url=resolved_base, api_key=key)
+
+
+async def mint_openai_realtime_session(
+    endpoint: RealtimeMintEndpoint,
+    model: str,
+    *,
+    expires_after_seconds: Optional[int] = None,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+    timeout_s: Optional[float] = None,
+) -> MintResult:
+    """Mint a realtime session, and report whether the route existed.
+
+    A 404 means the base URL points at something with no mint route: plain
+    OpenAI without the path, a third-party proxy, or a LangWatch gateway older
+    than this feature. That is an absence, so the caller may fall back to
+    dialling the vendor directly.
+
+    Any other error status is a refusal by an endpoint that DOES have the
+    route: a rejected key, an exhausted budget, a session cap, an outage.
+    Those raise. Falling back on a refusal would spend a direct provider key
+    on a call the gateway just declined to bill, which defeats the whole point
+    of minting through it.
+    """
+    body: Dict[str, Any] = {"session": {"type": "realtime", "model": model}}
+    if expires_after_seconds is not None:
+        body["expires_after"] = {
+            "anchor": "created_at",
+            "seconds": expires_after_seconds,
+        }
+
+    response = await _request(
+        "POST",
+        f"{endpoint.base_url}{REALTIME_MINT_PATH}",
+        headers={
+            "Authorization": f"Bearer {endpoint.api_key}",
+            "Content-Type": "application/json",
+        },
+        json_body=body,
+        transport=transport,
+        timeout_s=timeout_s if timeout_s is not None else MINT_TIMEOUT_S,
+    )
+
+    if response.status_code == 404:
+        return MintResult(minted=False, status=404)
+    _raise_if_refused(response, endpoint.base_url, "realtime mint")
+
+    parsed = _parse_json(response, "realtime mint")
+    client_secret = _read_client_secret(parsed)
+    if not client_secret:
+        raise VoiceGatewayMintError("realtime mint returned no client secret")
+    return MintResult(
+        minted=True,
+        credential=client_secret,
+        session_id=_session_id(response),
+    )
+
+
+async def mint_elevenlabs_signed_url(
+    endpoint: ElevenLabsMintEndpoint,
+    agent_id: str,
+    *,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+    timeout_s: Optional[float] = None,
+) -> MintResult:
+    """Mint an ElevenLabs ConvAI signed URL, and report whether the route
+    existed.
+
+    Same split as :func:`mint_openai_realtime_session`: 404 is an absent
+    route the caller may dial around, and every other error status is a
+    refusal that raises.
+
+    The key travels as ``xi-api-key`` because that is the vendor's own header,
+    and the gateway reads it too, so one request shape reaches either.
+    """
+    response = await _request(
+        "GET",
+        f"{endpoint.base_url}{ELEVENLABS_SIGNED_URL_PATH}"
+        f"?agent_id={quote(agent_id, safe='')}",
+        headers={"xi-api-key": endpoint.api_key},
+        json_body=None,
+        transport=transport,
+        timeout_s=timeout_s if timeout_s is not None else MINT_TIMEOUT_S,
+    )
+
+    if response.status_code == 404:
+        return MintResult(minted=False, status=404)
+    _raise_if_refused(response, endpoint.base_url, "ElevenLabs signed-URL mint")
+
+    parsed = _parse_json(response, "ElevenLabs signed-URL mint")
+    signed_url = parsed.get("signed_url")
+    if not isinstance(signed_url, str) or not signed_url:
+        raise VoiceGatewayMintError(
+            "ElevenLabs signed-URL mint returned no signed_url"
+        )
+    return MintResult(
+        minted=True,
+        credential=signed_url,
+        session_id=_session_id(response),
+    )
+
+
+async def report_openai_realtime_usage(
+    endpoint: RealtimeMintEndpoint,
+    session_id: str,
+    usage: Dict[str, Any],
+    *,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+    timeout_s: Optional[float] = None,
+) -> Optional[BaseException]:
+    """Report what the socket measured, closing the session's spend record.
+
+    OpenAI reports usage over the socket, in ``response.done``, and that
+    socket runs client to vendor, so this is the only path by which those
+    numbers reach a gateway. A session that never reports is not lost: the
+    gateway settles it as cost-unknown once its grace expires.
+
+    Never raises. A failed report costs accuracy on one session, and raising
+    here would fail a test whose subject is the agent, not the billing. The
+    failure is RETURNED instead, so a caller that wants to log it can, and
+    ``None`` means the report landed.
+    """
+    # No session id means the vendor minted this credential, so there is no
+    # spend record anywhere to close.
+    if not session_id:
+        return None
+    try:
+        response = await _request(
+            "POST",
+            f"{endpoint.base_url}/realtime/sessions/"
+            f"{quote(session_id, safe='')}/usage",
+            headers={
+                "Authorization": f"Bearer {endpoint.api_key}",
+                "Content-Type": "application/json",
+            },
+            json_body={"usage": usage},
+            transport=transport,
+            timeout_s=(
+                timeout_s if timeout_s is not None else USAGE_REPORT_TIMEOUT_S
+            ),
+        )
+    except BaseException as error:  # noqa: BLE001 - reported, never raised
+        return error
+    # A refused report is a failure that answers. Reading only the raised case
+    # would treat a 404 for an unknown session, or a 401 for a rotated key, as
+    # a report that landed, and the session would settle as cost-unknown with
+    # nobody told why.
+    if response.status_code >= 400:
+        return VoiceGatewayMintError(
+            f"realtime usage report refused with HTTP {response.status_code}"
+        )
+    return None
+
+
+def warn_direct_dial_fallback(
+    base_url: str,
+    mint_path: str,
+    credential_source: str,
+) -> None:
+    """Warn that a mint route was absent and a direct provider key is in use.
+
+    Loud on purpose. A silent fall back to a direct key looks exactly like a
+    successful brokered run while producing no spend record at all, so a test
+    run that proved nothing would read as a run that proved everything.
+
+    ``credential_source`` names where the key being dialled came from, because
+    an adapter reads several in order and naming a fixed one sends the reader
+    to a variable that is not set.
+    """
+    message = (
+        f"voice mint route not found at {base_url}{mint_path}; dialling the "
+        f"vendor directly with {credential_source}. This session is not "
+        f"billed or budgeted by the gateway at {base_url}."
+    )
+    logger.warning(message)
+    # stacklevel=2 puts the warning on the adapter's connect(), which is the
+    # line a reader can act on.
+    warnings.warn(message, VoiceGatewayFallbackWarning, stacklevel=2)
+
+
+# --------------------------------------------------------------------- internals
+
+
+async def _request(
+    method: str,
+    url: str,
+    *,
+    headers: Dict[str, str],
+    json_body: Optional[Dict[str, Any]],
+    transport: Optional[httpx.AsyncBaseTransport],
+    timeout_s: float,
+) -> httpx.Response:
+    """One HTTP round trip, bounded, over a client the caller may replace.
+
+    ``transport`` is the injection seam the tests use (``httpx.MockTransport``);
+    the timeout still comes from the client built here, so a test can prove the
+    bound is the module's and not its own.
+    """
+    async with httpx.AsyncClient(
+        transport=transport, timeout=httpx.Timeout(timeout_s)
+    ) as client:
+        return await client.request(method, url, headers=headers, json=json_body)
+
+
+def _raise_if_refused(response: httpx.Response, base_url: str, what: str) -> None:
+    """Raise unless the endpoint minted.
+
+    Reached only after 404 has been handled, so every status here belongs to
+    an endpoint that HAS the route and declined to use it. 401 and 403 are a
+    rejected key, 429 a session cap or rate limit, 5xx an outage. All of them
+    mean the gateway refused this session, and none of them may be dialled
+    around.
+    """
+    if response.status_code < 400:
+        return
+    detail = response.text[:500]
+    raise VoiceGatewayMintError(
+        f"{what} refused with HTTP {response.status_code}: the gateway at "
+        f"{base_url} refused the mint, so this session must not fall back to "
+        f"a direct provider key. {detail}"
+    )
+
+
+def _parse_json(response: httpx.Response, what: str) -> Dict[str, Any]:
+    try:
+        parsed = response.json()
+    except Exception as error:  # noqa: BLE001 - the body itself is the fault
+        raise VoiceGatewayMintError(
+            f"{what} returned a body that is not JSON"
+        ) from error
+    if not isinstance(parsed, dict):
+        raise VoiceGatewayMintError(f"{what} returned a body that is not JSON")
+    return parsed
+
+
+def _session_id(response: httpx.Response) -> str:
+    return response.headers.get(SESSION_ID_HEADER, "") or ""
+
+
+def _read_client_secret(body: Dict[str, Any]) -> str:
+    """The credential, wherever the mint put it.
+
+    OpenAI returns ``{"value": ...}`` at the top level today and has
+    previously nested it under ``client_secret``, so both are read rather than
+    pinning the adapter to one release's shape.
+    """
+    value = body.get("value")
+    if isinstance(value, str) and value:
+        return value
+    nested = body.get("client_secret")
+    if isinstance(nested, dict):
+        nested_value = nested.get("value")
+        if isinstance(nested_value, str) and nested_value:
+            return nested_value
+    return ""

--- a/python/scenario/voice/broker.py
+++ b/python/scenario/voice/broker.py
@@ -352,6 +352,21 @@ async def report_openai_realtime_usage(
     return None
 
 
+def zero_realtime_usage() -> Dict[str, Any]:
+    """The usage of a session that consumed nothing.
+
+    The counts are stated rather than left out. A gateway reads a usage report
+    by looking for ``input_tokens`` or ``output_tokens``, and refuses a body
+    that carries neither, so an empty object is rejected with HTTP 400 and the
+    session stays open until the gateway's own grace expires. Measured against
+    the live gateway on 2026-08-21.
+
+    A fresh dict each call, because it is used as the starting total a session
+    accumulates into.
+    """
+    return {"input_tokens": 0, "output_tokens": 0}
+
+
 def accumulate_realtime_usage(
     total: Optional[Dict[str, Any]], usage: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -398,19 +413,14 @@ async def close_unused_realtime_session(
 ) -> Optional[Exception]:
     """Close a session whose socket never opened, at zero.
 
-    The counts are stated rather than left out. A gateway reads a usage report
-    by looking for ``input_tokens`` or ``output_tokens``, and refuses a body
-    that carries neither, so an empty object is rejected with HTTP 400 and the
-    session stays open until the gateway's own grace expires. Measured against
-    the live gateway on 2026-08-21.
-
     Zero is the truth rather than a placeholder: an ephemeral credential that
-    opened no socket consumed nothing at the vendor.
+    opened no socket consumed nothing at the vendor. See
+    :func:`zero_realtime_usage` for why the counts are stated.
     """
     return await report_openai_realtime_usage(
         endpoint,
         session_id,
-        {"input_tokens": 0, "output_tokens": 0},
+        zero_realtime_usage(),
         transport=transport,
         timeout_s=timeout_s,
     )

--- a/python/scenario/voice/broker.py
+++ b/python/scenario/voice/broker.py
@@ -352,6 +352,33 @@ async def report_openai_realtime_usage(
     return None
 
 
+async def close_unused_realtime_session(
+    endpoint: RealtimeMintEndpoint,
+    session_id: str,
+    *,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+    timeout_s: Optional[float] = None,
+) -> Optional[Exception]:
+    """Close a session whose socket never opened, at zero.
+
+    The counts are stated rather than left out. A gateway reads a usage report
+    by looking for ``input_tokens`` or ``output_tokens``, and refuses a body
+    that carries neither, so an empty object is rejected with HTTP 400 and the
+    session stays open until the gateway's own grace expires. Measured against
+    the live gateway on 2026-08-21.
+
+    Zero is the truth rather than a placeholder: an ephemeral credential that
+    opened no socket consumed nothing at the vendor.
+    """
+    return await report_openai_realtime_usage(
+        endpoint,
+        session_id,
+        {"input_tokens": 0, "output_tokens": 0},
+        transport=transport,
+        timeout_s=timeout_s,
+    )
+
+
 def warn_direct_dial_fallback(
     base_url: str,
     mint_path: str,

--- a/python/tests/voice/conftest.py
+++ b/python/tests/voice/conftest.py
@@ -54,6 +54,41 @@ if os.getenv("OPENAI_API_KEY"):
 
 
 # --------------------------------------------------------------------- #
+# Unit-suite network guard                                              #
+# --------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _no_gateway_mint_in_unit_tests(request: pytest.FixtureRequest, monkeypatch):
+    """Keep the voice unit suite off the network.
+
+    Both realtime adapters now mint a session credential over HTTP before
+    they open their socket, and that mint is a real request to whatever
+    OPENAI_BASE_URL or ELEVENLABS_BASE_URL names. A unit test that drives a
+    fake socket would otherwise reach a live vendor on every ``connect()``,
+    which is slow, costs money, and fails differently on every machine
+    depending on what the developer has exported.
+
+    Only the ENDPOINT RESOLUTION is neutralised, so a test that passes an
+    explicit endpoint still exercises the whole mint. Integration tests, whose
+    point is to reach a live provider, keep resolution; so does anything
+    marked ``voice_gateway_mint``, which is testing resolution itself.
+    """
+    if request.node.get_closest_marker("integration"):
+        return
+    if request.node.get_closest_marker("voice_gateway_mint"):
+        return
+    monkeypatch.setattr(
+        "scenario.voice.adapters.openai_realtime.resolve_realtime_mint_endpoint",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "scenario.voice.adapters.elevenlabs.resolve_elevenlabs_mint_endpoint",
+        lambda *_args, **_kwargs: None,
+    )
+
+
+# --------------------------------------------------------------------- #
 # Helpers                                                               #
 # --------------------------------------------------------------------- #
 

--- a/python/tests/voice/conftest.py
+++ b/python/tests/voice/conftest.py
@@ -59,7 +59,9 @@ if os.getenv("OPENAI_API_KEY"):
 
 
 @pytest.fixture(autouse=True)
-def _no_gateway_mint_in_unit_tests(request: pytest.FixtureRequest, monkeypatch):
+def _no_gateway_mint_in_unit_tests(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Keep the voice unit suite off the network.
 
     Both realtime adapters now mint a session credential over HTTP before

--- a/python/tests/voice/test_broker.py
+++ b/python/tests/voice/test_broker.py
@@ -13,7 +13,7 @@ Mirrors ``javascript/src/voice/__tests__/broker.test.ts``.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, Optional
 
 import httpx
 import pytest
@@ -55,10 +55,10 @@ def clean_env(monkeypatch: pytest.MonkeyPatch):
 
 
 def recording_transport(
-    handler,
-) -> tuple[httpx.MockTransport, List[httpx.Request]]:
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[httpx.MockTransport, list[httpx.Request]]:
     """A transport that answers with ``handler`` and keeps every request."""
-    seen: List[httpx.Request] = []
+    seen: list[httpx.Request] = []
 
     def _handle(request: httpx.Request) -> httpx.Response:
         seen.append(request)

--- a/python/tests/voice/test_broker.py
+++ b/python/tests/voice/test_broker.py
@@ -27,6 +27,7 @@ from scenario.voice.broker import (
     RealtimeMintEndpoint,
     VoiceGatewayFallbackWarning,
     VoiceGatewayMintError,
+    close_unused_realtime_session,
     mint_elevenlabs_signed_url,
     mint_openai_realtime_session,
     normalize_elevenlabs_base_url,
@@ -499,6 +500,24 @@ class TestReportOpenAIRealtimeUsage:
         )
 
         assert isinstance(error, httpx.TimeoutException)
+
+    @pytest.mark.asyncio
+    async def test_closing_an_unused_session_states_its_zeros(self):
+        # A gateway reads a usage report by looking for input_tokens or
+        # output_tokens and refuses a body that carries neither, so posting an
+        # empty object is answered with HTTP 400 and the session stays open,
+        # holding one of the key's slots until its grace expires. Measured
+        # against the live gateway on 2026-08-21.
+        transport, seen = recording_transport(lambda _r: httpx.Response(202))
+
+        error = await close_unused_realtime_session(
+            ENDPOINT, "req_dead", transport=transport
+        )
+
+        assert error is None
+        assert json.loads(seen[0].content) == {
+            "usage": {"input_tokens": 0, "output_tokens": 0}
+        }
 
     def test_the_usage_report_bound_is_short(self):
         # It is awaited inside disconnect(), so a generous bound would show up

--- a/python/tests/voice/test_broker.py
+++ b/python/tests/voice/test_broker.py
@@ -1,0 +1,524 @@
+"""
+Minting a voice session.
+
+The subject is the contract between an adapter and whatever answers the
+vendor's base URL: which key mints, what the socket then dials with, how the
+adapter learns a gateway brokered the call, and what closes the spend record.
+Money depends on all four, so each is asserted rather than inferred from a
+connection succeeding.
+
+Mirrors ``javascript/src/voice/__tests__/broker.test.ts``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+from scenario.voice.broker import (
+    ELEVENLABS_SIGNED_URL_PATH,
+    MINT_TIMEOUT_S,
+    REALTIME_MINT_PATH,
+    USAGE_REPORT_TIMEOUT_S,
+    ElevenLabsMintEndpoint,
+    RealtimeMintEndpoint,
+    VoiceGatewayFallbackWarning,
+    VoiceGatewayMintError,
+    mint_elevenlabs_signed_url,
+    mint_openai_realtime_session,
+    normalize_elevenlabs_base_url,
+    report_openai_realtime_usage,
+    resolve_elevenlabs_mint_endpoint,
+    resolve_realtime_mint_endpoint,
+    warn_direct_dial_fallback,
+)
+
+
+ENV_KEYS = (
+    "OPENAI_BASE_URL",
+    "OPENAI_API_KEY",
+    "OPENAI_REALTIME_API_KEY",
+    "ELEVENLABS_BASE_URL",
+    "ELEVENLABS_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    """Every case states its own environment, so none inherits the shell's."""
+    for key in ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def recording_transport(
+    handler,
+) -> tuple[httpx.MockTransport, List[httpx.Request]]:
+    """A transport that answers with ``handler`` and keeps every request."""
+    seen: List[httpx.Request] = []
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    return httpx.MockTransport(_handle), seen
+
+
+def json_response(
+    status: int, body: Dict[str, Any], session_id: Optional[str] = None
+) -> httpx.Response:
+    headers = {"content-type": "application/json"}
+    if session_id is not None:
+        headers["x-langwatch-session-id"] = session_id
+    return httpx.Response(status, content=json.dumps(body), headers=headers)
+
+
+# ------------------------------------------------- resolving where to mint
+
+
+class TestResolveRealtimeMintEndpoint:
+    """The environment scenario already uses for chat is the whole config."""
+
+    def test_unset_base_url_mints_at_openai(self, monkeypatch: pytest.MonkeyPatch):
+        # The mint path is OpenAI's own, so the vendor answers it too.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-provider")
+
+        assert resolve_realtime_mint_endpoint() == RealtimeMintEndpoint(
+            base_url="https://api.openai.com/v1", api_key="sk-provider"
+        )
+
+    def test_gateway_base_url_needs_nothing_else(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1/")
+        monkeypatch.setenv("OPENAI_API_KEY", "vk-lw-test")
+
+        assert resolve_realtime_mint_endpoint() == RealtimeMintEndpoint(
+            base_url="https://gateway.example/v1", api_key="vk-lw-test"
+        )
+
+    def test_explicit_arguments_beat_the_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://from-env.example/v1")
+        monkeypatch.setenv("OPENAI_API_KEY", "vk-from-env")
+
+        assert resolve_realtime_mint_endpoint(
+            base_url="https://explicit.example/v1", api_key="vk-explicit"
+        ) == RealtimeMintEndpoint(
+            base_url="https://explicit.example/v1", api_key="vk-explicit"
+        )
+
+    def test_realtime_key_alone_does_not_mint(self, monkeypatch: pytest.MonkeyPatch):
+        # OPENAI_REALTIME_API_KEY holds a direct provider key. Minting with it
+        # would present a gateway a credential it did not issue and cannot
+        # bill, and the refusal would read as a gateway outage.
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+        monkeypatch.setenv("OPENAI_REALTIME_API_KEY", "sk-real-provider-key")
+
+        assert resolve_realtime_mint_endpoint() is None
+
+
+class TestNormalizeElevenLabsBaseUrl:
+    def test_empty_means_unset(self):
+        assert normalize_elevenlabs_base_url(None) is None
+        assert normalize_elevenlabs_base_url("  ") is None
+
+    def test_trailing_slash_is_dropped(self):
+        assert (
+            normalize_elevenlabs_base_url("https://gateway.example/")
+            == "https://gateway.example"
+        )
+
+    def test_v1_suffix_is_refused(self):
+        # This module appends /v1 itself, so a base URL carrying it would
+        # request /v1/v1/convai/... and 404 with no cause named.
+        with pytest.raises(ValueError, match="must not include /v1"):
+            normalize_elevenlabs_base_url("https://gateway.example/v1")
+
+    def test_non_http_scheme_is_refused(self):
+        # urlparse accepts schemes no REST request can be made over, so
+        # parsing alone is not a check.
+        with pytest.raises(ValueError, match="must be http or https"):
+            normalize_elevenlabs_base_url("wss://gateway.example")
+
+
+class TestResolveElevenLabsMintEndpoint:
+    def test_unset_base_url_leaves_the_adapter_on_its_direct_dial(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # ElevenLabs defines no base-URL variable of its own, so an
+        # unconfigured adapter must connect exactly as it always has.
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "xi-provider")
+
+        assert resolve_elevenlabs_mint_endpoint() is None
+
+    def test_environment_base_url_points_the_mint_at_a_gateway(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ELEVENLABS_BASE_URL", "https://gateway.example/")
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "vk-lw-test")
+
+        assert resolve_elevenlabs_mint_endpoint() == ElevenLabsMintEndpoint(
+            base_url="https://gateway.example", api_key="vk-lw-test"
+        )
+
+    def test_no_key_means_no_mint(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ELEVENLABS_BASE_URL", "https://gateway.example")
+
+        assert resolve_elevenlabs_mint_endpoint() is None
+
+
+# ------------------------------------------------------ the realtime mint
+
+ENDPOINT = RealtimeMintEndpoint(
+    base_url="https://gateway.example/v1", api_key="vk-lw-test"
+)
+
+
+class TestMintOpenAIRealtimeSession:
+    @pytest.mark.asyncio
+    async def test_sends_the_key_and_reads_back_the_secret_and_session_id(self):
+        transport, seen = recording_transport(
+            lambda _r: json_response(
+                200, {"value": "ek_abc", "expires_at": 1}, session_id="req_123"
+            )
+        )
+
+        result = await mint_openai_realtime_session(
+            ENDPOINT, "gpt-realtime", transport=transport
+        )
+
+        assert result.minted is True
+        assert result.credential == "ek_abc"
+        assert result.session_id == "req_123"
+        assert str(seen[0].url) == f"https://gateway.example/v1{REALTIME_MINT_PATH}"
+        assert seen[0].headers["authorization"] == "Bearer vk-lw-test"
+        assert json.loads(seen[0].content) == {
+            "session": {"type": "realtime", "model": "gpt-realtime"}
+        }
+
+    @pytest.mark.asyncio
+    async def test_expiry_is_sent_only_when_asked_for(self):
+        transport, seen = recording_transport(
+            lambda _r: json_response(200, {"value": "ek_abc"})
+        )
+
+        await mint_openai_realtime_session(
+            ENDPOINT, "gpt-realtime", expires_after_seconds=600, transport=transport
+        )
+
+        assert json.loads(seen[0].content)["expires_after"] == {
+            "anchor": "created_at",
+            "seconds": 600,
+        }
+
+    @pytest.mark.asyncio
+    async def test_vendor_answer_carries_no_session_id(self):
+        # This is how the adapter learns what it is talking to. OpenAI's own
+        # mint carries no such header, so there is nothing to report usage to
+        # and nothing that would accept a report.
+        transport, _ = recording_transport(
+            lambda _r: json_response(200, {"value": "ek_from_openai"})
+        )
+
+        result = await mint_openai_realtime_session(
+            ENDPOINT, "gpt-realtime", transport=transport
+        )
+
+        assert result.minted is True
+        assert result.session_id == ""
+
+    @pytest.mark.asyncio
+    async def test_absent_route_is_reported_rather_than_raised(self):
+        # A plain proxy, or a LangWatch gateway older than this feature,
+        # answers 404 here. That is an absence, not a refusal, so the caller
+        # may dial the vendor directly.
+        transport, _ = recording_transport(
+            lambda _r: httpx.Response(404, text="not found")
+        )
+
+        result = await mint_openai_realtime_session(
+            ENDPOINT, "gpt-realtime", transport=transport
+        )
+
+        assert result.minted is False
+        assert result.status == 404
+
+    @pytest.mark.parametrize("status", [401, 403, 429, 500, 503])
+    @pytest.mark.asyncio
+    async def test_a_refusal_raises_so_it_cannot_be_dialled_around(
+        self, status: int
+    ):
+        # The endpoint HAS the route and declined to use it: a rejected key, a
+        # budget, a session cap, an outage. Falling back would run exactly the
+        # call the gateway refused to bill.
+        transport, _ = recording_transport(
+            lambda _r: json_response(
+                status,
+                {
+                    "error": {
+                        "code": "realtime_session_limit",
+                        "message": "this virtual key already holds the most "
+                        "voice sessions",
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(VoiceGatewayMintError) as excinfo:
+            await mint_openai_realtime_session(
+                ENDPOINT, "gpt-realtime", transport=transport
+            )
+
+        message = str(excinfo.value)
+        assert f"HTTP {status}" in message
+        assert "refused the mint" in message
+        assert "realtime_session_limit" in message
+
+    @pytest.mark.asyncio
+    async def test_a_mint_with_no_credential_is_refused(self):
+        transport, _ = recording_transport(
+            lambda _r: json_response(200, {"expires_at": 1})
+        )
+
+        with pytest.raises(VoiceGatewayMintError, match="no client secret"):
+            await mint_openai_realtime_session(
+                ENDPOINT, "gpt-realtime", transport=transport
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_nested_client_secret_is_still_read(self):
+        # OpenAI has previously nested the credential, so both shapes are read
+        # rather than pinning the adapter to one release.
+        transport, _ = recording_transport(
+            lambda _r: json_response(200, {"client_secret": {"value": "ek_nested"}})
+        )
+
+        result = await mint_openai_realtime_session(
+            ENDPOINT, "gpt-realtime", transport=transport
+        )
+
+        assert result.credential == "ek_nested"
+
+    @pytest.mark.asyncio
+    async def test_a_body_that_is_not_json_is_refused(self):
+        transport, _ = recording_transport(
+            lambda _r: httpx.Response(200, text="<html>gateway</html>")
+        )
+
+        with pytest.raises(VoiceGatewayMintError, match="not JSON"):
+            await mint_openai_realtime_session(
+                ENDPOINT, "gpt-realtime", transport=transport
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_stalled_endpoint_gives_up_rather_than_leaving_connect_pending(
+        self,
+    ):
+        # connect() waits for the mint before it opens the socket, so an
+        # unbounded request leaves connection setup pending forever and the
+        # caller never learns why.
+        def stall(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectTimeout("stalled")
+
+        transport, _ = recording_transport(stall)
+
+        with pytest.raises(httpx.TimeoutException):
+            await mint_openai_realtime_session(
+                ENDPOINT, "gpt-realtime", transport=transport, timeout_s=0.05
+            )
+
+    def test_the_mint_bound_is_finite(self):
+        # A default of None would make the request unbounded, which is the
+        # failure the timeout exists to prevent.
+        assert 0 < MINT_TIMEOUT_S < 60
+
+
+# ------------------------------------------------ the ElevenLabs signed URL
+
+EL_ENDPOINT = ElevenLabsMintEndpoint(
+    base_url="https://gateway.example", api_key="vk-lw-test"
+)
+
+
+class TestMintElevenLabsSignedUrl:
+    @pytest.mark.asyncio
+    async def test_sends_the_key_and_reads_back_the_signed_url_and_session_id(self):
+        transport, seen = recording_transport(
+            lambda _r: json_response(
+                200, {"signed_url": "wss://vendor.example/x?token=y"},
+                session_id="req_el",
+            )
+        )
+
+        result = await mint_elevenlabs_signed_url(
+            EL_ENDPOINT, "agent_abc", transport=transport
+        )
+
+        assert result.minted is True
+        assert result.credential == "wss://vendor.example/x?token=y"
+        assert result.session_id == "req_el"
+        assert seen[0].url.path == ELEVENLABS_SIGNED_URL_PATH
+        assert seen[0].url.params["agent_id"] == "agent_abc"
+        # xi-api-key is the vendor's own header, and the gateway reads it too,
+        # so one request shape reaches either.
+        assert seen[0].headers["xi-api-key"] == "vk-lw-test"
+
+    @pytest.mark.asyncio
+    async def test_absent_route_is_reported_rather_than_raised(self):
+        transport, _ = recording_transport(
+            lambda _r: httpx.Response(404, text="404 page not found")
+        )
+
+        result = await mint_elevenlabs_signed_url(
+            EL_ENDPOINT, "agent_abc", transport=transport
+        )
+
+        assert result.minted is False
+        assert result.status == 404
+
+    @pytest.mark.parametrize("status", [401, 403, 429, 500])
+    @pytest.mark.asyncio
+    async def test_a_refusal_raises_so_it_cannot_be_dialled_around(
+        self, status: int
+    ):
+        transport, _ = recording_transport(
+            lambda _r: json_response(status, {"error": "budget_exceeded"})
+        )
+
+        with pytest.raises(VoiceGatewayMintError) as excinfo:
+            await mint_elevenlabs_signed_url(
+                EL_ENDPOINT, "agent_abc", transport=transport
+            )
+
+        message = str(excinfo.value)
+        assert f"HTTP {status}" in message
+        assert "refused the mint" in message
+
+    @pytest.mark.asyncio
+    async def test_a_mint_with_no_signed_url_is_refused(self):
+        transport, _ = recording_transport(
+            lambda _r: json_response(200, {"agent_id": "agent_abc"})
+        )
+
+        with pytest.raises(VoiceGatewayMintError, match="no signed_url"):
+            await mint_elevenlabs_signed_url(
+                EL_ENDPOINT, "agent_abc", transport=transport
+            )
+
+
+# ---------------------------------------------- the usage report at the end
+
+
+class TestReportOpenAIRealtimeUsage:
+    @pytest.mark.asyncio
+    async def test_posts_the_vendor_usage_object_against_the_session_id(self):
+        transport, seen = recording_transport(lambda _r: httpx.Response(202))
+
+        error = await report_openai_realtime_usage(
+            ENDPOINT,
+            "req_123",
+            {"input_tokens": 15, "output_tokens": 43},
+            transport=transport,
+        )
+
+        assert error is None
+        assert (
+            str(seen[0].url)
+            == "https://gateway.example/v1/realtime/sessions/req_123/usage"
+        )
+        assert json.loads(seen[0].content) == {
+            "usage": {"input_tokens": 15, "output_tokens": 43}
+        }
+
+    @pytest.mark.asyncio
+    async def test_sends_nothing_when_the_vendor_minted_the_session(self):
+        transport, seen = recording_transport(lambda _r: httpx.Response(202))
+
+        error = await report_openai_realtime_usage(
+            ENDPOINT, "", {"input_tokens": 1}, transport=transport
+        )
+
+        assert error is None
+        assert seen == []
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_is_returned_because_a_rejected_report_is_not_a_delivered_one(
+        self,
+    ):
+        # A 404 for an unknown session, or a 401 for a rotated key, answers,
+        # so nothing raises. Reading only the raised case would treat both as
+        # a report that landed, and the session would settle as cost-unknown
+        # with nobody told why.
+        transport, _ = recording_transport(lambda _r: httpx.Response(404, text="no"))
+
+        error = await report_openai_realtime_usage(
+            ENDPOINT, "req_123", {"input_tokens": 1}, transport=transport
+        )
+
+        assert error is not None
+        assert "HTTP 404" in str(error)
+
+    @pytest.mark.asyncio
+    async def test_never_raises_because_billing_must_not_fail_the_test_it_measures(
+        self,
+    ):
+        # The session still settles: the gateway closes an unreported
+        # admission as cost-unknown once its grace expires.
+        def unreachable(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("gateway unreachable")
+
+        transport, _ = recording_transport(unreachable)
+
+        error = await report_openai_realtime_usage(
+            ENDPOINT, "req_123", {"input_tokens": 1}, transport=transport
+        )
+
+        assert isinstance(error, httpx.ConnectError)
+
+    @pytest.mark.asyncio
+    async def test_gives_up_on_a_stalled_gateway_rather_than_holding_the_socket(
+        self,
+    ):
+        # disconnect() awaits this, so an unbounded request keeps the
+        # websocket open and the test that owns it never finishes.
+        def stall(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ReadTimeout("stalled")
+
+        transport, _ = recording_transport(stall)
+
+        error = await report_openai_realtime_usage(
+            ENDPOINT,
+            "req_123",
+            {"input_tokens": 1},
+            transport=transport,
+            timeout_s=0.05,
+        )
+
+        assert isinstance(error, httpx.TimeoutException)
+
+    def test_the_usage_report_bound_is_short(self):
+        # It is awaited inside disconnect(), so a generous bound would show up
+        # as a hang at the end of every run.
+        assert 0 < USAGE_REPORT_TIMEOUT_S <= 10
+
+
+class TestWarnDirectDialFallback:
+    def test_the_fallback_is_loud(self):
+        # A silent fall back to a direct key looks exactly like a successful
+        # brokered run while producing no spend record at all, so a run that
+        # proved nothing would read as a run that proved everything.
+        with pytest.warns(VoiceGatewayFallbackWarning) as record:
+            warn_direct_dial_fallback(
+                "https://gateway.example/v1",
+                REALTIME_MINT_PATH,
+                "OPENAI_API_KEY",
+            )
+
+        message = str(record[0].message)
+        assert "https://gateway.example/v1/realtime/client_secrets" in message
+        assert "OPENAI_API_KEY" in message
+        assert "not billed" in message

--- a/python/tests/voice/test_openai_realtime_user_e2e.py
+++ b/python/tests/voice/test_openai_realtime_user_e2e.py
@@ -23,14 +23,20 @@ async def test_demo_openai_realtime_user_e2e_success(requires_llm):
     """OpenAI Realtime adapter (USER role) drives simulator; result.success is True."""
     try:
         from openai_realtime_user import main  # type: ignore[import]
-    except SystemExit as demo_skipped:
+    except SystemExit as demo_exit:
         # The demo guards itself at import with sys.exit(0) while
         # cross-adapter audio bridging is unimplemented, so importing it here
         # raised SystemExit and pytest reported a hard failure. Code that has
         # not shipped is the one case TESTING.md calls a legitimate skip, and
         # the demo's own message says which feature is missing. When the
         # bridge ships, the guard goes and this branch stops being taken.
-        pytest.skip(f"demo skipped itself at import: {demo_skipped}")
+        #
+        # Only the clean exit skips. The same demo also exits with a message
+        # when its environment is incomplete, and missing infrastructure is a
+        # failure here, not a skip.
+        if demo_exit.code not in (None, 0):
+            raise
+        pytest.skip(f"demo skipped itself at import: {demo_exit}")
 
     result = await main()
 

--- a/python/tests/voice/test_openai_realtime_user_e2e.py
+++ b/python/tests/voice/test_openai_realtime_user_e2e.py
@@ -21,7 +21,16 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "examples" / "voice
 @pytest.mark.asyncio
 async def test_demo_openai_realtime_user_e2e_success(requires_llm):
     """OpenAI Realtime adapter (USER role) drives simulator; result.success is True."""
-    from openai_realtime_user import main  # type: ignore[import]
+    try:
+        from openai_realtime_user import main  # type: ignore[import]
+    except SystemExit as demo_skipped:
+        # The demo guards itself at import with sys.exit(0) while
+        # cross-adapter audio bridging is unimplemented, so importing it here
+        # raised SystemExit and pytest reported a hard failure. Code that has
+        # not shipped is the one case TESTING.md calls a legitimate skip, and
+        # the demo's own message says which feature is missing. When the
+        # bridge ships, the guard goes and this branch stops being taken.
+        pytest.skip(f"demo skipped itself at import: {demo_skipped}")
 
     result = await main()
 

--- a/python/tests/voice/test_recording_playback_e2e.py
+++ b/python/tests/voice/test_recording_playback_e2e.py
@@ -32,16 +32,18 @@ async def test_demo_recording_playback_wav_written(requires_llm, requires_pipeca
     WAV file is written with non-zero size when a live bot is present.
     Skipped when no audio is recorded (headless / no live bot).
     """
-    import tempfile
-    from recording_playback import main, OUT_DIR  # type: ignore[import]
+    from _recording_helper import demo_recording_dir  # type: ignore[import]
+    from recording_playback import main  # type: ignore[import]
 
     result = await main()
 
     if result.audio is None:
         pytest.skip("No audio recorded (no live bot); skipping file-size assertion")
 
-    wav_path = OUT_DIR / "demo.wav"
+    # The demo writes through save_demo_recording, which lays out
+    # segments/, full.wav and manifest.json under the demo's own directory.
+    wav_path = demo_recording_dir("recording_playback") / "full.wav"
     if not wav_path.exists():
         pytest.skip("WAV not written (likely no live bot connection)")
 
-    assert wav_path.stat().st_size > 0, "demo.wav must be non-empty"
+    assert wav_path.stat().st_size > 0, "full.wav must be non-empty"

--- a/python/tests/voice/test_voice_gateway_mint.py
+++ b/python/tests/voice/test_voice_gateway_mint.py
@@ -92,6 +92,7 @@ def mint_transport(response_for) -> httpx.MockTransport:
 BROKER_CALLERS = {
     "mint_openai_realtime_session": "openai_realtime",
     "report_openai_realtime_usage": "openai_realtime",
+    "close_unused_realtime_session": "openai_realtime",
     "mint_elevenlabs_signed_url": "elevenlabs",
 }
 
@@ -226,7 +227,7 @@ class TestRealtimeAdapterMint:
 
         transport = mint_transport(handle)
         patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
-        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
+        patch_mint(monkeypatch, "close_unused_realtime_session", transport)
 
         import websockets
 
@@ -242,7 +243,13 @@ class TestRealtimeAdapterMint:
         usage_posts = [r for r in posted if r.url.path.endswith("/usage")]
         assert len(usage_posts) == 1
         assert usage_posts[0].url.path == "/v1/realtime/sessions/req_dead/usage"
-        assert json.loads(usage_posts[0].content) == {"usage": {}}
+        # The zeros are stated, not left out. A gateway reads a usage report
+        # by looking for input_tokens or output_tokens and refuses a body
+        # carrying neither, so an empty object is answered with HTTP 400 and
+        # the session stays open until its grace expires.
+        assert json.loads(usage_posts[0].content) == {
+            "usage": {"input_tokens": 0, "output_tokens": 0}
+        }
 
     @pytest.mark.asyncio
     async def test_disconnect_reports_what_the_socket_measured(

--- a/python/tests/voice/test_voice_gateway_mint.py
+++ b/python/tests/voice/test_voice_gateway_mint.py
@@ -10,13 +10,13 @@ dialling the vendor around it.
 
 from __future__ import annotations
 
+import importlib
 import json
 from typing import Any, Dict, List, Optional
 
 import httpx
 import pytest
 
-import scenario.voice.broker as broker
 from scenario.voice.adapters.elevenlabs import ElevenLabsAgentAdapter
 from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
 from scenario.voice.broker import (
@@ -101,16 +101,20 @@ def patch_mint(monkeypatch: pytest.MonkeyPatch, name: str, transport) -> None:
 
     The real function still runs; only the socket underneath it is replaced.
     Stubbing the function instead would test the stub.
+
+    The original is read off the adapter module rather than the broker module,
+    so the thing wrapped here is exactly the object the adapter will call.
     """
-    original = getattr(broker, name)
+    module = importlib.import_module(
+        f"scenario.voice.adapters.{BROKER_CALLERS[name]}"
+    )
+    original = getattr(module, name)
 
     async def _with_transport(*args, **kwargs):
         kwargs.setdefault("transport", transport)
         return await original(*args, **kwargs)
 
-    monkeypatch.setattr(
-        f"scenario.voice.adapters.{BROKER_CALLERS[name]}.{name}", _with_transport
-    )
+    monkeypatch.setattr(module, name, _with_transport)
 
 
 class TestRealtimeAdapterMint:

--- a/python/tests/voice/test_voice_gateway_mint.py
+++ b/python/tests/voice/test_voice_gateway_mint.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import importlib
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import httpx
 import pytest
@@ -63,7 +63,11 @@ def fake_ws(monkeypatch: pytest.MonkeyPatch):
     calls: List[Dict[str, Any]] = []
     socket = FakeSocket()
 
-    async def _connect(url: str, additional_headers=None, **_kwargs):
+    async def _connect(
+        url: str,
+        additional_headers: Optional[Dict[str, str]] = None,
+        **_kwargs: Any,
+    ) -> FakeSocket:
         calls.append({"url": url, "headers": dict(additional_headers or {})})
         return socket
 
@@ -83,7 +87,9 @@ def clean_env(monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv(key, raising=False)
 
 
-def mint_transport(response_for) -> httpx.MockTransport:
+def mint_transport(
+    response_for: Callable[[httpx.Request], httpx.Response],
+) -> httpx.MockTransport:
     return httpx.MockTransport(response_for)
 
 
@@ -97,7 +103,11 @@ BROKER_CALLERS = {
 }
 
 
-def patch_mint(monkeypatch: pytest.MonkeyPatch, name: str, transport) -> None:
+def patch_mint(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    transport: httpx.AsyncBaseTransport,
+) -> None:
     """Give the adapter's broker call a transport, leaving its behaviour whole.
 
     The real function still runs; only the socket underneath it is replaced.
@@ -111,7 +121,7 @@ def patch_mint(monkeypatch: pytest.MonkeyPatch, name: str, transport) -> None:
     )
     original = getattr(module, name)
 
-    async def _with_transport(*args, **kwargs):
+    async def _with_transport(*args: Any, **kwargs: Any) -> Any:
         kwargs.setdefault("transport", transport)
         return await original(*args, **kwargs)
 
@@ -231,7 +241,7 @@ class TestRealtimeAdapterMint:
 
         import websockets
 
-        async def _refuse(*_args, **_kwargs):
+        async def _refuse(*_args: Any, **_kwargs: Any) -> FakeSocket:
             raise ConnectionRefusedError("socket refused")
 
         monkeypatch.setattr(websockets, "connect", _refuse)

--- a/python/tests/voice/test_voice_gateway_mint.py
+++ b/python/tests/voice/test_voice_gateway_mint.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 import pytest
 
+import scenario.voice.broker as broker
 from scenario.voice.adapters.elevenlabs import ElevenLabsAgentAdapter
 from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
 from scenario.voice.broker import (
@@ -101,8 +102,6 @@ def patch_mint(monkeypatch: pytest.MonkeyPatch, name: str, transport) -> None:
     The real function still runs; only the socket underneath it is replaced.
     Stubbing the function instead would test the stub.
     """
-    import scenario.voice.broker as broker
-
     original = getattr(broker, name)
 
     async def _with_transport(*args, **kwargs):

--- a/python/tests/voice/test_voice_gateway_mint.py
+++ b/python/tests/voice/test_voice_gateway_mint.py
@@ -1,0 +1,434 @@
+"""
+What the adapters do with a minted session.
+
+The broker's own contract is covered in ``test_broker.py``. The subject here
+is the handoff: that the ephemeral credential the mint returned is what
+reaches the socket, that a long-lived key does not, that an absent mint route
+falls back loudly, and that a refused mint stops the connection instead of
+dialling the vendor around it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+from scenario.voice.adapters.elevenlabs import ElevenLabsAgentAdapter
+from scenario.voice.adapters.openai_realtime import OpenAIRealtimeAgentAdapter
+from scenario.voice.broker import (
+    ElevenLabsMintEndpoint,
+    RealtimeMintEndpoint,
+    VoiceGatewayFallbackWarning,
+    VoiceGatewayMintError,
+)
+
+
+GATEWAY = RealtimeMintEndpoint(
+    base_url="https://gateway.example/v1", api_key="vk-lw-test"
+)
+EL_GATEWAY = ElevenLabsMintEndpoint(
+    base_url="https://gateway.example", api_key="vk-lw-test"
+)
+
+
+class FakeSocket:
+    """Records what the adapter sent, and replays what it should receive."""
+
+    def __init__(self, inbound: Optional[List[Dict[str, Any]]] = None) -> None:
+        self.sent: List[Dict[str, Any]] = []
+        self._inbound = list(inbound or [])
+        self.closed = False
+
+    async def send(self, raw: str) -> None:
+        self.sent.append(json.loads(raw))
+
+    async def recv(self) -> str:
+        if not self._inbound:
+            raise AssertionError("FakeSocket: nothing left to receive")
+        return json.dumps(self._inbound.pop(0))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_ws(monkeypatch: pytest.MonkeyPatch):
+    """Replaces the real websocket dial, and captures its URL and headers."""
+    import websockets
+
+    calls: List[Dict[str, Any]] = []
+    socket = FakeSocket()
+
+    async def _connect(url: str, additional_headers=None, **_kwargs):
+        calls.append({"url": url, "headers": dict(additional_headers or {})})
+        return socket
+
+    monkeypatch.setattr(websockets, "connect", _connect)
+    return {"calls": calls, "socket": socket}
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    for key in (
+        "OPENAI_BASE_URL",
+        "OPENAI_API_KEY",
+        "OPENAI_REALTIME_API_KEY",
+        "ELEVENLABS_BASE_URL",
+        "ELEVENLABS_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def mint_transport(response_for) -> httpx.MockTransport:
+    return httpx.MockTransport(response_for)
+
+
+#: Which adapter module imported each broker function, so the test patches
+#: the name the adapter actually calls rather than the one it was defined on.
+BROKER_CALLERS = {
+    "mint_openai_realtime_session": "openai_realtime",
+    "report_openai_realtime_usage": "openai_realtime",
+    "mint_elevenlabs_signed_url": "elevenlabs",
+}
+
+
+def patch_mint(monkeypatch: pytest.MonkeyPatch, name: str, transport) -> None:
+    """Give the adapter's broker call a transport, leaving its behaviour whole.
+
+    The real function still runs; only the socket underneath it is replaced.
+    Stubbing the function instead would test the stub.
+    """
+    import scenario.voice.broker as broker
+
+    original = getattr(broker, name)
+
+    async def _with_transport(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        f"scenario.voice.adapters.{BROKER_CALLERS[name]}.{name}", _with_transport
+    )
+
+
+class TestRealtimeAdapterMint:
+    @pytest.mark.asyncio
+    async def test_the_socket_dials_with_the_ephemeral_secret_not_the_long_lived_key(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        transport = mint_transport(
+            lambda _r: httpx.Response(
+                200,
+                json={"value": "ek_ephemeral"},
+                headers={"x-langwatch-session-id": "req_123"},
+            )
+        )
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-long-lived", mint=GATEWAY)
+
+        await adapter.connect()
+
+        assert fake_ws["calls"][0]["headers"]["Authorization"] == "Bearer ek_ephemeral"
+        assert "sk-long-lived" not in json.dumps(fake_ws["calls"][0])
+        assert adapter.brokered is True
+
+    @pytest.mark.asyncio
+    async def test_a_vendor_mint_leaves_the_adapter_unbrokered(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        # Only a gateway names the session it opened, so an answer without the
+        # header means there is no spend record to report against.
+        transport = mint_transport(
+            lambda _r: httpx.Response(200, json={"value": "ek_from_openai"})
+        )
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+
+        await adapter.connect()
+
+        assert adapter.brokered is False
+
+    @pytest.mark.asyncio
+    async def test_an_absent_mint_route_falls_back_loudly(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        transport = mint_transport(lambda _r: httpx.Response(404, text="not found"))
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+
+        with pytest.warns(VoiceGatewayFallbackWarning):
+            await adapter.connect()
+
+        assert fake_ws["calls"][0]["headers"]["Authorization"] == "Bearer sk-provider"
+        assert adapter.brokered is False
+
+    @pytest.mark.parametrize("status", [401, 403, 429, 500])
+    @pytest.mark.asyncio
+    async def test_a_refused_mint_never_reaches_the_vendor(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws, status: int
+    ):
+        # This is the whole point of brokering. Dialling the vendor with a
+        # direct provider key after the gateway declined would run the call
+        # the gateway refused to bill, off budget and off the ledger.
+        transport = mint_transport(
+            lambda _r: httpx.Response(status, json={"error": "budget_exceeded"})
+        )
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+
+        with pytest.raises(VoiceGatewayMintError, match="refused the mint"):
+            await adapter.connect()
+
+        assert fake_ws["calls"] == []
+
+    @pytest.mark.asyncio
+    async def test_mint_false_dials_the_vendor_with_no_mint_request(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        # An unconfigured adapter must connect exactly as it always has.
+        def refuse(_request: httpx.Request) -> httpx.Response:
+            raise AssertionError("mint=False must not make a mint request")
+
+        patch_mint(
+            monkeypatch, "mint_openai_realtime_session", mint_transport(refuse)
+        )
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=False)
+
+        await adapter.connect()
+
+        assert fake_ws["calls"][0]["headers"]["Authorization"] == "Bearer sk-provider"
+        assert adapter.brokered is False
+
+    @pytest.mark.asyncio
+    async def test_a_session_whose_socket_never_opened_is_closed_at_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The mint booked it and only a report can close it. Leaving it open
+        # would hold one of the key's session slots and book a call that never
+        # happened.
+        posted: List[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            posted.append(request)
+            if request.url.path.endswith("/usage"):
+                return httpx.Response(202)
+            return httpx.Response(
+                200,
+                json={"value": "ek_ephemeral"},
+                headers={"x-langwatch-session-id": "req_dead"},
+            )
+
+        transport = mint_transport(handle)
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
+
+        import websockets
+
+        async def _refuse(*_args, **_kwargs):
+            raise ConnectionRefusedError("socket refused")
+
+        monkeypatch.setattr(websockets, "connect", _refuse)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+
+        with pytest.raises(ConnectionRefusedError):
+            await adapter.connect()
+
+        usage_posts = [r for r in posted if r.url.path.endswith("/usage")]
+        assert len(usage_posts) == 1
+        assert usage_posts[0].url.path == "/v1/realtime/sessions/req_dead/usage"
+        assert json.loads(usage_posts[0].content) == {"usage": {}}
+
+    @pytest.mark.asyncio
+    async def test_disconnect_reports_what_the_socket_measured(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        posted: List[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            posted.append(request)
+            if request.url.path.endswith("/usage"):
+                return httpx.Response(202)
+            return httpx.Response(
+                200,
+                json={"value": "ek_ephemeral"},
+                headers={"x-langwatch-session-id": "req_123"},
+            )
+
+        transport = mint_transport(handle)
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+        await adapter.connect()
+
+        # The usage capture reads every inbound event, not only the branch the
+        # audio drain takes, because a drain that ends on tail silence never
+        # reaches the terminal event.
+        adapter._capture_usage(
+            {
+                "type": "response.done",
+                "response": {"usage": {"input_tokens": 15, "output_tokens": 43}},
+            }
+        )
+        await adapter.disconnect()
+
+        usage_posts = [r for r in posted if r.url.path.endswith("/usage")]
+        assert len(usage_posts) == 1
+        assert json.loads(usage_posts[0].content) == {
+            "usage": {"input_tokens": 15, "output_tokens": 43}
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_second_disconnect_does_not_report_the_session_twice(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        posted: List[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            posted.append(request)
+            if request.url.path.endswith("/usage"):
+                return httpx.Response(202)
+            return httpx.Response(
+                200,
+                json={"value": "ek_ephemeral"},
+                headers={"x-langwatch-session-id": "req_123"},
+            )
+
+        transport = mint_transport(handle)
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+        await adapter.connect()
+        adapter._capture_usage(
+            {"type": "response.done", "response": {"usage": {"input_tokens": 1}}}
+        )
+
+        await adapter.disconnect()
+        await adapter.disconnect()
+
+        assert len([r for r in posted if r.url.path.endswith("/usage")]) == 1
+
+    @pytest.mark.asyncio
+    async def test_an_unbrokered_session_reports_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        posted: List[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            posted.append(request)
+            return httpx.Response(200, json={"value": "ek_from_openai"})
+
+        transport = mint_transport(handle)
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+        await adapter.connect()
+        adapter._capture_usage(
+            {"type": "response.done", "response": {"usage": {"input_tokens": 1}}}
+        )
+
+        await adapter.disconnect()
+
+        assert [r for r in posted if r.url.path.endswith("/usage")] == []
+
+
+class TestElevenLabsAdapterMint:
+    @pytest.mark.asyncio
+    async def test_the_socket_dials_the_signed_url_with_no_key_on_it(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        transport = mint_transport(
+            lambda _r: httpx.Response(
+                200,
+                json={"signed_url": "wss://api.elevenlabs.io/x?token=abc"},
+                headers={"x-langwatch-session-id": "req_el"},
+            )
+        )
+        patch_mint(monkeypatch, "mint_elevenlabs_signed_url", transport)
+        adapter = ElevenLabsAgentAdapter(
+            agent_id="agent_abc", api_key="vk-lw-test", mint=EL_GATEWAY
+        )
+
+        await adapter.connect()
+
+        assert fake_ws["calls"][0]["url"] == "wss://api.elevenlabs.io/x?token=abc"
+        assert fake_ws["calls"][0]["headers"] == {}
+        assert adapter.brokered is True
+
+    @pytest.mark.asyncio
+    async def test_an_absent_mint_route_falls_back_loudly(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        transport = mint_transport(
+            lambda _r: httpx.Response(404, text="404 page not found")
+        )
+        patch_mint(monkeypatch, "mint_elevenlabs_signed_url", transport)
+        adapter = ElevenLabsAgentAdapter(
+            agent_id="agent_abc", api_key="xi-provider", mint=EL_GATEWAY
+        )
+
+        with pytest.warns(VoiceGatewayFallbackWarning):
+            await adapter.connect()
+
+        assert fake_ws["calls"][0]["url"].startswith(
+            "wss://api.elevenlabs.io/v1/convai/conversation"
+        )
+        assert fake_ws["calls"][0]["headers"] == {"xi-api-key": "xi-provider"}
+        assert adapter.brokered is False
+
+    @pytest.mark.parametrize("status", [401, 403, 429, 500])
+    @pytest.mark.asyncio
+    async def test_a_refused_mint_never_reaches_the_vendor(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws, status: int
+    ):
+        transport = mint_transport(
+            lambda _r: httpx.Response(status, json={"error": "budget_exceeded"})
+        )
+        patch_mint(monkeypatch, "mint_elevenlabs_signed_url", transport)
+        adapter = ElevenLabsAgentAdapter(
+            agent_id="agent_abc", api_key="xi-provider", mint=EL_GATEWAY
+        )
+
+        with pytest.raises(VoiceGatewayMintError, match="refused the mint"):
+            await adapter.connect()
+
+        assert fake_ws["calls"] == []
+
+    @pytest.mark.asyncio
+    async def test_an_unconfigured_adapter_connects_exactly_as_before(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        def refuse(_request: httpx.Request) -> httpx.Response:
+            raise AssertionError("an unconfigured adapter must not mint")
+
+        patch_mint(monkeypatch, "mint_elevenlabs_signed_url", mint_transport(refuse))
+        adapter = ElevenLabsAgentAdapter(agent_id="agent_abc", api_key="xi-provider")
+
+        await adapter.connect()
+
+        assert fake_ws["calls"][0]["url"] == adapter.url
+        assert fake_ws["calls"][0]["headers"] == {"xi-api-key": "xi-provider"}
+        assert adapter.brokered is False
+
+    @pytest.mark.voice_gateway_mint
+    @pytest.mark.asyncio
+    async def test_the_environment_base_url_is_enough_to_broker(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        # No bespoke broker variable: the vendor's own base URL is the switch.
+        monkeypatch.setenv("ELEVENLABS_BASE_URL", "https://gateway.example")
+        transport = mint_transport(
+            lambda _r: httpx.Response(
+                200,
+                json={"signed_url": "wss://api.elevenlabs.io/x?token=abc"},
+                headers={"x-langwatch-session-id": "req_el"},
+            )
+        )
+        patch_mint(monkeypatch, "mint_elevenlabs_signed_url", transport)
+        adapter = ElevenLabsAgentAdapter(agent_id="agent_abc", api_key="vk-lw-test")
+
+        await adapter.connect()
+
+        assert adapter.brokered is True

--- a/python/tests/voice/test_voice_gateway_mint.py
+++ b/python/tests/voice/test_voice_gateway_mint.py
@@ -98,7 +98,6 @@ def mint_transport(
 BROKER_CALLERS = {
     "mint_openai_realtime_session": "openai_realtime",
     "report_openai_realtime_usage": "openai_realtime",
-    "close_unused_realtime_session": "openai_realtime",
     "mint_elevenlabs_signed_url": "elevenlabs",
 }
 
@@ -237,7 +236,7 @@ class TestRealtimeAdapterMint:
 
         transport = mint_transport(handle)
         patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
-        patch_mint(monkeypatch, "close_unused_realtime_session", transport)
+        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
 
         import websockets
 
@@ -364,6 +363,40 @@ class TestRealtimeAdapterMint:
                 },
                 "output_token_details": {"audio_tokens": 6, "text_tokens": 2},
             }
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_session_that_never_responded_is_still_closed(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        # Connect and disconnect with no response.done in between. Without a
+        # total that starts at zero there is nothing to report, so the record
+        # stays open and holds one of the key's slots until its grace expires.
+        posted: List[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            posted.append(request)
+            if request.url.path.endswith("/usage"):
+                return httpx.Response(202)
+            return httpx.Response(
+                200,
+                json={"value": "ek_ephemeral"},
+                headers={"x-langwatch-session-id": "req_quiet"},
+            )
+
+        transport = mint_transport(handle)
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+
+        await adapter.connect()
+        await adapter.disconnect()
+
+        usage_posts = [r for r in posted if r.url.path.endswith("/usage")]
+        assert len(usage_posts) == 1
+        assert usage_posts[0].url.path == "/v1/realtime/sessions/req_quiet/usage"
+        assert json.loads(usage_posts[0].content) == {
+            "usage": {"input_tokens": 0, "output_tokens": 0}
         }
 
     @pytest.mark.asyncio

--- a/python/tests/voice/test_voice_gateway_mint.py
+++ b/python/tests/voice/test_voice_gateway_mint.py
@@ -301,6 +301,72 @@ class TestRealtimeAdapterMint:
         }
 
     @pytest.mark.asyncio
+    async def test_every_response_counts_toward_the_session_total(
+        self, monkeypatch: pytest.MonkeyPatch, fake_ws
+    ):
+        # OpenAI reports usage per response, not per session: two turns on one
+        # socket report output_tokens 4 and 4, never 4 and 8 (measured against
+        # the live API on 2026-08-21). A session that kept only the last
+        # response.done would bill for its last turn and nothing else.
+        posted: List[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            posted.append(request)
+            if request.url.path.endswith("/usage"):
+                return httpx.Response(202)
+            return httpx.Response(
+                200,
+                json={"value": "ek_ephemeral"},
+                headers={"x-langwatch-session-id": "req_123"},
+            )
+
+        transport = mint_transport(handle)
+        patch_mint(monkeypatch, "mint_openai_realtime_session", transport)
+        patch_mint(monkeypatch, "report_openai_realtime_usage", transport)
+        adapter = OpenAIRealtimeAgentAdapter(api_key="sk-provider", mint=GATEWAY)
+        await adapter.connect()
+
+        for _ in range(2):
+            adapter._capture_usage(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "usage": {
+                            "input_tokens": 120,
+                            "output_tokens": 4,
+                            "input_token_details": {
+                                "audio_tokens": 100,
+                                "text_tokens": 20,
+                                "cached_tokens": 8,
+                            },
+                            "output_token_details": {
+                                "audio_tokens": 3,
+                                "text_tokens": 1,
+                            },
+                        }
+                    },
+                }
+            )
+        await adapter.disconnect()
+
+        usage_posts = [r for r in posted if r.url.path.endswith("/usage")]
+        assert json.loads(usage_posts[0].content) == {
+            "usage": {
+                "input_tokens": 240,
+                "output_tokens": 8,
+                # The breakdowns are priced separately by a gateway, so they
+                # have to add up alongside the totals rather than keep one
+                # response's numbers.
+                "input_token_details": {
+                    "audio_tokens": 200,
+                    "text_tokens": 40,
+                    "cached_tokens": 16,
+                },
+                "output_token_details": {"audio_tokens": 6, "text_tokens": 2},
+            }
+        }
+
+    @pytest.mark.asyncio
     async def test_a_second_disconnect_does_not_report_the_session_twice(
         self, monkeypatch: pytest.MonkeyPatch, fake_ws
     ):

--- a/python/tests/voice/test_voice_gateway_routing_e2e.py
+++ b/python/tests/voice/test_voice_gateway_routing_e2e.py
@@ -1,0 +1,74 @@
+"""
+E2E check: the realtime mint actually reaches a LangWatch AI Gateway.
+
+Every other proof of routing in this repository is indirect. The voice job
+holds no provider key, so a run that reached OpenAI directly could not pass,
+and a direct-dial fallback is promoted to a test failure there. Both are real
+guarantees, and both are arguments about what did NOT happen.
+
+This asserts what DID. A gateway names the session it opened on the
+``X-LangWatch-Session-Id`` response header and the vendor does not, so the
+header is the one thing that cannot be told a lie about what answered. The
+session id it returns is the id of the spend record the mint opened.
+
+Nothing here opens a media socket. The mint alone is what proves the route,
+and the session it books is closed immediately with a zero usage report,
+which is the truth for a credential that opened no socket.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from scenario.config.voice_models import OPENAI_REALTIME_MODEL
+from scenario.voice.broker import (
+    OPENAI_DEFAULT_BASE_URL,
+    mint_openai_realtime_session,
+    report_openai_realtime_usage,
+    resolve_realtime_mint_endpoint,
+)
+
+
+@pytest.mark.asyncio
+async def test_the_realtime_mint_is_answered_by_a_gateway(requires_llm):
+    base_url = os.environ.get("OPENAI_BASE_URL", "")
+    if not base_url or base_url.rstrip("/") == OPENAI_DEFAULT_BASE_URL:
+        pytest.fail(
+            "OPENAI_BASE_URL is unset or points at OpenAI, so there is no "
+            "gateway to route through and this check cannot mean anything. "
+            "Set it to the gateway base URL, for example "
+            "https://gateway.langwatch.ai/v1. Missing infrastructure is a "
+            "failure here, not a skip."
+        )
+
+    endpoint = resolve_realtime_mint_endpoint()
+    assert endpoint is not None, (
+        "no mint endpoint resolved: OPENAI_API_KEY is empty, so the adapter "
+        "would dial the vendor directly instead of minting"
+    )
+
+    result = await mint_openai_realtime_session(endpoint, OPENAI_REALTIME_MODEL)
+
+    assert result.minted, (
+        f"the mint route at {endpoint.base_url} answered 404, so this base URL "
+        "is not a LangWatch gateway and voice is not being metered"
+    )
+    assert result.credential.startswith("ek_"), (
+        "the mint returned something that is not an OpenAI ephemeral client "
+        "secret, so the socket would not authenticate"
+    )
+    assert result.session_id, (
+        "the mint succeeded but carried no X-LangWatch-Session-Id, so OpenAI "
+        "answered it directly and no spend record was opened"
+    )
+    # Printed on purpose: this id is the spend record the mint opened, so a run
+    # can be matched to a row in the ledger from its own log.
+    print(f"\ngateway spend record for this mint: {result.session_id}\n")
+
+    # Close it at zero. The mint booked the session and only a report can
+    # close it; leaving it open would hold one of the key's session slots
+    # until the gateway's own grace expires.
+    error = await report_openai_realtime_usage(endpoint, result.session_id, {})
+    assert error is None, f"the gateway refused the closing usage report: {error}"

--- a/python/tests/voice/test_voice_gateway_routing_e2e.py
+++ b/python/tests/voice/test_voice_gateway_routing_e2e.py
@@ -33,7 +33,9 @@ from scenario.voice.broker import (
 
 
 @pytest.mark.asyncio
-async def test_the_realtime_mint_is_answered_by_a_gateway(requires_llm):
+async def test_the_realtime_mint_is_answered_by_a_gateway(
+    requires_llm: None,
+) -> None:
     base_url = os.environ.get("OPENAI_BASE_URL", "")
     if not base_url or base_url.rstrip("/") == OPENAI_DEFAULT_BASE_URL:
         pytest.fail(

--- a/python/tests/voice/test_voice_gateway_routing_e2e.py
+++ b/python/tests/voice/test_voice_gateway_routing_e2e.py
@@ -25,8 +25,8 @@ import pytest
 from scenario.config.voice_models import OPENAI_REALTIME_MODEL
 from scenario.voice.broker import (
     OPENAI_DEFAULT_BASE_URL,
+    close_unused_realtime_session,
     mint_openai_realtime_session,
-    report_openai_realtime_usage,
     resolve_realtime_mint_endpoint,
 )
 
@@ -69,6 +69,8 @@ async def test_the_realtime_mint_is_answered_by_a_gateway(requires_llm):
 
     # Close it at zero. The mint booked the session and only a report can
     # close it; leaving it open would hold one of the key's session slots
-    # until the gateway's own grace expires.
-    error = await report_openai_realtime_usage(endpoint, result.session_id, {})
+    # until the gateway's own grace expires. A gateway that had not opened a
+    # spend record would refuse this with 404, so the report landing is also
+    # evidence that the record exists.
+    error = await close_unused_realtime_session(endpoint, result.session_id)
     assert error is None, f"the gateway refused the closing usage report: {error}"

--- a/python/tests/voice/test_voice_gateway_routing_e2e.py
+++ b/python/tests/voice/test_voice_gateway_routing_e2e.py
@@ -19,6 +19,7 @@ which is the truth for a credential that opened no socket.
 from __future__ import annotations
 
 import os
+from typing import Optional
 
 import pytest
 
@@ -55,22 +56,35 @@ async def test_the_realtime_mint_is_answered_by_a_gateway(requires_llm):
         f"the mint route at {endpoint.base_url} answered 404, so this base URL "
         "is not a LangWatch gateway and voice is not being metered"
     )
-    assert result.credential.startswith("ek_"), (
-        "the mint returned something that is not an OpenAI ephemeral client "
-        "secret, so the socket would not authenticate"
-    )
-    assert result.session_id, (
-        "the mint succeeded but carried no X-LangWatch-Session-Id, so OpenAI "
-        "answered it directly and no spend record was opened"
-    )
-    # Printed on purpose: this id is the spend record the mint opened, so a run
-    # can be matched to a row in the ledger from its own log.
-    print(f"\ngateway spend record for this mint: {result.session_id}\n")
 
-    # Close it at zero. The mint booked the session and only a report can
-    # close it; leaving it open would hold one of the key's session slots
-    # until the gateway's own grace expires. A gateway that had not opened a
-    # spend record would refuse this with 404, so the report landing is also
-    # evidence that the record exists.
-    error = await close_unused_realtime_session(endpoint, result.session_id)
-    assert error is None, f"the gateway refused the closing usage report: {error}"
+    # Every assertion about the response runs inside the try so the session
+    # this mint booked is closed even when one of them fails. Without that, a
+    # failing check leaves the record open and holding one of the key's slots
+    # until the gateway's grace expires.
+    close_error: Optional[Exception] = None
+    try:
+        assert result.credential.startswith("ek_"), (
+            "the mint returned something that is not an OpenAI ephemeral "
+            "client secret, so the socket would not authenticate"
+        )
+        assert result.session_id, (
+            "the mint succeeded but carried no X-LangWatch-Session-Id, so "
+            "OpenAI answered it directly and no spend record was opened"
+        )
+        # Printed on purpose: this id is the spend record the mint opened, so
+        # a run can be matched to a row in the ledger from its own log.
+        print(f"\ngateway spend record for this mint: {result.session_id}\n")
+    finally:
+        if result.session_id:
+            # Close it at zero. Only a report can close a booked session, and
+            # a gateway that had not opened a spend record would refuse this
+            # with 404, so the report landing is also evidence of the record.
+            close_error = await close_unused_realtime_session(
+                endpoint, result.session_id
+            )
+
+    # Asserted after the finally so a cleanup failure never hides the primary
+    # assertion that got us here.
+    assert close_error is None, (
+        f"the gateway refused the closing usage report: {close_error}"
+    )

--- a/python/tests/voice/test_voice_spans_realtime.py
+++ b/python/tests/voice/test_voice_spans_realtime.py
@@ -345,6 +345,9 @@ async def test_rconnect_stamps_realtime_vendor_attrs_on_connect_span():
         model="gpt-realtime-mini",
         voice="alloy",
         tools=[{"type": "function", "name": "noop"}],
+        # connect() refuses to dial with no credential at all, so the key is
+        # stated here rather than inherited from whatever the runner exports.
+        api_key="sk-test",
     )
     executor = _exec(adapter)
 


### PR DESCRIPTION
## What this does

The Python voice adapters can now mint their session through the LangWatch AI
Gateway. This is the port of [scenario#935](https://github.com/langwatch/scenario/pull/935),
which did the same for TypeScript, and it keeps the two SDKs on the same
semantics.

A gateway brokers a realtime session rather than relaying it. The client
presents a virtual key, the gateway checks the budget and the open-session cap
and mints the vendor's own short-lived credential, and the media socket still
runs client to vendor. Audio never crosses the gateway, so latency and the wire
protocol do not change, and the call lands on one spend record.

Before this, neither Python adapter could reach a gateway. `OpenAIRealtimeAgentAdapter`
dialled a fixed endpoint with a long-lived provider key from
`OPENAI_REALTIME_API_KEY` and had no mint step. `ElevenLabsAgentAdapter` dialled
the vendor websocket with a raw `xi-api-key`. So the part of the voice suite
that spends the most money was the part the gateway could not meter.

## How it is configured

There is no broker URL and no broker key. Each adapter reads the variables its
own vendor already defines:

| Vendor | Base URL | Key | Mint path |
| --- | --- | --- | --- |
| OpenAI Realtime | `OPENAI_BASE_URL` | `OPENAI_API_KEY` | `POST /realtime/client_secrets` |
| ElevenLabs ConvAI | `ELEVENLABS_BASE_URL` | `ELEVENLABS_API_KEY` | `GET /v1/convai/conversation/get-signed-url` |

Point them at the vendor and the mint happens at the vendor. Point them at a
gateway and the mint happens through the broker. Whether a gateway answered is
read from the `X-LangWatch-Session-Id` response header, not from a flag, because
the response is the one thing that cannot be told a lie about what answered.

`OPENAI_REALTIME_API_KEY` is never used to mint. It holds a direct provider key,
so presenting it to a gateway would offer a credential the gateway did not issue
and cannot bill. It stays what it was: the fallback for a direct dial.

## A refused mint can no longer be bypassed

Mint failures split by status:

- **404** means the base URL has no mint route: a plain proxy, or a gateway
  older than this feature. That is an absence. The adapter falls back to a
  direct dial and warns.
- **401, 403, 429, 5xx** mean the endpoint has the route and declined to use
  it: a rejected key, an exhausted budget, a session cap, an outage. Those
  raise. The message names the status and says the gateway refused the mint.

Quietly dialling the vendor around a refusal would run exactly the call the
gateway declined to bill, off budget and off the ledger. The TypeScript side
applies the same rule.

Evidence that the refusal path holds, from `python/tests/voice/test_voice_gateway_mint.py`:
for each of 401, 403, 429 and 500, `connect()` raises and the websocket dial
list is empty, so nothing reached the vendor. Both new test files were checked
against deliberately broken production code: making the broker treat every
error as an absent route turns 17 tests red, and making the adapter keep the
long-lived key after a successful mint turns one specific test red.

## Evidence that Python voice now routes through the gateway

`voice-integration.yml` no longer sets `OPENAI_REALTIME_API_KEY`. With no
provider key anywhere in the job there is nothing to fall back to, so a run
that reached OpenAI directly cannot pass. That is the same proof the
`python-ci` examples lane already relies on: routing is shown by the absence of
an alternative rather than asserted in a comment.

The three pytest steps also run with
`-W error::scenario.voice.broker.VoiceGatewayFallbackWarning`. A direct-dial
fallback is a warning for a library and a failure here, because an unbilled
session looks exactly like a billed one in a log. The job can only go green if
every voice session was actually minted.

The workflow was dispatched on this branch five times to measure it. On the
last, run
[32532711104](https://github.com/langwatch/scenario/actions/runs/32532711104),
against the head commit:

- `tests/voice/test_voice_gateway_routing_e2e.py::test_the_realtime_mint_is_answered_by_a_gateway`
  **passed**. It mints against `OPENAI_BASE_URL`, and asserts the answer is a
  real `ek_` ephemeral secret, that the response carried
  `X-LangWatch-Session-Id`, and that the gateway accepted a closing usage
  report against that id. Only a gateway sends that header, and only a gateway
  that opened a spend record accepts a report against it, so the pass covers
  the route and the record. The ids look like
  `req_3f9b8c6a8ce63ac29307f4e64fff49`.
- `tests/voice/test_openai_realtime_agent_e2e.py::test_demo_openai_realtime_agent_e2e_success`
  **passed**. That is a full live OpenAI Realtime session, in a job with no
  provider key, so the socket authenticated with a credential the gateway
  minted.
- Zero `VoiceGatewayMintError`, zero `VoiceGatewayFallbackWarning` and zero
  failed usage reports across all five runs. Every mint was answered by the
  gateway and every session was closed.

## A gateway defect the dispatch found

The check above failed on its first live run, and the reason is worth naming.
A mint that succeeded followed by a socket that never opened is closed with a
zero usage report, and that report was an empty object. The gateway refuses
it: its parser reads a usage report by looking for `input_tokens` or
`output_tokens` and rejects a body carrying neither, so the close came back
HTTP 400, the failure went into a debug log, and the session stayed open
holding one of the key's slots until its grace expired.

The counts are now stated as zero, which parses and closes the record at the
number that is true for a credential that opened no socket. One
`close_unused_realtime_session` in the broker owns that shape so the adapter
and the routing check cannot drift apart on it.

**The TypeScript adapter has the same defect.** `_closeUnusedSession` in
`javascript/src/voice/adapters/openai-realtime.ts` posts `usage: {}` and
swallows the refusal the same way. That file is outside this change, so it is
flagged here rather than edited.

## What voice-integration still fails, and why it is not this change

This workflow has never been green. The run before this branch,
[30174711730](https://github.com/langwatch/scenario/actions/runs/30174711730)
on 2026-07-25, ended `9 failed, 14 passed, 6 skipped` in its marker-tagged
step while dialling OpenAI directly with a provider key. The five runs on this
branch end 9, 10, 8, 10 and 9 failed, on a rotating set: `accent_loop`,
`long_hold`, `observability` and `silence_handling` fail in one run and pass
in the next.

Two of the original nine were hard defects and are fixed here. A demo that
guards itself with a module-level `sys.exit(0)` made its wrapper raise
`SystemExit`, so a demo saying "skipped" in its own message read as a failure.
Another wrapper imported `OUT_DIR` from a demo that never defined it and
raised `ImportError` before running, because recordings moved to
`save_demo_recording` and the test kept a stale copy of the old layout.

Everything left is a live judge verdict on a voice demo with real audio,
interruption timing and VAD. Making that set reliable is real work, each
iteration costs a 45-minute run against live vendors, and none of it is about
the gateway, so it is left out of this change rather than folded into it.

## Usage reporting

OpenAI reports realtime usage over the socket, in `response.done`, and that
socket runs client to vendor, so the client is the only path by which those
numbers reach a gateway. `disconnect()` posts them to
`POST /realtime/sessions/{id}/usage`. The capture reads every inbound event
rather than only the audio branch, because a drain that ends on tail silence
never reaches the terminal event and a session whose usage was never captured
bills as cost-unknown.

A mint that succeeded followed by a socket that failed to open is closed with a
zero usage report. Zero is the truth rather than a placeholder: an ephemeral
credential that opened no socket consumed nothing at the vendor. Leaving it
open would hold one of the key's session slots and book a call that never
happened.

The report never raises. A failed report costs accuracy on one session, and
raising would fail a test whose subject is the agent, not the billing.

## The red python-ci is fixed

`Test (Examples)` has failed on every push since 2026-08-20, on a rotating pair
drawn from three examples. Neither cause is judge noise.

`test_lovable_clone` failed on the same criterion five times out of five:
"agent modified the index.css file, not only the Index.tsx file". The agent's
system prompt said to "start by the src/index.css and tailwind.config.ts
files", with no verb, so the model read them and moved on. The prompt now says
to update `src/index.css`, which is what the criterion has always described.

`test_running_in_parallel::test_user_is_hungry` let the user simulator drive
three free-form follow-up turns. It wandered into asking for meat, the agent's
hard rule made it decline, and the judge then failed the three criteria that
ask for an actual recipe. Its sibling in `test_running_in_parallel_with_arun`
already fixed this with fixed follow-up strings and two agent turns, and it
passes. Both files now use that shape.

Four tests carried `@pytest.mark.flaky` under `@pytest.mark.asyncio_concurrent`,
which does nothing at all. pytest-asyncio-concurrent runs a group from its own
protocol hook, and pytest-rerunfailures implements reruns in
`pytest_runtest_protocol`, which that hook never calls. It emits no warning and
the run summary counts no reruns, so a test declared to survive four attempts
was reported as a hard failure on its first. The dead markers are gone, and a
collection guard in `python/conftest.py` refuses the combination so it cannot
come back silently.

Verified with three consecutive green local runs of all five tests in the two
parallel example files plus `test_lovable_clone`.

## Unit tests no longer reach the network

Both adapters now make an HTTP request before they open a socket, so a unit
test driving a fake socket would have called a live vendor on every
`connect()`. A guard in `python/tests/voice/conftest.py` neutralises endpoint
resolution for non-integration tests. Only resolution is neutralised, so a test
that passes an explicit endpoint still exercises the whole mint.

## What is not in this change

The ElevenLabs lane is not enabled in `voice-integration.yml`. The adapter and
the gateway route both work, but the credential does not fit yet: the gateway
resolves whatever arrives in `xi-api-key` as a LangWatch virtual key, and in
that job `ELEVENLABS_API_KEY` also authenticates ElevenLabs speech-to-text and
the agent-provisioning step, neither of which the gateway fronts. Enabling it
needs a separate credential for those two. The workflow carries the two lines
to add and the reason, in the same style `python-ci.yml` documents the Gemini
lane.

## Deployment Impact

None. This is an SDK and CI change with no server component. `OPENAI_REALTIME_API_KEY`
stays supported for direct dials and is only removed from this repository's own
voice workflow.
