### PR TITLE
refactor(voice): one constructor for a background agent turn (#576)

### DIFF
--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -184,6 +184,49 @@ const DEFAULT_WAIT_FOR_SPEECH_MS = 15_000;
  * console.log("Scenario result:", result.success);
  * ```
  */
+/**
+ * A background agent turn, and what the interrupt path needs to know about it.
+ *
+ * `done` is polled rather than awaited, because the barge-in has to fire while
+ * the turn is still in flight: awaiting it would mean the bot always finished
+ * first and the interrupt never happened. `error` captures a rejection instead
+ * of letting it escape as an unhandled promise, so it can be re-thrown at
+ * drain or interrupt time by whoever is in a position to report it.
+ */
+interface AgentTaskEntry {
+  promise: Promise<void>;
+  done: boolean;
+  /** Captured rejection, if any. Re-thrown by {@link ScenarioExecution.fireUserInterrupt}. */
+  error: unknown | null;
+}
+
+/**
+ * Wrap a background agent turn so its settling is observable without awaiting
+ * it.
+ *
+ * The `.catch` and `.finally` close over the entry that is being assigned in
+ * the same statement, which is the part worth doing once: they run only after
+ * the turn settles, by which point the field holds the real promise, so there
+ * is no placeholder to leak. Written out at each call site, the two copies
+ * agreed by inspection and nothing held them together.
+ */
+function makeTaskEntry(run: () => Promise<unknown>): AgentTaskEntry {
+  const entry: AgentTaskEntry = {
+    promise: run()
+      .then(() => undefined)
+      .catch((err: unknown) => {
+        // Captured, not swallowed: re-thrown at drain or interrupt time.
+        entry.error = err;
+      })
+      .finally(() => {
+        entry.done = true;
+      }),
+    done: false,
+    error: null,
+  };
+  return entry;
+}
+
 export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorState {
   /** LangWatch tracer for scenario execution */
   private tracer = getLangWatchTracer("@langwatch/scenario");
@@ -246,12 +289,7 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
    * `error` captures any rejection from the background turn so it can be
    * re-thrown after the promise settles (rather than silently swallowed).
    */
-  private pendingAgentTask: {
-    promise: Promise<void>;
-    done: boolean;
-    /** Captured rejection, if any. Re-thrown by {@link fireUserInterrupt}. */
-    error: unknown | null;
-  } | null = null;
+  private pendingAgentTask: AgentTaskEntry | null = null;
 
   /**
    * Snapshot of voice adapters for the in-flight execution. Captured at
@@ -1473,23 +1511,9 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
    * `void executor.agent().catch()` call sites did.
    */
   agentNonBlocking(content?: string | ModelMessage): void {
-    const entry: { promise: Promise<void>; done: boolean; error: unknown | null } = {
-      // Assigned in the same statement; the `.finally` below closes over
-      // `entry` and only runs after this turn settles, by which point the field
-      // holds the real promise (no dead Promise.resolve() placeholder — review
-      // H6).
-      promise: this.scriptCallAgent(AgentRole.AGENT, content)
-        .then(() => undefined)
-        .catch((err: unknown) => {
-          entry.error = err; // capture, don't swallow — re-thrown at drain/interrupt time
-        })
-        .finally(() => {
-          entry.done = true;
-        }),
-      done: false,
-      error: null,
-    };
-    this.pendingAgentTask = entry;
+    this.pendingAgentTask = makeTaskEntry(() =>
+      this.scriptCallAgent(AgentRole.AGENT, content),
+    );
   }
 
   /**
@@ -1826,23 +1850,8 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
    *
    * @internal Extracted from {@link maybeScheduleInterruptedAgentTurn}.
    */
-  private dispatchAgentBackground(idx: number): {
-    promise: Promise<void>;
-    done: boolean;
-    error: unknown | null;
-  } {
-    const entry: { promise: Promise<void>; done: boolean; error: unknown | null } = {
-      promise: this.callAgent(idx, AgentRole.AGENT)
-        .then(() => undefined)
-        .catch((err: unknown) => {
-          entry.error = err; // captured, re-thrown by fireUserInterrupt/drain
-        })
-        .finally(() => {
-          entry.done = true;
-        }),
-      done: false,
-      error: null,
-    };
+  private dispatchAgentBackground(idx: number): AgentTaskEntry {
+    const entry = makeTaskEntry(() => this.callAgent(idx, AgentRole.AGENT));
     this.pendingAgentTask = entry;
     return entry;
   }
@@ -1859,7 +1868,7 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
   private async prepareAndFireBargeIn(
     config: InterruptionConfig,
     voiceUserSim: VoiceUserSimulator,
-    entry: { promise: Promise<void>; done: boolean; error: unknown | null },
+    entry: AgentTaskEntry,
   ): Promise<boolean> {
     // Sample the delay BEFORE voiceifyText so it is applied AFTER
     // agentSpeakingEvent fires (in fireUserInterrupt) — not before TTS.


### PR DESCRIPTION
## Ticket

Closes #576.

## Premise, re-checked on current main

**Two of the three smells already landed.** Worth saying plainly, because it makes this PR much smaller than the ticket reads:

| smell | state on `main` |
|---|---|
| 1. three inline `setTimeout` sleeps | **done.** `javascript/src/voice/utils.ts` exports `sleep(ms)`, `scenario-execution.ts` has no inline sleep left, and `pipecat.ts` calls the shared one |
| 2. `appendEvent` module-private while barge-in inlines it | **done.** It is exported, and `scenario-execution.ts` imports it (`:60`) and calls it on the barge-in path (`:1976`, `:2157`) |
| 3. task-entry construction duplicated | **still true.** This PR |

## The duplication

`agentNonBlocking` and `dispatchAgentBackground` build the same entry, differing only in which call they wrap:

```ts
const entry: { promise: Promise<void>; done: boolean; error: unknown | null } = {
  promise: this.scriptCallAgent(AgentRole.AGENT, content)   // or this.callAgent(idx, AgentRole.AGENT)
    .then(() => undefined)
    .catch((err: unknown) => { entry.error = err; })
    .finally(() => { entry.done = true; }),
  done: false,
  error: null,
};
```

The shape itself was written out inline in **four** places (the field declaration, both constructions, and `prepareAndFireBargeIn`'s parameter), so adding a field meant finding all four.

## Change

An `AgentTaskEntry` interface and one `makeTaskEntry(run)`.

The part worth doing once is the self-reference: the `.catch` and `.finally` close over the entry being assigned in the same statement. That is correct because they run only after the turn settles, by which point the field holds the real promise, so there is no placeholder to leak. One of the two copies carried a comment explaining this and the other did not. They agreed by inspection and nothing held them together.

The doc comment now also states **why** the shape exists, which neither copy said: `done` is polled rather than awaited because the barge-in has to fire while the turn is still in flight, and awaiting it would mean the bot always finished first and the interrupt never happened.

Behaviour is unchanged. `dispatchAgentBackground` still returns the entry and still assigns `pendingAgentTask`; `agentNonBlocking` still only assigns.

## Evidence

- **604 passed, 1 skipped** across 67 files in `src/voice` and `src/execution`.
- The interrupt tests specifically, which are what exercise both entries: `proceed-interrupt`, `proceed-interrupt-errors`, `interrupt-truncation`, 16 passed.
- `tsc --noEmit -p tsconfig.json` reports only a pre-existing `TS2688: Cannot find type definition file for 'yauzl'`, present identically on a clean `main` checkout. No error from this change.
- Inline copies of the entry shape: **4 to 0**.

### Mutations, all 3 caught

| mutation | caught by |
|---|---|
| the rejection is swallowed instead of captured | interrupt suites |
| `done` is never set, so the barge-in never sees the turn finish | interrupt suites |
| the entry is not recorded on `pendingAgentTask` | interrupt suites |

These are the three invariants the helper now owns, and the existing suites hold all of them, which is the reason this extraction is safe to make without adding tests.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.
