### PR TITLE
chore(deps): the ElevenLabs SDK installs only for the people who use it

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "@ag-ui/core": "^0.0.58",
     "@ai-sdk/openai": "^3.0.26",
-    "@elevenlabs/elevenlabs-js": "^2.51.0",
     "@openai/agents": "^0.16.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "2.10.0",
@@ -78,6 +77,7 @@
   },
   "devDependencies": {
     "@amiceli/vitest-cucumber": "^7.0.0",
+    "@elevenlabs/elevenlabs-js": "^2.51.0",
     "@eslint/js": "^9.39.1",
     "@google/genai": "^2.5.0",
     "@types/jest": "^30.0.0",
@@ -128,11 +128,15 @@
     }
   },
   "peerDependencies": {
+    "@elevenlabs/elevenlabs-js": ">=2.51.0",
     "@google/genai": ">=2.0.0",
     "ai": ">=6.0.0",
     "vitest": ">=3.2.4"
   },
   "peerDependenciesMeta": {
+    "@elevenlabs/elevenlabs-js": {
+      "optional": true
+    },
     "@google/genai": {
       "optional": true
     }

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.26
         version: 3.0.65(zod@3.25.76)
-      '@elevenlabs/elevenlabs-js':
-        specifier: ^2.51.0
-        version: 2.64.0
       '@openai/agents':
         specifier: ^0.16.0
         version: 0.16.0(ws@8.21.3)(zod@3.25.76)
@@ -103,6 +100,9 @@ importers:
       '@amiceli/vitest-cucumber':
         specifier: ^7.0.0
         version: 7.0.0(vitest@4.1.10)
+      '@elevenlabs/elevenlabs-js':
+        specifier: ^2.51.0
+        version: 2.64.0
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.4


### PR DESCRIPTION
Every consumer of `@langwatch/scenario` installs the ElevenLabs SDK, whether or not they ever run a voice scenario. It is 82 MB in `node_modules`.

Nothing in the code needs it to be there. Both loaders in `src/voice/elevenlabs-sdk.ts` already import it lazily inside a `try`/`catch` and raise a plain "needs '@elevenlabs/elevenlabs-js', install it" error, and its types are deliberately kept out of the published declarations so the SDK is never named in an exported signature. That work was already done; only the manifest still said the dependency was mandatory.

## The change

`@elevenlabs/elevenlabs-js` moves from `dependencies` to an **optional peer dependency**, plus a `devDependency` so this repo's own build, typecheck and tests are unchanged. That is the shape `@google/genai` already uses in this package, so it introduces no new pattern.

People running ElevenLabs voice scenarios install the SDK themselves, which is what the error message has been telling them to do all along.

## Verified with the package actually removed

Renamed out of `node_modules`, then:

- `pnpm smoke:dist` — both the CJS and the ESM dist load.
- The ElevenLabs path raises its own error, not an unresolved-module crash: `The ElevenLabs voice backend needs '@elevenlabs/elevenlabs-js'. Install it to use elevenlabs voices, speech-to-text or the ElevenLabs agent adapter.`
- `dist/index.d.ts` names the package only in prose comments, with no `import(...)` or `from` reference, so consumers without it typecheck cleanly.

With it installed, as CI has it: `pnpm build` passes, and `pnpm test src/voice` is 550 passed / 1 skipped.

## Note on the rest of the audio stack

`ffmpeg-static` and `fft.js` were considered and deliberately left alone. Together they are about 108 KB, `resolveFfmpegPath()` is synchronous so making it lazy would push async through its callers, and bundling ffmpeg is a documented choice (Python parity, and CI runners without a system ffmpeg). The cost/benefit is not close to the same.

## Note for reviewers

`pnpm typecheck` reports 8 pre-existing errors in `src/events/event-reporter.ts` on `main`. They are byte-identical before and after this change and are unrelated to it.
