### PR TITLE
fix(js): print judge failure details by default

### DIFF
--- a/javascript/src/runner/__tests__/run.test.ts
+++ b/javascript/src/runner/__tests__/run.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { run, type RunOptions } from "../run";
 import { AgentRole, type AgentAdapter, type AgentInput, type ScenarioConfig } from "../../domain";
 import type { ScenarioEvent } from "../../events/schema";
+import { run, type RunOptions } from "../run";
 
 // Mock the EventBus - must use function keyword for constructor
 vi.mock("../../events/event-bus", () => ({
@@ -75,6 +75,20 @@ class TestJudgeAgent implements AgentAdapter {
   }
 }
 
+class FailingJudgeAgent implements AgentAdapter {
+  name = "FailingJudge";
+  role = AgentRole.JUDGE;
+
+  async call(_input: AgentInput) {
+    return {
+      success: false,
+      reasoning: "The response did not satisfy the requested constraints",
+      metCriteria: ["The agent responded"],
+      unmetCriteria: ["The answer is accurate", "The answer cites its source"],
+    };
+  }
+}
+
 function createScenarioConfig(name = "Test Scenario"): ScenarioConfig {
   return {
     name,
@@ -116,6 +130,30 @@ describe("run", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe("failure output", () => {
+    it("prints the judge reasoning and unmet criteria without verbose output", async () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const config = createScenarioConfig();
+      config.agents = [new TestAgent(), new FailingJudgeAgent()];
+      config.script = [
+        async (_state, executor) => {
+          await executor.judge();
+        },
+      ];
+
+      await run(config);
+
+      expect(log).toHaveBeenCalledWith("Scenario failed: Test Scenario");
+      expect(log).toHaveBeenCalledWith(
+        "Reasoning: The response did not satisfy the requested constraints"
+      );
+      expect(log).toHaveBeenCalledWith(
+        "Unmet criteria: The answer is accurate\n- The answer cites its source"
+      );
+      expect(log).not.toHaveBeenCalledWith("Met criteria: The agent responded");
+    });
   });
 
   describe("runId", () => {

--- a/javascript/src/runner/run.ts
+++ b/javascript/src/runner/run.ts
@@ -174,13 +174,17 @@ export async function run(cfg: ScenarioConfig, options?: RunOptions): Promise<Sc
 
     const startedAt = Date.now();
     const result = await execution.execute();
-    if (cfg.verbose && !result.success) {
+    if (!result.success) {
       console.log(`Scenario failed: ${cfg.name}`);
       console.log(`Reasoning: ${result.reasoning}`);
-      console.log("--------------------------------");
-      console.log(`Met criteria: ${result.metCriteria.join("\n- ")}`);
+      if (cfg.verbose) {
+        console.log("--------------------------------");
+        console.log(`Met criteria: ${result.metCriteria.join("\n- ")}`);
+      }
       console.log(`Unmet criteria: ${result.unmetCriteria.join("\n- ")}`);
-      console.log(result.messages.map(formatMessage).join("\n"));
+      if (cfg.verbose) {
+        console.log(result.messages.map(formatMessage).join("\n"));
+      }
     }
 
     // Auto-save red-team report when a RedTeamAgent participated.


### PR DESCRIPTION
## Why

A failed JavaScript scenario returned its result without printing the judge explanation in the default terminal output, so local and agent-driven test runs could not identify the unmet criteria without opening the platform run.

Closes #963

## What changed

- Always print the failure verdict, judge reasoning, and unmet criteria because they are the minimum actionable failure summary.
- Keep met criteria and the full conversation behind `verbose` so default output remains concise.
- Cover the default path with an offline runner regression test, avoiding provider credentials or network calls.

## Test plan

- `pnpm exec vitest run src/runner/__tests__/run.test.ts` — 23 passed
- `pnpm test` — 1,442 passed, 58 skipped
- `pnpm run typecheck`
- `pnpm exec eslint src/runner/run.ts src/runner/__tests__/run.test.ts`
- Regression assertion verifies default failure output includes the scenario verdict, judge reasoning, and every unmet criterion while excluding met criteria.

## How I can prove I was successful

No playable artifact — see the offline regression in `javascript/src/runner/__tests__/run.test.ts` and the Test plan.

## AI assistance

Codex was used for implementation, testing, and independent code review. This Draft remains subject to human review.
