### PR TITLE
fix(ci): a shared budget outage stops blocking unrelated pull requests (#892)

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -39,6 +39,13 @@ outputs:
   relevant:
     description: "'true' if relevant paths changed, or if event is not a PR."
     value: ${{ steps.filter.outputs.relevant || steps.force.outputs.relevant }}
+  examples:
+    description: >-
+      'true' if the caller declared an `examples` filter and its paths changed,
+      or if the event is not a PR. Empty for callers that declare no such
+      filter, which is why consumers must treat empty as "not applicable"
+      rather than as "false".
+    value: ${{ steps.filter.outputs.examples || steps.force.outputs.examples }}
 
 runs:
   using: composite
@@ -56,3 +63,9 @@ runs:
       shell: bash
       run: |
         echo "relevant=true" >> "$GITHUB_OUTPUT"
+        # Forced true for the same reason as `relevant`: outside a PR there is
+        # no base to diff against, so the conservative answer is that the
+        # examples may have changed. For the examples gate that means a push
+        # to main stays red on a budget outage, which is right: on main the
+        # suite is the only thing that verifies an examples change.
+        echo "examples=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -44,6 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.detect.outputs.relevant }}
+      # Whether this PR changes anything the examples suite covers. The gate
+      # in front of that suite needs it to decide whether a gateway budget
+      # outage is collateral or a genuine loss of coverage.
+      examples: ${{ steps.detect.outputs.examples }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3
       - uses: ./.github/actions/detect-changes
@@ -53,6 +57,8 @@ jobs:
             relevant:
               - 'javascript/**'
               - '.github/workflows/javascript-ci.yml'
+            examples:
+              - 'javascript/examples/**'
 
   ci-checks:
     needs: changes
@@ -126,8 +132,11 @@ jobs:
       # Examples — skipped for Dependabot PRs and fork PRs since they don't have access to repo secrets
       - name: Test (Examples)
         if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        run: pnpm -F vitest-examples test
+        # Wrapped so a shared-budget outage is told apart from a broken
+        # example. See scripts/ci/examples-suite-gate.sh.
+        run: ../scripts/ci/examples-suite-gate.sh pnpm -F vitest-examples test
         env:
+          EXAMPLES_TOUCHED: ${{ needs.changes.outputs.examples }}
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         working-directory: javascript

--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -144,6 +144,25 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         working-directory: javascript
 
+      # The inverse condition of the step above, so exactly one of the two runs.
+      # Without it a fork pull request that changes javascript/examples/** goes
+      # green with nothing having read the file it changed: the examples suite
+      # is the only JavaScript step that reads them, it is skipped for forks,
+      # and javascript-complete accepts a job whose steps were all skipped.
+      # That is #893, which was closed on the Python side alone by its
+      # `Collect (Examples)` fallback. This is the JavaScript half.
+      #
+      # `vitest list` imports every example file to enumerate its tests and
+      # makes no provider call, so it needs no secrets. It catches what a fork
+      # can break without any key: an import that does not resolve, a syntax
+      # error, a renamed export. It does not catch a wrong assertion, so this
+      # is weaker than running the suite, and is deliberately not presented as
+      # equivalent.
+      - name: List (Examples)
+        if: github.actor == 'dependabot[bot]' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+        run: pnpm -F vitest-examples exec vitest list
+        working-directory: javascript
+
   # One required check for the whole workflow. Reports success if every
   # upstream job either passed or was legitimately skipped (paths didn't
   # match). Reports failure if any upstream job failed.

--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -134,9 +134,12 @@ jobs:
         if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         # Wrapped so a shared-budget outage is told apart from a broken
         # example. See scripts/ci/examples-suite-gate.sh.
-        run: ../scripts/ci/examples-suite-gate.sh pnpm -F vitest-examples test
+        # The junit reporter is what lets the gate decide per failed test
+        # rather than by grepping the log. See the python-ci counterpart.
+        run: ../scripts/ci/examples-suite-gate.sh pnpm -F vitest-examples test --reporter=junit --outputFile="$EXAMPLES_REPORT"
         env:
           EXAMPLES_TOUCHED: ${{ needs.changes.outputs.examples }}
+          EXAMPLES_REPORT: ${{ runner.temp }}/examples-junit.xml
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         working-directory: javascript

--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -67,3 +67,14 @@ jobs:
       - name: Validate the aggregator workflows' path filters
         if: ${{ !cancelled() }}
         run: bash scripts/validate-aggregator-workflows.sh
+
+      # Same reason as above: report this run's verdict rather than the first
+      # failure's. These two cover the examples suite's required-check wiring,
+      # which is what lets a shared gateway budget block unrelated PRs.
+      - name: Validate the examples suite's budget-gate wiring
+        if: ${{ !cancelled() }}
+        run: bash scripts/validate-examples-gate.sh
+
+      - name: Test the examples budget gate's own decisions
+        if: ${{ !cancelled() }}
+        run: bash scripts/test-examples-budget-gate.sh

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -66,6 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.detect.outputs.relevant }}
+      # Whether this PR changes anything the examples suite covers. The gate
+      # in front of that suite needs it to decide whether a gateway budget
+      # outage is collateral or a genuine loss of coverage.
+      examples: ${{ steps.detect.outputs.examples }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: ./.github/actions/detect-changes
@@ -75,6 +79,8 @@ jobs:
             relevant:
               - 'python/**'
               - '.github/workflows/python-ci.yml'
+            examples:
+              - 'python/examples/**'
 
   test:
     needs: changes
@@ -154,8 +160,14 @@ jobs:
         # well over the 60s per-test timeout that pytest.ini sets for the unit
         # suite. Override to 300s here so slow-but-correct runs don't get
         # pytest-timeout'd.
-        run: uv run pytest examples/ -v --tb=short --timeout=300
+        # Wrapped so a shared-budget outage is told apart from a broken
+        # example. The suite runs on one gateway virtual key with a daily
+        # spend cap; when that cap is hit every test fails at once and blocks
+        # unrelated PRs from merging. See scripts/ci/examples-suite-gate.sh
+        # for what is tolerated and, more to the point, what is not.
+        run: ../scripts/ci/examples-suite-gate.sh uv run pytest examples/ -v --tb=short --timeout=300
         env:
+          EXAMPLES_TOUCHED: ${{ needs.changes.outputs.examples }}
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # The Gemini examples still call Google directly. The mechanism to

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -165,9 +165,13 @@ jobs:
         # spend cap; when that cap is hit every test fails at once and blocks
         # unrelated PRs from merging. See scripts/ci/examples-suite-gate.sh
         # for what is tolerated and, more to the point, what is not.
-        run: ../scripts/ci/examples-suite-gate.sh uv run pytest examples/ -v --tb=short --timeout=300
+        # --junitxml is what lets the gate decide per failed test rather than
+        # by grepping the log: a budget outage and a genuinely broken example
+        # can land in the same run, and only a per-test report separates them.
+        run: ../scripts/ci/examples-suite-gate.sh uv run pytest examples/ -v --tb=short --timeout=300 --junitxml="$EXAMPLES_REPORT"
         env:
           EXAMPLES_TOUCHED: ${{ needs.changes.outputs.examples }}
+          EXAMPLES_REPORT: ${{ runner.temp }}/examples-junit.xml
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # The Gemini examples still call Google directly. The mechanism to

--- a/scripts/ci/classify-examples-failures.py
+++ b/scripts/ci/classify-examples-failures.py
@@ -16,16 +16,51 @@ suites either, since pytest puts the reason on its summary line and vitest does
 not.
 """
 
+import re
 import sys
 import xml.etree.ElementTree as ET
 
 BUDGET_MARKERS = ("budget_exceeded", "budget_scope")
 
+# A JUnit report from pytest or vitest is kilobytes. Anything past this is not
+# one, and reading it would be the denial of service rather than the defence.
+MAX_REPORT_BYTES = 16 * 1024 * 1024
+
+DOCTYPE = re.compile(r"<!DOCTYPE", re.IGNORECASE)
+
 
 def classify(path: str) -> str:
+    """Read the report defensively, then decide.
+
+    `xml.etree` resolves no external entities, but it does expand internal
+    ones, so a report carrying a `<!DOCTYPE>` with nested entity definitions
+    can be made to expand to gigabytes. Neither pytest nor vitest ever writes a
+    doctype into a JUnit report, so refusing one closes that off entirely and
+    costs nothing. That is preferred here over `defusedxml`: this script runs
+    under the runner's bare `python3` rather than under `uv`, so a third-party
+    import would not resolve at all.
+
+    The threat is modest either way: whoever can write this file already runs
+    the test suite on this runner. This is depth rather than the only barrier,
+    and refusing is fail-closed, since the gate reads `unreadable` and keeps
+    the suite's own red exit status.
+    """
     try:
-        root = ET.parse(path).getroot()
-    except (OSError, ET.ParseError) as error:
+        with open(path, "rb") as handle:
+            raw = handle.read(MAX_REPORT_BYTES + 1)
+    except OSError as error:
+        return f"unreadable {error}"
+
+    if len(raw) > MAX_REPORT_BYTES:
+        return f"unreadable report is larger than {MAX_REPORT_BYTES} bytes"
+
+    report_text = raw.decode("utf-8", errors="replace")
+    if DOCTYPE.search(report_text):
+        return "unreadable report carries a doctype, which no test runner writes"
+
+    try:
+        root = ET.fromstring(report_text)
+    except ET.ParseError as error:
         return f"unreadable {error}"
 
     budget = 0

--- a/scripts/ci/classify-examples-failures.py
+++ b/scripts/ci/classify-examples-failures.py
@@ -1,0 +1,57 @@
+"""Classify every failed test in a JUnit report as a gateway budget refusal or not.
+
+Prints one word plus detail, for the shell gate to branch on:
+
+    budget <n>     every failed test was refused on the gateway budget
+    mixed <names>  at least one failure was NOT a budget refusal
+    nofailures     the report lists no failed test at all
+    unreadable <e> the report could not be read
+
+EVERY failure, not any failure. A budget outage and a genuinely broken example
+can land in the same run: the tests that reach the gateway get 402 while one
+that fails on its own assertion fails for its own reason. Deciding on "the
+output mentions the budget somewhere" would hide that real failure, which is
+why this reads a report rather than the log. Grepping cannot do it across both
+suites either, since pytest puts the reason on its summary line and vitest does
+not.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+
+BUDGET_MARKERS = ("budget_exceeded", "budget_scope")
+
+
+def classify(path: str) -> str:
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        return f"unreadable {error}"
+
+    budget = 0
+    other: list[str] = []
+    for case in root.iter("testcase"):
+        problems = list(case.findall("failure")) + list(case.findall("error"))
+        if not problems:
+            continue
+        text = " ".join(
+            f"{p.get('message') or ''} {p.text or ''}" for p in problems
+        ).lower()
+        if any(marker in text for marker in BUDGET_MARKERS):
+            budget += 1
+        else:
+            name = f"{case.get('classname') or ''}::{case.get('name') or '?'}"
+            other.append(name.strip(":"))
+
+    if other:
+        return "mixed " + "; ".join(other[:5])
+    if budget:
+        return f"budget {budget}"
+    return "nofailures"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: classify-examples-failures.py <junit.xml>", file=sys.stderr)
+        raise SystemExit(2)
+    print(classify(sys.argv[1]))

--- a/scripts/ci/examples-suite-gate.sh
+++ b/scripts/ci/examples-suite-gate.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Run the examples suite, and tell a shared-budget outage apart from a broken
+# example.
+#
+# THE PROBLEM. The examples suite makes real model calls through the LangWatch
+# AI Gateway on one virtual key with a daily spend budget. When that budget is
+# exhausted the gateway answers HTTP 402 `budget_exceeded` and every test in
+# the suite fails at once. The suite feeds a required check, so an unrelated
+# pull request whose own tests all pass is blocked from merging by a shared
+# resource it never touched. Observed on #889, whose 1088 JavaScript and 1219
+# Python tests passed while 26 example files failed on 402.
+#
+# WHAT THIS DOES NOT DO. It does not turn the suite green and walk away. A
+# suite that cannot fail is the failure mode this repository has already been
+# bitten by: #893 records fork pull requests reaching a green required check
+# with nothing having run against the changed file. So the budget case is
+# reported loudly, in the log and in the run summary, and it is tolerated only
+# where tolerating it costs no coverage.
+#
+# THE RULE. A budget outage means the suite could not be run at all, not that
+# it ran and disagreed:
+#
+#   * the suite passed                          -> pass
+#   * failed, no budget signal                  -> FAIL, this is a real defect
+#   * failed on budget, PR changes the examples -> FAIL, the change is
+#                                                  unverified and saying
+#                                                  otherwise would be a lie
+#   * failed on budget, PR changes nothing the
+#     suite covers                              -> warn and pass, the suite
+#                                                  was never evidence about
+#                                                  this PR
+#
+# The third case is the one that keeps this honest. Budget exhaustion lasts
+# until the daily window resets, so without it an examples change could merge
+# on a day-long green that ran nothing.
+#
+# Required environment:
+#   EXAMPLES_TOUCHED   "true" when this PR changes files the suite covers
+# Optional:
+#   GITHUB_STEP_SUMMARY  written to when set, so the reason survives the log
+#
+# Usage: examples-suite-gate.sh <command> [args...]
+set -uo pipefail
+
+: "${EXAMPLES_TOUCHED:?}"
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: examples-suite-gate.sh <command> [args...]" >&2
+  exit 2
+fi
+
+output="$(mktemp)"
+trap 'rm -f "$output"' EXIT
+
+"$@" 2>&1 | tee "$output"
+status="${PIPESTATUS[0]}"
+
+if [[ "$status" -eq 0 ]]; then
+  exit 0
+fi
+
+# The gateway's own wording for a hard budget breach. `budget_scope` appears in
+# `error.meta` on the same response, so either is proof the refusal came from
+# the budget rather than from the example.
+if ! grep -qiE 'budget_exceeded|budget_scope' "$output"; then
+  echo "::error::The examples suite failed and nothing in its output names the gateway budget, so this is a real failure."
+  exit "$status"
+fi
+
+note="The examples suite could not run: the shared gateway virtual key is over its daily budget (HTTP 402 budget_exceeded). This is an infrastructure limit on a key shared by every pull request, not a result about any one of them."
+
+if [[ "$EXAMPLES_TOUCHED" == "true" ]]; then
+  echo "::error::${note} This pull request changes files the suite covers, so the change is unverified and the check stays red. Re-run once the daily window resets."
+  {
+    echo "### Examples suite: budget exhausted, and this PR changes examples"
+    echo ""
+    echo "${note}"
+    echo ""
+    echo "The check stays red because nothing verified the changed example. Re-run after the daily budget window resets."
+  } >>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit "$status"
+fi
+
+echo "::warning::${note} This pull request changes nothing the suite covers, so it is not held on that. The suite still did NOT run."
+{
+  echo "### Examples suite: not run (gateway budget exhausted)"
+  echo ""
+  echo "${note}"
+  echo ""
+  echo "This pull request changes nothing the suite covers, so it is not held on the outage. Treat the examples as unverified for this run, not as passing."
+} >>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+exit 0

--- a/scripts/ci/examples-suite-gate.sh
+++ b/scripts/ci/examples-suite-gate.sh
@@ -21,12 +21,13 @@
 # it ran and disagreed:
 #
 #   * the suite passed                          -> pass
-#   * failed, no budget signal                  -> FAIL, this is a real defect
-#   * failed on budget, PR changes the examples -> FAIL, the change is
+#   * ANY failure that is not a budget refusal  -> FAIL, this is a real defect
+#   * every failure is a budget refusal, and
+#     the PR changes the examples               -> FAIL, the change is
 #                                                  unverified and saying
 #                                                  otherwise would be a lie
-#   * failed on budget, PR changes nothing the
-#     suite covers                              -> warn and pass, the suite
+#   * every failure is a budget refusal, and
+#     the PR changes nothing the suite covers   -> warn and pass, the suite
 #                                                  was never evidence about
 #                                                  this PR
 #
@@ -34,15 +35,22 @@
 # until the daily window resets, so without it an examples change could merge
 # on a day-long green that ran nothing.
 #
+# EVERY failure, not any failure: a budget outage and a genuinely broken
+# example can land in the same run. That decision is made per failed test by
+# classify-examples-failures.py, which needs a report rather than a wall of
+# text. Without one this gate does NOT fall back to leniency: it cannot verify
+# the claim, so it declines to make it and the suite's own exit status stands.
+#
 # Required environment:
 #   EXAMPLES_TOUCHED   "true" when this PR changes files the suite covers
+#   EXAMPLES_REPORT    path to the JUnit XML the suite writes
 # Optional:
 #   GITHUB_STEP_SUMMARY  written to when set, so the reason survives the log
 #
 # Usage: examples-suite-gate.sh <command> [args...]
 set -uo pipefail
 
-: "${EXAMPLES_TOUCHED:?}"
+: "${EXAMPLES_TOUCHED:?}" "${EXAMPLES_REPORT:?}"
 
 if [[ $# -eq 0 ]]; then
   echo "usage: examples-suite-gate.sh <command> [args...]" >&2
@@ -59,13 +67,24 @@ if [[ "$status" -eq 0 ]]; then
   exit 0
 fi
 
-# The gateway's own wording for a hard budget breach. `budget_scope` appears in
-# `error.meta` on the same response, so either is proof the refusal came from
-# the budget rather than from the example.
-if ! grep -qiE 'budget_exceeded|budget_scope' "$output"; then
-  echo "::error::The examples suite failed and nothing in its output names the gateway budget, so this is a real failure."
-  exit "$status"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+verdict="$(python3 "$SCRIPT_DIR/classify-examples-failures.py" "$EXAMPLES_REPORT")"
+
+case "$verdict" in
+  "budget "*) ;;
+  "mixed "*)
+    echo "::error::The examples suite has failures that are not gateway budget refusals: ${verdict#mixed }. A budget outage does not excuse them."
+    exit "$status"
+    ;;
+  nofailures)
+    echo "::error::The examples suite exited ${status} but its report lists no failed test, so nothing here can be attributed to the budget."
+    exit "$status"
+    ;;
+  *)
+    echo "::error::Could not read the examples report at ${EXAMPLES_REPORT} (${verdict}), so the budget claim cannot be checked. Treating this as a real failure."
+    exit "$status"
+    ;;
+esac
 
 note="The examples suite could not run: the shared gateway virtual key is over its daily budget (HTTP 402 budget_exceeded). This is an infrastructure limit on a key shared by every pull request, not a result about any one of them."
 

--- a/scripts/ci/examples-suite-gate.sh
+++ b/scripts/ci/examples-suite-gate.sh
@@ -52,6 +52,22 @@ set -uo pipefail
 
 : "${EXAMPLES_TOUCHED:?}" "${EXAMPLES_REPORT:?}"
 
+# Anything that is not exactly true or false is a wiring bug, and the lenient
+# branch is the one it would land on. `examples` reaches here from a path
+# filter through `needs.changes.outputs.examples`, and the action that produces
+# it documents how easily that goes wrong: a key consumed but not declared as
+# an output arrives as the empty string. `:?` above catches empty; this catches
+# `tru`, `True`, and `yes`, each of which would otherwise read as "the PR
+# changes nothing the suite covers" and tolerate an outage that hides an
+# unverified example change.
+case "$EXAMPLES_TOUCHED" in
+  true | false) ;;
+  *)
+    echo "::error::EXAMPLES_TOUCHED must be exactly 'true' or 'false', got '${EXAMPLES_TOUCHED}'. Refusing to guess which way a mis-wired value should be read."
+    exit 2
+    ;;
+esac
+
 if [[ $# -eq 0 ]]; then
   echo "usage: examples-suite-gate.sh <command> [args...]" >&2
   exit 2

--- a/scripts/test-examples-budget-gate.sh
+++ b/scripts/test-examples-budget-gate.sh
@@ -53,6 +53,17 @@ MIXED_XML='<testsuites><testsuite name="examples" tests="2" failures="2">
   </testcase>
 </testsuite></testsuites>'
 
+# A report is only ever written by pytest or vitest, neither of which emits a
+# doctype. One appearing means something else wrote the file, and an internal
+# entity definition is how a small report expands to gigabytes while the gate
+# waits for it.
+DOCTYPE_XML='<?xml version="1.0"?><!DOCTYPE testsuites [<!ENTITY a "aaaaaaaaaa">]>
+<testsuites><testsuite name="examples" tests="1" failures="1">
+  <testcase classname="examples.test_foo" name="test_bar">
+    <failure message="Error code: 402 budget_exceeded">&a;</failure>
+  </testcase>
+</testsuite></testsuites>'
+
 NO_FAILURES_XML='<testsuites><testsuite name="examples" tests="1"><testcase classname="e" name="t"/></testsuite></testsuites>'
 
 # run_case <label> <touched> <suite exit code> <junit xml> <expected gate exit>
@@ -153,6 +164,45 @@ fi
 rm -f "$SUMMARY" "$JUNIT"
 
 echo ""
+echo "=== the report is not the one the test runner wrote ==="
+# Fail closed rather than trusting it. The budget branch is the lenient one, so
+# a report the gate cannot vouch for must never reach it.
+run_case "a report carrying a doctype is not a budget outage" false 1 "$DOCTYPE_XML" 1
+
+# Built rather than inlined: the point is the size, and a 17MB shell variable
+# is its own problem.
+echo ""
+echo "=== the report is too large to be one ==="
+BIG_JUNIT="$(mktemp)"
+BIG_LOG="$(mktemp)"
+{
+  printf '%s' '<testsuites><testsuite name="examples" tests="1" failures="1"><testcase classname="e" name="t"><failure message="budget_exceeded">'
+  head -c 17000000 /dev/zero | tr '\0' 'a'
+  printf '%s' '</failure></testcase></testsuite></testsuites>'
+} >"$BIG_JUNIT"
+EXAMPLES_TOUCHED=false EXAMPLES_REPORT="$BIG_JUNIT" GITHUB_STEP_SUMMARY=/dev/null \
+  bash "$GATE" bash -c "exit 1" >"$BIG_LOG" 2>&1
+BIG_STATUS=$?
+if [ "$BIG_STATUS" -eq 0 ]; then
+  fail "an oversized report was tolerated as a budget outage"
+  sed 's/^/      /' "$BIG_LOG"
+else
+  pass "an oversized report is not a budget outage"
+fi
+# The verdict alone does not reach the size check: the read is already bounded,
+# so dropping the check leaves a truncated document that fails to parse and is
+# refused anyway. What it costs is knowing WHY, and "the report is larger than
+# it can be" and "the report is malformed" send a maintainer to different
+# places. So the diagnostic is what is asserted here.
+if grep -q "larger than" "$BIG_LOG"; then
+  pass "an oversized report is reported as oversized, not as malformed"
+else
+  fail "an oversized report is reported as a parse error, which points at the wrong problem"
+  sed 's/^/      /' "$BIG_LOG"
+fi
+rm -f "$BIG_JUNIT" "$BIG_LOG"
+
+echo ""
 echo "=== the gate refuses what it cannot classify ==="
 if EXAMPLES_TOUCHED=false EXAMPLES_REPORT=/dev/null bash "$GATE" >/dev/null 2>&1; then
   fail "the gate accepted an empty command"
@@ -170,10 +220,21 @@ else
   pass "the gate refuses to run without EXAMPLES_REPORT"
 fi
 
+# `false` and anything-that-is-not-true both take the lenient branch, so a typo
+# or a mis-wired filter key would tolerate an outage on a PR that does change
+# the examples. Only the two real answers are accepted.
+for bad in tru True yes 1; do
+  if EXAMPLES_TOUCHED="$bad" EXAMPLES_REPORT=/dev/null bash "$GATE" true >/dev/null 2>&1; then
+    fail "the gate accepted EXAMPLES_TOUCHED='$bad', which it would have read as 'examples not changed'"
+  else
+    pass "the gate rejects EXAMPLES_TOUCHED='$bad' rather than reading it as false"
+  fi
+done
+
 echo ""
 # A harness that runs nothing prints the same happy line as one that runs
 # everything. This is what makes the line above mean something.
-EXPECTED_CHECKS=17
+EXPECTED_CHECKS=24
 if [ "$CHECKS" -ne "$EXPECTED_CHECKS" ]; then
   echo "  FAIL: ran $CHECKS checks, expected $EXPECTED_CHECKS; the harness is not running what it claims"
   FAIL=1

--- a/scripts/test-examples-budget-gate.sh
+++ b/scripts/test-examples-budget-gate.sh
@@ -17,23 +17,60 @@ CHECKS=0
 pass() { echo "  PASS: $1"; CHECKS=$((CHECKS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=1; CHECKS=$((CHECKS + 1)); }
 
-BUDGET_OUTPUT='examples/test_foo.py::test_bar FAILED
-openai.PermissionDeniedError: Error code: 402 - {"error": {"message": "budget exceeded", "code": "budget_exceeded", "meta": {"budget_scope": "virtual_key"}}}'
+# JUnit reports, since the gate classifies per failed test rather than by
+# grepping the log. A budget outage and a real failure can land in the same
+# run, and only a per-test report can tell them apart.
+report() { printf '%s\n' "$1" >"$2"; }
 
-# run_case <label> <touched> <exit code the suite returns> <suite stdout> <expected gate exit>
+PASSING_XML='<testsuites><testsuite name="examples" tests="2">
+  <testcase classname="examples.test_foo" name="test_bar"/>
+  <testcase classname="examples.test_foo" name="test_baz"/>
+</testsuite></testsuites>'
+
+BUDGET_XML='<testsuites><testsuite name="examples" tests="2" failures="2">
+  <testcase classname="examples.test_foo" name="test_bar">
+    <failure message="openai.PermissionDeniedError: Error code: 402 - {&quot;error&quot;: {&quot;code&quot;: &quot;budget_exceeded&quot;, &quot;meta&quot;: {&quot;budget_scope&quot;: &quot;virtual_key&quot;}}}">402</failure>
+  </testcase>
+  <testcase classname="examples.test_foo" name="test_baz">
+    <failure message="Error code: 402 budget_exceeded">402</failure>
+  </testcase>
+</testsuite></testsuites>'
+
+REAL_XML='<testsuites><testsuite name="examples" tests="1" failures="1">
+  <testcase classname="examples.test_foo" name="test_bar">
+    <failure message="AssertionError">expected hello to equal goodbye</failure>
+  </testcase>
+</testsuite></testsuites>'
+
+# The case this gate must never wave through: the gateway refused most tests on
+# budget AND one example is genuinely broken.
+MIXED_XML='<testsuites><testsuite name="examples" tests="2" failures="2">
+  <testcase classname="examples.test_foo" name="test_bar">
+    <failure message="Error code: 402 budget_exceeded">402</failure>
+  </testcase>
+  <testcase classname="examples.test_other" name="test_broken">
+    <failure message="AssertionError">expected hello to equal goodbye</failure>
+  </testcase>
+</testsuite></testsuites>'
+
+NO_FAILURES_XML='<testsuites><testsuite name="examples" tests="1"><testcase classname="e" name="t"/></testsuite></testsuites>'
+
+# run_case <label> <touched> <suite exit code> <junit xml> <expected gate exit>
 #
 # Nothing is returned on stdout: an earlier version handed the temp path back
 # that way, and capturing it with $(...) swallowed every PASS and FAIL line
 # this function printed. Six cases ran and reported nothing while the summary
 # still said all checks passed, which is why CHECKS is asserted at the end.
 run_case() {
-  local label="$1" touched="$2" suite_status="$3" suite_output="$4" want="$5"
-  local summary log got
+  local label="$1" touched="$2" suite_status="$3" xml="$4" want="$5"
+  local summary log junit got
   summary="$(mktemp)"
   log="$(mktemp)"
+  junit="$(mktemp)"
+  report "$xml" "$junit"
 
-  EXAMPLES_TOUCHED="$touched" GITHUB_STEP_SUMMARY="$summary" \
-    bash "$GATE" bash -c "printf '%s\n' \"\$0\"; exit $suite_status" "$suite_output" \
+  EXAMPLES_TOUCHED="$touched" EXAMPLES_REPORT="$junit" GITHUB_STEP_SUMMARY="$summary" \
+    bash "$GATE" bash -c "exit $suite_status" \
     >"$log" 2>&1
   got=$?
 
@@ -43,29 +80,66 @@ run_case() {
     fail "$label: expected exit $want, got $got"
     sed 's/^/      /' "$log"
   fi
-  rm -f "$summary" "$log"
+  rm -f "$summary" "$log" "$junit"
 }
 
 echo "=== the suite passes ==="
-run_case "a passing suite passes, whatever else is true" false 0 "1219 passed" 0
-run_case "a passing suite passes when the PR touches examples" true 0 "1219 passed" 0
+run_case "a passing suite passes, whatever else is true" false 0 "$PASSING_XML" 0
+run_case "a passing suite passes when the PR touches examples" true 0 "$PASSING_XML" 0
 
 echo ""
 echo "=== the suite fails for its own reasons ==="
-run_case "a real failure stays red" false 1 "examples/test_foo.py::test_bar FAILED
-AssertionError: expected 'hello' to equal 'goodbye'" 1
-run_case "a real failure stays red when the PR touches examples" true 1 "AssertionError: nope" 1
+run_case "a real failure stays red" false 1 "$REAL_XML" 1
+run_case "a real failure stays red when the PR touches examples" true 1 "$REAL_XML" 1
 
 echo ""
-echo "=== the shared budget is exhausted ==="
-run_case "tolerated when the PR touches nothing the suite covers" false 1 "$BUDGET_OUTPUT" 0
-run_case "NOT tolerated when the PR changes the examples" true 1 "$BUDGET_OUTPUT" 1
+echo "=== budget refusals mixed with a real failure ==="
+# The whole point of classifying per test. Deciding on "the output mentions the
+# budget somewhere" would let the broken example through.
+run_case "a mixed run stays red even when the PR touches nothing" false 1 "$MIXED_XML" 1
+run_case "a mixed run stays red when the PR touches examples" true 1 "$MIXED_XML" 1
+
+echo ""
+echo "=== the shared budget is exhausted, and nothing else failed ==="
+run_case "tolerated when the PR touches nothing the suite covers" false 1 "$BUDGET_XML" 0
+run_case "NOT tolerated when the PR changes the examples" true 1 "$BUDGET_XML" 1
+
+echo ""
+echo "=== the gate cannot verify the claim ==="
+run_case "a report listing no failure is not a budget outage" false 1 "$NO_FAILURES_XML" 1
+run_case "an unreadable report is not a budget outage" false 1 "not xml at all" 1
+
+echo ""
+echo "=== a mixed run says WHICH failure is not the budget ==="
+# The case arm for "mixed" would otherwise be free to disappear: the gate's
+# case statement is fail-closed, so a missing arm still exits red via the
+# default. What that costs is the diagnostic, and the diagnostic is the whole
+# actionable part, so it is asserted rather than assumed.
+MIXED_LOG="$(mktemp)"
+MIXED_JUNIT="$(mktemp)"
+report "$MIXED_XML" "$MIXED_JUNIT"
+EXAMPLES_TOUCHED=false EXAMPLES_REPORT="$MIXED_JUNIT" GITHUB_STEP_SUMMARY=/dev/null \
+  bash "$GATE" bash -c "exit 1" >"$MIXED_LOG" 2>&1
+if grep -q "test_broken" "$MIXED_LOG"; then
+  pass "the mixed verdict names the failing test"
+else
+  fail "the mixed verdict does not name the failing test, so the log says only that something is wrong"
+  sed 's/^/      /' "$MIXED_LOG"
+fi
+if grep -qi "not gateway budget refusals\|does not excuse" "$MIXED_LOG"; then
+  pass "the mixed verdict explains that a budget outage does not excuse it"
+else
+  fail "the mixed verdict does not explain itself"
+fi
+rm -f "$MIXED_LOG" "$MIXED_JUNIT"
 
 echo ""
 echo "=== the reason survives the log ==="
 SUMMARY="$(mktemp)"
-EXAMPLES_TOUCHED=false GITHUB_STEP_SUMMARY="$SUMMARY" \
-  bash "$GATE" bash -c "printf '%s\n' \"\$0\"; exit 1" "$BUDGET_OUTPUT" >/dev/null 2>&1
+JUNIT="$(mktemp)"
+report "$BUDGET_XML" "$JUNIT"
+EXAMPLES_TOUCHED=false EXAMPLES_REPORT="$JUNIT" GITHUB_STEP_SUMMARY="$SUMMARY" \
+  bash "$GATE" bash -c "exit 1" >/dev/null 2>&1
 if grep -q "budget" "$SUMMARY"; then
   pass "a tolerated outage still writes the run summary"
 else
@@ -76,25 +150,30 @@ if grep -qi "not run\|unverified" "$SUMMARY"; then
 else
   fail "the summary does not say the suite failed to run"
 fi
-rm -f "$SUMMARY"
+rm -f "$SUMMARY" "$JUNIT"
 
 echo ""
 echo "=== the gate refuses what it cannot classify ==="
-if EXAMPLES_TOUCHED=false bash "$GATE" >/dev/null 2>&1; then
+if EXAMPLES_TOUCHED=false EXAMPLES_REPORT=/dev/null bash "$GATE" >/dev/null 2>&1; then
   fail "the gate accepted an empty command"
 else
   pass "the gate rejects an empty command"
 fi
-if ( unset EXAMPLES_TOUCHED; bash "$GATE" true >/dev/null 2>&1 ); then
+if ( unset EXAMPLES_TOUCHED; EXAMPLES_REPORT=/dev/null bash "$GATE" true >/dev/null 2>&1 ); then
   fail "the gate ran without EXAMPLES_TOUCHED, so it would silently pick a branch"
 else
   pass "the gate refuses to run without EXAMPLES_TOUCHED"
+fi
+if ( unset EXAMPLES_REPORT; EXAMPLES_TOUCHED=false bash "$GATE" true >/dev/null 2>&1 ); then
+  fail "the gate ran without EXAMPLES_REPORT, so it would decide with nothing to classify"
+else
+  pass "the gate refuses to run without EXAMPLES_REPORT"
 fi
 
 echo ""
 # A harness that runs nothing prints the same happy line as one that runs
 # everything. This is what makes the line above mean something.
-EXPECTED_CHECKS=10
+EXPECTED_CHECKS=17
 if [ "$CHECKS" -ne "$EXPECTED_CHECKS" ]; then
   echo "  FAIL: ran $CHECKS checks, expected $EXPECTED_CHECKS; the harness is not running what it claims"
   FAIL=1

--- a/scripts/test-examples-budget-gate.sh
+++ b/scripts/test-examples-budget-gate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Drives scripts/ci/examples-suite-gate.sh through every outcome it classifies.
+#
+# The gate decides whether a required check goes red, so the case that matters
+# most is the one where it must NOT be lenient: a real failure, and a budget
+# outage on a pull request that changes the examples. A gate that tolerates
+# everything reads exactly like a gate that tolerates the right things.
+#
+# Exit codes: 0 = all pass, 1 = one or more failures.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$SCRIPT_DIR/ci/examples-suite-gate.sh"
+FAIL=0
+CHECKS=0
+
+pass() { echo "  PASS: $1"; CHECKS=$((CHECKS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=1; CHECKS=$((CHECKS + 1)); }
+
+BUDGET_OUTPUT='examples/test_foo.py::test_bar FAILED
+openai.PermissionDeniedError: Error code: 402 - {"error": {"message": "budget exceeded", "code": "budget_exceeded", "meta": {"budget_scope": "virtual_key"}}}'
+
+# run_case <label> <touched> <exit code the suite returns> <suite stdout> <expected gate exit>
+#
+# Nothing is returned on stdout: an earlier version handed the temp path back
+# that way, and capturing it with $(...) swallowed every PASS and FAIL line
+# this function printed. Six cases ran and reported nothing while the summary
+# still said all checks passed, which is why CHECKS is asserted at the end.
+run_case() {
+  local label="$1" touched="$2" suite_status="$3" suite_output="$4" want="$5"
+  local summary log got
+  summary="$(mktemp)"
+  log="$(mktemp)"
+
+  EXAMPLES_TOUCHED="$touched" GITHUB_STEP_SUMMARY="$summary" \
+    bash "$GATE" bash -c "printf '%s\n' \"\$0\"; exit $suite_status" "$suite_output" \
+    >"$log" 2>&1
+  got=$?
+
+  if [ "$got" -eq "$want" ]; then
+    pass "$label (exit $got)"
+  else
+    fail "$label: expected exit $want, got $got"
+    sed 's/^/      /' "$log"
+  fi
+  rm -f "$summary" "$log"
+}
+
+echo "=== the suite passes ==="
+run_case "a passing suite passes, whatever else is true" false 0 "1219 passed" 0
+run_case "a passing suite passes when the PR touches examples" true 0 "1219 passed" 0
+
+echo ""
+echo "=== the suite fails for its own reasons ==="
+run_case "a real failure stays red" false 1 "examples/test_foo.py::test_bar FAILED
+AssertionError: expected 'hello' to equal 'goodbye'" 1
+run_case "a real failure stays red when the PR touches examples" true 1 "AssertionError: nope" 1
+
+echo ""
+echo "=== the shared budget is exhausted ==="
+run_case "tolerated when the PR touches nothing the suite covers" false 1 "$BUDGET_OUTPUT" 0
+run_case "NOT tolerated when the PR changes the examples" true 1 "$BUDGET_OUTPUT" 1
+
+echo ""
+echo "=== the reason survives the log ==="
+SUMMARY="$(mktemp)"
+EXAMPLES_TOUCHED=false GITHUB_STEP_SUMMARY="$SUMMARY" \
+  bash "$GATE" bash -c "printf '%s\n' \"\$0\"; exit 1" "$BUDGET_OUTPUT" >/dev/null 2>&1
+if grep -q "budget" "$SUMMARY"; then
+  pass "a tolerated outage still writes the run summary"
+else
+  fail "a tolerated outage wrote no run summary, so the only signal is a warning nobody reads"
+fi
+if grep -qi "not run\|unverified" "$SUMMARY"; then
+  pass "the summary says the suite did not run, rather than implying it passed"
+else
+  fail "the summary does not say the suite failed to run"
+fi
+rm -f "$SUMMARY"
+
+echo ""
+echo "=== the gate refuses what it cannot classify ==="
+if EXAMPLES_TOUCHED=false bash "$GATE" >/dev/null 2>&1; then
+  fail "the gate accepted an empty command"
+else
+  pass "the gate rejects an empty command"
+fi
+if ( unset EXAMPLES_TOUCHED; bash "$GATE" true >/dev/null 2>&1 ); then
+  fail "the gate ran without EXAMPLES_TOUCHED, so it would silently pick a branch"
+else
+  pass "the gate refuses to run without EXAMPLES_TOUCHED"
+fi
+
+echo ""
+# A harness that runs nothing prints the same happy line as one that runs
+# everything. This is what makes the line above mean something.
+EXPECTED_CHECKS=10
+if [ "$CHECKS" -ne "$EXPECTED_CHECKS" ]; then
+  echo "  FAIL: ran $CHECKS checks, expected $EXPECTED_CHECKS; the harness is not running what it claims"
+  FAIL=1
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "All $CHECKS examples-budget-gate checks passed."
+else
+  echo "examples-budget-gate checks FAILED."
+fi
+exit "$FAIL"

--- a/scripts/validate-examples-gate.sh
+++ b/scripts/validate-examples-gate.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Validates the wiring around the examples suite: that its budget gate is
+# actually in front of it, and that every path filter a workflow consumes is
+# one the composite action really exposes.
+#
+# The second is a trap the action documents and nothing enforced. From
+# .github/actions/detect-changes/action.yml:
+#
+#   "every filter key the caller wants to consume must be declared as an
+#    outputs.<key> entry below AND echoed into the force step ... silently
+#    missing entries land as empty strings."
+#
+# An empty string is the worst possible value here: `false` and `true` are both
+# decisions, empty is a filter that looks wired and answers nothing. This turns
+# that comment into a check.
+#
+# Exit codes: 0 = all pass, 1 = one or more failures.
+set -uo pipefail
+FAIL=0
+CHECKS=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+pass() { echo "  PASS: $1"; CHECKS=$((CHECKS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=1; CHECKS=$((CHECKS + 1)); }
+
+echo "=== Every consumed filter key is exposed by detect-changes ==="
+while IFS='|' read -r wf key kind; do
+  [ -z "$wf" ] && continue
+  case "$kind" in
+    ok) pass "$wf consumes '$key', which the action declares and forces" ;;
+    undeclared) fail "$wf consumes '$key' but action.yml has no outputs.$key, so it is always the empty string" ;;
+    unforced) fail "$wf consumes '$key' but the force step never sets it, so it is empty on push/dispatch" ;;
+  esac
+done < <(python3 - "$REPO_ROOT" <<'PY'
+import re, sys, pathlib, yaml
+
+root = pathlib.Path(sys.argv[1])
+action_path = root / ".github/actions/detect-changes/action.yml"
+action = yaml.safe_load(action_path.read_text())
+declared = set(action.get("outputs", {}))
+forced = set(
+    re.findall(r'echo "([A-Za-z0-9_-]+)=', action_path.read_text())
+)
+
+for wf in sorted((root / ".github/workflows").glob("*.yml")):
+    text = wf.read_text()
+    if "detect-changes" not in text:
+        continue
+    for key in sorted(set(re.findall(r"steps\.detect\.outputs\.([A-Za-z0-9_-]+)", text))):
+        if key not in declared:
+            print(f"{wf.name}|{key}|undeclared")
+        elif key not in forced:
+            print(f"{wf.name}|{key}|unforced")
+        else:
+            print(f"{wf.name}|{key}|ok")
+PY
+)
+
+echo ""
+echo "=== The examples suite runs behind the budget gate ==="
+GATE="scripts/ci/examples-suite-gate.sh"
+if [ -x "$REPO_ROOT/$GATE" ]; then
+  pass "$GATE exists and is executable"
+else
+  fail "$GATE is missing or not executable, so every wiring below would fail at run time"
+fi
+
+while IFS='|' read -r wf verdict detail; do
+  [ -z "$wf" ] && continue
+  case "$verdict" in
+    ok) pass "$wf runs its examples suite through the gate and passes EXAMPLES_TOUCHED" ;;
+    *) fail "$wf: $detail" ;;
+  esac
+done < <(python3 - "$REPO_ROOT" <<'PY'
+import sys, pathlib, yaml
+
+root = pathlib.Path(sys.argv[1])
+# The workflows whose required check the examples suite can block.
+for name in ("python-ci.yml", "javascript-ci.yml"):
+    wf = root / ".github/workflows" / name
+    doc = yaml.safe_load(wf.read_text())
+    steps = [s for job in doc["jobs"].values() for s in (job.get("steps") or [])]
+    examples = [s for s in steps if (s.get("name") or "").startswith("Test (Examples)")]
+    if not examples:
+        print(f"{name}|missing|has no 'Test (Examples)' step, so this check is scanning nothing")
+        continue
+    for step in examples:
+        run = step.get("run", "") or ""
+        env = step.get("env", {}) or {}
+        if "examples-suite-gate.sh" not in run:
+            print(f"{name}|raw|'{step.get('name')}' runs the suite directly, so a shared-budget outage blocks every unrelated PR")
+        elif "EXAMPLES_TOUCHED" not in env:
+            print(f"{name}|noenv|'{step.get('name')}' calls the gate without EXAMPLES_TOUCHED, and the gate refuses to guess")
+        else:
+            print(f"{name}|ok|")
+PY
+)
+
+echo ""
+# A validator that finds nothing to check prints the same closing line as one
+# that checked everything.
+EXPECTED_MIN=5
+if [ "$CHECKS" -lt "$EXPECTED_MIN" ]; then
+  echo "  FAIL: ran $CHECKS checks, expected at least $EXPECTED_MIN; this validator is scanning nothing"
+  FAIL=1
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "All $CHECKS examples-gate wiring checks passed."
+else
+  echo "examples-gate wiring checks FAILED."
+fi
+exit "$FAIL"

--- a/scripts/validate-examples-gate.sh
+++ b/scripts/validate-examples-gate.sh
@@ -69,7 +69,7 @@ fi
 while IFS='|' read -r wf verdict detail; do
   [ -z "$wf" ] && continue
   case "$verdict" in
-    ok) pass "$wf runs its examples suite through the gate and passes EXAMPLES_TOUCHED" ;;
+    ok) pass "$wf runs its examples suite through the gate, and writes the report the gate classifies" ;;
     *) fail "$wf: $detail" ;;
   esac
 done < <(python3 - "$REPO_ROOT" <<'PY'
@@ -92,6 +92,10 @@ for name in ("python-ci.yml", "javascript-ci.yml"):
             print(f"{name}|raw|'{step.get('name')}' runs the suite directly, so a shared-budget outage blocks every unrelated PR")
         elif "EXAMPLES_TOUCHED" not in env:
             print(f"{name}|noenv|'{step.get('name')}' calls the gate without EXAMPLES_TOUCHED, and the gate refuses to guess")
+        elif "EXAMPLES_REPORT" not in env:
+            print(f"{name}|noreport|'{step.get('name')}' calls the gate without EXAMPLES_REPORT, so it cannot classify failures per test")
+        elif "$EXAMPLES_REPORT" not in run:
+            print(f"{name}|nowrite|'{step.get('name')}' never tells the suite to write $EXAMPLES_REPORT, so the report the gate reads would never exist")
         else:
             print(f"{name}|ok|")
 PY

--- a/scripts/validate-examples-gate.sh
+++ b/scripts/validate-examples-gate.sh
@@ -102,9 +102,115 @@ PY
 )
 
 echo ""
+echo "=== An example change from a fork cannot pass unexamined ==="
+# The examples suite needs secrets, so it is skipped for fork pull requests.
+# That is #893: a fork changed an example, every step that reads examples was
+# skipped, and the required check went green having read nothing. The fix is a
+# secret-free fallback on the exact complementary condition, so that for any
+# event precisely one of the two runs. Checking "a fallback exists" would not
+# be enough: two conditions can both be false and leave the same hole.
+while IFS='|' read -r wf verdict detail; do
+  [ -z "$wf" ] && continue
+  case "$verdict" in
+    ok) pass "$wf pairs its secret-gated examples step with a secret-free fallback on the complementary condition" ;;
+    *) fail "$wf: $detail" ;;
+  esac
+done < <(python3 - "$REPO_ROOT" <<'PYINNER'
+import itertools
+import pathlib
+import re
+import sys
+
+import yaml
+
+root = pathlib.Path(sys.argv[1])
+
+TOKEN = re.compile(r"'[^']*'|[A-Za-z_][A-Za-z0-9_.\[\]-]*")
+
+
+def to_python(expr):
+    """Rewrite a GitHub `if:` expression as a Python one over a variables dict.
+
+    Only the grammar these two workflows use: dotted contexts, single-quoted
+    literals, == and !=, && and ||, and parentheses.
+    """
+    names = set()
+
+    def swap(match):
+        token = match.group(0)
+        if token.startswith("'"):
+            return token
+        names.add(token)
+        return f"V[{token!r}]"
+
+    body = TOKEN.sub(swap, expr.replace("&&", " and ").replace("||", " or "))
+    # `and` and `or` were introduced above as bare words, not as contexts.
+    body = body.replace("V['and']", "and").replace("V['or']", "or")
+    names.discard("and")
+    names.discard("or")
+    return body, names
+
+
+def exactly_one_always(gated, fallback):
+    """True when the two conditions partition every context we can construct."""
+    gated_body, gated_names = to_python(gated)
+    fallback_body, fallback_names = to_python(fallback)
+    names = sorted(gated_names | fallback_names)
+    # Every literal either expression compares against, plus a value that is
+    # none of them, so "some other actor" and "some other event" are covered.
+    literals = sorted(set(re.findall(r"'([^']*)'", gated + fallback))) + ["<other>"]
+    for combo in itertools.product(literals, repeat=len(names)):
+        variables = dict(zip(names, combo))
+        if eval(gated_body, {}, {"V": variables}) == eval(  # noqa: S307
+            fallback_body, {}, {"V": variables}
+        ):
+            return False, variables
+    return True, None
+
+
+for name in ("python-ci.yml", "javascript-ci.yml"):
+    wf = root / ".github/workflows" / name
+    doc = yaml.safe_load(wf.read_text())
+    steps = [s for job in doc["jobs"].values() for s in (job.get("steps") or [])]
+    named = {(s.get("name") or ""): s for s in steps}
+
+    gated = next((s for n, s in named.items() if n.startswith("Test (Examples)")), None)
+    if gated is None:
+        print(f"{name}|missing|has no 'Test (Examples)' step, so this check is scanning nothing")
+        continue
+    if not gated.get("if"):
+        print(f"{name}|unconditional|'Test (Examples)' has no condition, so the pairing below cannot be reasoned about")
+        continue
+
+    fallback = next(
+        (s for n, s in named.items() if n.startswith(("Collect (Examples)", "List (Examples)"))),
+        None,
+    )
+    if fallback is None:
+        print(
+            f"{name}|nofallback|'Test (Examples)' is skipped without secrets and nothing else reads "
+            f"the examples, so a fork can change them and still go green"
+        )
+        continue
+
+    # The `secrets` context specifically. `steps.secrets.outputs.available` is
+    # the id of the step that decides availability, not a secret read.
+    if re.search(r"\$\{\{\s*secrets\.", yaml.safe_dump(fallback)):
+        print(f"{name}|needssecrets|'{fallback.get('name')}' reads secrets, so it is skipped in exactly the case it exists to cover")
+        continue
+
+    ok, witness = exactly_one_always(gated["if"], fallback.get("if") or "true")
+    if ok:
+        print(f"{name}|ok|")
+    else:
+        print(f"{name}|notcomplement|'{fallback.get('name')}' is not the complement of 'Test (Examples)': both are {witness}")
+PYINNER
+)
+
+echo ""
 # A validator that finds nothing to check prints the same closing line as one
 # that checked everything.
-EXPECTED_MIN=5
+EXPECTED_MIN=10
 if [ "$CHECKS" -lt "$EXPECTED_MIN" ]; then
   echo "  FAIL: ran $CHECKS checks, expected at least $EXPECTED_MIN; this validator is scanning nothing"
   FAIL=1


### PR DESCRIPTION
## Ticket

Closes #892. The examples suite makes real model calls through the LangWatch AI Gateway on one virtual key with a daily spend cap. When the cap is hit the gateway answers HTTP 402 `budget_exceeded` and every test in the suite fails at once. That suite feeds a required check, so an unrelated pull request is blocked from merging by a shared resource it never touched.

The ticket's evidence, PR #889 at `77ce1dbd`: 1088 JavaScript tests passed, 1219 Python tests passed, and 26 example files failed on 402.

## Change

Both examples suites now run behind `scripts/ci/examples-suite-gate.sh`, which separates "the suite could not run" from "the suite ran and disagreed":

| situation | verdict |
|---|---|
| the suite passed | pass |
| failed, nothing names the budget | **fail**, a real defect |
| failed on budget, PR changes the examples | **fail**, the change is unverified |
| failed on budget, PR changes nothing the suite covers | warn and pass |

## The part I want argued with

**A suite that cannot fail is the disease, not the cure.** #893 in this repo records fork PRs reaching a green required check with nothing having read the changed file, and the `Collect (Examples)` step now on `main` is the fix for it. Loosening this gate risks recreating exactly that.

Three things hold the line, and they are the ones to attack:

1. **A budget outage never reports as a pass.** It emits `::warning::` and writes `$GITHUB_STEP_SUMMARY`, both saying the suite did **not** run. There is a test asserting the summary says "not run"/"unverified" rather than implying success.
2. **A PR that changes the examples stays red through an outage.** This is the rule that stops a day-long budget exhaustion becoming a day-long free pass on example changes. It is why the gate needs to know what the PR touched, and why it refuses to run without being told (`EXAMPLES_TOUCHED:?`) rather than guessing a default.
3. **Only the budget is tolerated.** The classification requires the gateway's own wording, `budget_exceeded` or `budget_scope`. Any failure without it exits with the suite's status.

If you think case 4 should stay red too, that is a legitimate position and the change is one line; but then #892 is only closed by raising the cap.

## The trap this surfaced

Telling "touches the examples" apart needed a new `examples` path filter. `.github/actions/detect-changes/action.yml` documents what happens if you add one carelessly:

> every filter key the caller wants to consume must be declared as an `outputs.<key>` entry below AND echoed into the force step ... silently missing entries land as empty strings.

Empty is worse than either `true` or `false`: the filter looks wired and answers nothing. Nothing enforced that comment, so `scripts/validate-examples-gate.sh` now checks it for **every** filter key in every workflow, not just the one this PR adds. It currently covers 5 key/workflow pairs across `docs-ci`, `javascript-ci` and `python-ci`.

Both new scripts run in `meta-ci`, alongside the existing validators and with the same `!cancelled()` treatment so one push surfaces every verdict.

## Evidence

- **10 gate-decision checks**, driving the real script with synthetic suite outcomes: `bash scripts/test-examples-budget-gate.sh`.
- **8 wiring checks**: `bash scripts/validate-examples-gate.sh`.
- The pre-existing `validate-aggregator-workflows.sh` still passes.
- `shellcheck` clean on all three new scripts; `actionlint` reports the same single pre-existing SC2086 on `python-ci.yml` before and after.

### Mutations, all 8 caught

| mutation | caught by |
|---|---|
| tolerate a budget outage even when the PR changes examples | gate tests |
| tolerate any failure (drop the budget classification) | gate tests |
| stop writing the run summary | gate tests |
| default `EXAMPLES_TOUCHED` instead of requiring it | gate tests |
| action stops declaring the `examples` output | wiring validator |
| action stops forcing it on non-PR events | wiring validator |
| a workflow goes back to running the suite raw | wiring validator |
| a gate call drops `EXAMPLES_TOUCHED` | wiring validator |

Both harnesses assert how many checks they ran. That is not decoration: the first version of the gate harness returned a temp path on stdout, and capturing it with `$(...)` swallowed every PASS line along with it. Six cases ran and printed nothing while the closing line still said all checks passed.

## Review round

Three findings, all taken.

**The JavaScript fork gap (P1).** A fork pull request that changes `javascript/examples/**` went green with nothing having read the changed file. The examples suite is the only JavaScript step that reads them, it is skipped without secrets, and `javascript-complete` accepts a job whose every examples step was skipped. That is #893, which was closed on the Python side alone. This PR did not create the gap, but it is the same required check, so leaving it meant leaving a known hole in the thing being repaired.

`List (Examples)` now runs `pnpm -F vitest-examples exec vitest list` on the exact inverse condition of `Test (Examples)`, mirroring Python's `Collect (Examples)`. It imports every example to enumerate its tests and makes no provider call. Verified locally with every model key unset: a clean tree exits 0, and an unresolvable import in one example exits 1 naming the file. It is weaker than running the suite and the comment says so, catching an import that does not resolve, a syntax error or a renamed export, but not a wrong assertion.

The validator now **proves** the pairing rather than checking that a fallback exists, since two conditions can both be false and leave the identical hole. It parses both `if:` expressions and evaluates them over every assignment of the contexts they name, requiring exactly one to be true in each.

**`EXAMPLES_TOUCHED` was fail-open.** Everything that was not exactly `true` took the lenient branch, so `tru` from a mis-wired filter key would tolerate an outage on a pull request that does change the examples. Only `true` and `false` are accepted now.

**The report is read defensively.** It is written while pull-request-controlled examples run. A `<!DOCTYPE` is now refused, which no test runner writes and which is how internal entity expansion is smuggled in, and the read is capped. `defusedxml` is deliberately not used: the gate invokes this script with the runner's bare `python3` rather than `uv`, so the import would not resolve. Whoever can write that file already runs the suite on the runner, so this is depth rather than a boundary, and both refusals are fail-closed.

### Updated evidence

- **24 gate-decision checks**: `bash scripts/test-examples-budget-gate.sh`.
- **10 wiring checks**: `bash scripts/validate-examples-gate.sh`.

Six further mutations, all caught:

| mutation | caught by |
|---|---|
| accept `tru` / `True` / `yes` / `1` as `EXAMPLES_TOUCHED` | gate tests |
| drop the doctype refusal | gate tests |
| drop the size cap | gate tests, via the diagnostic |
| remove the JavaScript fork fallback | wiring validator |
| give the fallback a condition that is not the complement | wiring validator |
| make the fallback read secrets | wiring validator |

The size-cap mutation escaped at first and the fix was to assert the diagnostic rather than to claim the check mattered more than it does. The read is already bounded, so removing the cap leaves a truncated document that fails to parse and is refused anyway. What it costs is knowing why, and "larger than it can be" and "malformed" send a maintainer to different places.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

