### PR TITLE
fix(cursor): quote the globs so the rule frontmatter parses

### DIFF
--- a/.cursor/rules/react-tsx.mdc
+++ b/.cursor/rules/react-tsx.mdc
@@ -1,6 +1,6 @@
 ---
 description: React and TSX component development guidelines
-globs: *.tsx
+globs: "*.tsx"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -1,6 +1,6 @@
 ---
 description:
-globs: *.tsx
+globs: "*.tsx"
 alwaysApply: false
 ---
 

--- a/docs/.cursor/rules/seo.mdc
+++ b/docs/.cursor/rules/seo.mdc
@@ -1,5 +1,5 @@
 ---
-globs: *.mdx
+globs: "*.mdx"
 alwaysApply: false
 ---
 

--- a/docs/.cursor/rules/writing-style.mdc
+++ b/docs/.cursor/rules/writing-style.mdc
@@ -1,5 +1,5 @@
 ---
-globs: *.mdx
+globs: "*.mdx"
 alwaysApply: false
 ---
 # Writing Style

--- a/python/.cursor/rules/python.mdc
+++ b/python/.cursor/rules/python.mdc
@@ -1,5 +1,5 @@
 ---
-globs: *.py
+globs: "*.py"
 alwaysApply: false
 ---
 


### PR DESCRIPTION
## Why

Five `.cursor/rules/*.mdc` files have frontmatter that is not valid YAML, so none of it is read — not just the glob, but `description` and `alwaysApply` with it. A bare `*` opens an alias in YAML, so `globs: *.tsx` is a reference to an anchor named `.tsx` that nothing defines, and the parse fails at that line. It is invisible because a rule that fails to load fails silently.

No linked issue — I found this from outside while running a static analyser over public repos' agent configuration. Happy to open one if your change-management process wants the ticket for the audit trail.

## What changed

- Quoted the value in the five affected files, rather than rewriting the globs. Quoting is the minimum change that makes the frontmatter parse, and it leaves the matching behaviour exactly as the author wrote it.
- Left the glob strings themselves untouched (`*.tsx` stays `*.tsx`). Widening them to `**/*.tsx` would make the rules match more files, and that is a scope decision for you, not a syntax fix — see *Anything surprising?*.
- Changed nothing else: five files, one line each, `+1/-1`, and every other frontmatter key parses to the same value it was meant to have.

## Test plan

From a checkout of this branch, comparing `main` against `HEAD` with stdlib PyYAML — no dependencies beyond `git`, `awk` and `python3`:

```bash
RULES=(.cursor/rules/react-tsx.mdc .cursor/rules/typescript.mdc \
       docs/.cursor/rules/seo.mdc docs/.cursor/rules/writing-style.mdc \
       python/.cursor/rules/python.mdc)

check() {
  for f in "${RULES[@]}"; do
    printf '  %-38s ' "$f"
    git show "$1:$f" | awk '/^---$/{n++; next} n==1' | python3 -c '
import sys, yaml
try:
    yaml.safe_load(sys.stdin.read()); print("parses")
except Exception as e:
    print("FAILS:", str(e).splitlines()[0])
'
  done
}

echo "on main:"; check main
echo "on this branch:"; check HEAD
```

No test file is added: these are configuration files, and the repo has no harness that parses them.

## How I can prove I was successful

Output of the command above, run on this branch:

```
on main:
  .cursor/rules/react-tsx.mdc            FAILS: while scanning an alias
  .cursor/rules/typescript.mdc           FAILS: while scanning an alias
  docs/.cursor/rules/seo.mdc             FAILS: while scanning an alias
  docs/.cursor/rules/writing-style.mdc   FAILS: while scanning an alias
  python/.cursor/rules/python.mdc        FAILS: while scanning an alias

on this branch:
  .cursor/rules/react-tsx.mdc            parses
  .cursor/rules/typescript.mdc           parses
  docs/.cursor/rules/seo.mdc             parses
  docs/.cursor/rules/writing-style.mdc   parses
  python/.cursor/rules/python.mdc        parses
```

I checked the same five files against four independent YAML parsers, so this does not rest on one implementation's strictness: **`yaml` (JS), `js-yaml`, PyYAML 6.0.3, and Ruby Psych 3.1.0 all reject every file before and accept every file after.** The parsed `globs` value is byte-identical to the string that was already there in all five.

## Anything surprising?

Two things worth your judgement, neither of which this PR acts on.

**The globs may not match what they look like they match.** Once the frontmatter parses, `*.tsx` is a path pattern anchored at the rule's directory, and every `.tsx` file in the repo is nested rather than sitting at that level. Same for the other two:

| rule | glob | files it matches | files of that type |
|---|---|---|---|
| `.cursor/rules/react-tsx.mdc` | `*.tsx` | 0 | 75 |
| `.cursor/rules/typescript.mdc` | `*.tsx` | 0 | 75 |
| `docs/.cursor/rules/seo.mdc` | `*.mdx` | 0 | 88 |
| `docs/.cursor/rules/writing-style.mdc` | `*.mdx` | 0 | 88 |
| `python/.cursor/rules/python.mdc` | `*.py` | 2 | 552 |

The obvious change is `**/*.tsx`, which Cursor's docs describe as "all `.ts` files in any directory". I deliberately did not make it, because it is not free: `**/*.tsx` from the repo root also picks up the 53 vendored `.tsx` files under `python/examples/lovable_clone/template/`, 48 of them shadcn/ui components, and `**/*.py` under `python/` picks up the 207 generated files in `python/scenario/_generated/`. Whether you want those rules attaching to vendored and generated code is a call for whoever owns the rules.

**`.cursor/rules/typescript.mdc` has an empty `description:` and scopes to `*.tsx` only.** For a rule named "typescript" I would have guessed `.ts` was meant to be in there too, but I have left it alone since that is intent rather than syntax.
