### PR TITLE
feat(ci): comment what the coding agents spent on each pull request

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pr-token-usage-scripts",
+  "private": true,
+  "type": "module",
+  "description": "Marks the CI scripts beside it as ES modules. Without it node infers the module type from the repository root, which declares none, and reparses the script on every run with a MODULE_TYPELESS_PACKAGE_JSON warning. This is not a package: nothing installs, builds or publishes it, and it declares no dependencies because the scripts have none."
+}

--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -10,6 +10,8 @@ import {
   formatCount,
   humanizeCount,
   interpretUsageResponse,
+  nextPageUrl,
+  readPullRequestHead,
   type PullRequestUsage,
   type UsageRow,
 } from "./pr-token-usage.ts";
@@ -267,6 +269,67 @@ describe("given a rollup with no sessions", () => {
       );
       assert.ok(body.includes("No coding agent sessions recorded"));
       assert.ok(!body.includes("| Contributor |"));
+    });
+  });
+});
+
+describe("given a comment listing that spans more pages than a fixed cap", () => {
+  describe("when the next page is read from the Link header", () => {
+    /** @scenario "The whole comment listing is searched for the marker" */
+    it("follows rel=next until the listing ends", () => {
+      assert.equal(
+        nextPageUrl(
+          '<https://api.github.com/repositories/1/issues/2/comments?page=12>; rel="next", ' +
+            '<https://api.github.com/repositories/1/issues/2/comments?page=40>; rel="last"',
+        ),
+        "https://api.github.com/repositories/1/issues/2/comments?page=12",
+      );
+      // The last page carries prev and first, never next: that ends the walk.
+      assert.equal(
+        nextPageUrl(
+          '<https://api.github.com/repositories/1/issues/2/comments?page=39>; rel="prev", ' +
+            '<https://api.github.com/repositories/1/issues/2/comments?page=1>; rel="first"',
+        ),
+        null,
+      );
+      assert.equal(nextPageUrl(null), null);
+    });
+  });
+});
+
+describe("given a manual refresh, which names only a pull request number", () => {
+  describe("when the pull request is read", () => {
+    /** @scenario "A manual refresh reports the pull request's own head commit" */
+    it("takes the head sha from the pull request, not from the dispatch ref", () => {
+      const head = readPullRequestHead({
+        repository: "acme/widgets",
+        pullRequest: {
+          head: { sha: "f00ba12345", repo: { full_name: "acme/widgets" } },
+        },
+      });
+      assert.equal(head.headSha, "f00ba12345");
+      assert.equal(head.isFork, false);
+    });
+
+    /** @scenario "A manual refresh still refuses a fork pull request" */
+    it("reads a head branch from another repository as a fork", () => {
+      assert.equal(
+        readPullRequestHead({
+          repository: "acme/widgets",
+          pullRequest: {
+            head: { sha: "f00ba12", repo: { full_name: "contributor/widgets" } },
+          },
+        }).isFork,
+        true,
+      );
+      // A deleted fork leaves no head repository at all.
+      assert.equal(
+        readPullRequestHead({
+          repository: "acme/widgets",
+          pullRequest: { head: { sha: "f00ba12", repo: null } },
+        }).isFork,
+        true,
+      );
     });
   });
 });

--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -1,0 +1,280 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  MARKER,
+  agentCell,
+  agentLabel,
+  buildCommentBody,
+  formatCost,
+  formatCount,
+  humanizeCount,
+  interpretUsageResponse,
+  type PullRequestUsage,
+  type UsageRow,
+} from "./pr-token-usage.ts";
+
+const row = (overrides: Partial<UsageRow> = {}): UsageRow => ({
+  projectSlug: "personal-abc",
+  contributorLabel: "Ada Lovelace",
+  contributorIsProject: false,
+  agent: "claude_code",
+  models: ["claude-fable-5"],
+  sessionsCount: 2,
+  inputTokens: 1_000,
+  outputTokens: 2_000,
+  cacheReadTokens: 30_000,
+  cacheCreationTokens: 4_000,
+  totalTokens: 37_000,
+  costUsd: 12.5,
+  ...overrides,
+});
+
+const usage = (overrides: Partial<PullRequestUsage> = {}): PullRequestUsage => ({
+  rows: [row()],
+  totals: {
+    sessionsCount: 2,
+    inputTokens: 1_000,
+    outputTokens: 2_000,
+    cacheReadTokens: 30_000,
+    cacheCreationTokens: 4_000,
+    totalTokens: 37_000,
+    costUsd: 12.5,
+  },
+  modelBreakdown: [
+    {
+      model: "claude-fable-5",
+      inputTokens: 1_000,
+      outputTokens: 2_000,
+      cacheReadTokens: 30_000,
+      cacheCreationTokens: 4_000,
+      totalTokens: 37_000,
+      costUsd: 12.5,
+    },
+  ],
+  ...overrides,
+});
+
+const build = (data: PullRequestUsage): string =>
+  buildCommentBody({
+    usage: data,
+    shortSha: "abc1234",
+    updatedAtIso: "2026-08-30T12:34:56.000Z",
+  });
+
+describe("given a usage rollup with rows for two contributors", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "The comment shows one row per contributor and agent" */
+    it("renders each contributor once with agent, sessions, tokens and cost, and a totals row", () => {
+      const body = build(
+        usage({
+          rows: [
+            row(),
+            row({ contributorLabel: "Grace Hopper", agent: "codex", costUsd: 3 }),
+          ],
+          totals: {
+            sessionsCount: 4,
+            inputTokens: 2_000,
+            outputTokens: 4_000,
+            cacheReadTokens: 60_000,
+            cacheCreationTokens: 8_000,
+            totalTokens: 74_000,
+            costUsd: 15.5,
+          },
+        }),
+      );
+      assert.ok(body.startsWith(MARKER));
+      assert.match(
+        body,
+        /\| Ada Lovelace \| <img [^|]+\/> Claude Code \| 2 \| 37 thousand \| \$12\.50 \|/,
+      );
+      assert.match(
+        body,
+        /\| Grace Hopper \| <img [^|]+\/> Codex \| 2 \| 37 thousand \| \$3\.00 \|/,
+      );
+      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*4\*\* \| \*\*74 thousand\*\* \| \*\*\$15\.50\*\* \|/);
+    });
+  });
+});
+
+describe("given a usage rollup with a model breakdown", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "The comment carries a per-model breakdown" */
+    it("lists each model's tokens and cost inside a collapsed details section", () => {
+      const body = build(usage());
+      const detailsStart = body.indexOf("<details>");
+      const detailsEnd = body.indexOf("</details>");
+      assert.ok(detailsStart !== -1 && detailsEnd > detailsStart);
+      const details = body.slice(detailsStart, detailsEnd);
+      assert.match(details, /`claude-fable-5`/);
+      assert.match(details, /\| 37 thousand \| \$12\.50 \|/);
+    });
+  });
+});
+
+describe("given a usage rollup whose cost fields are null", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "Costs the caller may not price render as unavailable" */
+    it("renders the cost cells as an em dash rather than zero", () => {
+      const body = build(
+        usage({
+          rows: [row({ costUsd: null })],
+          totals: { ...usage().totals, costUsd: null },
+        }),
+      );
+      assert.match(body, /\| Ada Lovelace \| <img [^|]+\/> Claude Code \| 2 \| 37 thousand \| — \|/);
+      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*2\*\* \| \*\*37 thousand\*\* \| \*\*—\*\* \|/);
+      assert.ok(!body.includes("$0.00"));
+    });
+  });
+});
+
+describe("given a usage rollup with a token count above one billion", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "Token counts render as words" */
+    it("renders the count as a spelled-out magnitude, never a letter abbreviation", () => {
+      const big = 2_603_257_062;
+      const body = build(
+        usage({
+          rows: [row({ totalTokens: big })],
+          totals: { ...usage().totals, totalTokens: big },
+        }),
+      );
+      assert.ok(body.includes("2.6 billion"));
+      assert.ok(!body.includes("2,603,257,062"));
+      assert.ok(!/\d(\.\d+)?[KMB]\b/.test(body));
+    });
+  });
+});
+
+describe("given the count humanizer", () => {
+  it("picks the right word, keeps small counts plain, and promotes on round-up", () => {
+    assert.equal(humanizeCount(0), "0");
+    assert.equal(humanizeCount(999), "999");
+    assert.equal(humanizeCount(37_000), "37 thousand");
+    assert.equal(humanizeCount(156_800), "157 thousand");
+    assert.equal(humanizeCount(1_888_045), "1.9 million");
+    assert.equal(humanizeCount(2_603_257_062), "2.6 billion");
+    assert.equal(humanizeCount(4_200_000_000_000), "4.2 trillion");
+    assert.equal(humanizeCount(999_960), "1 million");
+  });
+});
+
+describe("given a usage row's agent identifier", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "Agent identifiers render as product names with their icons" */
+    it("renders known identifiers with their product icon and unknown ones readably without one", () => {
+      assert.equal(agentLabel("claude_code"), "Claude Code");
+      assert.equal(agentLabel("gemini_cli"), "Gemini CLI");
+      assert.equal(
+        agentCell("claude_code"),
+        '<img src="https://app.langwatch.ai/images/external-icons/claude-code.svg" width="14" height="14" /> Claude Code',
+      );
+      assert.equal(
+        agentCell("codex"),
+        '<img src="https://app.langwatch.ai/images/external-icons/codex.svg" width="14" height="14" /> Codex',
+      );
+      assert.equal(agentCell("mystery_agent"), "Mystery Agent");
+    });
+  });
+});
+
+describe("given a usage rollup whose model rows cover far fewer tokens than the totals", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "A gap between session totals and per-model rows is called out" */
+    it("states how many of the total tokens the model rows cover", () => {
+      const body = build(
+        usage({
+          rows: [row({ totalTokens: 2_600_000_000 })],
+          totals: { ...usage().totals, totalTokens: 2_600_000_000 },
+          // modelBreakdown from the fixture covers only 37,000 tokens.
+        }),
+      );
+      assert.match(
+        body,
+        /> The per-model rows cover 37 thousand of the 2\.6 billion total tokens\./,
+      );
+    });
+
+    it("carries no note when the model rows match the totals", () => {
+      const body = build(usage());
+      assert.ok(!body.includes("per-model rows cover"));
+    });
+  });
+});
+
+describe("given the LangWatch API's answer", () => {
+  describe("when the pull request is not mapped", () => {
+    /** @scenario "An unmapped pull request reads as no usage" */
+    it("treats the refusal as no usage recorded, in every error envelope shape", () => {
+      // The v1 family's live shape: specific code beside generic status text.
+      const v1Flat = interpretUsageResponse({
+        status: 404,
+        body: {
+          code: "github_pr_not_mapped",
+          message: "github_pr_not_mapped",
+          error: "Not Found",
+          kind: "github_pr_not_mapped",
+        },
+      });
+      assert.equal(v1Flat.kind, "none");
+      const canonical = interpretUsageResponse({
+        status: 404,
+        body: {
+          error: {
+            type: "not_found",
+            code: "github_pr_not_mapped",
+            message: "pull request not found",
+          },
+        },
+      });
+      assert.equal(canonical.kind, "none");
+      const legacyFlat = interpretUsageResponse({
+        status: 404,
+        body: { error: "github_pr_not_mapped", message: "pull request not found" },
+      });
+      assert.equal(legacyFlat.kind, "none");
+    });
+  });
+
+  describe("when the API answers with any other failure", () => {
+    it("reads as an error naming the status and code", () => {
+      const outcome = interpretUsageResponse({
+        status: 401,
+        body: { error: "invalid_credentials" },
+      });
+      assert.equal(outcome.kind, "error");
+      assert.ok(outcome.kind === "error" && outcome.message.includes("401"));
+      assert.ok(
+        outcome.kind === "error" && outcome.message.includes("invalid_credentials"),
+      );
+    });
+  });
+
+  describe("when the API answers 200", () => {
+    it("passes the rollup through", () => {
+      const outcome = interpretUsageResponse({ status: 200, body: usage() });
+      assert.equal(outcome.kind, "usage");
+    });
+  });
+});
+
+describe("given a rollup with no sessions", () => {
+  describe("when the comment body is built anyway (an existing comment is refreshed)", () => {
+    it("states that no sessions are recorded instead of an empty table", () => {
+      const body = build(
+        usage({ rows: [], totals: { ...usage().totals, sessionsCount: 0 }, modelBreakdown: [] }),
+      );
+      assert.ok(body.includes("No coding agent sessions recorded"));
+      assert.ok(!body.includes("| Contributor |"));
+    });
+  });
+});
+
+describe("given the number and cost formatters", () => {
+  it("formats counts and costs the way the tables promise", () => {
+    assert.equal(formatCount(1234567), "1,234,567");
+    assert.equal(formatCost(2076.492055), "$2,076.49");
+    assert.equal(formatCost(null), "—");
+  });
+});

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -343,6 +343,42 @@ type GithubComment = {
   user?: { login?: string };
 };
 
+export type PullRequestHead = { headSha: string; isFork: boolean };
+
+/** A manual refresh names a pull request number and nothing else. The
+ * dispatch ref's sha belongs to the default branch rather than to the pull
+ * request, and the workflow's fork guard reads an event payload that a
+ * dispatch does not have. Both answers come from the pull request itself. */
+export const readPullRequestHead = ({
+  repository,
+  pullRequest,
+}: {
+  repository: string;
+  pullRequest: {
+    head?: { sha?: string; repo?: { full_name?: string } | null } | null;
+  };
+}): PullRequestHead => {
+  const head = pullRequest.head ?? {};
+  return {
+    headSha: head.sha ?? "",
+    // An absent head repository means the fork was deleted. Treating that as
+    // a fork is the safe reading: there is no branch here to trust.
+    isFork: (head.repo?.full_name ?? "") !== repository,
+  };
+};
+
+/** GitHub's `Link` header is the only reliable end-of-listing signal. A fixed
+ * page cap stops looking while the marker may still be ahead, and the upsert
+ * then POSTs a second comment onto a pull request that already carries one. */
+export const nextPageUrl = (linkHeader: string | null): string | null => {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+};
+
 const githubHeaders = (token: string) => ({
   Authorization: `Bearer ${token}`,
   Accept: "application/vnd.github+json",
@@ -361,11 +397,12 @@ const findExistingComment = async ({
   repository: string;
   prNumber: number;
 }): Promise<GithubComment | null> => {
-  for (let page = 1; page <= 10; page++) {
-    const response = await fetch(
-      `${apiUrl}/repos/${repository}/issues/${prNumber}/comments?per_page=100&page=${page}`,
-      { headers: githubHeaders(token) },
-    );
+  let url: string | null =
+    `${apiUrl}/repos/${repository}/issues/${prNumber}/comments?per_page=100`;
+  while (url) {
+    const response: Response = await fetch(url, {
+      headers: githubHeaders(token),
+    });
     if (!response.ok) {
       throw new Error(`Listing comments failed with ${response.status}`);
     }
@@ -376,9 +413,32 @@ const findExistingComment = async ({
         comment.body?.includes(MARKER),
     );
     if (existing) return existing;
-    if (comments.length < 100) return null;
+    url = nextPageUrl(response.headers.get("link"));
   }
   return null;
+};
+
+const fetchPullRequest = async ({
+  apiUrl,
+  token,
+  repository,
+  prNumber,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  prNumber: number;
+}): Promise<Parameters<typeof readPullRequestHead>[0]["pullRequest"]> => {
+  const response = await fetch(
+    `${apiUrl}/repos/${repository}/pulls/${prNumber}`,
+    { headers: githubHeaders(token) },
+  );
+  if (!response.ok) {
+    throw new Error(`Reading the pull request failed with ${response.status}`);
+  }
+  return (await response.json()) as Parameters<
+    typeof readPullRequestHead
+  >[0]["pullRequest"];
 };
 
 const upsertComment = async ({
@@ -425,8 +485,30 @@ const run = async (): Promise<void> => {
   const dryRun = process.argv.includes("--dry-run");
   const repository = requireEnv("PR_REPOSITORY");
   const prNumber = Number(requireEnv("PR_NUMBER"));
-  const shortSha = requireEnv("PR_HEAD_SHA").slice(0, 7);
   const endpoint = process.env.LANGWATCH_ENDPOINT ?? "https://app.langwatch.ai";
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+
+  // A `pull_request` run carries its own head sha and the workflow has
+  // already refused fork pull requests from the event payload. A manual
+  // refresh carries neither, so the pull request answers both questions.
+  let headSha = process.env.PR_HEAD_SHA ?? "";
+  if (!headSha) {
+    const head = readPullRequestHead({
+      repository,
+      pullRequest: await fetchPullRequest({
+        apiUrl,
+        token: requireEnv("GITHUB_TOKEN"),
+        repository,
+        prNumber,
+      }),
+    });
+    if (head.isFork) {
+      console.log(`${repository}#${prNumber} comes from a fork; skipping.`);
+      return;
+    }
+    headSha = head.headSha;
+  }
+  const shortSha = headSha.slice(0, 7);
 
   const outcome = await fetchUsage({
     endpoint,
@@ -459,7 +541,6 @@ const run = async (): Promise<void> => {
   }
 
   const token = requireEnv("GITHUB_TOKEN");
-  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
   const existing = await findExistingComment({ apiUrl, token, repository, prNumber });
 
   // No usage and no comment: stay silent rather than stamp every dependency

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -1,0 +1,498 @@
+// Builds and upserts the sticky "coding agent usage" comment on a pull
+// request, from the LangWatch pull-request usage API
+// (GET /api/v1/coding-agent/pull-request-usage): sessions, tokens and estimated
+// cost per contributor and agent, plus a per-model breakdown, over the pull
+// request's whole lifetime.
+//
+// Deliberately non-blocking: this script only describes what the work cost,
+// it never judges it. A LangWatch outage logs a warning and exits 0, so the
+// job can sit on every pull request without ever painting a red X for a
+// reporting failure.
+//
+// Deliberately dependency-free and run with `node --experimental-strip-types`:
+// there is no install step on the runner.
+//
+// Spec: specs/pr-token-usage.feature
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const MARKER = "<!-- pr-token-usage -->";
+
+/** The API refuses an unknown pull request with this code; it means "no usage
+ * recorded yet", not "something broke". */
+const PR_NOT_MAPPED_CODE = "github_pr_not_mapped";
+
+export type UsageRow = {
+  projectSlug: string;
+  contributorLabel: string;
+  contributorIsProject: boolean;
+  agent: string;
+  models: string[];
+  sessionsCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+};
+
+export type UsageTotals = {
+  sessionsCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+};
+
+export type ModelBreakdownRow = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+};
+
+export type PullRequestUsage = {
+  rows: UsageRow[];
+  totals: UsageTotals;
+  modelBreakdown: ModelBreakdownRow[];
+};
+
+/** "No usage recorded" and "the PR is not mapped yet" collapse into null:
+ * both mean there is nothing to say. */
+export type FetchOutcome =
+  | { kind: "usage"; usage: PullRequestUsage }
+  | { kind: "none" }
+  | { kind: "error"; message: string };
+
+const AGENT_LABELS: Record<string, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex",
+  opencode: "OpenCode",
+  cursor: "Cursor",
+  gemini_cli: "Gemini CLI",
+};
+
+/** A known agent identifier renders as its product name; an unknown one falls
+ * back to a readable form of itself rather than raw snake_case. */
+export const agentLabel = (agent: string): string =>
+  AGENT_LABELS[agent] ??
+  agent
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+/** Full numbers with separators: "2,603,257,062". Used for small counts. */
+export const formatCount = (n: number): string => n.toLocaleString("en-US");
+
+const COUNT_WORDS = ["thousand", "million", "billion", "trillion"];
+
+/** Token counts render as words, not digits or letter abbreviations:
+ * 2,603,257,062 is "2.6 billion". One decimal below one hundred of a unit,
+ * none above; a value that rounds up to a whole next unit is promoted. */
+export const humanizeCount = (n: number): string => {
+  if (n < 1_000) return formatCount(n);
+  let index = Math.min(Math.floor(Math.log10(n) / 3), COUNT_WORDS.length) - 1;
+  const display = (i: number): string => {
+    const value = n / 10 ** ((i + 1) * 3);
+    return value >= 100 ? value.toFixed(0) : value.toFixed(1);
+  };
+  let digits = display(index);
+  if (Number(digits) >= 1_000 && index < COUNT_WORDS.length - 1) {
+    index += 1;
+    digits = display(index);
+  }
+  return `${digits.replace(/\.0$/, "")} ${COUNT_WORDS[index]}`;
+};
+
+const AGENT_ICONS: Record<string, string> = {
+  claude_code: "claude-code.svg",
+  codex: "codex.svg",
+  opencode: "opencode.svg",
+  cursor: "cursor.svg",
+  gemini_cli: "gemini.svg",
+  github_copilot: "github-copilot.svg",
+};
+
+/** A known agent renders with its product icon before the name; an unknown
+ * one renders as its label alone rather than a broken image. */
+export const agentCell = (agent: string): string => {
+  const icon = AGENT_ICONS[agent];
+  const label = agentLabel(agent);
+  return icon
+    ? `<img src="https://app.langwatch.ai/images/external-icons/${icon}" width="14" height="14" /> ${label}`
+    : label;
+};
+
+/** null cost means the caller may not price this row — an em dash, not $0. */
+export const formatCost = (cost: number | null): string =>
+  cost === null ? "—" : `$${cost.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const usageTable = (rows: UsageRow[], totals: UsageTotals): string[] => {
+  const line = (cells: string[]) => `| ${cells.join(" | ")} |`;
+  const out = [
+    line(["Contributor", "Agent", "Sessions", "Total tokens", "Estimated cost"]),
+    line(["---", "---", "--:", "--:", "--:"]),
+  ];
+  for (const row of rows) {
+    out.push(
+      line([
+        row.contributorLabel,
+        agentCell(row.agent),
+        formatCount(row.sessionsCount),
+        humanizeCount(row.totalTokens),
+        formatCost(row.costUsd),
+      ]),
+    );
+  }
+  out.push(
+    line([
+      "**Total**",
+      "",
+      `**${formatCount(totals.sessionsCount)}**`,
+      `**${humanizeCount(totals.totalTokens)}**`,
+      `**${formatCost(totals.costUsd)}**`,
+    ]),
+  );
+  return out;
+};
+
+const tokenDetailTable = (
+  rows: UsageRow[],
+  totals: UsageTotals,
+): string[] => {
+  const line = (cells: string[]) => `| ${cells.join(" | ")} |`;
+  const out = [
+    line(["Contributor", "Input", "Output", "Cache read", "Cache write"]),
+    line(["---", "--:", "--:", "--:", "--:"]),
+  ];
+  for (const row of rows) {
+    out.push(
+      line([
+        row.contributorLabel,
+        humanizeCount(row.inputTokens),
+        humanizeCount(row.outputTokens),
+        humanizeCount(row.cacheReadTokens),
+        humanizeCount(row.cacheCreationTokens),
+      ]),
+    );
+  }
+  out.push(
+    line([
+      "**Total**",
+      `**${humanizeCount(totals.inputTokens)}**`,
+      `**${humanizeCount(totals.outputTokens)}**`,
+      `**${humanizeCount(totals.cacheReadTokens)}**`,
+      `**${humanizeCount(totals.cacheCreationTokens)}**`,
+    ]),
+  );
+  return out;
+};
+
+const modelTable = (breakdown: ModelBreakdownRow[]): string[] => {
+  const line = (cells: string[]) => `| ${cells.join(" | ")} |`;
+  const out = [
+    line(["Model", "Input", "Output", "Cache read", "Cache write", "Total tokens", "Estimated cost"]),
+    line(["---", "--:", "--:", "--:", "--:", "--:", "--:"]),
+  ];
+  for (const row of breakdown) {
+    out.push(
+      line([
+        `\`${row.model}\``,
+        humanizeCount(row.inputTokens),
+        humanizeCount(row.outputTokens),
+        humanizeCount(row.cacheReadTokens),
+        humanizeCount(row.cacheCreationTokens),
+        humanizeCount(row.totalTokens),
+        formatCost(row.costUsd),
+      ]),
+    );
+  }
+  return out;
+};
+
+export const buildCommentBody = ({
+  usage,
+  shortSha,
+  updatedAtIso,
+}: {
+  usage: PullRequestUsage;
+  shortSha: string;
+  updatedAtIso: string;
+}): string => {
+  const updated = updatedAtIso.replace("T", " ").slice(0, 16);
+  const parts = [MARKER, "### Coding agent usage on this pull request", ""];
+
+  if (usage.totals.sessionsCount === 0) {
+    parts.push("No coding agent sessions recorded for this pull request.");
+  } else {
+    parts.push(...usageTable(usage.rows, usage.totals));
+    const details: string[] = [];
+    details.push("", "<details>", "<summary>Token and model breakdown</summary>", "");
+    details.push(...tokenDetailTable(usage.rows, usage.totals));
+    if (usage.modelBreakdown.length > 0) {
+      details.push("", ...modelTable(usage.modelBreakdown));
+      // The contributor totals come from session-level counters; the model
+      // rows come from stored per-turn events. A session whose turns were
+      // never stored (an outage, a client too old to send them) still counts
+      // in the totals, so the model rows can legitimately cover less. Say so
+      // rather than leave two tables that appear to contradict each other.
+      const modelSum = usage.modelBreakdown.reduce(
+        (sum, row) => sum + row.totalTokens,
+        0,
+      );
+      if (modelSum < usage.totals.totalTokens * 0.95) {
+        details.push(
+          "",
+          `> The per-model rows cover ${humanizeCount(modelSum)} of the ` +
+            `${humanizeCount(usage.totals.totalTokens)} total tokens. The rest ` +
+            "belongs to session turns whose per-call events were not stored, " +
+            "so only their session totals are known.",
+        );
+      }
+    }
+    details.push("", "</details>");
+    parts.push(...details);
+  }
+
+  parts.push(
+    "",
+    "<sub>Tokens as reported by the agents to " +
+      "[LangWatch](https://app.langwatch.ai); cost estimated from model list " +
+      "prices, over the pull request's whole lifetime. Updated for " +
+      `\`${shortSha}\` · ${updated} UTC</sub>`,
+  );
+  return parts.join("\n");
+};
+
+/** The v1 family answers `{"code": "...", "error": "Bad Request", ...}` —
+ * the specific code beside a generic status text — while the legacy flat
+ * shape carried the code AS the `error` string, and the canonical envelope
+ * nests it under `error.code`. Read all three, most specific first, so the
+ * script survives either side of the API family migration. */
+const errorCodeOf = (body: unknown): string => {
+  if (typeof body !== "object" || body === null) return "";
+  const record = body as { code?: unknown; error?: unknown };
+  if (typeof record.code === "string") return record.code;
+  const error = record.error;
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null && "code" in error) {
+    return String((error as { code: unknown }).code);
+  }
+  return "";
+};
+
+/** The rollup's whole-response shape is the API's; only what the comment
+ * renders is typed above, and unknown fields pass through untouched. */
+export const interpretUsageResponse = ({
+  status,
+  body,
+}: {
+  status: number;
+  body: unknown;
+}): FetchOutcome => {
+  if (status === 200) {
+    return { kind: "usage", usage: body as PullRequestUsage };
+  }
+  const code = errorCodeOf(body);
+  if (status === 404 && code === PR_NOT_MAPPED_CODE) {
+    return { kind: "none" };
+  }
+  return {
+    kind: "error",
+    message: `LangWatch answered ${status}${code ? ` (${code})` : ""}`,
+  };
+};
+
+const fetchUsage = async ({
+  endpoint,
+  apiKey,
+  repository,
+  prNumber,
+}: {
+  endpoint: string;
+  apiKey: string;
+  repository: string;
+  prNumber: number;
+}): Promise<FetchOutcome> => {
+  const url =
+    `${endpoint}/api/v1/coding-agent/pull-request-usage` +
+    `?repository=${encodeURIComponent(repository)}&pullRequest=${prNumber}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+  } catch (error) {
+    return { kind: "error", message: `LangWatch unreachable: ${String(error)}` };
+  }
+  const body: unknown = await response.json().catch(() => null);
+  return interpretUsageResponse({ status: response.status, body });
+};
+
+type GithubComment = {
+  id: number;
+  body?: string;
+  user?: { login?: string };
+};
+
+const githubHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "Content-Type": "application/json",
+});
+
+const findExistingComment = async ({
+  apiUrl,
+  token,
+  repository,
+  prNumber,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  prNumber: number;
+}): Promise<GithubComment | null> => {
+  for (let page = 1; page <= 10; page++) {
+    const response = await fetch(
+      `${apiUrl}/repos/${repository}/issues/${prNumber}/comments?per_page=100&page=${page}`,
+      { headers: githubHeaders(token) },
+    );
+    if (!response.ok) {
+      throw new Error(`Listing comments failed with ${response.status}`);
+    }
+    const comments = (await response.json()) as GithubComment[];
+    const existing = comments.find(
+      (comment) =>
+        comment.user?.login === "github-actions[bot]" &&
+        comment.body?.includes(MARKER),
+    );
+    if (existing) return existing;
+    if (comments.length < 100) return null;
+  }
+  return null;
+};
+
+const upsertComment = async ({
+  apiUrl,
+  token,
+  repository,
+  prNumber,
+  body,
+  existing,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  prNumber: number;
+  body: string;
+  existing: GithubComment | null;
+}): Promise<void> => {
+  const target = existing
+    ? {
+        url: `${apiUrl}/repos/${repository}/issues/comments/${existing.id}`,
+        method: "PATCH",
+      }
+    : {
+        url: `${apiUrl}/repos/${repository}/issues/${prNumber}/comments`,
+        method: "POST",
+      };
+  const response = await fetch(target.url, {
+    method: target.method,
+    headers: githubHeaders(token),
+    body: JSON.stringify({ body }),
+  });
+  if (!response.ok) {
+    throw new Error(`${target.method} comment failed with ${response.status}`);
+  }
+};
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var ${name}`);
+  return value;
+};
+
+const run = async (): Promise<void> => {
+  const dryRun = process.argv.includes("--dry-run");
+  const repository = requireEnv("PR_REPOSITORY");
+  const prNumber = Number(requireEnv("PR_NUMBER"));
+  const shortSha = requireEnv("PR_HEAD_SHA").slice(0, 7);
+  const endpoint = process.env.LANGWATCH_ENDPOINT ?? "https://app.langwatch.ai";
+
+  const outcome = await fetchUsage({
+    endpoint,
+    apiKey: requireEnv("LANGWATCH_API_KEY"),
+    repository,
+    prNumber,
+  });
+
+  // Reporting must never block the pull request: a LangWatch failure is a
+  // warning annotation and a green job, and the comment is left as it was.
+  if (outcome.kind === "error") {
+    console.log(`::warning title=pr-token-usage::${outcome.message}`);
+    return;
+  }
+
+  const usage: PullRequestUsage =
+    outcome.kind === "usage"
+      ? outcome.usage
+      : { rows: [], totals: emptyTotals(), modelBreakdown: [] };
+
+  const body = buildCommentBody({
+    usage,
+    shortSha,
+    updatedAtIso: new Date().toISOString(),
+  });
+
+  if (dryRun) {
+    console.log(body);
+    return;
+  }
+
+  const token = requireEnv("GITHUB_TOKEN");
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const existing = await findExistingComment({ apiUrl, token, repository, prNumber });
+
+  // No usage and no comment: stay silent rather than stamp every dependency
+  // bump with an empty table. An existing comment is still refreshed, so a
+  // rollup that empties never leaves stale numbers behind.
+  if (usage.totals.sessionsCount === 0 && !existing) {
+    console.log(`No usage recorded for ${repository}#${prNumber}; skipping.`);
+    return;
+  }
+
+  await upsertComment({ apiUrl, token, repository, prNumber, body, existing });
+  console.log(
+    `${existing ? "Updated" : "Created"} usage comment on ${repository}#${prNumber}.`,
+  );
+};
+
+const emptyTotals = (): UsageTotals => ({
+  sessionsCount: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  totalTokens: 0,
+  costUsd: null,
+});
+
+const isMain =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isMain) {
+  run().catch((error) => {
+    // Even an unexpected failure only warns: see the non-blocking note above.
+    console.log(`::warning title=pr-token-usage::${String(error)}`);
+  });
+}

--- a/.github/workflows/pr-token-usage.yml
+++ b/.github/workflows/pr-token-usage.yml
@@ -43,7 +43,8 @@ jobs:
   comment:
     # Fork PRs get a read-only GITHUB_TOKEN and no secrets, so the LangWatch
     # read and the comment POST would both fail. Skip quietly rather than
-    # paint a red X on a contributor's first PR.
+    # paint a red X on a contributor's first PR. A dispatch has no event
+    # payload to read, so the script re-checks the fork question itself.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -63,5 +64,8 @@ jobs:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_PR_USAGE_API_KEY }}
           PR_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Empty on a manual refresh, where `github.sha` would be the default
+          # branch rather than the pull request. The script then reads the head
+          # sha from the pull request, and refuses it if it is a fork.
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node --experimental-strip-types .github/scripts/pr-token-usage.ts

--- a/.github/workflows/pr-token-usage.yml
+++ b/.github/workflows/pr-token-usage.yml
@@ -1,0 +1,67 @@
+name: pr-token-usage
+
+# Posts a single sticky comment stating what the coding agents spent on this
+# pull request (sessions, tokens and estimated cost per contributor and per
+# model, read from the LangWatch pull-request usage API), and rewrites that
+# same comment on every subsequent push.
+#
+# `synchronize` IS "a new commit was pushed to this PR", so one `pull_request`
+# trigger covers both "on open" and "on every push". Usage accrues while the
+# work happens, so each push refreshes the numbers; `workflow_dispatch` exists
+# for a manual refresh after the last commit.
+#
+# Deliberately non-blocking: this workflow only describes what the work cost,
+# it never judges it. A LangWatch outage logs a warning and the job stays
+# green, so nothing here should gate a merge or join branch protection.
+#
+# Deliberately NOT path-filtered. Agent usage accrues against the pull request
+# regardless of which files the work touched, so a filter would silence the
+# report on exactly the pull requests that cost the most to produce.
+#
+# Spec: specs/pr-token-usage.feature
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: "Pull request number to refresh"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Two pushes in quick succession would otherwise race: both runs read "no
+# existing comment" and both POST, leaving duplicates on the thread.
+concurrency:
+  group: pr-token-usage-${{ github.event.pull_request.number || inputs.pull_request }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Fork PRs get a read-only GITHUB_TOKEN and no secrets, so the LangWatch
+    # read and the comment POST would both fail. Skip quietly rather than
+    # paint a red X on a contributor's first PR.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      # The same logic that is about to write the comment proves itself first;
+      # `node --test` with type stripping needs no install step.
+      - name: Test the comment builder
+        run: node --test --experimental-strip-types .github/scripts/pr-token-usage.test.ts
+
+      - name: Build and upsert the usage comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_PR_USAGE_API_KEY }}
+          PR_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node --experimental-strip-types .github/scripts/pr-token-usage.ts

--- a/specs/pr-token-usage.feature
+++ b/specs/pr-token-usage.feature
@@ -1,0 +1,102 @@
+Feature: PR token usage comment
+  As a reviewer
+  I want a single comment stating what the coding agents spent on a pull request
+  So that the cost of the work is visible next to the work itself
+
+  The data comes from the LangWatch pull-request usage API
+  (GET /api/v1/coding-agent/pull-request-usage), which rolls a pull request's
+  whole lifetime up into sessions, tokens and cost per contributor and agent.
+  The workflow only reads and comments: it never gates a merge.
+
+  Background:
+    Given the pr-token-usage workflow runs on pull_request events
+    And it identifies its own comment by the hidden marker "<!-- pr-token-usage -->"
+
+  Scenario: A comment is posted when usage exists for the pull request
+    Given LangWatch has recorded sessions for the pull request
+    When the workflow runs
+    Then a comment carrying the usage marker is posted exactly once
+
+  Scenario: The existing comment is updated when new commits are pushed
+    Given a pull request already has a comment carrying the usage marker
+    When a new commit is pushed to the pull request branch
+    Then the existing comment is updated in place
+    And no additional comment is created
+
+  Scenario: A pull request with no recorded usage gets no comment
+    Given LangWatch has no sessions recorded for the pull request
+    And the pull request has no comment carrying the usage marker
+    When the workflow runs
+    Then no comment is created
+    And the workflow does not fail
+
+  Scenario: An existing comment is refreshed even when usage drops to zero
+    Given a pull request already has a comment carrying the usage marker
+    And LangWatch now reports no sessions for the pull request
+    When the workflow runs
+    Then the existing comment is updated rather than left stale
+
+  Scenario: A LangWatch outage never blocks the pull request
+    Given the LangWatch API is unreachable or answers with an error
+    When the workflow runs
+    Then the workflow logs a warning and succeeds
+    And no comment is created or modified
+
+  Scenario: Pull requests from forks are skipped
+    Given a pull request originates from a forked repository
+    When the workflow is triggered
+    Then no comment is attempted
+    And the workflow does not fail
+
+  Scenario: Rapid successive pushes do not create duplicate comments
+    Given a pull request receives two pushes in quick succession
+    When both workflow runs are triggered
+    Then the earlier run is cancelled before it posts
+    And the pull request carries exactly one usage comment
+
+  @unit
+  Scenario: The comment shows one row per contributor and agent
+    Given a usage rollup with rows for two contributors
+    When the comment body is built
+    Then each contributor appears once with its agent, sessions, tokens and cost
+    And a totals row sums them
+
+  @unit
+  Scenario: The comment carries a per-model breakdown
+    Given a usage rollup with a model breakdown
+    When the comment body is built
+    Then each model's tokens and cost appear in a collapsed details section
+
+  @unit
+  Scenario: Costs the caller may not price render as unavailable
+    Given a usage rollup whose cost fields are null
+    When the comment body is built
+    Then the cost cells render as an em dash rather than zero
+
+  @unit
+  Scenario: Token counts render as words
+    Given a usage rollup with a token count above one billion
+    When the comment body is built
+    Then the count renders as a spelled-out magnitude such as "2.6 billion"
+    And the unit is a word, never a letter abbreviation
+    And a count below one thousand stays a plain number
+
+  @unit
+  Scenario: Agent identifiers render as product names with their icons
+    Given a usage row whose agent is "claude_code"
+    When the comment body is built
+    Then the agent renders as "Claude Code" beside its product icon
+    And an unknown agent identifier falls back to a readable form of itself, without a broken image
+
+  @unit
+  Scenario: A gap between session totals and per-model rows is called out
+    Given a usage rollup whose model rows cover far fewer tokens than the totals
+    When the comment body is built
+    Then a note states how many of the total tokens the model rows cover
+    And a rollup whose model rows match the totals carries no such note
+
+  @unit
+  Scenario: An unmapped pull request reads as no usage
+    Given the LangWatch API answers that the pull request is not mapped
+    When the response is interpreted
+    Then it is treated as "no usage recorded" rather than an error

--- a/specs/pr-token-usage.feature
+++ b/specs/pr-token-usage.feature
@@ -48,6 +48,27 @@ Feature: PR token usage comment
     Then no comment is attempted
     And the workflow does not fail
 
+  @unit
+  Scenario: A manual refresh reports the pull request's own head commit
+    Given a manual refresh names a pull request number and nothing else
+    When the pull request is read
+    Then the commit named in the comment is the pull request's head commit
+    And never the branch the refresh was dispatched from
+
+  @unit
+  Scenario: A manual refresh still refuses a fork pull request
+    Given a manual refresh names a pull request whose head branch is in another repository
+    When the pull request is read
+    Then it is treated as a fork and no comment is attempted
+    And a pull request whose fork was deleted is treated the same way
+
+  @unit
+  Scenario: The whole comment listing is searched for the marker
+    Given a pull request carries more comments than one listing page holds
+    When the next page is read from the Link header
+    Then the search follows every page until the listing ends
+    And the marker is never missed into a duplicate comment
+
   Scenario: Rapid successive pushes do not create duplicate comments
     Given a pull request receives two pushes in quick succession
     When both workflow runs are triggered


### PR DESCRIPTION
Brings the `pr-token-usage` workflow to this repository. It already runs on `langwatch/langwatch` (langwatch/langwatch#7676), where it posts and refreshes its own comment on itself.

## What it does

On every pull request open, push and reopen, it reads the LangWatch pull-request usage API for this repository and this pull request number, and keeps **one** comment in step with the answer:

| Contributor | Agent | Sessions | Total tokens | Estimated cost |
| --- | --- | --: | --: | --: |
| 🏭 Background Agents | <img src="https://app.langwatch.ai/images/external-icons/claude-code.svg" width="14" height="14" /> Claude Code | 1 | 268 million | $201.12 |
| **Total** |  | **1** | **268 million** | **$201.12** |

A details section carries the input / output / cache split per contributor and a per-model breakdown. Counts read as words, so a nine-digit number stays legible.

The comment is found again by a hidden marker and rewritten in place, so a pull request never collects a trail of stale tables.

## It never gates a merge

This job reports; it does not judge.

- A LangWatch outage or an error answer logs a `::warning` annotation and the job **stays green**. Do not add it to branch protection.
- A pull request with no recorded usage and no existing comment is left untouched, rather than stamped with an empty table. An existing comment is still refreshed, so numbers never go stale.
- Fork pull requests are skipped. They get a read-only token and no secrets, so both the read and the comment would fail; a quiet skip beats a red X on a first contribution.

## Shape

- `.github/scripts/pr-token-usage.ts` builds and upserts the comment. Dependency-free, run under `node --experimental-strip-types`, so there is no install step on the runner.
- `.github/scripts/pr-token-usage.test.ts` covers the builder. The workflow runs it **first**, in the same job, from the same checkout, so the logic that is about to write a comment proves itself on every run.
- `.github/scripts/package.json` marks those two files as ES modules. Without it node infers the module type from the repository root, which declares none, and reparses on every run with a `MODULE_TYPELESS_PACKAGE_JSON` warning. Nothing installs or publishes it.
- `specs/pr-token-usage.feature` holds the scenarios; six of them are bound by the test suite through `@scenario` annotations.

## Verified before pushing

- 13/13 tests pass locally.
- The API answers for this repository with the configured key: `langwatch/scenario#954` returns 200, `#956` returns `github_pr_not_mapped`, which the script reads as "no usage recorded" rather than an error.
- A dry run against both renders the "No coding agent sessions recorded" body, and a dry run against a pull request that does have sessions renders the table above.

## One thing to know

Every mapped pull request in this repository currently reports **zero sessions**. The repository is known to LangWatch; no coding agent session has been attributed to it yet. So this workflow will stay quiet here until sessions start landing, which is the correct behaviour and not a failure. Investigating that attribution gap is separate work.

## Setup

`LANGWATCH_PR_USAGE_API_KEY` is already set as a repository secret. No other configuration.
