### PR TITLE
fix(execution): clear the sampled barge-in delay on every skip path (#578)

### DIFF
--- a/javascript/src/execution/__tests__/proceed-interruptions.test.ts
+++ b/javascript/src/execution/__tests__/proceed-interruptions.test.ts
@@ -267,8 +267,17 @@ type BargeInInternals = {
  * A live entry is the precondition the substep runs under: its sole caller
  * dispatches the AGENT first, so `done` is false unless the bot beat the TTS.
  */
-function liveEntry(done = false) {
-  return { promise: Promise.resolve(), done, error: null };
+function liveEntry() {
+  return { promise: Promise.resolve(), done: false, error: null };
+}
+
+/** A promise whose settling the test controls, to pin an ordering. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
 }
 
 /** A voice user simulator whose TTS outcome the test decides. */
@@ -362,21 +371,36 @@ describe("prepareAndFireBargeIn (substep 4)", () => {
     expect(inner.interruptBargeInDelayMs).toBeUndefined();
   });
 
-  it("skips the barge-in when the bot finished before the phrase was voiced", async () => {
+  it("skips the barge-in when the bot finishes while the phrase is being voiced", async () => {
     const { exec, inner, fired } = makeBargeInExec();
     exec.interruptOverrides = { rng: () => 0 };
     const config = new InterruptionConfig({
       strategy: "random_phrase",
       delayRange: [2, 2],
     });
+    // Live when the substep starts, which is what its sole caller guarantees.
+    const entry = liveEntry();
 
-    const result = await inner.prepareAndFireBargeIn(
-      config,
-      simThat({ voiced }),
-      liveEntry(true),
-    );
+    const ttsStarted = deferred<void>();
+    const ttsFinishes = deferred<void>();
+    const sim = {
+      voice: "alloy",
+      async voiceifyText(): Promise<ModelMessage> {
+        ttsStarted.resolve();
+        await ttsFinishes.promise;
+        return voiced;
+      },
+    };
 
-    expect(result).toBe(true);
+    const pending = inner.prepareAndFireBargeIn(config, sim, entry);
+    await ttsStarted.promise;
+    // The bot finishing DURING the TTS call is the situation the check exists
+    // for, and the ordering is the whole of it: a check that ran before the
+    // phrase was voiced would have seen a live entry and barged in anyway.
+    entry.done = true;
+    ttsFinishes.resolve();
+
+    await expect(pending).resolves.toBe(true);
     expect(fired).toEqual([]);
   });
 

--- a/javascript/src/execution/__tests__/proceed-interruptions.test.ts
+++ b/javascript/src/execution/__tests__/proceed-interruptions.test.ts
@@ -9,6 +9,7 @@
  * determinism; no network, no real keys.
  */
 
+import type { ModelMessage } from "ai";
 import { describe, it, expect, vi } from "vitest";
 
 import {
@@ -18,8 +19,8 @@ import {
   type AgentReturnTypes,
   UserSimulatorAgentAdapter,
 } from "../../domain";
-import { ScenarioExecution } from "../scenario-execution";
 import { InterruptionConfig } from "../../voice/interruption";
+import { ScenarioExecution } from "../scenario-execution";
 
 class MockAgent extends AgentAdapter {
   role = AgentRole.AGENT;
@@ -248,6 +249,169 @@ describe("consumePendingRolesUntilAgent (substep 2)", () => {
 
     expect(exec._i.pendingAgentsOnTurn.has(agent)).toBe(false);
     expect(exec._i.pendingRolesOnTurn).toEqual([]);
+  });
+});
+
+type BargeInInternals = {
+  interruptBargeInDelayMs?: number;
+  pendingAgentTask: { promise: Promise<void>; done: boolean; error: unknown | null } | null;
+  prepareAndFireBargeIn(
+    config: InterruptionConfig,
+    voiceUserSim: { voice: string; voiceifyText(text: string, cfg?: unknown): Promise<ModelMessage> },
+    entry: { promise: Promise<void>; done: boolean; error: unknown | null },
+  ): Promise<boolean>;
+  fireUserInterrupt(voicedMessage: ModelMessage): Promise<void>;
+};
+
+/**
+ * A live entry is the precondition the substep runs under: its sole caller
+ * dispatches the AGENT first, so `done` is false unless the bot beat the TTS.
+ */
+function liveEntry(done = false) {
+  return { promise: Promise.resolve(), done, error: null };
+}
+
+/** A voice user simulator whose TTS outcome the test decides. */
+function simThat(outcome: { voiced: ModelMessage } | { throws: Error }) {
+  const calls: string[] = [];
+  return {
+    calls,
+    voice: "alloy",
+    async voiceifyText(text: string): Promise<ModelMessage> {
+      calls.push(text);
+      if ("throws" in outcome) throw outcome.throws;
+      return outcome.voiced;
+    },
+  };
+}
+
+/**
+ * Substep 4 is the only one of the four with no targeted coverage, and it is
+ * the one that decides whether a barge-in happens at all: three of its four
+ * paths return `true` without firing one. `true` therefore does not mean "the
+ * user interrupted", it means "the AGENT was dispatched", so asserting the
+ * return value alone cannot tell the paths apart. These assert the side
+ * effects instead: whether the interrupt fired, and what the sampled delay
+ * was left as.
+ */
+describe("prepareAndFireBargeIn (substep 4)", () => {
+  const voiced: ModelMessage = { role: "user", content: "hold on" };
+
+  function makeBargeInExec() {
+    const exec = makeExecWithAgents([new MockAgent(), new RecordingUserSim()]);
+    const inner = exec as unknown as BargeInInternals;
+    const fired: ModelMessage[] = [];
+    // Stub the barge-in itself: substep 4's job is deciding whether to call
+    // it and with what, not what it does afterwards.
+    inner.fireUserInterrupt = async (message) => {
+      fired.push(message);
+    };
+    inner.pendingAgentTask = liveEntry();
+    return { exec, inner, fired };
+  }
+
+  it("samples the delay onto the barge-in field before voicing the phrase", async () => {
+    const { exec, inner, fired } = makeBargeInExec();
+    exec.interruptOverrides = { rng: () => 0 };
+    const config = new InterruptionConfig({
+      strategy: "random_phrase",
+      delayRange: [2, 2],
+    });
+    const sim = simThat({ voiced });
+
+    const result = await inner.prepareAndFireBargeIn(config, sim, liveEntry());
+
+    expect(result).toBe(true);
+    expect(inner.interruptBargeInDelayMs).toBe(2000);
+    expect(fired).toEqual([voiced]);
+  });
+
+  it("leaves the barge-in field unset when the sampled delay is zero", async () => {
+    const { exec, inner } = makeBargeInExec();
+    exec.interruptOverrides = { rng: () => 0 };
+    const config = new InterruptionConfig({
+      strategy: "random_phrase",
+      delayRange: [0, 0],
+    });
+
+    await inner.prepareAndFireBargeIn(config, simThat({ voiced }), liveEntry());
+
+    // Writing 0 would be indistinguishable from "no delay sampled" at the
+    // consumer, which reads the field with `??`.
+    expect(inner.interruptBargeInDelayMs).toBeUndefined();
+  });
+
+  it("skips the barge-in and clears the sampled delay when TTS fails", async () => {
+    const { exec, inner, fired } = makeBargeInExec();
+    exec.interruptOverrides = { rng: () => 0 };
+    const config = new InterruptionConfig({
+      strategy: "random_phrase",
+      delayRange: [2, 2],
+    });
+
+    const result = await inner.prepareAndFireBargeIn(
+      config,
+      simThat({ throws: new Error("tts unavailable") }),
+      liveEntry(),
+    );
+
+    expect(result).toBe(true);
+    expect(fired).toEqual([]);
+    // The delay was sampled before the TTS attempt, so leaving it set would
+    // hand a later successful barge-in this failed attempt's value.
+    expect(inner.interruptBargeInDelayMs).toBeUndefined();
+  });
+
+  it("skips the barge-in when the bot finished before the phrase was voiced", async () => {
+    const { exec, inner, fired } = makeBargeInExec();
+    exec.interruptOverrides = { rng: () => 0 };
+    const config = new InterruptionConfig({
+      strategy: "random_phrase",
+      delayRange: [2, 2],
+    });
+
+    const result = await inner.prepareAndFireBargeIn(
+      config,
+      simThat({ voiced }),
+      liveEntry(true),
+    );
+
+    expect(result).toBe(true);
+    expect(fired).toEqual([]);
+  });
+
+  it("records the voiced turn on the conversation when the barge-in fires", async () => {
+    const { exec, inner, fired } = makeBargeInExec();
+    exec.interruptOverrides = { rng: () => 0 };
+    const config = new InterruptionConfig({
+      strategy: "random_phrase",
+      delayRange: [2, 2],
+    });
+
+    await inner.prepareAndFireBargeIn(config, simThat({ voiced }), liveEntry());
+
+    expect(fired).toEqual([voiced]);
+    // The judge and the following turns only see the interrupt if it lands in
+    // the conversation, so firing without recording is a silent half-barge-in.
+    // Matched on shape rather than identity: the conversation stamps its own
+    // id onto every message it accepts.
+    expect(exec.messages).toContainEqual(
+      expect.objectContaining({ role: "user", content: "hold on" }),
+    );
+  });
+
+  it("voices the phrase the config picked, not the user simulator's own turn", async () => {
+    const { exec, inner } = makeBargeInExec();
+    exec.interruptOverrides = { rng: () => 0 };
+    const config = new InterruptionConfig({
+      strategy: "random_phrase",
+      delayRange: [2, 2],
+    });
+    const sim = simThat({ voiced });
+
+    await inner.prepareAndFireBargeIn(config, sim, liveEntry());
+
+    expect(sim.calls).toEqual([config.pickRandomPhrase(() => 0)]);
   });
 });
 

--- a/javascript/src/execution/__tests__/proceed-interruptions.test.ts
+++ b/javascript/src/execution/__tests__/proceed-interruptions.test.ts
@@ -335,21 +335,6 @@ describe("prepareAndFireBargeIn (substep 4)", () => {
     expect(fired).toEqual([voiced]);
   });
 
-  it("leaves the barge-in field unset when the sampled delay is zero", async () => {
-    const { exec, inner } = makeBargeInExec();
-    exec.interruptOverrides = { rng: () => 0 };
-    const config = new InterruptionConfig({
-      strategy: "random_phrase",
-      delayRange: [0, 0],
-    });
-
-    await inner.prepareAndFireBargeIn(config, simThat({ voiced }), liveEntry());
-
-    // Writing 0 would be indistinguishable from "no delay sampled" at the
-    // consumer, which reads the field with `??`.
-    expect(inner.interruptBargeInDelayMs).toBeUndefined();
-  });
-
   it("skips the barge-in and clears the sampled delay when TTS fails", async () => {
     const { exec, inner, fired } = makeBargeInExec();
     exec.interruptOverrides = { rng: () => 0 };
@@ -402,6 +387,57 @@ describe("prepareAndFireBargeIn (substep 4)", () => {
 
     await expect(pending).resolves.toBe(true);
     expect(fired).toEqual([]);
+  });
+
+  /**
+   * The delay is sampled before the TTS attempt, so every exit that does not
+   * fire a barge-in owns clearing it. `fireUserInterrupt` consumes it on the
+   * path that does fire. The two skip paths have to do it themselves, and a
+   * later call has to overwrite it even when the fresh sample is zero, or the
+   * next barge-in silently runs on a delay it never sampled.
+   *
+   * A fresh executor cannot show any of that: its field starts `undefined`, so
+   * "never set" and "cleared" look identical. These seed a real stale value
+   * through the production path first, then assert the second call.
+   */
+  describe("when a prior call left a sampled delay behind", () => {
+    /** Drives the entry-done bail so the field is set by production code. */
+    async function seedStaleDelay(inner: BargeInInternals) {
+      const doneEntry = { promise: Promise.resolve(), done: true, error: null };
+      await inner.prepareAndFireBargeIn(
+        new InterruptionConfig({ strategy: "random_phrase", delayRange: [2, 2] }),
+        simThat({ voiced }),
+        doneEntry,
+      );
+      return inner.interruptBargeInDelayMs;
+    }
+
+    it("clears the delay on the bot-finished bail, as the TTS bail does", async () => {
+      const { exec, inner } = makeBargeInExec();
+      exec.interruptOverrides = { rng: () => 0 };
+
+      const afterBail = await seedStaleDelay(inner);
+
+      // Nothing fired, so nothing consumed it. Leaving it set hands the next
+      // barge-in a delay belonging to a turn that never interrupted.
+      expect(afterBail).toBeUndefined();
+    });
+
+    it("overwrites a stale delay when the next sample is zero", async () => {
+      const { exec, inner } = makeBargeInExec();
+      exec.interruptOverrides = { rng: () => 0 };
+      inner.interruptBargeInDelayMs = 2000;
+
+      await inner.prepareAndFireBargeIn(
+        new InterruptionConfig({ strategy: "random_phrase", delayRange: [0, 0] }),
+        simThat({ voiced }),
+        liveEntry(),
+      );
+
+      // A zero sample means this turn wants no delay. Skipping the write keeps
+      // the previous turn's value instead, which is not what was sampled.
+      expect(inner.interruptBargeInDelayMs).toBeUndefined();
+    });
   });
 
   it("records the voiced turn on the conversation when the barge-in fires", async () => {

--- a/javascript/src/execution/scenario-execution.ts
+++ b/javascript/src/execution/scenario-execution.ts
@@ -1875,10 +1875,12 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     // agentSpeakingEvent fires (in fireUserInterrupt) — not before TTS.
     // Placing the sleep before TTS causes burst-TTS bots (pipecat stub) to
     // drain to entry.done=true and silently skip the barge-in window.
+    // Always write what this turn sampled. A conditional write would leave a
+    // previous turn's value in place whenever the fresh sample is zero, and
+    // the barge-in would then run on a delay it never sampled.
     const delaySeconds = config.sampleDelay(this.interruptRng);
-    if (delaySeconds > 0) {
-      this.interruptBargeInDelayMs = Math.floor(delaySeconds * 1000);
-    }
+    this.interruptBargeInDelayMs =
+      delaySeconds > 0 ? Math.floor(delaySeconds * 1000) : undefined;
 
     const phrase = config.pickRandomPhrase(this.interruptRng);
     let voicedMessage: ModelMessage | null = null;
@@ -1896,7 +1898,10 @@ export class ScenarioExecution implements ScenarioExecutionLike, VoiceExecutorSt
     }
 
     if (entry.done) {
-      // Bot finished before TTS completed — nothing to interrupt.
+      // Bot finished before TTS completed, so there is nothing to interrupt.
+      // Clear the sampled delay for the same reason the TTS failure does: no
+      // barge-in fires here, so nothing downstream consumes it.
+      this.interruptBargeInDelayMs = undefined;
       return true;
     }
     await this.fireUserInterrupt(voicedMessage);


### PR DESCRIPTION
## Ticket

Closes #578.

## Premise, re-checked on current main: most of it already landed

Worth stating up front, because it makes this PR much smaller than the ticket reads.

| acceptance criterion | state on `main` |
|---|---|
| `maybeScheduleInterruptedAgentTurn` is <= 30 lines | **done.** It is 17 lines, and reads as orchestration: five named substeps and the bail conditions |
| each extracted substep has at least one targeted unit test | **three of four done.** `resolveNextAgentForInlineBarge`, `consumePendingRolesUntilAgent` and `dispatchAgentBackground` each have a `describe(... substep N)` block in `proceed-interruptions.test.ts` |
| all existing tests still pass | unchanged here |

So what is left is the fourth substep. `prepareAndFireBargeIn` was extracted with the others and is the only one that never got its block.

## Why that gap is the interesting one

It is the substep that decides whether a barge-in happens at all, and it is 43 lines with four exits. Three of the four return `true` **without** firing one:

- the sampled delay is recorded, TTS succeeds, the bot is still talking, the barge-in fires;
- TTS throws, so the barge-in is skipped;
- the bot finished while TTS was running, so there is nothing to interrupt;
- and the happy path.

`true` therefore does not mean "the user interrupted", it means "the AGENT was dispatched". A test that asserts the return value cannot tell any of these apart. So these assert the side effects: whether the interrupt fired, whether the voiced turn reached the conversation, and what the sampled delay was left as.

The stale-delay case is the one worth having. The delay is sampled *before* the TTS attempt, so the failure path has to clear it; if it does not, a later successful barge-in silently inherits the failed attempt's value. The code comments call that a P2 fix and nothing pinned it.

## Change

Tests in one file, following the `substep N` convention already in it, **plus a production fix that review turned up**.

### The bug review found

This PR started test-only. Writing the coverage exposed a real defect, so it now carries the fix too.

The barge-in delay is sampled *before* the TTS attempt, so any exit that fires no barge-in owns clearing it: nothing downstream consumes it, because `fireUserInterrupt` is what consumes it and it never runs on a skip path. Only the TTS failure cleared it. Two things were wrong:

1. the bot-finished bail (`entry.done`) returned with the value still set;
2. the write itself was conditional on a positive sample, so a later turn sampling zero kept the earlier turn's value.

Either alone is a leak, and together they mean a barge-in can run on a delay sampled by a turn that never interrupted. It is reachable: `delayRange` is caller-settable (`init.delayRange ?? [0.5, 3.0]`), so a range starting at zero produces a zero sample. The stock range is always positive, which always overwrites, and that is what hid it.

Both bail paths now clear the field, and the write is unconditional.

I also deleted one of my own tests rather than keep it. It asserted the field was unset after a zero sample on a freshly built executor, where the field starts unset anyway, so it could not distinguish "never written" from "cleared" and passed whatever production did. The stale-value test supersedes it strictly.

## Evidence

- `vitest run src/execution/__tests__/proceed-interruptions.test.ts`: **16 passed** (10 before).
- `vitest run src/execution src/voice src/domain`: **631 passed, 1 skipped** across 70 files.
- `eslint` clean on the changed file, and `lint:lib` clean.
- Typecheck: **0 errors naming this file**. Total diagnostics are identical with my change and with `main`'s version of the file (8 either way, all pre-existing and in files this PR does not touch), and the run was confirmed live by injecting a deliberate type error and seeing it reported.

### Mutations, all 8 caught

Re-derived against the current code rather than carried over, because the fix changed what the anchors are:

| mutation | result |
|---|---|
| the TTS bail stops clearing the sampled delay | 1 failed |
| TTS failure fires the barge-in anyway | 1 failed |
| the bot-finished check is removed entirely | 2 failed |
| the barge-in fires but the turn is never recorded on the conversation | 1 failed |
| a different phrase is voiced than the one the config picked | 1 failed |
| the bot-finished bail stops clearing the sampled delay | 1 failed |
| the delay write becomes conditional on a positive sample again | 1 failed |
| the bot-finished bail is moved to before the TTS call | 1 failed |

Two notes on how that table was produced, since both are ways a mutation table lies.

**A mutation has to land where you meant.** `this.state.addMessage(voicedMessage)` appears twice in `scenario-execution.ts` and only the second is in this substep, so a first-occurrence replacement patches the wrong call site, the suite stays green, and it reads as an escaped mutation. That row is line-targeted.

**Moving a guard means deleting it from the old place too.** The last row initially came back green because the edit added the check above the TTS call while leaving the original below it, which preserves behaviour exactly. A guard that is only added is not moved.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.



