### PR TITLE
feat: agent adapters carry a name and runs report their agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ scenario.configure(default_model="openai/gpt-4.1-mini")
 @pytest.mark.asyncio
 async def test_vegetarian_recipe_agent():
     class Agent(scenario.AgentAdapter):
+        name = "VegetarianRecipeAgent"
+
         async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
             return vegetarian_recipe_agent(input.messages)
 
@@ -191,6 +193,7 @@ import { describe, it, expect } from "vitest";
 
 describe("Vegetarian Recipe Agent", () => {
   const agent: AgentAdapter = {
+    name: "VegetarianRecipeAgent",
     role: AgentRole.AGENT,
     call: async (input) => {
       const response = await generateText({

--- a/docs/docs/pages/agent-integration.mdx
+++ b/docs/docs/pages/agent-integration.mdx
@@ -81,6 +81,8 @@ class MyAgent implements AgentAdapter {
 
 Each run reports its agents to LangWatch. LangWatch shows the name of the agent as the
 target of the run. When you set no name, the framework uses the class name of the adapter.
+An adapter written as a plain object has no class name of its own, so set a name there to
+see the agent as the target of the run.
 
 ### AgentInput
 

--- a/docs/docs/pages/agent-integration.mdx
+++ b/docs/docs/pages/agent-integration.mdx
@@ -23,6 +23,7 @@ interface. This adapter pattern allows you to:
 
 The <RefLink link={{ python: "agent_adapter.html#scenario.agent_adapter.AgentAdapter", typescript: "classes/AgentAdapter.html" }} code={{ python: "AgentAdapter", typescript: "AgentAdapter" }} /> interface defines a contract for Scenario to work with any agent implementation. You only need to provide:
 
+- `name`: The name that LangWatch shows as the target of the run. The class name of the adapter is the default.
 - `role`: The agent’s role in the scenario (default to `AGENT`)
 - `call`: An async function that receives the full conversation history and returns the agent’s next response
 
@@ -42,6 +43,8 @@ Agent `call` functions must receive the full chat history via `input.messages` t
 import scenario
 
 class MyAgent(scenario.AgentAdapter):
+    name = "MyAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         # Your integration logic here
         pass
@@ -52,6 +55,7 @@ import scenario, { type AgentAdapter, AgentRole } from "@langwatch/scenario";
 
 // Object style
 const myAgent: AgentAdapter = {
+  name: "MyAgent",
   role: AgentRole.AGENT,
   async call(input) {
     // Your integration logic here
@@ -64,6 +68,7 @@ import type { AgentInput, AgentReturnTypes } from "@langwatch/scenario";
 import { AgentRole } from "@langwatch/scenario";
 
 class MyAgent implements AgentAdapter {
+  name = "MyAgent";
   role = AgentRole.AGENT;
   async call(input): Promise<AgentReturnTypes> {
     // Your integration logic here
@@ -73,6 +78,9 @@ class MyAgent implements AgentAdapter {
 ```
 
 :::
+
+Each run reports its agents to LangWatch. LangWatch shows the name of the agent as the
+target of the run. When you set no name, the framework uses the class name of the adapter.
 
 ### AgentInput
 

--- a/docs/docs/pages/agent-integration/agentkit.mdx
+++ b/docs/docs/pages/agent-integration/agentkit.mdx
@@ -47,6 +47,7 @@ const createAgent = (): AgentAdapter => {
   const agentState = createState();
 
   return {
+    name: "AgentKitAgent",
     role: AgentRole.AGENT,
     call: async (input) => {
       const latestMessage = input.messages.at(-1)?.content || "";

--- a/docs/docs/pages/agent-integration/agno.mdx
+++ b/docs/docs/pages/agent-integration/agno.mdx
@@ -39,6 +39,8 @@ Integrate with Scenario as follows:
 
 ```python
 class Agent(scenario.AgentAdapter):
+    name = "AgnoAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         result = agent.run(
             input.last_new_user_message_str(), session_id=input.thread_id
@@ -55,6 +57,8 @@ import scenario
 from agno.models.openai import OpenAIChat
 
 class AgnoAgentAdapter(scenario.AgentAdapter):
+    name = "AgnoAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         # Get the current message count to identify new messages
         current_messages_count = len(

--- a/docs/docs/pages/agent-integration/crewai.mdx
+++ b/docs/docs/pages/agent-integration/crewai.mdx
@@ -59,6 +59,8 @@ import scenario
 import uuid
 
 class CrewAIAgentAdapter(scenario.AgentAdapter):
+    name = "CrewAIAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         context = {"thread_id": input.thread_id or str(uuid.uuid4())}
         response_content = await call_crew(

--- a/docs/docs/pages/agent-integration/google-adk.mdx
+++ b/docs/docs/pages/agent-integration/google-adk.mdx
@@ -42,6 +42,8 @@ from google.genai.types import Content, Part
 import google.adk.models.lite_llm as litellm
 
 class GoogleADKAgentAdapter(scenario.AgentAdapter):
+    name = "GoogleADKAgent"
+
     def __init__(self):
         self.session_service = InMemorySessionService()
         self.runner = Runner(

--- a/docs/docs/pages/agent-integration/https.mdx
+++ b/docs/docs/pages/agent-integration/https.mdx
@@ -21,6 +21,7 @@ HTTPS integration is ideal when your agent is deployed as a web service, microse
 import scenario, { AgentAdapter, AgentRole } from "@langwatch/scenario";
 
 const httpsAgentAdapter: AgentAdapter = {
+  name: "HTTPSAgent",
   role: AgentRole.AGENT,
   call: async (input) => {
     // Extract the latest user message
@@ -69,6 +70,8 @@ import os
 
 
 class HTTPSAgentAdapter(scenario.AgentAdapter):
+    name = "HTTPSAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         # Extract the latest user message
         last_message = input.last_new_user_message_str()

--- a/docs/docs/pages/agent-integration/langgraph.mdx
+++ b/docs/docs/pages/agent-integration/langgraph.mdx
@@ -51,6 +51,8 @@ from langchain_core.messages import (
 )
 
 class LangGraphAgentAdapter(scenario.AgentAdapter):
+    name = "LangGraphAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         result = []
 

--- a/docs/docs/pages/agent-integration/litellm.mdx
+++ b/docs/docs/pages/agent-integration/litellm.mdx
@@ -18,6 +18,8 @@ import scenario
 import litellm
 
 class LiteLLMAgentAdapter(scenario.AgentAdapter):
+    name = "LiteLLMAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         response = litellm.completion(
             model="openai/gpt-4.1-mini",

--- a/docs/docs/pages/agent-integration/mastra.mdx
+++ b/docs/docs/pages/agent-integration/mastra.mdx
@@ -35,6 +35,7 @@ You can integrate it with Scenario like this:
 import scenario, { type AgentAdapter, AgentRole } from "@langwatch/scenario";
 
 const weatherAgent: AgentAdapter = {
+  name: "WeatherAgent",
   role: AgentRole.AGENT,
   call: async (input) => {
     const result = await weatherAgentMastra.generate(input.messages);

--- a/docs/docs/pages/agent-integration/openai.mdx
+++ b/docs/docs/pages/agent-integration/openai.mdx
@@ -18,6 +18,8 @@ import scenario
 import openai
 
 class OpenAIAgentAdapter(scenario.AgentAdapter):
+    name = "OpenAIAgent"
+
     async def call(self, input: scenario.AgentInput) -> scenario.AgentReturnTypes:
         response = openai.chat.completions.create(
             model="gpt-4.1-mini",

--- a/docs/docs/pages/agent-integration/pydantic-ai.mdx
+++ b/docs/docs/pages/agent-integration/pydantic-ai.mdx
@@ -47,6 +47,8 @@ from pydantic_ai.models.openai import OpenAIModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
 class PydanticAIAgentAdapter(scenario.AgentAdapter):
+    name = "PydanticAIAgent"
+
     def __init__(self):
         # Store conversation history in memory - Pydantic AI doesn't have built-in memory yet: https://github.com/pydantic/pydantic-ai/issues/530
         self.history: dict[str, List[ModelMessage]] = {}

--- a/docs/docs/pages/agent-integration/vercel-ai.mdx
+++ b/docs/docs/pages/agent-integration/vercel-ai.mdx
@@ -43,6 +43,7 @@ import scenario, { type AgentAdapter } from '@langwatch/scenario';
 
 const createMyAgentAdapter = (): AgentAdapter => {
   return {
+    name: "VercelAIAgent",
     call: async (input) => {
       const result = await myAgent(input.messages.at(-1)?.content);
       return result.response.messages;

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -203,7 +203,8 @@ export interface AgentAdapter {
 
 Each run reports its agents to LangWatch. LangWatch shows the name of the agent as
 the target of the run. When you set no name, the framework uses the class name of
-the adapter.
+the adapter. An adapter written as a plain object has no class name of its own, so
+set a name there to see the agent as the target of the run.
 
 Scenario provides built-in agents for common testing needs:
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -37,6 +37,7 @@ import scenario, { type AgentAdapter, AgentRole } from "@langwatch/scenario";
 
 // 1. Create an adapter for your agent
 const echoAgent: AgentAdapter = {
+  name: "EchoAgent",
   role: AgentRole.AGENT,
   call: async (input) => {
     // This agent simply echoes back the last message content
@@ -94,6 +95,7 @@ describe("Weather Agent", () => {
 
     // 2. Create an adapter for your agent
     const weatherAgent: AgentAdapter = {
+      name: "WeatherAgent",
       role: AgentRole.AGENT,
       call: async (input) => {
         const response = await generateText({
@@ -193,10 +195,15 @@ Agents are the participants in a scenario. They are defined by the `AgentAdapter
 
 ```typescript
 export interface AgentAdapter {
+  name?: string; // Shown by LangWatch as the target of the run
   role: AgentRole; // USER, AGENT, or JUDGE
   call: (input: AgentInput) => Promise<AgentReturnTypes>;
 }
 ```
+
+Each run reports its agents to LangWatch. LangWatch shows the name of the agent as
+the target of the run. When you set no name, the framework uses the class name of
+the adapter.
 
 Scenario provides built-in agents for common testing needs:
 

--- a/javascript/src/domain/agents/__tests__/resolve-agent-name.test.ts
+++ b/javascript/src/domain/agents/__tests__/resolve-agent-name.test.ts
@@ -1,0 +1,74 @@
+// Ref: specs/agent-adapter-names.feature
+import { describe, expect, it } from "vitest";
+import { AgentAdapter, AgentRole, resolveAgentName } from "..";
+import type { AgentInput, AgentReturnTypes } from "..";
+
+class PlainAgent extends AgentAdapter {
+  role = AgentRole.AGENT;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return "Hey, how can I help you?";
+  }
+}
+
+class BlankNameAgent extends PlainAgent {
+  name = "   ";
+}
+
+class PaddedNameAgent extends PlainAgent {
+  name = "  MyAgent  ";
+}
+
+describe("resolveAgentName", () => {
+  describe("when the adapter sets a name", () => {
+    it("reports it without the space around it", () => {
+      expect(resolveAgentName(new PaddedNameAgent())).toBe("MyAgent");
+    });
+  });
+
+  describe("when the name is blank", () => {
+    it("reports the class name instead", () => {
+      expect(resolveAgentName(new BlankNameAgent())).toBe("BlankNameAgent");
+    });
+  });
+
+  describe("when the adapter is a plain object", () => {
+    it("reports no name, since Object names the language, not the agent", () => {
+      const agent: AgentAdapter = {
+        role: AgentRole.AGENT,
+        call: async () => "Hey, how can I help you?",
+      };
+
+      expect(resolveAgentName(agent)).toBeUndefined();
+    });
+  });
+
+  describe("when the adapter carries a constructor key of its own", () => {
+    it("reports no name, since that key is data, not the class", () => {
+      const agent = {
+        role: AgentRole.AGENT,
+        constructor: { name: "Fake" },
+        call: async () => "Hey, how can I help you?",
+      } as unknown as AgentAdapter;
+
+      expect(resolveAgentName(agent)).toBeUndefined();
+    });
+  });
+
+  describe("when the adapter is a test double", () => {
+    it("reports no name, since every property of it answers a function", () => {
+      // The shape a mocking library gives an adapter: `name` reads as a
+      // function, not as a string. The examples suite runs adapters like this.
+      const agent = new Proxy(
+        { role: AgentRole.AGENT },
+        {
+          get: (target, property) =>
+            property in target
+              ? target[property as keyof typeof target]
+              : () => undefined,
+        },
+      ) as unknown as AgentAdapter;
+
+      expect(resolveAgentName(agent)).toBeUndefined();
+    });
+  });
+});

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -149,6 +149,25 @@ export abstract class AgentAdapter {
 }
 
 /**
+ * The name a run reports for an agent adapter.
+ *
+ * The adapter's own name comes first, without the space around it. A blank name
+ * counts as no name, so the class name of the adapter is used instead. An
+ * adapter written as a plain object has no class of its own, and an anonymous
+ * class carries no name either: both return undefined, and the run leaves the
+ * agent out of the list instead of reporting a name that means nothing. The
+ * Python SDK follows the same steps.
+ */
+export function resolveAgentName(agent: AgentAdapter): string | undefined {
+  const explicit = agent.name?.trim();
+  if (explicit) return explicit;
+
+  const ownClass = (agent as { constructor?: { name?: string } }).constructor;
+  if (!ownClass || ownClass === Object) return undefined;
+  return ownClass.name?.trim() || undefined;
+}
+
+/**
  * Abstract base class for user simulator agents.
  * User simulator agents are responsible for generating user messages to drive the conversation.
  */

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -114,6 +114,7 @@ export interface AgentInput {
  * @example
  * ```typescript
  * class MyAgent extends AgentAdapter {
+ *   name = "MyAgent";
  *   role = AgentRole.AGENT;
  *
  *   async call(input: AgentInput): Promise<AgentReturnTypes> {
@@ -127,6 +128,10 @@ export interface AgentInput {
  * ```
  */
 export abstract class AgentAdapter {
+  /**
+   * The name that LangWatch shows as the target of the run. When you do not set
+   * it, the framework uses the class name of the adapter.
+   */
   name?: string;
   role: AgentRole = AgentRole.AGENT;
 

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -157,14 +157,27 @@ export abstract class AgentAdapter {
  * class carries no name either: both return undefined, and the run leaves the
  * agent out of the list instead of reporting a name that means nothing. The
  * Python SDK follows the same steps.
+ *
+ * Only a string counts as a name. A test double built by a mocking library
+ * answers every property with a function, and a JavaScript caller can set any
+ * value, so the type says less here than it does elsewhere.
  */
 export function resolveAgentName(agent: AgentAdapter): string | undefined {
-  const explicit = agent.name?.trim();
+  const explicit = nameFrom(agent.name);
   if (explicit) return explicit;
 
-  const ownClass = (agent as { constructor?: { name?: string } }).constructor;
+  // The class comes from the prototype, not from the object: an adapter that
+  // carries a `constructor` key of its own would otherwise name the run.
+  const ownClass = (Object.getPrototypeOf(agent) as { constructor?: unknown })
+    ?.constructor;
   if (!ownClass || ownClass === Object) return undefined;
-  return ownClass.name?.trim() || undefined;
+  return nameFrom((ownClass as { name?: unknown }).name);
+}
+
+/** The value when it is a string that holds more than space. */
+function nameFrom(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.trim() || undefined;
 }
 
 /**

--- a/javascript/src/events/__tests__/run-agent-schema.test.ts
+++ b/javascript/src/events/__tests__/run-agent-schema.test.ts
@@ -1,0 +1,30 @@
+// Ref: specs/agent-adapter-names.feature
+import { describe, expect, it } from "vitest";
+import { scenarioRunAgentSchema } from "../schema";
+
+describe("scenarioRunAgentSchema", () => {
+  describe("when the name holds a word", () => {
+    it("takes it without the space around it", () => {
+      const parsed = scenarioRunAgentSchema.parse({
+        name: "  MyAgent  ",
+        role: "agent",
+      });
+
+      expect(parsed.name).toBe("MyAgent");
+    });
+  });
+
+  describe("when the name is blank", () => {
+    it("refuses an empty name", () => {
+      expect(() =>
+        scenarioRunAgentSchema.parse({ name: "", role: "agent" }),
+      ).toThrow();
+    });
+
+    it("refuses a name of space alone", () => {
+      expect(() =>
+        scenarioRunAgentSchema.parse({ name: "   ", role: "agent" }),
+      ).toThrow();
+    });
+  });
+});

--- a/javascript/src/events/schema.ts
+++ b/javascript/src/events/schema.ts
@@ -72,7 +72,7 @@ const baseScenarioEventSchema = baseEventSchema.extend({
  * it can name it, so the name is never blank.
  */
 export const scenarioRunAgentSchema = z.object({
-  name: z.string().min(1),
+  name: z.string().trim().min(1),
   role: z.enum(["agent", "user", "judge"]),
 });
 export type ScenarioRunAgent = z.infer<typeof scenarioRunAgentSchema>;

--- a/javascript/src/events/schema.ts
+++ b/javascript/src/events/schema.ts
@@ -66,15 +66,28 @@ const baseScenarioEventSchema = baseEventSchema.extend({
 });
 
 /**
+ * Scenario Run Agent Schema
+ * One agent that takes part in a scenario run. The name is the adapter's own name,
+ * or its class name when the adapter sets none.
+ */
+export const scenarioRunAgentSchema = z.object({
+  name: z.string(),
+  role: z.enum(["agent", "user", "judge"]),
+});
+export type ScenarioRunAgent = z.infer<typeof scenarioRunAgentSchema>;
+
+/**
  * Scenario Run Started Event Schema
  * Captures the initiation of a scenario run with metadata about the scenario being executed.
- * Contains the scenario name and optional description for identification purposes.
+ * Contains the scenario name, an optional description for identification purposes, and the
+ * agents that the run uses.
  */
 export const scenarioRunStartedSchema = baseScenarioEventSchema.extend({
   type: z.literal(ScenarioEventType.RUN_STARTED),
   metadata: z.object({
     name: z.string().optional(),
     description: z.string().optional(),
+    agents: z.array(scenarioRunAgentSchema).optional(),
   }).catchall(z.unknown()),
 });
 

--- a/javascript/src/events/schema.ts
+++ b/javascript/src/events/schema.ts
@@ -70,6 +70,9 @@ const baseScenarioEventSchema = baseEventSchema.extend({
  * One agent that takes part in a scenario run. The name is the adapter's own name,
  * or its class name when the adapter sets none. A run reports an agent only when
  * it can name it, so the name is never blank.
+ *
+ * Parsing takes the space off the name and refuses what is left when it is
+ * empty, which is a `ZodError` on `parse` and `success: false` on `safeParse`.
  */
 export const scenarioRunAgentSchema = z.object({
   name: z.string().trim().min(1),

--- a/javascript/src/events/schema.ts
+++ b/javascript/src/events/schema.ts
@@ -68,10 +68,11 @@ const baseScenarioEventSchema = baseEventSchema.extend({
 /**
  * Scenario Run Agent Schema
  * One agent that takes part in a scenario run. The name is the adapter's own name,
- * or its class name when the adapter sets none.
+ * or its class name when the adapter sets none. A run reports an agent only when
+ * it can name it, so the name is never blank.
  */
 export const scenarioRunAgentSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1),
   role: z.enum(["agent", "user", "judge"]),
 });
 export type ScenarioRunAgent = z.infer<typeof scenarioRunAgentSchema>;

--- a/javascript/src/execution/__tests__/run-started-agents.test.ts
+++ b/javascript/src/execution/__tests__/run-started-agents.test.ts
@@ -8,9 +8,9 @@ import {
   AgentReturnTypes,
 } from "../../domain";
 import { UserSimulatorAgentAdapter } from "../../domain/agents";
+import { ScenarioEventType, type ScenarioRunStartedEvent } from "../../events";
 import { user, agent, judge } from "../../script";
 import { ScenarioExecution } from "../scenario-execution";
-import { ScenarioEventType, type ScenarioRunStartedEvent } from "../../events";
 
 class NamedAgent extends AgentAdapter {
   name = "MyAgent";
@@ -26,6 +26,30 @@ class PlainAgent extends AgentAdapter {
     return { role: "assistant" as const, content: "Hey, how can I help you?" };
   }
 }
+
+class BlankNameAgent extends AgentAdapter {
+  name = "   ";
+  role = AgentRole.AGENT;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return { role: "assistant" as const, content: "Hey, how can I help you?" };
+  }
+}
+
+class PaddedNameAgent extends AgentAdapter {
+  name = "  MyAgent  ";
+  role = AgentRole.AGENT;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return { role: "assistant" as const, content: "Hey, how can I help you?" };
+  }
+}
+
+/** The object style that the docs show, written without a name. */
+const plainObjectAgent: AgentAdapter = {
+  role: AgentRole.AGENT,
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return { role: "assistant" as const, content: "Hey, how can I help you?" };
+  },
+};
 
 class MockUserSimulatorAgent extends UserSimulatorAgentAdapter {
   role = AgentRole.USER;
@@ -100,6 +124,39 @@ describe("run started agents metadata", () => {
         name: "PlainAgent",
         role: "agent",
       });
+    });
+  });
+
+  describe("when an adapter sets a name with space around it", () => {
+    it("reports the name without that space", async () => {
+      const metadata = await runStartedMetadata(new PaddedNameAgent());
+
+      expect((metadata.agents as unknown[])[0]).toEqual({
+        name: "MyAgent",
+        role: "agent",
+      });
+    });
+  });
+
+  describe("when an adapter sets a blank name", () => {
+    it("reports the class name, the way the Python SDK does", async () => {
+      const metadata = await runStartedMetadata(new BlankNameAgent());
+
+      expect((metadata.agents as unknown[])[0]).toEqual({
+        name: "BlankNameAgent",
+        role: "agent",
+      });
+    });
+  });
+
+  describe("when an adapter is a plain object with no name", () => {
+    it("leaves it out of the list instead of reporting Object", async () => {
+      const metadata = await runStartedMetadata(plainObjectAgent);
+
+      expect(metadata.agents).toEqual([
+        { name: "UserSimulatorAgent", role: "user" },
+        { name: "JudgeAgent", role: "judge" },
+      ]);
     });
   });
 

--- a/javascript/src/execution/__tests__/run-started-agents.test.ts
+++ b/javascript/src/execution/__tests__/run-started-agents.test.ts
@@ -1,0 +1,143 @@
+// Ref: specs/agent-adapter-names.feature
+import { describe, it, expect } from "vitest";
+import {
+  AgentRole,
+  AgentAdapter,
+  JudgeAgentAdapter,
+  AgentInput,
+  AgentReturnTypes,
+} from "../../domain";
+import { UserSimulatorAgentAdapter } from "../../domain/agents";
+import { user, agent, judge } from "../../script";
+import { ScenarioExecution } from "../scenario-execution";
+import { ScenarioEventType, type ScenarioRunStartedEvent } from "../../events";
+
+class NamedAgent extends AgentAdapter {
+  name = "MyAgent";
+  role = AgentRole.AGENT;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return { role: "assistant" as const, content: "Hey, how can I help you?" };
+  }
+}
+
+class PlainAgent extends AgentAdapter {
+  role = AgentRole.AGENT;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return { role: "assistant" as const, content: "Hey, how can I help you?" };
+  }
+}
+
+class MockUserSimulatorAgent extends UserSimulatorAgentAdapter {
+  role = AgentRole.USER;
+  async call(_input: AgentInput): Promise<AgentReturnTypes> {
+    return "Hi, I'm a user";
+  }
+}
+
+class MockJudgeAgent extends JudgeAgentAdapter {
+  criteria = ["test criterion passes"];
+  async call(input: AgentInput) {
+    if (!input.judgmentRequest) return null;
+    return {
+      success: true,
+      reasoning: "All criteria passed",
+      metCriteria: input.judgmentRequest.criteria ?? [],
+      unmetCriteria: [],
+    };
+  }
+}
+
+async function runStartedMetadata(
+  agentUnderTest: AgentAdapter,
+  metadata?: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const execution = new ScenarioExecution(
+    {
+      name: "agents scenario",
+      description: "test agents metadata",
+      agents: [
+        agentUnderTest,
+        new MockUserSimulatorAgent(),
+        new MockJudgeAgent(),
+      ],
+      metadata,
+    },
+    [user("hello"), agent(), judge({ criteria: ["test criterion passes"] })],
+    "test-batch-id"
+  );
+
+  const events: ScenarioRunStartedEvent[] = [];
+  execution.events$.subscribe((event) => {
+    if (event.type === ScenarioEventType.RUN_STARTED) {
+      events.push(event as ScenarioRunStartedEvent);
+    }
+  });
+
+  await execution.execute();
+
+  expect(events.length).toBeGreaterThan(0);
+  return events[0]!.metadata as Record<string, unknown>;
+}
+
+describe("run started agents metadata", () => {
+  describe("when an adapter sets an explicit name", () => {
+    it("reports that name with the agent role", async () => {
+      const metadata = await runStartedMetadata(new NamedAgent());
+
+      expect(metadata.agents).toBeDefined();
+      expect((metadata.agents as unknown[])[0]).toEqual({
+        name: "MyAgent",
+        role: "agent",
+      });
+    });
+  });
+
+  describe("when an adapter sets no name", () => {
+    it("reports the class name of the adapter", async () => {
+      const metadata = await runStartedMetadata(new PlainAgent());
+
+      expect((metadata.agents as unknown[])[0]).toEqual({
+        name: "PlainAgent",
+        role: "agent",
+      });
+    });
+  });
+
+  describe("when the scenario lists a user simulator and a judge", () => {
+    it("reports every role in the order of the agents list", async () => {
+      const metadata = await runStartedMetadata(new PlainAgent());
+
+      expect(metadata.agents).toEqual([
+        { name: "PlainAgent", role: "agent" },
+        { name: "UserSimulatorAgent", role: "user" },
+        { name: "JudgeAgent", role: "judge" },
+      ]);
+    });
+  });
+
+  describe("when the user sets a langwatch metadata key", () => {
+    it("keeps the agents list at the top level and the key untouched", async () => {
+      const metadata = await runStartedMetadata(new PlainAgent(), {
+        langwatch: { threadId: "thread-1" },
+      });
+
+      expect((metadata.agents as { name: string }[])[0]!.name).toBe(
+        "PlainAgent"
+      );
+      expect(metadata.langwatch).toEqual({ threadId: "thread-1" });
+    });
+  });
+
+  describe("when the user sets other metadata keys", () => {
+    it("passes them through next to the agents list", async () => {
+      const metadata = await runStartedMetadata(new PlainAgent(), {
+        promptId: "abc-123",
+        environment: "staging",
+      });
+
+      expect(metadata.promptId).toBe("abc-123");
+      expect(metadata.environment).toBe("staging");
+      expect((metadata.agents as unknown[]).length).toBe(3);
+    });
+  });
+});

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -24,6 +24,7 @@ import {
   ScenarioConfigFinal,
   DEFAULT_MAX_TURNS,
   DEFAULT_VERBOSE,
+  resolveAgentName,
 } from "../domain";
 import {
   isRealtimeUserAgent,
@@ -2632,10 +2633,16 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
         ...this.config.metadata,
         name: this.config.name,
         description: this.config.description,
-        agents: this.config.agents.map((agent) => ({
-          name: agent.name ?? agent.constructor.name,
-          role: agent.role.toLowerCase() as "agent" | "user" | "judge",
-        })),
+        agents: this.config.agents.flatMap((agent) => {
+          const name = resolveAgentName(agent);
+          if (!name) return [];
+          return [
+            {
+              name,
+              role: agent.role.toLowerCase() as "agent" | "user" | "judge",
+            },
+          ];
+        }),
       },
     } as ScenarioRunStartedEvent);
   }

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -2632,6 +2632,10 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
         ...this.config.metadata,
         name: this.config.name,
         description: this.config.description,
+        agents: this.config.agents.map((agent) => ({
+          name: agent.name ?? agent.constructor.name,
+          role: agent.role.toLowerCase() as "agent" | "user" | "judge",
+        })),
       },
     } as ScenarioRunStartedEvent);
   }

--- a/python/scenario/_events/__init__.py
+++ b/python/scenario/_events/__init__.py
@@ -9,6 +9,7 @@ for converting between different message formats.
 from .events import (
     ScenarioEvent,
     ScenarioRunStartedEvent,
+    ScenarioRunStartedEventAgent,
     ScenarioRunStartedEventMetadata,
     ScenarioRunFinishedEvent,
     ScenarioRunFinishedEventResults,
@@ -39,6 +40,7 @@ __all__ = [
     # Event types
     "ScenarioEvent",
     "ScenarioRunStartedEvent",
+    "ScenarioRunStartedEventAgent",
     "ScenarioRunStartedEventMetadata",
     "ScenarioRunFinishedEvent",
     "ScenarioRunFinishedEventResults",

--- a/python/scenario/_events/events.py
+++ b/python/scenario/_events/events.py
@@ -8,7 +8,11 @@ the backend, and provides a single import location for event models.
 If you need to add custom logic or helpers, you can extend or wrap these models here.
 """
 
-from typing import Union, Any, Optional, TypeAlias
+from dataclasses import dataclass
+from typing import Union, Any, List, Optional, TypeAlias
+
+from attrs import define as _attrs_define
+
 from scenario._generated.langwatch_api_client.lang_watch_api_client.models import (
     PostApiScenarioEventsBodyType0,
     PostApiScenarioEventsBodyType0Metadata,
@@ -18,10 +22,54 @@ from scenario._generated.langwatch_api_client.lang_watch_api_client.models impor
     PostApiScenarioEventsBodyType1Status,
     PostApiScenarioEventsBodyType2,
 )
+from scenario._generated.langwatch_api_client.lang_watch_api_client.types import (
+    UNSET,
+    Unset,
+)
 from .messages import MessageType
 
-# Create alias for cleaner naming
-ScenarioRunStartedEventMetadata: TypeAlias = PostApiScenarioEventsBodyType0Metadata
+
+@dataclass(frozen=True)
+class ScenarioRunStartedEventAgent:
+    """
+    One agent that takes part in a scenario run.
+
+    Args:
+        name (str): The adapter's explicit name, or its class name when it sets none
+        role (str): The adapter's role in lower case: "agent", "user" or "judge"
+    """
+
+    name: str
+    role: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "role": self.role}
+
+
+@_attrs_define
+class ScenarioRunStartedEventMetadata(PostApiScenarioEventsBodyType0Metadata):
+    """
+    Metadata of a scenario run, extended with the agents that the run uses.
+
+    The generated model carries `name` and `description`. `agents` is added here
+    because the generated client is not regenerated for this field. It stays a
+    top level key next to `name` and `description`, and it never goes into the
+    `langwatch` key, which the platform reserves for itself.
+
+    Args:
+        agents (Union[Unset, List[ScenarioRunStartedEventAgent]]): The agents of the
+            run, in the order in which the scenario lists them
+    """
+
+    agents: Union[Unset, List[ScenarioRunStartedEventAgent]] = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict = super().to_dict()
+        if not isinstance(self.agents, Unset):
+            field_dict["agents"] = [agent.to_dict() for agent in self.agents]
+        return field_dict
+
+
 ScenarioRunFinishedEventResults: TypeAlias = PostApiScenarioEventsBodyType1ResultsType0
 ScenarioRunFinishedEventVerdict: TypeAlias = PostApiScenarioEventsBodyType1ResultsType0Verdict
 ScenarioRunFinishedEventStatus: TypeAlias = PostApiScenarioEventsBodyType1Status
@@ -152,6 +200,7 @@ ScenarioEvent = Union[
 __all__ = [
     "ScenarioEvent",
     "ScenarioRunStartedEvent",
+    "ScenarioRunStartedEventAgent",
     "ScenarioRunStartedEventMetadata",
     "ScenarioRunFinishedEvent",
     "ScenarioRunFinishedEventResults",

--- a/python/scenario/_events/events.py
+++ b/python/scenario/_events/events.py
@@ -9,7 +9,7 @@ If you need to add custom logic or helpers, you can extend or wrap these models 
 """
 
 from dataclasses import dataclass
-from typing import Union, Any, List, Optional, TypeAlias
+from typing import Union, Any, Optional, TypeAlias
 
 from attrs import define as _attrs_define
 
@@ -57,11 +57,11 @@ class ScenarioRunStartedEventMetadata(PostApiScenarioEventsBodyType0Metadata):
     `langwatch` key, which the platform reserves for itself.
 
     Args:
-        agents (Union[Unset, List[ScenarioRunStartedEventAgent]]): The agents of the
+        agents (Union[Unset, list[ScenarioRunStartedEventAgent]]): The agents of the
             run, in the order in which the scenario lists them
     """
 
-    agents: Union[Unset, List[ScenarioRunStartedEventAgent]] = UNSET
+    agents: Union[Unset, list[ScenarioRunStartedEventAgent]] = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         field_dict = super().to_dict()

--- a/python/scenario/agent_adapter.py
+++ b/python/scenario/agent_adapter.py
@@ -8,7 +8,7 @@ architecture or API.
 """
 
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 from .types import AgentInput, AgentReturnTypes, AgentRole
 
@@ -23,6 +23,8 @@ class AgentAdapter(ABC):
     the conversation state and returns responses in a standardized format.
 
     Attributes:
+        name: The name that LangWatch shows as the target of the run. When you do not
+            set it, the framework uses the class name of the adapter.
         role: The role this agent plays in scenarios (USER, AGENT, or JUDGE)
 
     Example:
@@ -31,6 +33,8 @@ class AgentAdapter(ABC):
         from my_agent import MyCustomAgent
 
         class MyAgentAdapter(scenario.AgentAdapter):
+            name = "MyAgent"
+
             def __init__(self):
                 self.agent = MyCustomAgent()
 
@@ -67,6 +71,7 @@ class AgentAdapter(ABC):
         - For stateless agents, use input.messages for the full conversation history
     """
 
+    name: ClassVar[Optional[str]] = None
     role: ClassVar[AgentRole] = AgentRole.AGENT
 
     @abstractmethod

--- a/python/scenario/agent_adapter.py
+++ b/python/scenario/agent_adapter.py
@@ -118,3 +118,26 @@ class AgentAdapter(ABC):
             ```
         """
         pass
+
+
+def resolve_agent_name(agent: AgentAdapter) -> Optional[str]:
+    """
+    The name a run reports for an agent adapter.
+
+    The adapter's own name comes first, without the space around it. A blank name
+    counts as no name, so the class name of the adapter is used instead. The
+    result is None only for an adapter with no class name of its own, which
+    Python does not produce but the TypeScript SDK does for a plain object. The
+    TypeScript SDK follows the same steps.
+
+    Args:
+        agent: The adapter that takes part in the run
+
+    Returns:
+        The name to report, or None when the adapter carries no usable name
+    """
+    explicit = getattr(agent, "name", None)
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+
+    return type(agent).__name__.strip() or None

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -72,6 +72,7 @@ from ._events import (
     ScenarioRunStartedEvent,
     ScenarioMessageSnapshotEvent,
     ScenarioRunFinishedEvent,
+    ScenarioRunStartedEventAgent,
     ScenarioRunStartedEventMetadata,
     ScenarioRunFinishedEventResults,
     ScenarioRunFinishedEventVerdict,
@@ -1853,10 +1854,17 @@ class ScenarioExecutor:
         metadata = ScenarioRunStartedEventMetadata(
             name=self.name,
             description=self.description,
+            agents=[
+                ScenarioRunStartedEventAgent(
+                    name=getattr(agent, "name", None) or type(agent).__name__,
+                    role=agent.role.value.lower(),
+                )
+                for agent in self.agents
+            ],
         )
         if self.metadata:
             for key, value in self.metadata.items():
-                if key not in ("name", "description"):
+                if key not in ("name", "description", "agents"):
                     metadata.additional_properties[key] = value
 
         event = ScenarioRunStartedEvent(

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -62,7 +62,7 @@ from .types import (
 )
 from ._error_messages import agent_response_not_awaitable
 from .cache import context_scenario
-from .agent_adapter import AgentAdapter
+from .agent_adapter import AgentAdapter, resolve_agent_name
 from .script import proceed
 from pksuid import PKSUID
 from .scenario_state import ScenarioState
@@ -1851,16 +1851,24 @@ class ScenarioExecutor:
             scenario_run_id: Unique identifier for the current scenario run
         """
         common_fields = self._create_common_event_fields(scenario_run_id)
+
+        # A run reports an agent only when it can name it, so the platform never
+        # reads a blank target name.
+        agents: List[ScenarioRunStartedEventAgent] = []
+        for agent in self.agents:
+            name = resolve_agent_name(agent)
+            if name:
+                agents.append(
+                    ScenarioRunStartedEventAgent(
+                        name=name,
+                        role=agent.role.value.lower(),
+                    )
+                )
+
         metadata = ScenarioRunStartedEventMetadata(
             name=self.name,
             description=self.description,
-            agents=[
-                ScenarioRunStartedEventAgent(
-                    name=getattr(agent, "name", None) or type(agent).__name__,
-                    role=agent.role.value.lower(),
-                )
-                for agent in self.agents
-            ],
+            agents=agents,
         )
         if self.metadata:
             for key, value in self.metadata.items():

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from typing import Any, cast as _cast, List, Tuple, Dict
+from typing import Any, cast as _cast, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 from scenario import JudgeAgent, UserSimulatorAgent, succeed
@@ -474,3 +474,101 @@ async def test_empty_user_turn_state_unchanged_after_snapshot() -> None:
         msg.get("role") == "user" and msg.get("content") == ""
         for msg in captured_messages_at_snapshot
     ), "_state.messages must contain the empty-content user turn unchanged after snapshot emission"
+
+
+# ---------------------------------------------------------------------------
+# Ref: specs/agent-adapter-names.feature
+# ---------------------------------------------------------------------------
+
+
+class NamedAgent(AgentAdapter):
+    name = "MyAgent"
+
+    async def call(self, input: AgentInput) -> str:
+        return "Hey, how can I help you?"
+
+
+class PlainAgent(AgentAdapter):
+    async def call(self, input: AgentInput) -> str:
+        return "Hey, how can I help you?"
+
+
+async def _run_started_metadata(
+    agent: AgentAdapter,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run a scenario with the given agent and return the RUN_STARTED metadata dict."""
+    mock_reporter = MockEventReporter()
+    event_bus = ScenarioEventBus(event_reporter=mock_reporter)
+
+    executor = ScenarioExecutor(
+        name="agents scenario",
+        description="test agents metadata",
+        agents=[
+            agent,
+            MockUserSimulatorAgent(model="none"),
+            MockJudgeAgent(model="none", criteria=["test criteria"]),
+        ],
+        event_bus=event_bus,
+        metadata=metadata,
+    )
+
+    events: List[ScenarioEvent] = []
+    executor.events.subscribe(events.append)
+    await executor.run()
+
+    start_event: ScenarioRunStartedEvent = next(
+        e for e in events if isinstance(e, ScenarioRunStartedEvent)
+    )
+    return start_event.metadata.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_adapter_with_explicit_name_reports_it() -> None:
+    """An adapter that sets a name reports that name with role "agent"."""
+    metadata_dict = await _run_started_metadata(NamedAgent())
+
+    assert metadata_dict["agents"][0] == {"name": "MyAgent", "role": "agent"}
+
+
+@pytest.mark.asyncio
+async def test_adapter_without_name_reports_its_class_name() -> None:
+    """An adapter that sets no name reports its class name."""
+    metadata_dict = await _run_started_metadata(PlainAgent())
+
+    assert metadata_dict["agents"][0] == {"name": "PlainAgent", "role": "agent"}
+
+
+@pytest.mark.asyncio
+async def test_user_simulator_and_judge_report_their_roles() -> None:
+    """The agents list keeps the scenario order and reports each role."""
+    metadata_dict = await _run_started_metadata(PlainAgent())
+
+    assert metadata_dict["agents"] == [
+        {"name": "PlainAgent", "role": "agent"},
+        {"name": "MockUserSimulatorAgent", "role": "user"},
+        {"name": "MockJudgeAgent", "role": "judge"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_agents_stay_out_of_the_langwatch_namespace() -> None:
+    """The agents list is a top level key and the langwatch key is untouched."""
+    metadata_dict = await _run_started_metadata(
+        PlainAgent(), metadata={"langwatch": {"threadId": "thread-1"}}
+    )
+
+    assert metadata_dict["agents"][0]["name"] == "PlainAgent"
+    assert metadata_dict["langwatch"] == {"threadId": "thread-1"}
+
+
+@pytest.mark.asyncio
+async def test_user_metadata_passes_through_next_to_the_agents_list() -> None:
+    """User metadata keys still reach the event alongside the agents list."""
+    metadata_dict = await _run_started_metadata(
+        PlainAgent(), metadata={"promptId": "abc-123", "environment": "staging"}
+    )
+
+    assert metadata_dict["promptId"] == "abc-123"
+    assert metadata_dict["environment"] == "staging"
+    assert len(metadata_dict["agents"]) == 3

--- a/python/tests/test_scenario_executor_events.py
+++ b/python/tests/test_scenario_executor_events.py
@@ -493,6 +493,20 @@ class PlainAgent(AgentAdapter):
         return "Hey, how can I help you?"
 
 
+class BlankNameAgent(AgentAdapter):
+    name = "   "
+
+    async def call(self, input: AgentInput) -> str:
+        return "Hey, how can I help you?"
+
+
+class PaddedNameAgent(AgentAdapter):
+    name = "  MyAgent  "
+
+    async def call(self, input: AgentInput) -> str:
+        return "Hey, how can I help you?"
+
+
 async def _run_started_metadata(
     agent: AgentAdapter,
     metadata: Optional[Dict[str, Any]] = None,
@@ -537,6 +551,25 @@ async def test_adapter_without_name_reports_its_class_name() -> None:
     metadata_dict = await _run_started_metadata(PlainAgent())
 
     assert metadata_dict["agents"][0] == {"name": "PlainAgent", "role": "agent"}
+
+
+@pytest.mark.asyncio
+async def test_name_keeps_no_space_around_it() -> None:
+    """An adapter name reports without the space around it."""
+    metadata_dict = await _run_started_metadata(PaddedNameAgent())
+
+    assert metadata_dict["agents"][0] == {"name": "MyAgent", "role": "agent"}
+
+
+@pytest.mark.asyncio
+async def test_blank_name_counts_as_no_name() -> None:
+    """A blank name reports the class name, the way the TypeScript SDK does."""
+    metadata_dict = await _run_started_metadata(BlankNameAgent())
+
+    assert metadata_dict["agents"][0] == {
+        "name": "BlankNameAgent",
+        "role": "agent",
+    }
 
 
 @pytest.mark.asyncio

--- a/specs/agent-adapter-names.feature
+++ b/specs/agent-adapter-names.feature
@@ -1,0 +1,42 @@
+Feature: Agent adapters carry a name and runs report their agents
+  As a developer who runs scenarios from code
+  I want every agent adapter to carry a name and every run to report its agents
+  So that LangWatch can show the real target of the run instead of "default"
+
+  Background:
+    Given a scenario that runs an agent adapter, a user simulator and a judge
+    And the scenario emits a SCENARIO_RUN_STARTED event
+
+  @unit
+  Scenario: An adapter with an explicit name reports that name
+    Given an agent adapter that sets name to "MyAgent"
+    When the scenario run starts
+    Then metadata.agents contains an entry with name "MyAgent" and role "agent"
+
+  @unit
+  Scenario: An adapter without a name reports its class name
+    Given an agent adapter class "PlainAgent" that sets no name
+    When the scenario run starts
+    Then metadata.agents contains an entry with name "PlainAgent" and role "agent"
+
+  @unit
+  Scenario: The user simulator and the judge report their roles
+    Given the scenario lists a user simulator agent and a judge agent
+    When the scenario run starts
+    Then metadata.agents contains an entry with role "user" for the user simulator
+    And metadata.agents contains an entry with role "judge" for the judge
+    And the entries keep the order in which the scenario lists the agents
+
+  @unit
+  Scenario: The agents list stays out of the reserved langwatch namespace
+    Given the scenario sets metadata with a "langwatch" key
+    When the scenario run starts
+    Then metadata.agents is a top level key next to name and description
+    And the "langwatch" key holds only the value that the user set
+
+  @unit
+  Scenario: User metadata still passes through next to the agents list
+    Given the scenario sets metadata with the keys "promptId" and "environment"
+    When the scenario run starts
+    Then metadata carries "promptId" and "environment" unchanged
+    And metadata carries the agents list as well

--- a/specs/agent-adapter-names.feature
+++ b/specs/agent-adapter-names.feature
@@ -20,6 +20,26 @@ Feature: Agent adapters carry a name and runs report their agents
     Then metadata.agents contains an entry with name "PlainAgent" and role "agent"
 
   @unit
+  Scenario: A name keeps no space around it
+    Given an agent adapter that sets name to "  MyAgent  "
+    When the scenario run starts
+    Then metadata.agents contains an entry with name "MyAgent" and role "agent"
+
+  @unit
+  Scenario: A blank name counts as no name
+    Given an agent adapter class "PlainAgent" that sets name to "   "
+    When the scenario run starts
+    Then metadata.agents contains an entry with name "PlainAgent" and role "agent"
+    And both SDKs report the same name for the same adapter
+
+  @unit
+  Scenario: An adapter that carries no usable name stays out of the list
+    Given an agent adapter that is a plain object with no name
+    When the scenario run starts
+    Then metadata.agents holds no entry for that adapter
+    And the platform reads the run under the default target
+
+  @unit
   Scenario: The user simulator and the judge report their roles
     Given the scenario lists a user simulator agent and a judge agent
     When the scenario run starts


### PR DESCRIPTION
## What

Every agent adapter can now carry a name, and every scenario run reports its agents on the `SCENARIO_RUN_STARTED` event.

- Python: `AgentAdapter` gets `name: ClassVar[Optional[str]] = None`.
- TypeScript: `AgentAdapter.name` is documented with its default.
- Both executors add `metadata.agents` to the run started event.

## Why

LangWatch could not name the target of a run that came from code, so it showed the run as "default". The run now says which agents it uses and what each one is called.

## Wire contract

On `SCENARIO_RUN_STARTED`, `metadata.agents` is an array of `{ "name": string, "role": "agent" | "user" | "judge" }`, one entry per agent, in the order the scenario lists them.

- `agents` is a top level key of `metadata`, next to `name` and `description`. It never goes into the `metadata.langwatch` namespace, which the platform reserves for itself.
- `name` follows three steps, the same in both SDKs: the explicit name of the adapter without the space around it, else the class name of the adapter, else no entry at all. A blank name therefore counts as no name, and `metadata.agents` never carries a blank one.
- A TypeScript adapter written as a plain object has no class name of its own, so it needs an explicit name. Without one it stays out of the list, and the platform reads the run under the default target, the way it reads a run from an older SDK. Reporting `Object` would name the target after the language, and a shared invented name would merge two different agents into one target.
- `role` is the `AgentRole` of the adapter in lower case.
- User metadata keys still pass through unchanged.

Example payload:

```json
{
  "type": "SCENARIO_RUN_STARTED",
  "metadata": {
    "name": "dinner idea",
    "description": "The user looks for a recipe",
    "agents": [
      { "name": "VegetarianRecipeAgent", "role": "agent" },
      { "name": "UserSimulatorAgent", "role": "user" },
      { "name": "JudgeAgent", "role": "judge" }
    ]
  }
}
```

The change is additive. An adapter that sets no name keeps working and reports its class name.

## Changes

- `specs/agent-adapter-names.feature`: eight `@unit` scenarios for the contract, three of them for a name that is blank, padded with space, or missing on a plain object.
- `python/scenario/agent_adapter.py`: the `name` class variable, with docstring and example, and `resolve_agent_name`, which holds the three steps.
- `python/scenario/_events/events.py`: `ScenarioRunStartedEventAgent`, and `ScenarioRunStartedEventMetadata` now extends the generated model with an optional `agents` field. The generated client under `python/scenario/_generated` is untouched.
- `python/scenario/scenario_executor.py`: builds the agents list next to `name` and `description`.
- `javascript/src/domain/agents/index.ts`: JSDoc for `name`, and `resolveAgentName`, which holds the same three steps.
- `javascript/src/execution/scenario-execution.ts`: builds the agents list on the run started event.
- `javascript/src/events/schema.ts`: the optional `agents` array on the run started metadata, with `name` as `z.string().min(1)`.
- Docs and READMEs: every adapter example sets a name, with one sentence about the default.

## Verification

- `uv run pytest tests/test_scenario_executor_events.py -q`: 21 passed.
- `uv run pytest tests/ -q --ignore=tests/voice`: 736 passed, 3 failed. The three failures are real LLM tests (`test_arun_real_llm_integration.py::test_concurrent_arun_with_real_simulator_and_judge`, `test_red_team_agent.py::test_red_team_live_3_turns`, `test_red_team_agent.py::test_red_team_live_10_turns_full_phases`) that fail with a provider 401 in this environment. They do not touch this change.
- `uv run pyright .`: 0 errors.
- `pnpm test` in `javascript`: 110 files passed, 1371 tests passed, 58 skipped. `npx vitest run src/events src/execution` after the name rule: 14 files, 69 tests passed.
- `pnpm lint:lib` in `javascript`: clean.
- `pnpm typecheck` in `javascript`: same eight errors as `origin/main` in `src/agents/__tests__/realtime-adapter-key-resolution.test.ts` and `src/events/event-reporter.ts`, verified against a stashed working tree. This change adds none.

