### PR TITLE
fix(js): retry empty user simulator completion

### DIFF
--- a/javascript/src/agents/__tests__/user-simulator-empty-response.test.ts
+++ b/javascript/src/agents/__tests__/user-simulator-empty-response.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentInput } from "../../domain";
+import { userSimulatorAgent } from "../user-simulator-agent";
+
+vi.mock("../../config", () => ({
+  getProjectConfig: vi.fn().mockResolvedValue({
+    defaultModel: { model: "openai/gpt-4.1-mini", temperature: 0 },
+  }),
+}));
+
+const input = {
+  threadId: "empty-response-thread",
+  messages: [],
+  newMessages: [],
+  requestedRole: "User",
+  scenarioConfig: {
+    name: "test",
+    description: "A test scenario",
+  } as AgentInput["scenarioConfig"],
+  scenarioState: {} as AgentInput["scenarioState"],
+} as AgentInput;
+
+describe("UserSimulatorAgent empty responses", () => {
+  it("retries one empty completion", async () => {
+    const sim = userSimulatorAgent({});
+    const invokeLLM = vi
+      .fn()
+      .mockResolvedValueOnce({ text: "", toolCalls: [], steps: [] })
+      .mockResolvedValueOnce({ text: "continue", toolCalls: [], steps: [] });
+    sim.invokeLLM = invokeLLM;
+
+    await expect(sim.call(input)).resolves.toMatchObject({
+      role: "user",
+      content: "continue",
+    });
+    expect(invokeLLM).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the existing error after two empty completions", async () => {
+    const sim = userSimulatorAgent({});
+    const invokeLLM = vi.fn().mockResolvedValue({
+      text: "",
+      toolCalls: [],
+      steps: [],
+    });
+    sim.invokeLLM = invokeLLM;
+
+    await expect(sim.call(input)).rejects.toThrow(
+      "No response content from LLM"
+    );
+    expect(invokeLLM).toHaveBeenCalledTimes(2);
+  });
+});

--- a/javascript/src/agents/user-simulator-agent.ts
+++ b/javascript/src/agents/user-simulator-agent.ts
@@ -469,12 +469,17 @@ class UserSimulatorAgent extends UserSimulatorAgentAdapter {
     // User to assistant role reversal (mirrors Python's role reversal to avoid LLM bias).
     const reversedMessages = messageRoleReversal(messages);
 
-    const completion = await this.invokeLLM({
+    const invokeParams = {
       model: mergedConfig.model,
       messages: reversedMessages,
       temperature: mergedConfig.temperature,
       maxOutputTokens: mergedConfig.maxTokens,
-    });
+    };
+
+    let completion = await this.invokeLLM(invokeParams);
+    if (!completion.text) {
+      completion = await this.invokeLLM(invokeParams);
+    }
 
     const messageContent = completion.text;
     if (!messageContent) {


### PR DESCRIPTION
## Why

An empty user-simulator model completion currently turns an otherwise successful scenario into an infrastructure error. Retrying that transient empty completion once keeps the run moving without changing executor or judge semantics.

Closes langwatch/langwatch#955

Also addresses the dogfooding report in [langwatch/tasks#737](https://github.com/langwatch/tasks/issues/737).

## What changed

- Retry only when the first simulator completion has no text, limiting the extra model call to one.
- Preserve the existing `No response content from LLM` error when the retry is also empty.
- Cover both the recovered and terminal-empty paths in a focused unit test.

## Test plan

- `pnpm exec vitest run src/agents/__tests__/user-simulator-empty-response.test.ts` (2 passed)
- `pnpm test -- src/agents/__tests__/user-simulator-empty-response.test.ts` (full configured suite: 1,384 passed, 58 skipped)
- `pnpm exec eslint src/agents/user-simulator-agent.ts src/agents/__tests__/user-simulator-empty-response.test.ts`
- `pnpm typecheck` (blocked by existing errors in `realtime-adapter-key-resolution.test.ts` and `event-reporter.ts`; no errors in the changed files)

The regression test fails without the retry because the first empty completion throws before the second mocked response can be consumed.

## How I can prove I was successful

No playable artifact for this library-only reliability fix; run the focused regression test above.

## Anything surprising?

The retry deliberately uses the same messages and model parameters. It does not treat empty content as conversation completion, so the only behavioral risk is one additional model call after an empty response.
