### PR TITLE
feat: scenario.run accepts a connected agent function

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ This is how it will look like:
 
 You can find the same code example in [python/examples/](python/examples/test_vegetarian_recipe_agent.py) or [javascript/examples/](javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts).
 
+An agent already connected to LangWatch with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter class: pass the decorated function straight to `run`, as in `scenario.run(agents=[support_agent, scenario.UserSimulatorAgent(), scenario.JudgeAgent(...)])`.
+
 Now check out the [full documentation](https://scenario.langwatch.ai) to learn more and next steps.
 
 ## Simulation on Autopilot

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ This is how it will look like:
 
 You can find the same code example in [python/examples/](python/examples/test_vegetarian_recipe_agent.py) or [javascript/examples/](javascript/examples/vitest/tests/vegetarian-recipe-agent.test.ts).
 
-An agent already connected to LangWatch with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter class: pass the decorated function straight to `run`, as in `scenario.run(agents=[support_agent, scenario.UserSimulatorAgent(), scenario.JudgeAgent(...)])`.
+An agent already [connected to LangWatch](https://langwatch.ai/docs/agent-testing/connect-your-agent) with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter class: pass the decorated function straight to `run`, as in `scenario.run(agents=[support_agent, scenario.UserSimulatorAgent(), scenario.JudgeAgent(...)])`.
 
 Now check out the [full documentation](https://scenario.langwatch.ai) to learn more and next steps.
 

--- a/docs/docs/pages/agent-integration.mdx
+++ b/docs/docs/pages/agent-integration.mdx
@@ -30,6 +30,30 @@ You can wrap any agent (OpenAI, AgentKit, Mastra, custom, etc.) as an AgentAdapt
 
 When writing a Scenario test, you pass your agents as AgentAdapter objects. Scenario will call your agent’s call function whenever it’s their turn in the conversation, passing in the latest state and message history.
 
+An agent connected to LangWatch with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter: pass the decorated function straight to `run`. Scenario wraps it, sends it the connected agent turn fields (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`), echoes the `session` it returns on the next turn of the same thread, and passes the run `parameters` you set on the scenario.
+
+:::code-group
+
+```python [python]
+result = await scenario.run(
+    name="support",
+    description="The user asks for a refund",
+    agents=[support_agent, scenario.UserSimulatorAgent(), scenario.JudgeAgent(criteria=[...])],
+    parameters={"model": "gpt-5-mini"},
+)
+```
+
+```typescript [typescript]
+const result = await scenario.run({
+  name: "support",
+  description: "The user asks for a refund",
+  agents: [supportAgent, scenario.userSimulatorAgent(), scenario.judgeAgent({ criteria: [...] })],
+  parameters: { model: "gpt-5-mini" },
+});
+```
+
+:::
+
 :::tip
 **Message Mocking Requirement**
 

--- a/docs/docs/pages/agent-integration.mdx
+++ b/docs/docs/pages/agent-integration.mdx
@@ -30,7 +30,7 @@ You can wrap any agent (OpenAI, AgentKit, Mastra, custom, etc.) as an AgentAdapt
 
 When writing a Scenario test, you pass your agents as AgentAdapter objects. Scenario will call your agent’s call function whenever it’s their turn in the conversation, passing in the latest state and message history.
 
-An agent connected to LangWatch with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter: pass the decorated function straight to `run`. Scenario wraps it, sends it the connected agent turn fields (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`), echoes the `session` it returns on the next turn of the same thread, and passes the run `parameters` you set on the scenario.
+An agent connected to LangWatch with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter: pass the decorated function straight to `run`. Scenario wraps it and sends it the connected agent turn fields: in Python `messages`, `new_messages`, `thread_id`, `session`, `trace_id` and the run `parameters`; in TypeScript one object with `messages`, `newMessages`, `threadId`, `session`, `traceId` and `params`. The `session` the function returns comes back on the next turn of the same thread, and the run `parameters` you set on the scenario reach the function.
 
 :::code-group
 

--- a/docs/docs/pages/agent-integration.mdx
+++ b/docs/docs/pages/agent-integration.mdx
@@ -30,7 +30,7 @@ You can wrap any agent (OpenAI, AgentKit, Mastra, custom, etc.) as an AgentAdapt
 
 When writing a Scenario test, you pass your agents as AgentAdapter objects. Scenario will call your agent’s call function whenever it’s their turn in the conversation, passing in the latest state and message history.
 
-An agent connected to LangWatch with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter: pass the decorated function straight to `run`. Scenario wraps it and sends it the connected agent turn fields: in Python `messages`, `new_messages`, `thread_id`, `session`, `trace_id` and the run `parameters`; in TypeScript one object with `messages`, `newMessages`, `threadId`, `session`, `traceId` and `params`. The `session` the function returns comes back on the next turn of the same thread, and the run `parameters` you set on the scenario reach the function.
+An agent [connected to LangWatch](https://langwatch.ai/docs/agent-testing/connect-your-agent) with `langwatch.connect_agent` (Python) or `connectAgent` (TypeScript) needs no adapter: pass the decorated function straight to `run`. Scenario wraps it and sends it the connected agent turn fields: in Python `messages`, `new_messages`, `thread_id`, `session`, `trace_id` and the run `parameters`; in TypeScript one object with `messages`, `newMessages`, `threadId`, `session`, `traceId` and `params`. The `session` the function returns comes back on the next turn of the same thread, and the run `parameters` you set on the scenario reach the function.
 
 :::code-group
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -198,6 +198,8 @@ export interface AgentAdapter {
 }
 ```
 
+A function returned by `connectAgent` from the `langwatch` package is accepted as is: `scenario.run({ agents: [supportAgent, userSimulatorAgent(), judgeAgent({ criteria })] })` runs it as the agent under test, and `parameters: { model: "gpt-5-mini" }` on the config sets its run parameters.
+
 Scenario provides built-in agents for common testing needs:
 
 - `userSimulatorAgent(config)`: Simulates a human user, generating realistic messages based on the scenario description.

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -198,7 +198,7 @@ export interface AgentAdapter {
 }
 ```
 
-A function returned by `connectAgent` from the `langwatch` package is accepted as is: `scenario.run({ agents: [supportAgent, userSimulatorAgent(), judgeAgent({ criteria })] })` runs it as the agent under test, and `parameters: { model: "gpt-5-mini" }` on the config sets its run parameters.
+A function returned by [`connectAgent`](https://langwatch.ai/docs/agent-testing/connect-your-agent) from the `langwatch` package is accepted as is: `scenario.run({ agents: [supportAgent, userSimulatorAgent(), judgeAgent({ criteria })] })` runs it as the agent under test, and `parameters: { model: "gpt-5-mini" }` on the config sets its run parameters.
 
 Scenario provides built-in agents for common testing needs:
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "pnpm run typecheck && pnpm run build",
     "clean:all": "pnpm -r --parallel exec rm -rf dist *.tgz .cache",
     "build:all": "pnpm run build",
-    "typecheck:all": "pnpm -r --parallel run typecheck",
+    "typecheck:all": "pnpm -r --parallel --include-workspace-root run typecheck",
     "lint:all": "pnpm -r --parallel run lint",
     "format:all": "pnpm -r --parallel run format",
     "test:all": "pnpm -r --parallel run test",

--- a/javascript/src/__tests__/features.ts
+++ b/javascript/src/__tests__/features.ts
@@ -34,3 +34,7 @@ function featurePath(name: string): string {
 }
 
 export const VOICE_AGENTS_FEATURE = featurePath("voice-agents.feature");
+
+export const CONNECTED_AGENT_ADAPTER_FEATURE = featurePath(
+  "connected-agent-adapter.feature"
+);

--- a/javascript/src/agents/__tests__/connected-agent.test.ts
+++ b/javascript/src/agents/__tests__/connected-agent.test.ts
@@ -13,6 +13,7 @@ import { CONNECTED_AGENT_ADAPTER_FEATURE } from "../../__tests__/features";
 import {
   AgentRole,
   isConnectedAgent,
+  resolveAgentName,
   type AgentAdapter,
   type AgentInput,
   type AgentReturnTypes,
@@ -299,6 +300,29 @@ describeFeature(feature, ({ Background, Scenario }) => {
     });
     Then("the function receives no parameter and uses its own default", () => {
       expect(fake.calls[0]?.params).toEqual({});
+    });
+  });
+
+  Scenario("A run reports the connected agent under the name of the function", ({ Given, When, Then, And }) => {
+    let fake: Fake;
+    let resolved: AgentAdapter[];
+
+    Given("a scenario with the decorated function in its agents list", () => {
+      fake = makeFake("support-agent");
+    });
+    When("the scenario run starts", () => {
+      resolved = resolveAgents([fake.agent], {});
+    });
+    Then("the run reports the agent under the name the decorator gave the function", () => {
+      expect(resolveAgentName(resolved[0] as AgentAdapter)).toBe("support-agent");
+    });
+    And("it does not report the name of the wrapper class", () => {
+      expect(resolveAgentName(resolved[0] as AgentAdapter)).not.toBe("ConnectedAgentAdapter");
+    });
+    And("both SDKs report the same name for the same function", () => {
+      // The Python twin asserts the same in
+      // python/tests/test_connected_agent_adapter.py, class TestReportedName.
+      expect(resolved[0]?.name).toBe("support-agent");
     });
   });
 });

--- a/javascript/src/agents/__tests__/connected-agent.test.ts
+++ b/javascript/src/agents/__tests__/connected-agent.test.ts
@@ -20,6 +20,9 @@ import {
   type ConnectedAgentCall,
   type ConnectedAgentFunction,
 } from "../../domain";
+import { ScenarioEventType, type ScenarioRunStartedEvent } from "../../events";
+import { ScenarioExecution } from "../../execution/scenario-execution";
+import { agent as agentStep, succeed, user } from "../../script";
 import { ConnectedAgentAdapter, readReply, resolveAgents } from "../connected-agent";
 
 const feature = await loadFeature(CONNECTED_AGENT_ADAPTER_FEATURE);
@@ -87,6 +90,14 @@ function makeInput(overrides: Partial<AgentInput> = {}): AgentInput {
   };
 }
 
+const scriptedUser: AgentAdapter = {
+  name: "scripted-user",
+  role: AgentRole.USER,
+  async call(): Promise<AgentReturnTypes> {
+    throw new Error("the script supplies every user message");
+  },
+};
+
 const plainAdapter: AgentAdapter = {
   name: "plain",
   role: AgentRole.AGENT,
@@ -94,6 +105,32 @@ const plainAdapter: AgentAdapter = {
     return "plain";
   },
 };
+
+/** The agents a real run reports, from the started event it emits. */
+async function runStartedAgents(
+  agent: ConnectedAgentFunction,
+): Promise<{ name: string; role: string }[]> {
+  const execution = new ScenarioExecution(
+    {
+      name: "connected agent name",
+      description: "the run reports the agent it runs",
+      agents: [agent, scriptedUser],
+    },
+    [user("hello"), agentStep(), succeed()],
+    "test-batch-id",
+  );
+
+  const started: ScenarioRunStartedEvent[] = [];
+  execution.events$.subscribe((event) => {
+    if (event.type === ScenarioEventType.RUN_STARTED) {
+      started.push(event as ScenarioRunStartedEvent);
+    }
+  });
+  await execution.execute();
+
+  expect(started.length).toBeGreaterThan(0);
+  return (started[0]!.metadata as { agents: { name: string; role: string }[] }).agents;
+}
 
 describeFeature(feature, ({ Background, Scenario }) => {
   Background(({ Given, And }) => {
@@ -305,24 +342,28 @@ describeFeature(feature, ({ Background, Scenario }) => {
 
   Scenario("A run reports the connected agent under the name of the function", ({ Given, When, Then, And }) => {
     let fake: Fake;
-    let resolved: AgentAdapter[];
+    let reported: { name: string; role: string }[];
 
     Given("a scenario with the decorated function in its agents list", () => {
       fake = makeFake("support-agent");
     });
-    When("the scenario run starts", () => {
-      resolved = resolveAgents([fake.agent], {});
+    When("the scenario run starts", async () => {
+      // The whole path runs: the execution wraps the function, the run starts,
+      // and the started event carries what the platform reads.
+      reported = await runStartedAgents(fake.agent);
     });
     Then("the run reports the agent under the name the decorator gave the function", () => {
-      expect(resolveAgentName(resolved[0] as AgentAdapter)).toBe("support-agent");
+      expect(reported[0]).toEqual({ name: "support-agent", role: "agent" });
     });
     And("it does not report the name of the wrapper class", () => {
-      expect(resolveAgentName(resolved[0] as AgentAdapter)).not.toBe("ConnectedAgentAdapter");
+      expect(reported[0]?.name).not.toBe("ConnectedAgentAdapter");
     });
     And("both SDKs report the same name for the same function", () => {
-      // The Python twin asserts the same in
+      // The Python twin asserts the same on its own run in
       // python/tests/test_connected_agent_adapter.py, class TestReportedName.
-      expect(resolved[0]?.name).toBe("support-agent");
+      expect(resolveAgentName(resolveAgents([fake.agent], {})[0] as AgentAdapter)).toBe(
+        "support-agent",
+      );
     });
   });
 });

--- a/javascript/src/agents/__tests__/connected-agent.test.ts
+++ b/javascript/src/agents/__tests__/connected-agent.test.ts
@@ -1,0 +1,304 @@
+/**
+ * `scenario.run` accepts the function `connectAgent` returns.
+ *
+ * Binds `specs/connected-agent-adapter.feature`. The decorated function is
+ * replaced by a fake with the same duck-typed shape: a function with a
+ * `name` and an `environment`. No network and no LangWatch connection.
+ */
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import type { ModelMessage } from "ai";
+import { expect } from "vitest";
+
+import { CONNECTED_AGENT_ADAPTER_FEATURE } from "../../__tests__/features";
+import {
+  AgentRole,
+  isConnectedAgent,
+  type AgentAdapter,
+  type AgentInput,
+  type AgentReturnTypes,
+  type ConnectedAgentCall,
+  type ConnectedAgentFunction,
+} from "../../domain";
+import { ConnectedAgentAdapter, readReply, resolveAgents } from "../connected-agent";
+
+const feature = await loadFeature(CONNECTED_AGENT_ADAPTER_FEATURE);
+
+/** A fake with the SDK's own call and reply types, so assignability is checked at compile time. */
+interface SdkMessage {
+  role: string;
+  content?: unknown;
+  [key: string]: unknown;
+}
+interface SdkDirectCall<P> {
+  messages: SdkMessage[];
+  newMessages?: SdkMessage[];
+  threadId?: string;
+  session?: unknown;
+  params?: Partial<P>;
+  traceId?: string;
+}
+interface SdkResult {
+  output: string | SdkMessage | SdkMessage[];
+  session?: unknown;
+}
+interface SdkConnectedAgent<P> {
+  (call: SdkDirectCall<P>): Promise<SdkResult>;
+  readonly name: string;
+  readonly environment: string;
+  readonly parameters: Record<string, unknown>;
+  disconnect: () => Promise<void>;
+}
+
+interface Fake {
+  agent: SdkConnectedAgent<{ model: string }>;
+  calls: SdkDirectCall<{ model: string }>[];
+  replies: unknown[];
+}
+
+function makeFake(name = "support-agent"): Fake {
+  const calls: SdkDirectCall<{ model: string }>[] = [];
+  const replies: unknown[] = [];
+  const invoke = async (call: SdkDirectCall<{ model: string }>): Promise<SdkResult> => {
+    calls.push(call);
+    const reply = replies.length > 0 ? replies.shift() : `turn ${calls.length}`;
+    return reply as SdkResult;
+  };
+  const agent = Object.assign(invoke, {
+    environment: "development",
+    parameters: {},
+    disconnect: async () => undefined,
+  });
+  Object.defineProperty(agent, "name", { value: name, configurable: true });
+  return { agent: agent as SdkConnectedAgent<{ model: string }>, calls, replies };
+}
+
+function makeInput(overrides: Partial<AgentInput> = {}): AgentInput {
+  const messages: ModelMessage[] = [{ role: "user", content: "hello" }];
+  return {
+    threadId: "thread-1",
+    messages,
+    newMessages: messages,
+    requestedRole: AgentRole.AGENT,
+    propagationHeaders: {},
+    scenarioState: {} as AgentInput["scenarioState"],
+    scenarioConfig: {} as AgentInput["scenarioConfig"],
+    ...overrides,
+  };
+}
+
+const plainAdapter: AgentAdapter = {
+  name: "plain",
+  role: AgentRole.AGENT,
+  async call(): Promise<AgentReturnTypes> {
+    return "plain";
+  },
+};
+
+describeFeature(feature, ({ Background, Scenario }) => {
+  Background(({ Given, And }) => {
+    Given("a function decorated with the LangWatch connect agent decorator", () => {
+      expect(typeof makeFake().agent).toBe("function");
+    });
+    And("the decorated object is callable and exposes the connected agent shape", () => {
+      expect(isConnectedAgent(makeFake().agent)).toBe(true);
+    });
+  });
+
+  Scenario(
+    "The decorated function is accepted as an agent without an adapter subclass",
+    ({ Given, When, Then, And }) => {
+      let fake: Fake;
+      let resolved: AgentAdapter[];
+
+      Given("a scenario with the decorated function in its agents list", () => {
+        fake = makeFake();
+      });
+      When("the scenario resolves its agents", () => {
+        // The SDK type is accepted where the duck-typed shape is declared.
+        const accepted: ConnectedAgentFunction = fake.agent;
+        resolved = resolveAgents([accepted, plainAdapter], { model: "gpt-5-mini" });
+      });
+      Then("the decorated function is wrapped into an agent adapter with the AGENT role", () => {
+        expect(resolved[0]).toBeInstanceOf(ConnectedAgentAdapter);
+        expect(resolved[0]?.role).toBe(AgentRole.AGENT);
+        expect(resolved[0]?.name).toBe("support-agent");
+        expect(isConnectedAgent(fake.agent)).toBe(true);
+        expect(isConnectedAgent(plainAdapter)).toBe(false);
+        expect(isConnectedAgent(() => "hi")).toBe(false);
+      });
+      And("an agent adapter in the same list is passed through unchanged", () => {
+        expect(resolved[1]).toBe(plainAdapter);
+      });
+    },
+  );
+
+  Scenario("The wrapper builds the connected call from the scenario input", ({ Given, When, Then, And }) => {
+    const fake = makeFake();
+    const adapter = new ConnectedAgentAdapter(fake.agent);
+    const messages: ModelMessage[] = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "reply" },
+      { role: "user", content: "second" },
+    ];
+    const traceId = "0af7651916cd43dd8448eb211c80319c";
+    let input: AgentInput;
+
+    Given("the scenario calls the wrapped agent with messages, new messages and a thread id", () => {
+      input = makeInput({
+        threadId: "thread-7",
+        messages,
+        newMessages: messages.slice(2),
+        propagationHeaders: { traceparent: `00-${traceId}-b7ad6b7169203331-01` },
+      });
+    });
+    When("the wrapper invokes the decorated function", async () => {
+      await adapter.call(input);
+    });
+    Then("the function receives the full messages and the new messages", () => {
+      expect(fake.calls[0]?.messages).toEqual(messages);
+      expect(fake.calls[0]?.newMessages).toEqual(messages.slice(2));
+    });
+    And("the function receives the scenario thread id", () => {
+      expect(fake.calls[0]?.threadId).toBe("thread-7");
+    });
+    And("the function receives the trace id of the current turn", () => {
+      expect(fake.calls[0]?.traceId).toBe(traceId);
+    });
+    And("the session is null on the first turn of a thread", () => {
+      expect(fake.calls[0]?.session).toBeNull();
+    });
+  });
+
+  Scenario("A string reply becomes the agent's message", ({ When, Then }) => {
+    const fake = makeFake();
+    let output: AgentReturnTypes;
+    When("the decorated function returns a string", async () => {
+      fake.replies.push("hello there");
+      output = await new ConnectedAgentAdapter(fake.agent).call(makeInput());
+    });
+    Then("the scenario receives that string", () => {
+      expect(output).toBe("hello there");
+    });
+  });
+
+  Scenario("A single message reply is returned as is", ({ When, Then }) => {
+    const fake = makeFake();
+    const message: ModelMessage = { role: "assistant", content: "one message" };
+    let output: AgentReturnTypes;
+    When("the decorated function returns one message", async () => {
+      fake.replies.push(message);
+      output = await new ConnectedAgentAdapter(fake.agent).call(makeInput());
+    });
+    Then("the scenario receives that message", () => {
+      expect(output).toEqual(message);
+    });
+  });
+
+  Scenario("A list of messages reply is returned as is", ({ When, Then }) => {
+    const fake = makeFake();
+    const messages: ModelMessage[] = [
+      { role: "assistant", content: "step one" },
+      { role: "assistant", content: "step two" },
+    ];
+    let output: AgentReturnTypes;
+    When("the decorated function returns a list of messages", async () => {
+      fake.replies.push(messages);
+      output = await new ConnectedAgentAdapter(fake.agent).call(makeInput());
+    });
+    Then("the scenario receives that list", () => {
+      expect(output).toEqual(messages);
+    });
+  });
+
+  Scenario("An output with session reply is unwrapped", ({ When, Then }) => {
+    const fake = makeFake();
+    const adapter = new ConnectedAgentAdapter(fake.agent);
+    let output: AgentReturnTypes;
+    When("the decorated function returns an output with a session", async () => {
+      fake.replies.push({ output: "wrapped", session: { cursor: 1 } });
+      output = await adapter.call(makeInput());
+    });
+    Then("the scenario receives the output alone", () => {
+      expect(output).toBe("wrapped");
+      expect(adapter.sessionFor("thread-1")).toEqual({ cursor: 1 });
+      expect(readReply(null)).toEqual({ output: "", session: undefined });
+      expect(readReply(42)).toEqual({ output: "42", session: undefined });
+      expect(readReply({ output: undefined, session: "s" })).toEqual({ output: "", session: "s" });
+    });
+  });
+
+  Scenario(
+    "The session from one turn arrives on the next turn of the same thread",
+    ({ Given, When, Then, And }) => {
+      const fake = makeFake();
+      const adapter = new ConnectedAgentAdapter(fake.agent);
+
+      Given("the decorated function returned a session on the first turn of a thread", async () => {
+        fake.replies.push({ output: "first", session: { conversation: "abc" } });
+        await adapter.call(makeInput({ threadId: "thread-a" }));
+      });
+      When("the wrapper invokes the decorated function for the second turn of that thread", async () => {
+        await adapter.call(makeInput({ threadId: "thread-a" }));
+      });
+      Then("the function receives that session", () => {
+        expect(fake.calls[0]?.session).toBeNull();
+        expect(fake.calls[1]?.session).toEqual({ conversation: "abc" });
+      });
+      And("a turn on another thread receives no session", async () => {
+        await adapter.call(makeInput({ threadId: "thread-b" }));
+        expect(fake.calls[2]?.session).toBeNull();
+      });
+    },
+  );
+
+  Scenario("A reply without a session keeps the session of the thread", ({ Given, And, When, Then }) => {
+    const fake = makeFake();
+    const adapter = new ConnectedAgentAdapter(fake.agent);
+
+    Given("the decorated function returned a session on the first turn of a thread", async () => {
+      fake.replies.push({ output: "first", session: "s-1" });
+      await adapter.call(makeInput());
+    });
+    And("it returned a string on the second turn", async () => {
+      fake.replies.push("plain second");
+      await adapter.call(makeInput());
+    });
+    When("the wrapper invokes the decorated function for the third turn", async () => {
+      await adapter.call(makeInput());
+    });
+    Then("the function still receives the session from the first turn", () => {
+      expect(fake.calls[2]?.session).toBe("s-1");
+    });
+  });
+
+  Scenario("Run parameters from the scenario reach the function", ({ Given, When, Then }) => {
+    const fake = makeFake();
+    let adapter: ConnectedAgentAdapter;
+    Given("a scenario that sets a run parameter", () => {
+      adapter = new ConnectedAgentAdapter(fake.agent, { model: "gpt-5-mini" });
+    });
+    When("the wrapper invokes the decorated function", async () => {
+      await adapter.call(makeInput());
+      // The function may change what it received; the next call gets a fresh copy.
+      (fake.calls[0] as ConnectedAgentCall).params.model = "changed by the function";
+      await adapter.call(makeInput());
+    });
+    Then("the function receives that parameter value", () => {
+      expect(fake.calls[1]?.params).toEqual({ model: "gpt-5-mini" });
+    });
+  });
+
+  Scenario("A run parameter the scenario does not set takes the function default", ({ Given, When, Then }) => {
+    const fake = makeFake();
+    let adapter: ConnectedAgentAdapter;
+    Given("a scenario that sets no run parameter", () => {
+      adapter = new ConnectedAgentAdapter(fake.agent);
+    });
+    When("the wrapper invokes the decorated function", async () => {
+      await adapter.call(makeInput());
+    });
+    Then("the function receives no parameter and uses its own default", () => {
+      expect(fake.calls[0]?.params).toEqual({});
+    });
+  });
+});

--- a/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
+++ b/javascript/src/agents/__tests__/realtime-adapter-key-resolution.test.ts
@@ -36,6 +36,22 @@ function mintResponse(status: number, sessionId?: string): Response {
   });
 }
 
+/**
+ * A `fetch` stand-in that answers every call with one mint response.
+ *
+ * The parameters are written out so `mock.calls` carries the URL and the
+ * request. A `vi.fn` that declares none types its calls as an empty tuple, and
+ * every read of an argument is then a type error.
+ */
+function mintFetch(status: number, sessionId?: string) {
+  return vi.fn(
+    async (
+      _input: Parameters<typeof fetch>[0],
+      _init?: Parameters<typeof fetch>[1],
+    ): Promise<Response> => mintResponse(status, sessionId),
+  );
+}
+
 function makeAdapter(
   recorded: ConnectParams[],
   overrides: Partial<ConstructorParameters<typeof RealtimeAgentAdapter>[0]> = {},
@@ -86,7 +102,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
       process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
       process.env.OPENAI_API_KEY = "vk-lw-test";
       process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
-      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      const fetchSpy = mintFetch(200, "req_abc");
       vi.stubGlobal("fetch", fetchSpy);
 
       const recorded: ConnectParams[] = [];
@@ -104,16 +120,14 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
     it("mints for the model the session was built with", async () => {
       process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
       process.env.OPENAI_API_KEY = "vk-lw-test";
-      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      const fetchSpy = mintFetch(200, "req_abc");
       vi.stubGlobal("fetch", fetchSpy);
 
       await makeAdapter([], {}, "gpt-realtime").connect();
 
       // The gateway prices and budgets against this model, so a default here
       // would bill a session that opened as something else.
-      const body = JSON.parse(
-        String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body),
-      );
+      const body = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body));
       expect(body.session.model).toBe("gpt-realtime");
     });
 
@@ -122,16 +136,14 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
       // mint for the session's model would bill something the call never used.
       process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
       process.env.OPENAI_API_KEY = "vk-lw-test";
-      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      const fetchSpy = mintFetch(200, "req_abc");
       vi.stubGlobal("fetch", fetchSpy);
 
       await makeAdapter([], {}, "gpt-realtime").connect({
         model: "gpt-realtime-mini",
       } as Parameters<RealtimeAgentAdapter["connect"]>[0]);
 
-      const body = JSON.parse(
-        String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body),
-      );
+      const body = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body));
       expect(body.session.model).toBe("gpt-realtime-mini");
     });
   });
@@ -139,7 +151,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
   describe("when the vendor answers the mint", () => {
     it("dials with the ephemeral secret but reports no session, because OpenAI names none", async () => {
       process.env.OPENAI_API_KEY = "sk-provider";
-      const fetchSpy = vi.fn(async () => mintResponse(200));
+      const fetchSpy = mintFetch(200);
       vi.stubGlobal("fetch", fetchSpy);
 
       const recorded: ConnectParams[] = [];
@@ -162,7 +174,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
       process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
       vi.stubGlobal(
         "fetch",
-        vi.fn(async () => mintResponse(404)),
+        mintFetch(404),
       );
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -183,7 +195,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
       process.env.OPENAI_API_KEY = "sk-plain";
       vi.stubGlobal(
         "fetch",
-        vi.fn(async () => mintResponse(404)),
+        mintFetch(404),
       );
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -204,7 +216,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
         process.env.OPENAI_REALTIME_API_KEY = "sk-direct-provider-key";
         vi.stubGlobal(
           "fetch",
-          vi.fn(async () => mintResponse(status)),
+          mintFetch(status),
         );
 
         const recorded: ConnectParams[] = [];
@@ -220,7 +232,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
     it("an explicit params.apiKey skips the mint entirely", async () => {
       process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
       process.env.OPENAI_API_KEY = "vk-lw-test";
-      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      const fetchSpy = mintFetch(200, "req_abc");
       vi.stubGlobal("fetch", fetchSpy);
 
       const recorded: ConnectParams[] = [];
@@ -233,7 +245,7 @@ describe("RealtimeAgentAdapter.connect credential resolution", () => {
     it("`mint: false` dials the vendor directly with no mint attempt", async () => {
       process.env.OPENAI_BASE_URL = "https://gateway.example/v1";
       process.env.OPENAI_API_KEY = "sk-plain";
-      const fetchSpy = vi.fn(async () => mintResponse(200, "req_abc"));
+      const fetchSpy = mintFetch(200, "req_abc");
       vi.stubGlobal("fetch", fetchSpy);
 
       const recorded: ConnectParams[] = [];

--- a/javascript/src/agents/connected-agent.ts
+++ b/javascript/src/agents/connected-agent.ts
@@ -89,8 +89,8 @@ export class ConnectedAgentAdapter implements AgentAdapter {
 
   async call(input: AgentInput): Promise<AgentReturnTypes> {
     const call: ConnectedAgentCall = {
-      messages: input.messages,
-      newMessages: input.newMessages,
+      messages: [...input.messages],
+      newMessages: [...input.newMessages],
       threadId: input.threadId,
       session: this.sessions.get(input.threadId) ?? null,
       params: { ...this.parameters },

--- a/javascript/src/agents/connected-agent.ts
+++ b/javascript/src/agents/connected-agent.ts
@@ -1,0 +1,116 @@
+/**
+ * A connected agent function as a scenario agent.
+ *
+ * `connectAgent` from the LangWatch SDK returns a function that is still
+ * directly callable with the turn fields of the connected agent contract:
+ * `messages`, `newMessages`, `threadId`, `session`, `params` and `traceId`.
+ * This module wraps it into an {@link AgentAdapter}, so
+ * `scenario.run({ agents: [...] })` accepts it directly and the local test
+ * and the platform run share one piece of code for the agent.
+ *
+ * @see specs/connected-agent-adapter.feature
+ */
+import type { ModelMessage } from "ai";
+import {
+  AgentAdapter,
+  AgentRole,
+  isConnectedAgent,
+  type AgentInput,
+  type AgentReturnTypes,
+  type ConnectedAgentCall,
+  type ConnectedAgentFunction,
+  type ConnectedAgentParameterValue,
+} from "../domain";
+
+/** The trace id of a W3C `traceparent` header, empty when there is none. */
+export function traceIdFromHeaders(headers: Record<string, string> | undefined): string {
+  const traceparent = headers?.traceparent;
+  if (typeof traceparent !== "string") return "";
+  const parts = traceparent.split("-");
+  return parts.length >= 3 && parts[1]?.length === 32 ? parts[1] : "";
+}
+
+const isMessage = (value: unknown): value is ModelMessage =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  typeof (value as { role?: unknown }).role === "string";
+
+/**
+ * The output and the session of one reply. Accepts a string, one message, a
+ * list of messages, or `{ output, session }`. The session is `undefined`
+ * when the reply carries none.
+ */
+export function readReply(reply: unknown): { output: AgentReturnTypes; session: unknown } {
+  let output: unknown = reply;
+  let session: unknown = undefined;
+  if (typeof reply === "object" && reply !== null && !Array.isArray(reply) && "output" in reply) {
+    const wrapped = reply as { output: unknown; session?: unknown };
+    output = wrapped.output;
+    session = wrapped.session;
+  }
+  if (output === null || output === undefined) return { output: "", session };
+  if (typeof output === "string") return { output, session };
+  if (Array.isArray(output)) return { output: output.filter(isMessage), session };
+  if (isMessage(output)) return { output, session };
+  return { output: String(output), session };
+}
+
+/**
+ * Runs a connected agent function as the agent under test.
+ *
+ * Builds the connected call from the scenario's {@link AgentInput}, keeps the
+ * `session` the function returns per thread, and sends it back on the next
+ * turn of the same thread, the same echo the platform does.
+ */
+export class ConnectedAgentAdapter implements AgentAdapter {
+  readonly name: string;
+  readonly role = AgentRole.AGENT;
+  readonly parameters: Record<string, ConnectedAgentParameterValue>;
+  private readonly sessions = new Map<string, unknown>();
+
+  constructor(
+    readonly agent: ConnectedAgentFunction,
+    parameters?: Record<string, ConnectedAgentParameterValue>,
+  ) {
+    if (!isConnectedAgent(agent)) {
+      throw new Error(
+        "ConnectedAgentAdapter expects the function connectAgent returns: a function with a name and an environment",
+      );
+    }
+    this.name = agent.name;
+    this.parameters = { ...parameters };
+  }
+
+  /** The session held for a thread, `undefined` before the first reply. */
+  sessionFor(threadId: string): unknown {
+    return this.sessions.get(threadId);
+  }
+
+  async call(input: AgentInput): Promise<AgentReturnTypes> {
+    const call: ConnectedAgentCall = {
+      messages: input.messages,
+      newMessages: input.newMessages,
+      threadId: input.threadId,
+      session: this.sessions.get(input.threadId) ?? null,
+      params: { ...this.parameters },
+      traceId: traceIdFromHeaders(input.propagationHeaders),
+    };
+    const invoke = this.agent as unknown as (call: ConnectedAgentCall) => unknown;
+    const { output, session } = readReply(await invoke(call));
+    if (session !== undefined) {
+      this.sessions.set(input.threadId, session);
+    }
+    return output;
+  }
+}
+
+/** Every connected agent function wrapped, every adapter as is. */
+export function resolveAgents(
+  agents: ReadonlyArray<AgentAdapter | ConnectedAgentFunction>,
+  parameters?: Record<string, ConnectedAgentParameterValue>,
+): AgentAdapter[] {
+  return agents.map((agent) =>
+    isConnectedAgent(agent) ? new ConnectedAgentAdapter(agent, parameters) : agent,
+  );
+}

--- a/javascript/src/agents/index.ts
+++ b/javascript/src/agents/index.ts
@@ -3,4 +3,5 @@ export * from "./types";
 export * from "./user-simulator-agent";
 export * from "./realtime";
 export * from "./claude-code";
+export * from "./connected-agent";
 export * from "./red-team";

--- a/javascript/src/domain/agents/connected-agent.types.ts
+++ b/javascript/src/domain/agents/connected-agent.types.ts
@@ -1,0 +1,54 @@
+/**
+ * The shape `connectAgent` from the LangWatch SDK returns, as `scenario.run`
+ * accepts it. Types only: nothing here imports the SDK, the accept is duck
+ * typed on `name` and `environment`.
+ *
+ * @see specs/connected-agent-adapter.feature
+ */
+import type { ModelMessage } from "ai";
+
+/** The value of one run parameter. */
+export type ConnectedAgentParameterValue = string | number | boolean;
+
+/** One turn as the connected agent contract sends it. */
+export interface ConnectedAgentCall {
+  /** The full conversation. */
+  messages: ModelMessage[];
+  /** The messages added since the last turn of this thread. */
+  newMessages: ModelMessage[];
+  /** The scenario thread id. */
+  threadId: string;
+  /** The session the function returned on the previous turn of this thread, null on the first. */
+  session: unknown;
+  /** The run parameters the scenario sets. A parameter not set here takes the function default. */
+  params: Record<string, ConnectedAgentParameterValue>;
+  /** The trace id of the current turn, empty when no span is active. */
+  traceId: string;
+}
+
+/** What the function may return: a string, one message, or a list of messages. */
+export type ConnectedAgentOutput = string | ModelMessage | ModelMessage[];
+
+/** The output of one turn plus the session the function keeps for the next turn of the thread. */
+export interface ConnectedAgentReply {
+  output: ConnectedAgentOutput;
+  session?: unknown;
+}
+
+/**
+ * The decorated function: callable with a {@link ConnectedAgentCall}, with a
+ * `name` and an `environment`. The call signature is left open because the
+ * SDK types the call by the parameters the agent declares.
+ */
+export interface ConnectedAgentFunction {
+  (...args: never[]): unknown;
+  readonly name: string;
+  readonly environment: string;
+}
+
+/** True for a function with a string `name` and a string `environment`. */
+export function isConnectedAgent(value: unknown): value is ConnectedAgentFunction {
+  if (typeof value !== "function") return false;
+  const candidate = value as { name?: unknown; environment?: unknown };
+  return typeof candidate.name === "string" && typeof candidate.environment === "string";
+}

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -3,6 +3,7 @@ import { ScenarioExecutionStateLike } from "../core/execution";
 import { ScenarioConfig } from "../scenarios";
 import { AgentReturnTypes } from "./types/agent-return.types";
 export * from "./types/agent-return.types";
+export * from "./connected-agent.types";
 export {
   isRealtimeUserAgent,
   isVoiceUserSim,

--- a/javascript/src/domain/agents/index.ts
+++ b/javascript/src/domain/agents/index.ts
@@ -161,7 +161,21 @@ export abstract class AgentAdapter {
  *
  * Only a string counts as a name. A test double built by a mocking library
  * answers every property with a function, and a JavaScript caller can set any
- * value, so the type says less here than it does elsewhere.
+ * value, so the type says less here than it does elsewhere. Reading a name
+ * raises nothing, whatever the adapter carries.
+ *
+ * @param agent - The adapter that takes part in the run. Its `name` may come
+ *   from the class body, from the instance, or not at all.
+ * @returns The name to report, or `undefined` when the adapter carries no
+ *   usable name: a blank name on a plain object, or an anonymous class.
+ *
+ * @example
+ * ```ts
+ * class SupportAgent extends AgentAdapter {}
+ * resolveAgentName(new SupportAgent());              // "SupportAgent"
+ * resolveAgentName({ name: "  Support  ", ... });    // "Support"
+ * resolveAgentName({ role: AgentRole.AGENT, ... });  // undefined
+ * ```
  */
 export function resolveAgentName(agent: AgentAdapter): string | undefined {
   const explicit = nameFrom(agent.name);

--- a/javascript/src/domain/scenarios/index.ts
+++ b/javascript/src/domain/scenarios/index.ts
@@ -2,6 +2,10 @@ import { ModelMessage } from "ai";
 import type { AudioChunk } from "../../voice/audio-chunk";
 import type { VoiceConfig } from "../../voice/config";
 import type { VoiceEvent } from "../../voice/recording.types";
+import type {
+  ConnectedAgentFunction,
+  ConnectedAgentParameterValue,
+} from "../agents/connected-agent.types";
 import { AgentAdapter } from "../agents/index";
 import { ScenarioExecutionStateLike, ScenarioResult } from "../core/execution";
 
@@ -41,9 +45,16 @@ export interface ScenarioConfig {
   description: string;
 
   /**
-   * The agents participating in the scenario.
+   * The agents participating in the scenario. An {@link AgentAdapter}, or
+   * the function `connectAgent` from the LangWatch SDK returns, which runs
+   * as the agent under test with no adapter.
    */
-  agents: AgentAdapter[];
+  agents: (AgentAdapter | ConnectedAgentFunction)[];
+  /**
+   * Run parameters for the connected agent functions in {@link agents}.
+   * A parameter not set here takes the default the function declares.
+   */
+  parameters?: Record<string, ConnectedAgentParameterValue>;
   /**
    * The script of steps to execute for the scenario.
    */
@@ -207,9 +218,11 @@ export interface ScenarioConfig {
 export interface ScenarioConfigFinal
   extends Omit<
     ScenarioConfig,
-    "id" | "script" | "threadId" | "verbose" | "maxTurns"
+    "id" | "agents" | "script" | "threadId" | "verbose" | "maxTurns"
   > {
   id: string;
+  /** Every agent as an adapter: connected agent functions are wrapped by then. */
+  agents: AgentAdapter[];
   script: ScriptStep[];
 
   verbose: boolean;

--- a/javascript/src/events/event-reporter.ts
+++ b/javascript/src/events/event-reporter.ts
@@ -102,10 +102,10 @@ export class EventReporter {
    *   - other   → JSON.stringify-ed defensively (kept from PR #42's original
    *     coercion for AG-UI's string-typed content).
    *
-   *   AG-UI's `MessagesSnapshotEventSchema` types message `content` as
-   *   `string`, but post-180bab4 it carries arrays at runtime — the same
-   *   mismatch 180bab4 bridges with a cast at the conversion boundary. We cast
-   *   back here.
+   *   AG-UI declares a `content` type per message role: a string for most of
+   *   them, a record for an activity message. Normalisation answers the
+   *   wire-safe value for every role, which no single role's declared type
+   *   covers, so the rebuilt list is cast back to the event's own type once.
    */
   private processEventForApi(event: ScenarioEvent): ScenarioEvent {
     if (event.type === ScenarioEventType.MESSAGE_SNAPSHOT) {
@@ -113,12 +113,8 @@ export class EventReporter {
         ...event,
         messages: event.messages.map((message) => ({
           ...message,
-          // AG-UI types `content` as `string`; the normalised value may be an
-          // array (runtime audio content) or `undefined` (optional assistant
-          // content). Cast at the boundary like 180bab4's converter — the
-          // ingest schema accepts the union via `chatMessageSchema.content`.
-          content: normalizeMessageContent(message.content) as unknown as string,
-        })),
+          content: normalizeMessageContent(message.content),
+        })) as typeof event.messages,
       };
     }
     return event;
@@ -132,23 +128,19 @@ export class EventReporter {
  * ingest extractor can walk them and externalise inline `input_audio` — see
  * `processEventForApi`). Any other runtime shape is JSON.stringify-ed.
  *
- * AG-UI types `content` as `string`; arrays only appear at runtime
- * (post-180bab4), so the return is cast back to `string` at this boundary. The
- * runtime payload is valid per the ingest `chatMessageSchema.content` union of
- * string and array.
+ * The parameter and the return are `unknown` because the value crosses roles:
+ * AG-UI declares a string for most message roles and a record for an activity
+ * message, and arrays appear at runtime (post-180bab4). The runtime payload is
+ * valid per the ingest `chatMessageSchema.content` union of string and array.
  */
-function normalizeMessageContent(
-  content: string | undefined
-): string | undefined {
-  const runtimeContent = content as unknown;
-
+function normalizeMessageContent(content: unknown): unknown {
   if (
-    runtimeContent == null ||
-    typeof runtimeContent === "string" ||
-    Array.isArray(runtimeContent)
+    content == null ||
+    typeof content === "string" ||
+    Array.isArray(content)
   ) {
-    return runtimeContent as string | undefined;
+    return content;
   }
 
-  return JSON.stringify(runtimeContent);
+  return JSON.stringify(content);
 }

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -8,6 +8,7 @@ import {
   ScenarioExecutionState,
   StateChangeEventType,
 } from "./scenario-execution-state";
+import { resolveAgents } from "../agents/connected-agent";
 import { getGlobalSettings } from "../config/configure";
 import {
   type ScenarioResult,
@@ -392,7 +393,7 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
       id: config.id ?? generateScenarioId(),
       name: config.name,
       description: config.description,
-      agents: config.agents,
+      agents: resolveAgents(config.agents, config.parameters),
       script: script,
       verbose: config.verbose ?? DEFAULT_VERBOSE,
       maxTurns,

--- a/javascript/src/runner/run.ts
+++ b/javascript/src/runner/run.ts
@@ -9,6 +9,7 @@
  */
 import { AssistantContent, ToolContent, ModelMessage } from "ai";
 import { Subscription } from "rxjs";
+import { resolveAgents } from "../agents/connected-agent";
 import { judgeSpanCollector } from "../agents/judge/judge-span-collector";
 import { getEnv } from "../config";
 import { getProjectConfig } from "../config/get-project-config";
@@ -115,11 +116,17 @@ export async function run(cfg: ScenarioConfig, options?: RunOptions): Promise<Sc
   if (cfg.agents.length === 0) {
     throw new Error("At least one agent is required");
   }
-  if (!cfg.agents.find((agent) => agent.role === AgentRole.AGENT)) {
+
+  // A connected agent function runs as the agent under test; it is wrapped
+  // once here so every later reader of `cfg.agents` sees adapters only.
+  const agents = resolveAgents(cfg.agents, cfg.parameters);
+  cfg.agents = agents;
+
+  if (!agents.find((agent) => agent.role === AgentRole.AGENT)) {
     throw new Error("At least one non-user/non-judge agent is required");
   }
 
-  cfg.agents.forEach((agent, i) => {
+  agents.forEach((agent, i) => {
     if (!allAgentRoles.includes(agent.role)) {
       throw new Error(`Agent ${i} has invalid role: ${agent.role}`);
     }

--- a/python/scenario/__init__.py
+++ b/python/scenario/__init__.py
@@ -114,6 +114,7 @@ from ._tracing.live import RealtimeLangWatchSession as realtime_langwatch_sessio
 from .scenario_executor import run, arun
 from .scenario_state import ScenarioState
 from .agent_adapter import AgentAdapter
+from .connected_agent import ConnectedAgentAdapter, ConnectedAgentCall
 from .judge_agent import JudgeAgent
 from .user_simulator_agent import UserSimulatorAgent
 from .red_team_agent import RedTeamAgent
@@ -260,6 +261,8 @@ __all__ = [
     # Classes
     "ScenarioState",
     "AgentAdapter",
+    "ConnectedAgentAdapter",
+    "ConnectedAgentCall",
     "UserSimulatorAgent",
     "RedTeamAgent",
     "AttackerOutput",

--- a/python/scenario/agent_adapter.py
+++ b/python/scenario/agent_adapter.py
@@ -71,7 +71,11 @@ class AgentAdapter(ABC):
         - For stateless agents, use input.messages for the full conversation history
     """
 
-    name: ClassVar[Optional[str]] = None
+    # Not a ClassVar: most adapters set the name in the class body, but an
+    # adapter that wraps something named at runtime, such as the connected
+    # agent adapter, sets it on the instance. The TypeScript SDK declares the
+    # same field on the instance.
+    name: Optional[str] = None
     role: ClassVar[AgentRole] = AgentRole.AGENT
 
     @abstractmethod

--- a/python/scenario/connected_agent.py
+++ b/python/scenario/connected_agent.py
@@ -1,0 +1,191 @@
+"""
+A connected agent function as a scenario agent.
+
+``langwatch.connect_agent`` returns an object that is still the original
+function, and that also answers ``invoke(call)`` with the turn fields of the
+connected agent contract: ``messages``, ``new_messages``, ``thread_id``,
+``session``, ``trace_id`` and the run ``parameters``. This module wraps such
+an object into an :class:`AgentAdapter`, so ``scenario.run(agents=[...])``
+accepts it directly and the local test and the platform run share one piece
+of code for the agent.
+
+The accept is duck typed. Nothing here imports the LangWatch SDK: any callable
+with a ``name`` and an awaitable ``invoke`` is a connected agent.
+
+See ``specs/connected-agent-adapter.feature``.
+"""
+
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Awaitable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    TypeGuard,
+    Union,
+    cast,
+    runtime_checkable,
+)
+
+from .agent_adapter import AgentAdapter
+from .types import AgentInput, AgentReturnTypes, AgentRole
+
+
+@dataclass
+class ConnectedAgentCall:
+    """One turn as the connected agent contract sends it.
+
+    The attribute names match the ``AgentCall`` of the LangWatch SDK, so the
+    decorated function reads the same fields locally and on the platform.
+    """
+
+    messages: List[Any]
+    new_messages: List[Any] = field(default_factory=list)
+    thread_id: str = ""
+    session: Any = None
+    trace_id: Optional[str] = None
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+    def turn_fields(self) -> Dict[str, Any]:
+        return {
+            "messages": self.messages,
+            "new_messages": self.new_messages,
+            "thread_id": self.thread_id,
+            "session": self.session,
+            "trace_id": self.trace_id,
+        }
+
+
+@runtime_checkable
+class ConnectedAgentLike(Protocol):
+    """The shape ``langwatch.connect_agent`` returns.
+
+    ``invoke`` receives a :class:`ConnectedAgentCall` and returns the reply:
+    a string, one message, a list of messages, or an object with ``output``
+    and ``session``.
+    """
+
+    name: str
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def invoke(self, call: Any) -> Awaitable[Any]: ...
+
+
+AgentLike = Union[AgentAdapter, ConnectedAgentLike]
+
+
+def is_connected_agent(value: Any) -> TypeGuard[ConnectedAgentLike]:
+    """True for a callable with a string ``name`` and a callable ``invoke``."""
+    return (
+        not isinstance(value, AgentAdapter)
+        and callable(value)
+        and isinstance(getattr(value, "name", None), str)
+        and callable(getattr(value, "invoke", None))
+    )
+
+
+def trace_id_from_headers(headers: Mapping[str, str]) -> Optional[str]:
+    """The trace id of a W3C ``traceparent`` header, or None."""
+    traceparent = headers.get("traceparent")
+    if not isinstance(traceparent, str):
+        return None
+    parts = traceparent.split("-")
+    if len(parts) >= 3 and len(parts[1]) == 32:
+        return parts[1]
+    return None
+
+
+def read_reply(reply: Any) -> Tuple[AgentReturnTypes, Any]:
+    """The output and the session of one reply.
+
+    Accepts a string, one message, a list of messages, a mapping with an
+    ``output`` key, or an object with an ``output`` attribute (the SDK's
+    ``AgentReply``). The session is None when the reply carries none.
+    """
+    session: Any = None
+    output: Any = reply
+    if isinstance(reply, Mapping) and "output" in reply:
+        output = reply["output"]
+        session = reply.get("session")
+    elif not isinstance(reply, (str, list, tuple, Mapping)) and hasattr(
+        reply, "output"
+    ):
+        output = getattr(reply, "output")
+        session = getattr(reply, "session", None)
+
+    if output is None:
+        output = ""
+    elif isinstance(output, tuple):
+        output = list(output)
+    elif not isinstance(output, (str, list, Mapping)):
+        output = str(output)
+    return cast(AgentReturnTypes, output), session
+
+
+class ConnectedAgentAdapter(AgentAdapter):
+    """Runs a connected agent function as the agent under test.
+
+    Builds the connected call from the scenario's :class:`AgentInput`, keeps
+    the ``session`` the function returns per thread, and sends it back on the
+    next turn of the same thread, the same echo the platform does.
+
+    Args:
+        agent: The decorated function.
+        parameters: The run parameters for every call. A parameter that is
+            not set here takes the default the function declares.
+    """
+
+    role = AgentRole.AGENT
+
+    def __init__(
+        self,
+        agent: ConnectedAgentLike,
+        parameters: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        if not is_connected_agent(agent):
+            raise TypeError(
+                "ConnectedAgentAdapter expects the object langwatch.connect_agent "
+                "returns: a callable with a name and an invoke method"
+            )
+        self.agent = agent
+        self.name = agent.name
+        self.parameters: Dict[str, Any] = dict(parameters or {})
+        self._sessions: Dict[str, Any] = {}
+
+    def session_for(self, thread_id: str) -> Any:
+        """The session held for a thread, None before the first reply."""
+        return self._sessions.get(thread_id)
+
+    async def call(self, input: AgentInput) -> AgentReturnTypes:
+        call = ConnectedAgentCall(
+            messages=list(input.messages),
+            new_messages=list(input.new_messages),
+            thread_id=input.thread_id,
+            session=self._sessions.get(input.thread_id),
+            trace_id=trace_id_from_headers(input.propagation_headers),
+            parameters=dict(self.parameters),
+        )
+        reply = await self.agent.invoke(call)
+        output, session = read_reply(reply)
+        if session is not None:
+            self._sessions[input.thread_id] = session
+        return output
+
+
+def resolve_agents(
+    agents: Sequence[AgentLike],
+    parameters: Optional[Mapping[str, Any]] = None,
+) -> List[AgentAdapter]:
+    """Every connected agent function wrapped, every adapter as is."""
+    return [
+        ConnectedAgentAdapter(agent, parameters)
+        if is_connected_agent(agent)
+        else cast(AgentAdapter, agent)
+        for agent in agents
+    ]

--- a/python/scenario/connected_agent.py
+++ b/python/scenario/connected_agent.py
@@ -72,9 +72,13 @@ class ConnectedAgentLike(Protocol):
 
     name: str
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """The original function, with its own signature."""
+        raise NotImplementedError
 
-    def invoke(self, call: Any) -> Awaitable[Any]: ...
+    def invoke(self, call: Any) -> Awaitable[Any]:
+        """Runs one turn for a :class:`ConnectedAgentCall` and returns the reply."""
+        raise NotImplementedError
 
 
 AgentLike = Union[AgentAdapter, ConnectedAgentLike]

--- a/python/scenario/scenario_executor.py
+++ b/python/scenario/scenario_executor.py
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -63,6 +64,7 @@ from .types import (
 from ._error_messages import agent_response_not_awaitable
 from .cache import context_scenario
 from .agent_adapter import AgentAdapter
+from .connected_agent import AgentLike, resolve_agents
 from .script import proceed
 from pksuid import PKSUID
 from .scenario_state import ScenarioState
@@ -177,8 +179,9 @@ class ScenarioExecutor:
         self,
         name: str,
         description: str,
-        agents: List[AgentAdapter] = [],
+        agents: Sequence[AgentLike] = [],
         script: Optional[List[ScriptStep]] = None,
+        parameters: Optional[Dict[str, Any]] = None,
         # Config
         max_turns: Optional[int] = None,
         min_turns: Optional[int] = None,
@@ -205,6 +208,9 @@ class ScenarioExecutor:
                    Typically includes: agent under test, user simulator, and judge.
             script: Optional list of script steps to control scenario flow.
                    If not provided, defaults to automatic proceeding.
+            parameters: Run parameters for connected agent functions in
+                   ``agents``. A parameter not set here takes the default
+                   the function declares.
             max_turns: Maximum number of conversation turns before timeout.
                       Overrides global configuration for this scenario.
             min_turns: Minimum turns guaranteed before the judge may volunteer
@@ -232,7 +238,7 @@ class ScenarioExecutor:
         """
         self.name = name
         self.description = description
-        self.agents = agents
+        self.agents = resolve_agents(agents, parameters)
         self.script = script or [proceed()]
         self.metadata = metadata
         self._on_audio_chunk = on_audio_chunk
@@ -1945,7 +1951,7 @@ def _build_scenario(
     *,
     name: str,
     description: str,
-    agents: List[AgentAdapter],
+    agents: Sequence[AgentLike],
     max_turns: Optional[int],
     min_turns: Optional[int],
     verbose: Optional[Union[bool, int]],
@@ -1959,6 +1965,7 @@ def _build_scenario(
     on_audio_chunk: Optional[Callable[[Any], None]] = None,
     on_voice_event: Optional[Callable[[Any], None]] = None,
     audio_playback: bool = False,
+    parameters: Optional[Dict[str, Any]] = None,
 ) -> "ScenarioExecutor":
     """Shared setup used by both ``run()`` (threaded) and ``arun()`` (async-native)."""
     from ._tracing import ensure_tracing_initialized
@@ -1983,6 +1990,7 @@ def _build_scenario(
         on_audio_chunk=on_audio_chunk,
         on_voice_event=on_voice_event,
         audio_playback=audio_playback,
+        parameters=parameters,
     )
 
 
@@ -1999,7 +2007,7 @@ def _cleanup_scenario_spans(scenario: "ScenarioExecutor") -> None:
 async def arun(
     name: str,
     description: str,
-    agents: List[AgentAdapter] = [],
+    agents: Sequence[AgentLike] = [],
     max_turns: Optional[int] = None,
     min_turns: Optional[int] = None,
     verbose: Optional[Union[bool, int]] = None,
@@ -2013,6 +2021,7 @@ async def arun(
     on_audio_chunk: Optional[Callable[[Any], None]] = None,
     on_voice_event: Optional[Callable[[Any], None]] = None,
     audio_playback: bool = False,
+    parameters: Optional[Dict[str, Any]] = None,
 ) -> ScenarioResult:
     """Async-native counterpart of :func:`run`.
 
@@ -2047,6 +2056,7 @@ async def arun(
         on_audio_chunk=on_audio_chunk,
         on_voice_event=on_voice_event,
         audio_playback=audio_playback,
+        parameters=parameters,
     )
 
     try:
@@ -2063,7 +2073,7 @@ async def arun(
 async def run(
     name: str,
     description: str,
-    agents: List[AgentAdapter] = [],
+    agents: Sequence[AgentLike] = [],
     max_turns: Optional[int] = None,
     min_turns: Optional[int] = None,
     verbose: Optional[Union[bool, int]] = None,
@@ -2077,6 +2087,7 @@ async def run(
     on_audio_chunk: Optional[Callable[[Any], None]] = None,
     on_voice_event: Optional[Callable[[Any], None]] = None,
     audio_playback: bool = False,
+    parameters: Optional[Dict[str, Any]] = None,
 ) -> ScenarioResult:
     """
     High-level interface for running a scenario test.
@@ -2118,6 +2129,10 @@ async def run(
         metadata: Optional metadata to attach to the scenario run.
                  Accepts arbitrary key-value pairs. The ``langwatch`` key
                  is reserved for platform-internal use.
+        parameters: Run parameters for the connected agent functions in
+                 ``agents`` (the objects ``langwatch.connect_agent``
+                 returns). A parameter not set here takes the default the
+                 function declares.
 
     Returns:
         ScenarioResult containing the test outcome, conversation history,
@@ -2180,6 +2195,7 @@ async def run(
         on_audio_chunk=on_audio_chunk,
         on_voice_event=on_voice_event,
         audio_playback=audio_playback,
+        parameters=parameters,
     )
 
     # We'll use a thread pool to run the execution logic, we

--- a/python/tests/test_connected_agent_adapter.py
+++ b/python/tests/test_connected_agent_adapter.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, cast
 import pytest
 
 import scenario
-from scenario.agent_adapter import AgentAdapter, resolve_agent_name
+from scenario.agent_adapter import AgentAdapter
 from scenario.connected_agent import (
     ConnectedAgentAdapter,
     ConnectedAgentCall,
@@ -20,6 +20,7 @@ from scenario.connected_agent import (
     read_reply,
     resolve_agents,
 )
+from scenario._events import ScenarioEvent, ScenarioRunStartedEvent
 from scenario.scenario_executor import ScenarioExecutor
 from scenario.types import AgentInput, AgentRole
 
@@ -133,13 +134,33 @@ class TestAccept:
 class TestReportedName:
     """Scenario: A run reports the connected agent under the name of the function."""
 
-    def test_the_run_reports_the_name_of_the_function(self):
+    @pytest.mark.asyncio
+    async def test_the_run_reports_the_name_of_the_function(self):
+        """The whole path runs: the executor wraps the function, the run starts,
+        and the started event carries the name the decorator gave it."""
         fake = FakeConnectedAgent(name="support-agent")
 
-        wrapped = resolve_agents([fake])[0]
+        executor = ScenarioExecutor(
+            name="connected agent name",
+            description="the run reports the agent it runs",
+            agents=[fake, ScriptedUser()],
+            script=[
+                scenario.user("hello"),
+                scenario.agent(),
+                scenario.succeed(),
+            ],
+        )
+        events: List[ScenarioEvent] = []
+        executor.events.subscribe(events.append)
+        await executor.run()
 
-        assert resolve_agent_name(wrapped) == "support-agent"
-        assert resolve_agent_name(wrapped) != "ConnectedAgentAdapter"
+        started = next(
+            event for event in events if isinstance(event, ScenarioRunStartedEvent)
+        )
+        agents = started.metadata.to_dict()["agents"]
+
+        assert agents[0] == {"name": "support-agent", "role": "agent"}
+        assert agents[0]["name"] != "ConnectedAgentAdapter"
 
 
 class TestConnectedCall:

--- a/python/tests/test_connected_agent_adapter.py
+++ b/python/tests/test_connected_agent_adapter.py
@@ -1,0 +1,335 @@
+"""
+``scenario.run`` accepts the object ``langwatch.connect_agent`` returns.
+
+Covers ``specs/connected-agent-adapter.feature``. The decorated object is
+replaced by a fake with the same duck-typed shape: callable, a ``name`` and
+an awaitable ``invoke``. No network and no LangWatch connection is needed.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+
+import scenario
+from scenario.agent_adapter import AgentAdapter
+from scenario.connected_agent import (
+    ConnectedAgentAdapter,
+    ConnectedAgentCall,
+    is_connected_agent,
+    read_reply,
+    resolve_agents,
+)
+from scenario.scenario_executor import ScenarioExecutor
+from scenario.types import AgentInput, AgentRole
+
+
+@dataclass
+class FakeReply:
+    """The SDK's ``AgentReply``: an output and a session."""
+
+    output: Any
+    session: Any = None
+
+
+class FakeConnectedAgent:
+    """The shape ``langwatch.connect_agent`` returns.
+
+    ``invoke`` records every call it receives and answers with the reply
+    the test queued, or with a string that names the turn.
+    """
+
+    def __init__(self, name: str = "support-agent", model: str = "gpt-5-mini"):
+        self.name = name
+        self.environment = "development"
+        self.default_model = model
+        self.calls: List[ConnectedAgentCall] = []
+        self.replies: List[Any] = []
+
+    def __call__(self, messages: List[Any], model: Optional[str] = None) -> str:
+        return f"direct:{model or self.default_model}"
+
+    async def invoke(self, call: ConnectedAgentCall) -> Any:
+        self.calls.append(call)
+        if self.replies:
+            return self.replies.pop(0)
+        return f"turn {len(self.calls)}"
+
+
+def make_input(
+    thread_id: str = "thread-1",
+    messages: Optional[List[Any]] = None,
+    new_messages: Optional[List[Any]] = None,
+    propagation_headers: Optional[Dict[str, str]] = None,
+) -> AgentInput:
+    messages = messages if messages is not None else [
+        {"role": "user", "content": "hello"}
+    ]
+    return AgentInput(
+        thread_id=thread_id,
+        messages=messages,
+        new_messages=new_messages if new_messages is not None else messages,
+        judgment_request=None,
+        scenario_state=cast(Any, None),
+        propagation_headers=propagation_headers or {},
+    )
+
+
+class PlainAdapter(AgentAdapter):
+    async def call(self, input: AgentInput) -> str:
+        return "plain"
+
+
+class ScriptedUser(AgentAdapter):
+    """Holds the USER role; every user turn of the script carries its own text."""
+
+    role = AgentRole.USER
+
+    async def call(self, input: AgentInput) -> str:
+        raise AssertionError("the script supplies every user message")
+
+
+class TestAccept:
+    """Scenario: The decorated function is accepted as an agent without an adapter subclass."""
+
+    def test_wraps_the_decorated_function_and_keeps_adapters(self):
+        fake = FakeConnectedAgent()
+        plain = PlainAdapter()
+
+        resolved = resolve_agents([fake, plain])
+
+        assert isinstance(resolved[0], ConnectedAgentAdapter)
+        assert resolved[0].role == AgentRole.AGENT
+        assert resolved[0].name == "support-agent"
+        assert resolved[1] is plain
+
+    def test_only_a_callable_with_name_and_invoke_is_connected(self):
+        assert is_connected_agent(FakeConnectedAgent())
+        assert not is_connected_agent(PlainAdapter())
+        assert not is_connected_agent(lambda messages: "hi")
+        assert not is_connected_agent("support-agent")
+
+    def test_the_decorated_function_stays_directly_callable(self):
+        fake = FakeConnectedAgent()
+        resolve_agents([fake])
+
+        assert fake([{"role": "user", "content": "hi"}]) == "direct:gpt-5-mini"
+
+    def test_the_executor_accepts_the_decorated_function(self):
+        fake = FakeConnectedAgent()
+
+        executor = ScenarioExecutor(
+            name="accept",
+            description="a connected agent function in the agents list",
+            agents=[fake, scenario.JudgeAgent(criteria=["any"], model="openai/gpt-5-mini")],
+            parameters={"model": "gpt-5-mini"},
+        )
+
+        assert isinstance(executor.agents[0], ConnectedAgentAdapter)
+        assert executor.agents[0].parameters == {"model": "gpt-5-mini"}
+        assert isinstance(executor.agents[1], scenario.JudgeAgent)
+
+
+class TestConnectedCall:
+    """Scenario: The wrapper builds the connected call from the scenario input."""
+
+    @pytest.mark.asyncio
+    async def test_the_function_receives_the_turn_fields(self):
+        fake = FakeConnectedAgent()
+        adapter = ConnectedAgentAdapter(fake)
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ]
+        trace_id = "0af7651916cd43dd8448eb211c80319c"
+
+        await adapter.call(
+            make_input(
+                thread_id="thread-7",
+                messages=messages,
+                new_messages=messages[2:],
+                propagation_headers={
+                    "traceparent": f"00-{trace_id}-b7ad6b7169203331-01"
+                },
+            )
+        )
+
+        call = fake.calls[0]
+        assert call.messages == messages
+        assert call.new_messages == messages[2:]
+        assert call.thread_id == "thread-7"
+        assert call.trace_id == trace_id
+        assert call.session is None
+        assert call.turn_fields()["thread_id"] == "thread-7"
+
+    @pytest.mark.asyncio
+    async def test_no_trace_context_means_no_trace_id(self):
+        fake = FakeConnectedAgent()
+        adapter = ConnectedAgentAdapter(fake)
+
+        await adapter.call(make_input())
+
+        assert fake.calls[0].trace_id is None
+
+
+class TestReplyShapes:
+    """Scenarios: string, single message, list of messages, output with session."""
+
+    @pytest.mark.asyncio
+    async def test_a_string_reply(self):
+        fake = FakeConnectedAgent()
+        fake.replies = ["hello there"]
+
+        assert await ConnectedAgentAdapter(fake).call(make_input()) == "hello there"
+
+    @pytest.mark.asyncio
+    async def test_a_single_message_reply(self):
+        fake = FakeConnectedAgent()
+        message = {"role": "assistant", "content": "one message"}
+        fake.replies = [message]
+
+        assert await ConnectedAgentAdapter(fake).call(make_input()) == message
+
+    @pytest.mark.asyncio
+    async def test_a_list_of_messages_reply(self):
+        fake = FakeConnectedAgent()
+        messages = [
+            {"role": "assistant", "content": "step one"},
+            {"role": "assistant", "content": "step two"},
+        ]
+        fake.replies = [messages]
+
+        assert await ConnectedAgentAdapter(fake).call(make_input()) == messages
+
+    @pytest.mark.asyncio
+    async def test_an_output_with_session_reply_is_unwrapped(self):
+        fake = FakeConnectedAgent()
+        fake.replies = [FakeReply(output="wrapped", session={"cursor": 1})]
+
+        assert await ConnectedAgentAdapter(fake).call(make_input()) == "wrapped"
+
+    @pytest.mark.asyncio
+    async def test_a_mapping_with_output_and_session_is_unwrapped(self):
+        fake = FakeConnectedAgent()
+        fake.replies = [{"output": "from a dict", "session": "s-1"}]
+        adapter = ConnectedAgentAdapter(fake)
+
+        assert await adapter.call(make_input()) == "from a dict"
+        assert adapter.session_for("thread-1") == "s-1"
+
+    def test_read_reply_coerces_none_and_scalars(self):
+        assert read_reply(None) == ("", None)
+        assert read_reply(42) == ("42", None)
+        assert read_reply(FakeReply(output=None, session="s")) == ("", "s")
+
+
+class TestSessionEcho:
+    """Scenarios: the session round trip across turns and threads."""
+
+    @pytest.mark.asyncio
+    async def test_the_session_arrives_on_the_next_turn_of_the_same_thread(self):
+        fake = FakeConnectedAgent()
+        fake.replies = [FakeReply(output="first", session={"conversation": "abc"})]
+        adapter = ConnectedAgentAdapter(fake)
+
+        await adapter.call(make_input(thread_id="thread-a"))
+        await adapter.call(make_input(thread_id="thread-a"))
+        await adapter.call(make_input(thread_id="thread-b"))
+
+        assert fake.calls[0].session is None
+        assert fake.calls[1].session == {"conversation": "abc"}
+        assert fake.calls[2].session is None
+
+    @pytest.mark.asyncio
+    async def test_a_reply_without_a_session_keeps_the_session_of_the_thread(self):
+        fake = FakeConnectedAgent()
+        fake.replies = [FakeReply(output="first", session="s-1"), "plain second"]
+        adapter = ConnectedAgentAdapter(fake)
+
+        await adapter.call(make_input())
+        await adapter.call(make_input())
+        await adapter.call(make_input())
+
+        assert fake.calls[2].session == "s-1"
+
+    @pytest.mark.asyncio
+    async def test_a_new_session_replaces_the_old_one(self):
+        fake = FakeConnectedAgent()
+        fake.replies = [
+            FakeReply(output="first", session="s-1"),
+            FakeReply(output="second", session="s-2"),
+        ]
+        adapter = ConnectedAgentAdapter(fake)
+
+        await adapter.call(make_input())
+        await adapter.call(make_input())
+        await adapter.call(make_input())
+
+        assert fake.calls[2].session == "s-2"
+
+
+class TestRunParameters:
+    """Scenarios: run parameters reach the function, or the function default applies."""
+
+    @pytest.mark.asyncio
+    async def test_parameters_from_the_scenario_reach_the_function(self):
+        fake = FakeConnectedAgent()
+        adapter = ConnectedAgentAdapter(fake, parameters={"model": "gpt-5-mini"})
+
+        await adapter.call(make_input())
+
+        assert fake.calls[0].parameters == {"model": "gpt-5-mini"}
+
+    @pytest.mark.asyncio
+    async def test_no_parameters_means_the_function_default_applies(self):
+        fake = FakeConnectedAgent()
+        adapter = ConnectedAgentAdapter(fake)
+
+        await adapter.call(make_input())
+
+        assert fake.calls[0].parameters == {}
+
+    @pytest.mark.asyncio
+    async def test_each_call_gets_its_own_copy_of_the_parameters(self):
+        fake = FakeConnectedAgent()
+        adapter = ConnectedAgentAdapter(fake, parameters={"model": "gpt-5-mini"})
+
+        await adapter.call(make_input())
+        fake.calls[0].parameters["model"] = "changed by the function"
+        await adapter.call(make_input())
+
+        assert fake.calls[1].parameters == {"model": "gpt-5-mini"}
+
+
+class TestEndToEnd:
+    """A scripted scenario runs the decorated function through ``scenario.arun``."""
+
+    @pytest.mark.asyncio
+    async def test_a_multi_turn_scenario_echoes_the_session(self):
+        fake = FakeConnectedAgent()
+        fake.replies = [
+            FakeReply(output="how can I help?", session={"ticket": 1}),
+            FakeReply(output="done", session={"ticket": 2}),
+        ]
+
+        result = await scenario.arun(
+            name="connected agent",
+            description="the user asks for help twice",
+            agents=[fake, ScriptedUser()],
+            parameters={"model": "gpt-5-mini"},
+            script=[
+                scenario.user("I need help"),
+                scenario.agent(),
+                scenario.user("one more thing"),
+                scenario.agent(),
+                scenario.succeed(),
+            ],
+        )
+
+        assert result.success
+        assert [call.session for call in fake.calls] == [None, {"ticket": 1}]
+        assert fake.calls[1].parameters == {"model": "gpt-5-mini"}
+        assert len(fake.calls[1].messages) == 3
+        assert [m["role"] for m in fake.calls[1].new_messages] == ["user"]
+        assert fake.calls[1].messages[1]["content"] == "how can I help?"

--- a/python/tests/test_connected_agent_adapter.py
+++ b/python/tests/test_connected_agent_adapter.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, cast
 import pytest
 
 import scenario
-from scenario.agent_adapter import AgentAdapter
+from scenario.agent_adapter import AgentAdapter, resolve_agent_name
 from scenario.connected_agent import (
     ConnectedAgentAdapter,
     ConnectedAgentCall,
@@ -128,6 +128,18 @@ class TestAccept:
         assert isinstance(executor.agents[0], ConnectedAgentAdapter)
         assert executor.agents[0].parameters == {"model": "gpt-5-mini"}
         assert isinstance(executor.agents[1], scenario.JudgeAgent)
+
+
+class TestReportedName:
+    """Scenario: A run reports the connected agent under the name of the function."""
+
+    def test_the_run_reports_the_name_of_the_function(self):
+        fake = FakeConnectedAgent(name="support-agent")
+
+        wrapped = resolve_agents([fake])[0]
+
+        assert resolve_agent_name(wrapped) == "support-agent"
+        assert resolve_agent_name(wrapped) != "ConnectedAgentAdapter"
 
 
 class TestConnectedCall:

--- a/specs/connected-agent-adapter.feature
+++ b/specs/connected-agent-adapter.feature
@@ -1,0 +1,70 @@
+Feature: scenario.run accepts a connected agent function
+  As a developer who connected an agent to LangWatch with the SDK decorator
+  I want to pass that decorated function straight to scenario.run
+  So that the local test and the platform run share one piece of code for the agent
+
+  Background:
+    Given a function decorated with the LangWatch connect agent decorator
+    And the decorated object is callable and exposes the connected agent shape
+
+  @unit
+  Scenario: The decorated function is accepted as an agent without an adapter subclass
+    Given a scenario with the decorated function in its agents list
+    When the scenario resolves its agents
+    Then the decorated function is wrapped into an agent adapter with the AGENT role
+    And an agent adapter in the same list is passed through unchanged
+
+  @unit
+  Scenario: The wrapper builds the connected call from the scenario input
+    Given the scenario calls the wrapped agent with messages, new messages and a thread id
+    When the wrapper invokes the decorated function
+    Then the function receives the full messages and the new messages
+    And the function receives the scenario thread id
+    And the function receives the trace id of the current turn
+    And the session is null on the first turn of a thread
+
+  @unit
+  Scenario: A string reply becomes the agent's message
+    When the decorated function returns a string
+    Then the scenario receives that string
+
+  @unit
+  Scenario: A single message reply is returned as is
+    When the decorated function returns one message
+    Then the scenario receives that message
+
+  @unit
+  Scenario: A list of messages reply is returned as is
+    When the decorated function returns a list of messages
+    Then the scenario receives that list
+
+  @unit
+  Scenario: An output with session reply is unwrapped
+    When the decorated function returns an output with a session
+    Then the scenario receives the output alone
+
+  @unit
+  Scenario: The session from one turn arrives on the next turn of the same thread
+    Given the decorated function returned a session on the first turn of a thread
+    When the wrapper invokes the decorated function for the second turn of that thread
+    Then the function receives that session
+    And a turn on another thread receives no session
+
+  @unit
+  Scenario: A reply without a session keeps the session of the thread
+    Given the decorated function returned a session on the first turn of a thread
+    And it returned a string on the second turn
+    When the wrapper invokes the decorated function for the third turn
+    Then the function still receives the session from the first turn
+
+  @unit
+  Scenario: Run parameters from the scenario reach the function
+    Given a scenario that sets a run parameter
+    When the wrapper invokes the decorated function
+    Then the function receives that parameter value
+
+  @unit
+  Scenario: A run parameter the scenario does not set takes the function default
+    Given a scenario that sets no run parameter
+    When the wrapper invokes the decorated function
+    Then the function receives no parameter and uses its own default

--- a/specs/connected-agent-adapter.feature
+++ b/specs/connected-agent-adapter.feature
@@ -68,3 +68,11 @@ Feature: scenario.run accepts a connected agent function
     Given a scenario that sets no run parameter
     When the wrapper invokes the decorated function
     Then the function receives no parameter and uses its own default
+
+  @unit
+  Scenario: A run reports the connected agent under the name of the function
+    Given a scenario with the decorated function in its agents list
+    When the scenario run starts
+    Then the run reports the agent under the name the decorator gave the function
+    And it does not report the name of the wrapper class
+    And both SDKs report the same name for the same function


### PR DESCRIPTION
Closes langwatch/scenario#953. Follows langwatch/langwatch#7655 (ADR-128, connected agents).

## What changes

`scenario.run` accepts the object the LangWatch SDK decorator returns, in Python and in TypeScript. The customer writes one function, connects it to the platform with `langwatch.connect_agent` or `connectAgent`, and passes the same function to `scenario.run` for a local test. No `AgentAdapter` subclass is needed.

The accept is duck typed. The scenario package does not import the LangWatch SDK.

- Python: a callable with a string `name` and an awaitable `invoke(call)` is a connected agent. `invoke` receives a `ConnectedAgentCall` with `messages`, `new_messages`, `thread_id`, `session`, `trace_id` and `parameters`, the same attribute names as the SDK's `AgentCall`.
- TypeScript: a function with a string `name` and a string `environment` is a connected agent. It is called with `{ messages, newMessages, threadId, session, params, traceId }`, the same object a direct call of the wrapped function takes.

`resolve_agents` / `resolveAgents` wraps each connected agent into a `ConnectedAgentAdapter` with role `AGENT` and passes every other adapter through unchanged. The wrapper:

- builds the connected call from the scenario `AgentInput`, with the trace id read from the `traceparent` propagation header;
- maps the reply back: a string, one message, a list of messages, or `{ output, session }` (the SDK's `AgentReply`);
- keeps the returned `session` per thread and sends it on the next turn of the same thread. A reply with no session keeps the session the thread has, the same rule the platform applies.

`scenario.run` gains a `parameters` option (Python `parameters=`, TypeScript `parameters:`). The values reach the function as its run parameters. A parameter the scenario does not set takes the default the function declares.

## Files

- `specs/connected-agent-adapter.feature`: the scenarios, bound by the tests in both packages.
- `python/scenario/connected_agent.py`: `ConnectedAgentCall`, `ConnectedAgentLike`, `ConnectedAgentAdapter`, `resolve_agents`. Wired in `ScenarioExecutor`, `run` and `arun`. Exported from the package root.
- `javascript/src/domain/agents/connected-agent.types.ts`: the types and `isConnectedAgent`. `javascript/src/agents/connected-agent.ts`: `ConnectedAgentAdapter`, `resolveAgents`. Wired in `run()` and in the `ScenarioExecution` constructor. `ScenarioConfig.agents` accepts `AgentAdapter | ConnectedAgentFunction`.
- One paragraph in the root README, the JavaScript README and the agent integration docs page.

## Tests

- `python/tests/test_connected_agent_adapter.py`: 19 tests with a fake decorated object. The four reply shapes, the session round trip across turns and threads, the parameter defaults, and a scripted two turn `scenario.arun` that shows the session from turn one arriving on turn two.
- `javascript/src/agents/__tests__/connected-agent.test.ts`: the feature file bound with vitest-cucumber. The fake is typed with the SDK's own `ConnectedAgent` signature, so the assignability to the duck typed shape is checked at compile time.

Run locally: `uv run pytest tests/ -m "not integration"` and `uv run pyright .` in `python/`; `pnpm build:all`, `pnpm smoke:dist`, `pnpm lint:all`, `pnpm lint:lib`, `pnpm typecheck:all` and `pnpm run test:ci` in `javascript/`.

## Note for the SDK side

No change is needed in the LangWatch SDKs for the accept. One improvement is possible on the Python side: `ConnectedAgent.bind` reads `call.turn_fields()` and passes the call object itself to a function whose first parameter is annotated `langwatch.AgentCall`. With the scenario package that function receives a `ConnectedAgentCall` with the same attributes. If `bind` built its own `AgentCall` from any object that carries the turn attributes, the function would always receive the SDK type.

https://claude.ai/code/session_015SDgxHLdJP2wp71CDu5otq
