### PR TITLE
feat(javascript): claude code adapter returns structured messages, shapes the CLI env and leaves no orphan process

### DIFF
--- a/docs/docs/pages/agent-integration/claude-code.mdx
+++ b/docs/docs/pages/agent-integration/claude-code.mdx
@@ -71,6 +71,10 @@ const result = await scenario.run({
 | `logger` | `Logger` | no-op | Receives all diagnostic output (`log` and `warn`). Omit for silent operation. |
 | `extraArgs` | `string[]` | `[]` | Extra CLI arguments inserted before the prompt. Use for flags not modelled by config fields. |
 | `claudeBin` | `string` | `"claude"` | Path or name of the Claude Code binary. Resolution order: `claudeBin` → `CLAUDE_BIN` env var → `"claude"`. |
+| `env` | `Record<string, string \| undefined>` | `{}` | Applied over this process's environment. A key set to `undefined` is removed from what the CLI sees. `PATH` set here replaces the inherited one, so prefix it to put a local binary first. `FORCE_COLOR=0` is always set last. See [Environment](#environment). |
+| `output` | `"text" \| "messages"` | `"text"` | What a turn returns: the assistant-visible text with tool calls rendered inline, or AI SDK messages with `tool-call` and `tool-result` parts. See [Structured output](#structured-output). |
+| `maxToolResultChars` | `number` | `8000` | How many characters of one tool result reach the conversation. The rest is replaced by a line saying how many characters were dropped. |
+| `maxToolInputChars` | `number` | `30000` | How many characters of one string inside a tool call input reach the conversation. Nested strings are capped too. |
 
 ## Skill testing
 
@@ -78,9 +82,23 @@ The adapter's distinguishing feature is first-class skill testing:
 
 **Injection via `skillPath`** — pass an absolute path to a `SKILL.md` and the
 factory will copy it into `<workingDirectory>/.skills/<skill-name>/SKILL.md`
-and write a `CLAUDE.md` (if one does not already exist) that instructs Claude
-to read the skill before doing anything else. The injected layout matches
-Claude Code's native discovery conventions.
+and point the working directory's `CLAUDE.md` at it, so Claude reads the skill
+before doing anything else. A `CLAUDE.md` the fixture already ships is kept:
+only the skills it does not mention yet are appended, and the instruction is
+written once. The injected layout matches Claude Code's native discovery
+conventions.
+
+**Skills installed some other way**: when your harness copies skills into
+`.skills/` itself (several skills, a rendered `SKILL.md`, a fixture project),
+call `pointClaudeMdAtSkills(workingDirectory)` after the copy to get the same
+`CLAUDE.md` instruction for every skill it finds there.
+
+```typescript
+import { pointClaudeMdAtSkills } from "@langwatch/scenario";
+
+installMySkills(workingDirectory); // writes .skills/<name>/SKILL.md
+pointClaudeMdAtSkills(workingDirectory);
+```
 
 **Asserting the skill was read** — after the scenario run, call
 `assertSkillWasRead(state, skillName)` to verify that the skill file actually
@@ -97,6 +115,93 @@ assertSkillWasRead(result, "my-skill");
 
 `skillName` is the parent directory name of the `SKILL.md` — i.e. the segment
 in `.skills/<skillName>/SKILL.md`.
+
+**Reading what the agent ran**: with `output: "messages"` (below), the
+shell commands the agent ran are `tool-call` parts naming the `Bash` tool.
+`bashCommands(state)` lists them, and only them: a command quoted in the skill
+text or in the agent's own explanation is not a command that ran.
+
+```typescript
+import { bashCommands } from "@langwatch/scenario";
+
+const commands = bashCommands(result);
+expect(commands.some((c) => c.startsWith("langwatch prompts sync"))).toBe(true);
+```
+
+## Structured output
+
+By default a turn comes back as text, with each tool call and result rendered
+as a readable line (`Tool Called: Bash({"command":"ls"})`, `Tool Result: ...`).
+With `output: "messages"` a turn comes back as AI SDK messages instead: an
+assistant message with a text part and one `tool-call` part per tool the agent
+called, and a `tool` message with a `tool-result` part per result. The judge
+and the user simulator then read the calls structurally, and the LangWatch run
+view renders them as tool calls rather than as prose.
+
+```typescript
+claudeCodeAgent({
+  workingDirectory,
+  output: "messages",
+  maxToolResultChars: 4000,
+});
+```
+
+Both renderings cap what a tool result and a tool call input contribute to the
+conversation (`maxToolResultChars`, `maxToolInputChars`). The judge reads the
+whole conversation on every step, and one exported trace or log file in a tool
+result would push a long run past its context window for a reason that has
+nothing to do with the agent under test. A result keeps its first characters,
+where command names, ids and URLs stand; a call input keeps far more, since it
+is what the agent wrote and is the work under judgement. The dropped count is
+appended so the judge knows the text is cut. Thinking blocks are never part of
+either rendering, and a block the conversation has no part for (an image, a
+document) leaves a line naming it instead of disappearing.
+
+`toModelMessages(rawMessages, limits?)` and `parseStreamJson(stdout)` are
+exported for a harness that reads a stream-json transcript on its own.
+
+## Environment
+
+The CLI inherits this process's environment. `env` applies on top of it, and
+a key set to `undefined` is removed, which is how a test keeps a provider key
+for its judge while hiding it from the agent, or keeps the batch id of the
+harness out of the scenario runs the agent writes itself:
+
+```typescript
+claudeCodeAgent({
+  workingDirectory,
+  env: {
+    PATH: `${localBin}:${process.env.PATH}`,
+    OPENAI_API_KEY: undefined,
+    SCENARIO_BATCH_RUN_ID: undefined,
+  },
+});
+```
+
+`FORCE_COLOR=0` is always set last, so the transcript carries no escape codes.
+
+## Process lifecycle
+
+A `claude -p` run spawns its own children: the shell commands of its Bash
+tool, a test runner, a dev server. When the process that spawned Claude dies
+with a turn still running (a test runner killed under memory pressure, a
+Ctrl-C, a session restart), nothing would tell those processes to stop. They
+would reparent to pid 1 and keep running, burning tokens and memory into a
+pipe nobody reads. The adapter takes three measures so that does not happen:
+
+- The CLI is spawned as the leader of its own process group, so a kill aimed
+  at the group reaches every descendant, not only the CLI. The `timeout` kill
+  is such a group kill: SIGTERM to the group, then SIGKILL two seconds later.
+- On the harness's own `exit` every group still running gets SIGKILL. That
+  covers a normal exit, `process.exit()` and an uncaught exception.
+- A small shell watchdog (`claude-code-watchdog` in `ps`), detached from both,
+  polls the harness pid and the CLI pid once a second and terminates the CLI's
+  group when the harness is gone. That covers SIGKILL and any other death that
+  runs no JavaScript. The watchdog exits by itself the moment the CLI exits,
+  so a healthy turn leaves nothing behind.
+
+Process groups and the watchdog are POSIX. On Windows the CLI is spawned as
+before and only the exit hook applies.
 
 ## Error handling
 

--- a/javascript/src/agents/__tests__/claude-code-adapter.test.ts
+++ b/javascript/src/agents/__tests__/claude-code-adapter.test.ts
@@ -1800,6 +1800,51 @@ describe("ClaudeCodeAgentAdapter logger isolation", () => {
       consoleError.mockRestore();
     }
   });
+
+  describe("when a multibyte character is split across two chunks", () => {
+    /** @scenario "Live CLI output is logged as the CLI wrote it" */
+    it("logs the character intact instead of replacement characters", async () => {
+      const child = new FakeChild();
+      withChild(child);
+      const logger = spyLogger();
+
+      const adapter = new ClaudeCodeAgentAdapter({
+        workingDirectory: "/tmp/split",
+        logger,
+      });
+      const p = adapter.call(SIMPLE_INPUT);
+
+      // "é" is two UTF-8 bytes; cut the payload between them so each `data`
+      // event carries half of it, the way a real pipe can chunk.
+      const payload = Buffer.from(assistantLine("café") + "\n", "utf8");
+      const cut = payload.indexOf(0xc3) + 1;
+      child.stdout.emit("data", payload.subarray(0, cut));
+      child.stdout.emit("data", payload.subarray(cut));
+      child.stderr.emit("data", payload.subarray(0, cut));
+      child.stderr.emit("data", payload.subarray(cut));
+      child.close(0);
+      await p;
+
+      // The decoder holds the incomplete tail back, so the character lands in
+      // whichever log line completes it. What the diagnostic must never carry
+      // is a replacement character, and the lines together must reconstruct
+      // what the CLI wrote.
+      const streamed = (calls: unknown[][], prefix: string): string =>
+        calls
+          .flat()
+          .filter((arg): arg is string => typeof arg === "string" && arg.startsWith(prefix))
+          .map((line) => line.slice(prefix.length))
+          .join("");
+
+      const logged = streamed(logger.log.mock.calls, "Claude Code stdout: ");
+      expect(logged).toContain("café");
+      expect(logged).not.toContain("�");
+
+      const warned = streamed(logger.warn.mock.calls, "Claude Code stderr: ");
+      expect(warned).toContain("café");
+      expect(warned).not.toContain("�");
+    });
+  });
 });
 
 // --- 7. skill helpers -------------------------------------------------------

--- a/javascript/src/agents/__tests__/claude-code-adapter.test.ts
+++ b/javascript/src/agents/__tests__/claude-code-adapter.test.ts
@@ -2487,7 +2487,7 @@ describe("pointClaudeMdAtSkills", () => {
 
 const posix = process.platform !== "win32";
 
-class FakeWatchdog {
+class FakeWatchdog extends EventEmitter {
   unref = vi.fn();
 }
 
@@ -2565,6 +2565,21 @@ describe.skipIf(!posix)("ClaudeCodeAgentAdapter process lifecycle", () => {
 
     expect(claudeSpawnCalls()).toHaveLength(1);
     expect(watchdogSpawnCalls()).toHaveLength(0);
+  });
+
+  /** @scenario "A watchdog that cannot start does not fail the turn" */
+  it("resolves the turn when the watchdog itself fails to spawn", async () => {
+    const child = new FakeChild(4106);
+    const watchdog = withGuardedChild(child);
+
+    const p = new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x" }).call(SIMPLE_INPUT);
+    const err = new Error("ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    watchdog.emit("error", err);
+
+    child.pushStdout(assistantLine("hi") + "\n");
+    child.close();
+    await expect(p).resolves.toBe("hi");
   });
 
   /** @scenario "A timeout kills the whole process group" */

--- a/javascript/src/agents/__tests__/claude-code-adapter.test.ts
+++ b/javascript/src/agents/__tests__/claude-code-adapter.test.ts
@@ -51,6 +51,16 @@
  *      without; scoping.
  *  8.  `claudeCodeAgent` factory injects a `skillPath` as a construction effect.
  *  9.  `safeStringify` never throws.
+ *  10. `env`: this process's environment with `config.env` on top, `undefined`
+ *      removing a key, `FORCE_COLOR=0` last.
+ *  11. `output`: `"messages"` returns AI SDK messages with tool-call and
+ *      tool-result parts, the default returns rendered text; the caps apply.
+ *  12. `toModelMessages`: parts, empty text part on a tool-only turn, unknown
+ *      blocks named, error results, caps in both renderings.
+ *  13. `bashCommands` reads only Bash tool-call parts.
+ *  14. `pointClaudeMdAtSkills` appends missing skills to an existing CLAUDE.md.
+ *  15. process lifecycle: own process group, watchdog spawn, group kill on
+ *      timeout, SIGKILL of live groups on harness exit.
  *
  * CI note: the `RUN_CLAUDE_CODE_E2E=1` integration tests at the bottom are
  * DEV-ONLY smoke checks — they need a real `claude` binary (and, for two of
@@ -117,8 +127,12 @@ import {
   claudeCodeAgent,
   parseStreamJson,
   assertSkillWasRead,
+  bashCommands,
+  pointClaudeMdAtSkills,
+  toModelMessages,
   type Logger,
 } from "../claude-code/index.js";
+import { killGuardedProcesses } from "../claude-code/process-lifecycle.js";
 import { safeStringify } from "../claude-code/stream-json.js";
 
 /**
@@ -141,6 +155,15 @@ class FakeChild extends EventEmitter {
   stdout = new EventEmitter();
   stderr = new EventEmitter();
   kill = vi.fn();
+
+  /**
+   * A pid makes the adapter treat the child as a real process group leader:
+   * group kills go through `process.kill(-pid)` and a watchdog is spawned.
+   * Left undefined by default so the earlier groups see one spawn per turn.
+   */
+  constructor(readonly pid?: number) {
+    super();
+  }
 
   /** Push a chunk to stdout (as the CLI would). */
   pushStdout(chunk: string): void {
@@ -1984,6 +2007,615 @@ describe("safeStringify", () => {
     expect(safeStringify({ a: 1 })).toBe('{"a":1}');
     expect(safeStringify("hello")).toBe('"hello"');
     expect(safeStringify(null)).toBe("null");
+  });
+});
+
+// --- 10. env --------------------------------------------------------------
+
+describe("ClaudeCodeAgentAdapter env", () => {
+  const KEY = "CC_TEST_PROVIDER_KEY";
+  const BATCH = "CC_TEST_BATCH_ID";
+
+  beforeEach(() => {
+    process.env[KEY] = "sk-judge";
+    process.env[BATCH] = "batch-1";
+  });
+  afterEach(() => {
+    delete process.env[KEY];
+    delete process.env[BATCH];
+  });
+
+  /** @scenario "The CLI environment is this process's with the configured keys on top" */
+  it("gives the CLI this process's environment with config.env on top, undefined removing a key, and FORCE_COLOR=0 last", async () => {
+    const child = new FakeChild();
+    withChild(child);
+
+    const adapter = new ClaudeCodeAgentAdapter({
+      workingDirectory: "/tmp/x",
+      env: { CC_TEST_NEW: "1", [BATCH]: undefined, FORCE_COLOR: "1" },
+    });
+    const p = adapter.call(SIMPLE_INPUT);
+    child.pushStdout(assistantLine("hi") + "\n");
+    child.close();
+    await p;
+
+    const options = spawnMock.mock.calls.at(-1)?.[2] as { env: NodeJS.ProcessEnv };
+    expect(options.env.CC_TEST_NEW).toBe("1");
+    expect(options.env[KEY]).toBe("sk-judge");
+    expect(BATCH in options.env).toBe(false);
+    expect(options.env.FORCE_COLOR).toBe("0");
+  });
+});
+
+// --- 11. output ------------------------------------------------------------
+
+/** An assistant line carrying one `tool_use` block (and optional text before it). */
+function toolUseLine(
+  id: string,
+  name: string,
+  input: unknown,
+  text?: string,
+): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [
+        ...(text !== undefined ? [{ type: "text", text }] : []),
+        { type: "tool_use", id, name, input },
+      ],
+    },
+  });
+}
+
+/** A user line carrying one `tool_result` block. */
+function toolResultLine(toolUseId: string, content: unknown, isError = false): string {
+  return JSON.stringify({
+    type: "user",
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          content,
+          ...(isError ? { is_error: true } : {}),
+        },
+      ],
+    },
+  });
+}
+
+const TOOL_TURN_STDOUT = [
+  toolUseLine("toolu_1", "Bash", { command: "ls" }, "Reading."),
+  toolResultLine("toolu_1", [{ type: "text", text: "a.txt" }]),
+  assistantLine("Done."),
+].join("\n");
+
+describe("ClaudeCodeAgentAdapter output", () => {
+  /** @scenario "A turn is returned as AI SDK messages when output is messages" */
+  it("returns AI SDK messages with tool-call and tool-result parts when output is messages", async () => {
+    const child = new FakeChild();
+    withChild(child);
+
+    const adapter = new ClaudeCodeAgentAdapter({
+      workingDirectory: "/tmp/x",
+      output: "messages",
+    });
+    const p = adapter.call(SIMPLE_INPUT);
+    child.pushStdout(TOOL_TURN_STDOUT);
+    child.close();
+
+    await expect(p).resolves.toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Reading." },
+          {
+            type: "tool-call",
+            toolCallId: "toolu_1",
+            toolName: "Bash",
+            input: { command: "ls" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "toolu_1",
+            toolName: "Bash",
+            output: { type: "text", value: "a.txt" },
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "Done." }] },
+    ]);
+  });
+
+  /** @scenario "A turn is returned as text by default" */
+  it("returns the text with tool calls and results rendered inline by default", async () => {
+    const child = new FakeChild();
+    withChild(child);
+
+    const p = new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x" }).call(
+      SIMPLE_INPUT,
+    );
+    child.pushStdout(TOOL_TURN_STDOUT);
+    child.close();
+
+    await expect(p).resolves.toBe(
+      'Reading.\nTool Called: Bash({"command":"ls"})\n\nTool Result: a.txt\n\nDone.',
+    );
+  });
+
+  /** @scenario "The caps are configurable on the adapter" */
+  it("caps a tool result at maxToolResultChars and says how much it dropped", async () => {
+    const child = new FakeChild();
+    withChild(child);
+
+    const adapter = new ClaudeCodeAgentAdapter({
+      workingDirectory: "/tmp/x",
+      output: "messages",
+      maxToolResultChars: 100,
+    });
+    const p = adapter.call(SIMPLE_INPUT);
+    child.pushStdout(
+      [
+        toolUseLine("toolu_1", "Bash", { command: "cat big" }),
+        toolResultLine("toolu_1", "y".repeat(500)),
+      ].join("\n"),
+    );
+    child.close();
+
+    const messages = (await p) as ModelMessage[];
+    const result = (messages[1]?.content as Array<{ output: { value: string } }>)[0];
+    expect(result?.output.value.startsWith("y".repeat(100))).toBe(true);
+    expect(result?.output.value).toMatch(/\[400 more characters\]/);
+    expect(result?.output.value).not.toContain("y".repeat(101));
+  });
+});
+
+// --- 12. transcript conversion ---------------------------------------------
+
+describe("toModelMessages", () => {
+  const transcript = [
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "Read the skill first.", signature: "s" },
+        { type: "text", text: "I'll start by reading the skill instructions." },
+        {
+          type: "tool_use",
+          id: "toolu_01",
+          name: "Bash",
+          input: { command: "cat .skills/scenarios/SKILL.md" },
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_01",
+          content: [{ type: "text", text: "# Scenarios skill" }],
+        },
+      ],
+    },
+    { role: "assistant", content: [{ type: "text", text: "Done." }] },
+  ];
+
+  /** @scenario "A transcript becomes AI SDK messages with tool-call and tool-result parts" */
+  it("emits tool-call and tool-result parts, names the tool of a result, and drops thinking", () => {
+    const messages = toModelMessages(transcript);
+
+    expect(messages).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll start by reading the skill instructions." },
+          {
+            type: "tool-call",
+            toolCallId: "toolu_01",
+            toolName: "Bash",
+            input: { command: "cat .skills/scenarios/SKILL.md" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "toolu_01",
+            toolName: "Bash",
+            output: { type: "text", value: "# Scenarios skill" },
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "Done." }] },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain("Read the skill first.");
+  });
+
+  /** @scenario "An assistant turn that only calls tools keeps an empty text part" */
+  it("keeps an empty text part on a turn that only called tools", () => {
+    const messages = toModelMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_02", name: "Read", input: { file: "x" } }],
+      },
+    ]);
+    expect(messages[0]?.content).toEqual([
+      { type: "text", text: "" },
+      { type: "tool-call", toolCallId: "toolu_02", toolName: "Read", input: { file: "x" } },
+    ]);
+  });
+
+  /** @scenario "A block the conversation cannot carry leaves a line naming it" */
+  it("names a block the conversation has no part for instead of dropping it", () => {
+    const messages = toModelMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here is the screenshot." },
+          { type: "image", source: { type: "base64", data: "iVBORw0KGgo=" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "document", source: { type: "text", data: "x" } }],
+      },
+    ]);
+
+    expect(messages).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Here is the screenshot.\n[image block, not shown in the transcript]",
+          },
+        ],
+      },
+      { role: "user", content: "[document block, not shown in the transcript]" },
+    ]);
+  });
+
+  /** @scenario "A failed tool result is an error-text output" */
+  it("renders an is_error tool_result as an error-text output", () => {
+    const messages = toModelMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_03", name: "Bash", input: { command: "false" } }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_03", content: "exit 1", is_error: true },
+        ],
+      },
+    ]);
+    expect(messages[1]).toEqual({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "toolu_03",
+          toolName: "Bash",
+          output: { type: "error-text", value: "exit 1" },
+        },
+      ],
+    });
+  });
+
+  describe("when a tool call carries far more text than a judge can read", () => {
+    const huge = "x".repeat(60_000);
+    const bigTranscript = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_big",
+            name: "Bash",
+            input: { command: `cat > report.html <<EOF\n${huge}` },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_big",
+            content: [{ type: "text", text: huge }],
+          },
+        ],
+      },
+    ];
+    const messages = toModelMessages(bigTranscript);
+
+    /** @scenario "Tool inputs and results are capped in both renderings" */
+    it("caps the call input and says how much it dropped", () => {
+      const call = (messages[0]!.content as Array<{ type: string; input: { command: string } }>)[1]!;
+      expect(call.type).toBe("tool-call");
+      expect(call.input.command.length).toBeLessThan(31_000);
+      expect(call.input.command).toContain("cat > report.html");
+      expect(call.input.command).toMatch(/more characters/);
+    });
+
+    /** @scenario "Tool inputs and results are capped in both renderings" */
+    it("caps the result the same way", () => {
+      const result = (messages[1]!.content as Array<{ type: string; output: { value: string } }>)[0]!;
+      expect(result.type).toBe("tool-result");
+      expect(result.output.value.length).toBeLessThan(9000);
+      expect(result.output.value).toMatch(/more characters/);
+    });
+
+    /** @scenario "Tool inputs and results are capped in both renderings" */
+    it("caps a string nested inside the input too", () => {
+      const nested = toModelMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_nested",
+              name: "Write",
+              input: { payload: { html: huge }, files: [huge] },
+            },
+          ],
+        },
+      ]);
+      const call = (
+        nested[0]!.content as Array<{ input: { payload: { html: string }; files: string[] } }>
+      )[1]!;
+      expect(call.input.payload.html.length).toBeLessThan(31_000);
+      expect(call.input.payload.html).toMatch(/more characters/);
+      expect(call.input.files[0]!.length).toBeLessThan(31_000);
+    });
+
+    /** @scenario "Tool inputs and results are capped in both renderings" */
+    it("caps the text rendering of the same transcript the same way", () => {
+      const stdout = bigTranscript
+        .map((message) => JSON.stringify({ type: message.role, message }))
+        .join("\n");
+      const { text } = parseStreamJson(stdout);
+      expect(text.length).toBeLessThan(40_000);
+      expect(text).toContain("Tool Called: Bash(");
+      expect(text).toContain("Tool Result: ");
+      expect(text.match(/more characters/g)).toHaveLength(2);
+    });
+
+    /** @scenario "Tool inputs and results are capped in both renderings" */
+    it("leaves a small tool call alone", () => {
+      const small = toModelMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_small",
+              name: "Bash",
+              input: { command: "langwatch virtual-keys list" },
+            },
+          ],
+        },
+      ]);
+      expect(bashCommands({ messages: small } as ScenarioExecutionStateLike)).toEqual([
+        "langwatch virtual-keys list",
+      ]);
+    });
+  });
+});
+
+// --- 13. bashCommands --------------------------------------------------------
+
+describe("bashCommands", () => {
+  /** @scenario "The Bash commands of a run are read from the tool-call parts" */
+  it("lists only the commands of Bash tool-call parts, not quoted text or other tools", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "Please run `rm -rf build` for me." },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I would normally run `make test` here." },
+          { type: "tool-call", toolCallId: "1", toolName: "Bash", input: { command: "pytest -q" } },
+          { type: "tool-call", toolCallId: "2", toolName: "Read", input: { file_path: "x" } },
+        ],
+      },
+    ];
+    expect(bashCommands({ messages } as ScenarioExecutionStateLike)).toEqual(["pytest -q"]);
+  });
+});
+
+// --- 14. pointClaudeMdAtSkills ---------------------------------------------
+
+describe("pointClaudeMdAtSkills", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cc-point-wd-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function installSkill(name: string): void {
+    fs.mkdirSync(path.join(tmpDir, ".skills", name), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, ".skills", name, "SKILL.md"), `# ${name}\n`);
+  }
+
+  /** @scenario "An existing CLAUDE.md is pointed at the installed skills" */
+  it("keeps an existing CLAUDE.md and appends only the skills it does not mention, once", () => {
+    installSkill("alpha");
+    installSkill("beta");
+    const claudeMd = path.join(tmpDir, "CLAUDE.md");
+    const original = "# Fixture project\nRead .skills/alpha/SKILL.md first.\n";
+    fs.writeFileSync(claudeMd, original);
+
+    pointClaudeMdAtSkills(tmpDir);
+    const once = fs.readFileSync(claudeMd, "utf8");
+    expect(once.startsWith(original)).toBe(true);
+    expect(once).toContain(
+      "Read and follow the instructions in .skills/beta/SKILL.md before doing anything else.",
+    );
+    expect(once.match(/\.skills\/alpha\/SKILL\.md/g)).toHaveLength(1);
+
+    pointClaudeMdAtSkills(tmpDir);
+    expect(fs.readFileSync(claudeMd, "utf8")).toBe(once);
+  });
+
+  /** @scenario "A working directory without skills is left alone" */
+  it("writes nothing when the working directory has no skills", () => {
+    pointClaudeMdAtSkills(tmpDir);
+    expect(fs.existsSync(path.join(tmpDir, "CLAUDE.md"))).toBe(false);
+  });
+});
+
+// --- 15. process lifecycle ---------------------------------------------------
+//
+// The CLI leads its own process group, a detached shell watchdog kills that
+// group when the harness dies first, and the harness's own `exit` SIGKILLs
+// every group still running. The watchdog is a second `spawn`, so these tests
+// route the mock by binary: `/bin/sh` yields the fake watchdog, anything else
+// the fake CLI. Only a child WITH a pid gets a watchdog, so the earlier groups,
+// whose children have none, see exactly one spawn per turn as before.
+
+const posix = process.platform !== "win32";
+
+class FakeWatchdog {
+  unref = vi.fn();
+}
+
+/** Route `spawn` by binary: the watchdog for `/bin/sh`, `child` otherwise. */
+function withGuardedChild(child: FakeChild): FakeWatchdog {
+  const watchdog = new FakeWatchdog();
+  spawnMock.mockImplementation(((bin: string) =>
+    bin === "/bin/sh" ? watchdog : child) as unknown as typeof spawn);
+  return watchdog;
+}
+
+function claudeSpawnCalls() {
+  return spawnMock.mock.calls.filter((call) => call[0] !== "/bin/sh");
+}
+
+function watchdogSpawnCalls() {
+  return spawnMock.mock.calls.filter((call) => call[0] === "/bin/sh");
+}
+
+/** Run one clean turn on `child` and resolve it. */
+async function completeTurn(adapter: ClaudeCodeAgentAdapter, child: FakeChild): Promise<void> {
+  const p = adapter.call(SIMPLE_INPUT);
+  child.pushStdout(assistantLine("hi") + "\n");
+  child.close();
+  await p;
+}
+
+describe.skipIf(!posix)("ClaudeCodeAgentAdapter process lifecycle", () => {
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+  });
+  afterEach(() => {
+    killSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  /** @scenario "The CLI is spawned as the leader of its own process group" */
+  it("spawns the CLI detached, in its own process group", async () => {
+    const child = new FakeChild(4101);
+    withGuardedChild(child);
+
+    await completeTurn(new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x" }), child);
+
+    expect(claudeSpawnCalls()).toHaveLength(1);
+    expect(claudeSpawnCalls()[0]?.[2]).toMatchObject({ detached: true, cwd: "/tmp/x" });
+  });
+
+  /** @scenario "A watchdog outlives the harness and is told both pids" */
+  it("spawns a detached, unreferenced shell watchdog told the harness pid and the CLI pid", async () => {
+    const child = new FakeChild(4102);
+    const watchdog = withGuardedChild(child);
+
+    await completeTurn(new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x" }), child);
+
+    expect(watchdogSpawnCalls()).toHaveLength(1);
+    const [, args, options] = watchdogSpawnCalls()[0]!;
+    const argv = args as string[];
+    expect(argv[0]).toBe("-c");
+    expect(argv.slice(2)).toEqual(["claude-code-watchdog", String(process.pid), "4102"]);
+    expect(argv[1]).toContain('kill -0 "$harness"');
+    expect(argv[1]).toContain('kill -TERM -- "-$child"');
+    expect(argv[1]).toContain('kill -KILL -- "-$child"');
+    expect(options).toMatchObject({ detached: true, stdio: "ignore" });
+    expect(watchdog.unref).toHaveBeenCalledTimes(1);
+  });
+
+  /** @scenario "A watchdog outlives the harness and is told both pids" */
+  it("spawns no watchdog for a CLI that never got a pid", async () => {
+    const child = new FakeChild();
+    withGuardedChild(child);
+
+    await completeTurn(new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x" }), child);
+
+    expect(claudeSpawnCalls()).toHaveLength(1);
+    expect(watchdogSpawnCalls()).toHaveLength(0);
+  });
+
+  /** @scenario "A timeout kills the whole process group" */
+  it("sends SIGTERM then SIGKILL to the CLI's process group on timeout, not to the CLI alone", async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild(4103);
+    withGuardedChild(child);
+
+    const p = new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x", timeout: 50 }).call(
+      SIMPLE_INPUT,
+    );
+    const assertion = expect(p).rejects.toThrow(/timed out after 50ms/);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+    expect(killSpy).toHaveBeenCalledWith(-4103, "SIGTERM");
+    expect(killSpy).not.toHaveBeenCalledWith(-4103, "SIGKILL");
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(killSpy).toHaveBeenCalledWith(-4103, "SIGKILL");
+    expect(child.kill).not.toHaveBeenCalled();
+
+    // The CLI is gone now; its close disarms the guard.
+    child.emit("close", null, "SIGKILL");
+  });
+
+  /** @scenario "A CLI still running when the harness exits gets SIGKILL" */
+  it("SIGKILLs the group of a CLI still running when the harness exits", async () => {
+    const child = new FakeChild(4104);
+    withGuardedChild(child);
+
+    const p = new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x" }).call(SIMPLE_INPUT);
+
+    killGuardedProcesses();
+    expect(killSpy).toHaveBeenCalledWith(-4104, "SIGKILL");
+
+    child.pushStdout(assistantLine("hi") + "\n");
+    child.close();
+    await p;
+  });
+
+  /** @scenario "A turn that finished is not killed on harness exit" */
+  it("leaves a CLI that already exited alone when the harness exits", async () => {
+    const child = new FakeChild(4105);
+    withGuardedChild(child);
+
+    await completeTurn(new ClaudeCodeAgentAdapter({ workingDirectory: "/tmp/x" }), child);
+    killSpy.mockClear();
+
+    killGuardedProcesses();
+    expect(killSpy).not.toHaveBeenCalledWith(-4105, expect.anything());
   });
 });
 

--- a/javascript/src/agents/claude-code/claude-code-agent.adapter.ts
+++ b/javascript/src/agents/claude-code/claude-code-agent.adapter.ts
@@ -67,6 +67,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 
 import type { ModelMessage } from "ai";
 
@@ -605,14 +606,25 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
         fn();
       };
 
+      // The live diagnostics decode through a `StringDecoder` rather than
+      // `chunk.toString()`: a multibyte UTF-8 character split across two `data`
+      // events would otherwise reach the logger as replacement characters. The
+      // decoder holds the incomplete tail back and emits it with the next
+      // chunk, so what is logged is what the CLI wrote. A chunk that ends
+      // mid-character yields an empty string, which is not worth a log line.
+      const stdoutDecoder = new StringDecoder("utf8");
+      const stderrDecoder = new StringDecoder("utf8");
+
       child.stdout?.on("data", (data: Buffer) => {
         stdoutChunks.push(data);
-        logger.log(`Claude Code stdout: ${data.toString()}`);
+        const decoded = stdoutDecoder.write(data);
+        if (decoded) logger.log(`Claude Code stdout: ${decoded}`);
       });
 
       child.stderr?.on("data", (data: Buffer) => {
         stderrChunks.push(data);
-        logger.warn(`Claude Code stderr: ${data.toString()}`);
+        const decoded = stderrDecoder.write(data);
+        if (decoded) logger.warn(`Claude Code stderr: ${decoded}`);
       });
 
       child.on("error", (err: NodeJS.ErrnoException) => {

--- a/javascript/src/agents/claude-code/claude-code-agent.adapter.ts
+++ b/javascript/src/agents/claude-code/claude-code-agent.adapter.ts
@@ -607,6 +607,7 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
 
       child.stdout?.on("data", (data: Buffer) => {
         stdoutChunks.push(data);
+        logger.log(`Claude Code stdout: ${data.toString()}`);
       });
 
       child.stderr?.on("data", (data: Buffer) => {

--- a/javascript/src/agents/claude-code/claude-code-agent.adapter.ts
+++ b/javascript/src/agents/claude-code/claude-code-agent.adapter.ts
@@ -5,7 +5,9 @@
  * --verbose`) to the Scenario {@link AgentAdapter} interface. Each `call`
  * formats the conversation into a single prompt, spawns the CLI in a working
  * directory, parses the stream-json stdout (see {@link parseStreamJson}), and
- * returns the concatenated assistant-visible text as a `string`.
+ * returns the turn either as the concatenated assistant-visible text (the
+ * default) or as AI SDK messages with `tool-call` and `tool-result` parts
+ * (`output: "messages"`).
  *
  * Session continuation (multiturn): `claude -p` is one-shot — each turn exits
  * on its own — but the CLI keeps server-side session state keyed by a
@@ -33,6 +35,12 @@
  *        must happen inside the turn — `ScenarioExecution` rethrows anything
  *        `call()` throws, aborting the run, so a rejected turn has no successor
  *        to rebuild on.
+ *
+ * Process lifecycle: the CLI runs as the leader of its own process group, a
+ * detached watchdog kills that group if this process dies first, and the
+ * group gets SIGKILL on this process's `exit`. A turn never leaves a Claude,
+ * or anything Claude spawned, running after the harness is gone. See
+ * `process-lifecycle.ts`.
  *
  * Hardening over the install-orchard reference helper this is ported from:
  *  a. Structured `tool_result` content is rendered readably, never
@@ -62,7 +70,17 @@ import { spawn } from "node:child_process";
 
 import type { ModelMessage } from "ai";
 
-import { parseStreamJson, safeStringify } from "./stream-json.js";
+import {
+  guardAgainstOrphaning,
+  killProcessTree,
+  ownProcessGroup,
+} from "./process-lifecycle.js";
+import {
+  DEFAULT_TRANSCRIPT_LIMITS,
+  parseStreamJson,
+  safeStringify,
+  type TranscriptLimits,
+} from "./stream-json.js";
 import { AgentAdapter, AgentRole } from "../../domain/agents/index.js";
 import type { AgentInput, AgentReturnTypes } from "../../domain/agents/index.js";
 
@@ -270,6 +288,45 @@ export interface ClaudeCodeAgentAdapterConfig {
    * `claudeBin` → `process.env.CLAUDE_BIN` → `"claude"`.
    */
   claudeBin?: string;
+
+  /**
+   * Environment of the CLI process, applied over this process's environment.
+   * A key set to `undefined` is removed, which is how a test keeps a provider
+   * key for its judge while hiding it from the agent, or keeps the batch id
+   * of the harness out of the scenario runs the agent writes itself. `PATH`
+   * set here replaces the inherited one, so prefix it to put a local binary
+   * in front. `FORCE_COLOR=0` is always set last.
+   */
+  env?: Record<string, string | undefined>;
+
+  /**
+   * What `call` returns for a turn.
+   *
+   * - `"text"` (default): the assistant-visible text, with tool calls and
+   *   results rendered inline as readable lines.
+   * - `"messages"`: AI SDK messages, one text part plus a `tool-call` part per
+   *   tool the agent called, and a `tool` message with a `tool-result` part
+   *   per result. The judge and the user simulator then read the calls
+   *   structurally, and the LangWatch run view renders them as tool calls.
+   * @default "text"
+   */
+  output?: "text" | "messages";
+
+  /**
+   * How many characters of one tool result reach the conversation. The judge
+   * reads the whole conversation on every step, and one exported trace can
+   * hold hundreds of kilobytes.
+   * @default 8000
+   */
+  maxToolResultChars?: number;
+
+  /**
+   * How many characters of one string inside a tool call input reach the
+   * conversation. A call carries what the agent wrote, which is the work
+   * under judgement, so it keeps more room than a result.
+   * @default 30000
+   */
+  maxToolInputChars?: number;
 }
 
 /**
@@ -314,6 +371,29 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
     return this.config.claudeBin ?? process.env.CLAUDE_BIN ?? "claude";
   }
 
+  /** The transcript caps, from config over the defaults. */
+  private get limits(): TranscriptLimits {
+    return {
+      maxToolResultChars:
+        this.config.maxToolResultChars ?? DEFAULT_TRANSCRIPT_LIMITS.maxToolResultChars,
+      maxToolInputChars:
+        this.config.maxToolInputChars ?? DEFAULT_TRANSCRIPT_LIMITS.maxToolInputChars,
+    };
+  }
+
+  /**
+   * The environment the CLI runs with: this process's, then `config.env` on
+   * top with `undefined` removing a key, then `FORCE_COLOR=0`.
+   */
+  private buildEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env, ...(this.config.env ?? {}) };
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) delete env[key];
+    }
+    env.FORCE_COLOR = "0";
+    return env;
+  }
+
   /**
    * Build the CLI argv. Order is fixed:
    * `-p --output-format stream-json --verbose [--model M] [--dangerously-skip-permissions] [--resume <id>] [...extraArgs] <prompt>`.
@@ -338,7 +418,8 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
   }
 
   /**
-   * Process the conversation and return Claude Code's assistant text.
+   * Process the conversation and return Claude Code's turn, as text or as
+   * messages per `config.output`.
    *
    * A thread's first turn sends the FULL history and lets the CLI mint a
    * session; later turns `--resume` it and send only the delta.
@@ -358,7 +439,7 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
    * turn has no successor to rebuild on.
    *
    * @param input - Scenario agent input (conversation history etc.).
-   * @returns The concatenated assistant-visible text as a string.
+   * @returns The turn as text, or as AI SDK messages with `output: "messages"`.
    */
   async call(input: AgentInput): Promise<AgentReturnTypes> {
     // Validate before anything is spawned or any timer is scheduled, so a bad
@@ -377,17 +458,13 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
       try {
         // Continuation turn: the resumed session already holds the prior
         // transcript, so send ONLY the delta (`newMessages`).
-        const { text, sessionId } = await this.runTurn(
-          input.newMessages,
-          resumeSessionId,
-          timeoutMs,
-        );
-        if (sessionId) this.sessions.set(threadId, sessionId);
+        const turn = await this.runTurn(input.newMessages, resumeSessionId, timeoutMs);
+        if (turn.sessionId) this.sessions.set(threadId, turn.sessionId);
         // LOAD-BEARING return: without it a successful resume would fall through
         // to the shared full-history rebuild below (a second spawn). See the
         // fall-through INVARIANT note and its "successful resume spawns exactly
         // once" regression test.
-        return text;
+        return this.turnOutput(turn);
       } catch (error) {
         // A non-stale failure surfaces AS-IS and leaves the session cached: it
         // may still be valid (a rate limit, a signal, a timeout, or the
@@ -421,7 +498,7 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
         );
         // INVARIANT (regression-guarded): only a stale-session catch that opted
         // into replay may fall through to the shared full-history rebuild below.
-        // The SUCCESS path above returns `text` before it can reach here, so a
+        // The SUCCESS path above returns before it can reach here, so a
         // successful resume must NOT run the rebuild. The "successful resume
         // spawns exactly once" test pins this, failing the moment that
         // load-bearing `return` is dropped.
@@ -431,27 +508,28 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
     // First turn for this thread, or the opt-in rebuild after a vanished
     // session: send the full history and let the CLI mint a fresh session id to
     // resume next.
-    const { text, sessionId } = await this.runTurn(
-      input.messages,
-      undefined,
-      timeoutMs,
-    );
-    if (sessionId) this.sessions.set(threadId, sessionId);
-    return text;
+    const turn = await this.runTurn(input.messages, undefined, timeoutMs);
+    if (turn.sessionId) this.sessions.set(threadId, turn.sessionId);
+    return this.turnOutput(turn);
+  }
+
+  /** The turn in the shape `config.output` asks for. */
+  private turnOutput(turn: { text: string; messages: ModelMessage[] }): AgentReturnTypes {
+    return this.config.output === "messages" ? turn.messages : turn.text;
   }
 
   /**
-   * Run exactly ONE `claude -p` invocation and resolve its assistant text plus
-   * the session id it reported. PURE w.r.t. instance state: it reads config but
+   * Run exactly ONE `claude -p` invocation and resolve its transcript plus the
+   * session id it reported. PURE w.r.t. instance state: it reads config but
    * mutates nothing on `this` — the caller ({@link call}) owns all session-map
    * policy. It therefore neither reads nor evicts `this.sessions`.
    *
    * @param promptMessages - The messages to serialize into the prompt. The
    *   empty-prompt guard is computed against this SAME set, so an empty resume
    *   delta fails loudly rather than degenerating to `claude -p --resume <id> ""`.
-   * @returns `{ text, sessionId }` on success. `sessionId` is only ever set from
-   *   a SUCCESSFUL run (the failure paths reject first), so the caller never
-   *   persists an id minted by a failed turn.
+   * @returns `{ text, messages, sessionId }` on success. `sessionId` is only
+   *   ever set from a SUCCESSFUL run (the failure paths reject first), so the
+   *   caller never persists an id minted by a failed turn.
    * @throws {ClaudeCodeCliError} when the child dies on a signal, exits non-zero,
    *   or fields `is_error: true` on its terminal `result` envelope.
    */
@@ -459,7 +537,7 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
     promptMessages: ModelMessage[],
     resumeSessionId: string | undefined,
     timeoutMs: number,
-  ): Promise<{ text: string; sessionId?: string }> {
+  ): Promise<{ text: string; messages: ModelMessage[]; sessionId?: string }> {
     const prompt = formatMessagesAsPrompt(promptMessages);
 
     // Agent-first / empty-input guard. The realtime sibling handles a missing
@@ -482,15 +560,18 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
     const args = this.buildArgs(prompt, resumeSessionId);
     const cwd = this.config.workingDirectory;
     const logger = this.logger;
+    const limits = this.limits;
 
     logger.log(`Starting claude in: ${cwd}`);
 
-    return new Promise<{ text: string; sessionId?: string }>((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const child = spawn(bin, args, {
         cwd,
-        env: { ...process.env, FORCE_COLOR: "0" },
+        env: this.buildEnv(),
         stdio: ["ignore", "pipe", "pipe"],
+        ...ownProcessGroup(),
       });
+      const disarm = guardAgainstOrphaning(child);
 
       // Accumulate raw stdout chunks and decode ONCE at close: a multibyte
       // UTF-8 character split across two `data` events would corrupt if each
@@ -503,11 +584,11 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
       const timer = setTimeout(() => {
         if (settled) return;
         settled = true;
-        // Graceful terminate first…
-        child.kill();
+        // Graceful terminate first, the whole tree, not only the CLI…
+        killProcessTree(child, "SIGTERM");
         // …then a hard SIGKILL shortly after so a wedged child can't leak.
         // Cleared in `finish` if the child exits on its own first.
-        sigkillTimer = setTimeout(() => child.kill("SIGKILL"), 2000);
+        sigkillTimer = setTimeout(() => killProcessTree(child, "SIGKILL"), 2000);
         sigkillTimer.unref?.();
         reject(
           new Error(
@@ -534,6 +615,7 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
       });
 
       child.on("error", (err: NodeJS.ErrnoException) => {
+        disarm();
         if (err.code === "ENOENT") {
           finish(() =>
             reject(
@@ -548,6 +630,7 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
       });
 
       child.on("close", (exitCode, signal) => {
+        disarm();
         finish(() => {
           const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
           // Parse stdout FIRST: the CLI's terminal `result` envelope fields the
@@ -556,7 +639,11 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
           // `is_error: true`. Trusting the exit code alone would resolve such a
           // run as a silent empty-text success and even store its session id.
           const stdout = Buffer.concat(stdoutChunks).toString("utf8");
-          const { text, sessionId, result } = parseStreamJson(stdout, logger);
+          const { text, modelMessages, sessionId, result } = parseStreamJson(
+            stdout,
+            logger,
+            limits,
+          );
 
           // A turn FAILS if it died on a signal, exited non-zero, or the CLI's
           // own envelope says so. Failures reject with the structured error
@@ -601,7 +688,7 @@ export class ClaudeCodeAgentAdapter extends AgentAdapter {
           // an id from a run that SUCCEEDED (the failure paths above rejected
           // first), so a failed or partially-created session can never be left
           // behind for a later `--resume` to trip over.
-          resolve({ text, sessionId });
+          resolve({ text, messages: modelMessages, sessionId });
         });
       });
     });

--- a/javascript/src/agents/claude-code/index.ts
+++ b/javascript/src/agents/claude-code/index.ts
@@ -14,9 +14,15 @@ export type {
 export type {
   ClaudeStreamMessage,
   ClaudeResultEnvelope,
+  TranscriptLimits,
 } from "./stream-json.js";
-export { parseStreamJson } from "./stream-json.js";
-export { assertSkillWasRead, injectSkill } from "./skill-injection.js";
+export { parseStreamJson, toModelMessages } from "./stream-json.js";
+export {
+  assertSkillWasRead,
+  bashCommands,
+  injectSkill,
+  pointClaudeMdAtSkills,
+} from "./skill-injection.js";
 
 /**
  * Factory for {@link ClaudeCodeAgentAdapter}, mirroring the lowercase-factory

--- a/javascript/src/agents/claude-code/process-lifecycle.ts
+++ b/javascript/src/agents/claude-code/process-lifecycle.ts
@@ -107,6 +107,10 @@ export function guardAgainstOrphaning(child: ChildProcess): () => void {
     );
     // The watchdog must not keep the harness alive, and must not die with it.
     watchdog.unref?.();
+    // A watchdog that cannot start (no /bin/sh, no process slot) is not a
+    // reason to fail the turn: measures 1 and 2 still apply. Without a
+    // listener the error event would throw inside the harness.
+    watchdog.on("error", () => {});
   }
 
   return () => {

--- a/javascript/src/agents/claude-code/process-lifecycle.ts
+++ b/javascript/src/agents/claude-code/process-lifecycle.ts
@@ -1,0 +1,115 @@
+/**
+ * Keeps a spawned Claude Code CLI from outliving the process that spawned it.
+ *
+ * A `claude -p` run spawns its own children: the shell commands of its Bash
+ * tool, a test runner, a dev server, a Python venv. When the harness that
+ * spawned Claude dies with it still running (a test runner killed under memory
+ * pressure, a Ctrl-C, a session restart) nothing tells those processes to
+ * stop. They reparent to pid 1 and keep running, burning tokens and memory
+ * into a pipe nobody reads.
+ *
+ * Three measures, each covering a case the others cannot:
+ *
+ *  1. The CLI is spawned as the leader of its own process group, so a kill
+ *     aimed at the group reaches every descendant, not only the CLI.
+ *  2. On the harness's own `exit` the live groups get SIGKILL. That covers a
+ *     normal exit, `process.exit()` and an uncaught exception.
+ *  3. A watchdog shell process, detached from both, polls the harness pid and
+ *     kills the group when the harness is gone. That covers SIGKILL and any
+ *     other death that runs no JavaScript. The watchdog exits by itself the
+ *     moment the CLI exits, so a healthy turn leaves nothing behind.
+ *
+ * Process groups and the watchdog are POSIX. On Windows the CLI is spawned as
+ * before and only measure 2 applies.
+ */
+
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+
+const posix = process.platform !== "win32";
+
+/**
+ * The watchdog. `$1` is the harness pid, `$2` the CLI pid, which is also its
+ * process group id (see {@link ownProcessGroup}). It polls once a second while
+ * both are alive, then either exits, when the CLI finished on its own, or
+ * terminates the CLI's group when the harness went first.
+ */
+const WATCHDOG_SCRIPT = [
+  'harness="$1"; child="$2"',
+  'while kill -0 "$harness" 2>/dev/null && kill -0 "$child" 2>/dev/null; do sleep 1; done',
+  'kill -0 "$child" 2>/dev/null || exit 0',
+  'kill -TERM -- "-$child" 2>/dev/null',
+  "sleep 5",
+  'kill -KILL -- "-$child" 2>/dev/null',
+  "exit 0",
+].join("\n");
+
+/** The name the watchdog shows in `ps`, so a reader knows what it is. */
+const WATCHDOG_NAME = "claude-code-watchdog";
+
+/**
+ * Spawn options that make the CLI the leader of its own process group, so
+ * {@link killProcessTree} can reach its descendants.
+ */
+export function ownProcessGroup(): Pick<SpawnOptions, "detached"> {
+  return { detached: posix };
+}
+
+/**
+ * Send `signal` to the CLI and everything it spawned. Falls back to the CLI
+ * alone where a group kill is not possible (Windows, or a child that never
+ * got a pid).
+ */
+export function killProcessTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (posix && child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // The group is already gone; the child itself may still answer.
+    }
+  }
+  child.kill(signal);
+}
+
+/** The kills to run when this process exits, one per live CLI. */
+const onExitKills = new Set<() => void>();
+let exitHookInstalled = false;
+
+/**
+ * SIGKILL the group of every CLI still running. This is what the harness's
+ * `exit` runs; a test calls it directly, since emitting `exit` on the real
+ * process would run the test runner's own handlers.
+ */
+export function killGuardedProcesses(): void {
+  for (const kill of onExitKills) kill();
+}
+
+function installExitHook(): void {
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+  process.once("exit", killGuardedProcesses);
+}
+
+/**
+ * Arms measures 2 and 3 for a freshly spawned CLI. Returns the function that
+ * disarms them once the CLI has exited on its own.
+ */
+export function guardAgainstOrphaning(child: ChildProcess): () => void {
+  const killOnExit = () => killProcessTree(child, "SIGKILL");
+  onExitKills.add(killOnExit);
+  installExitHook();
+
+  if (posix && child.pid !== undefined) {
+    const watchdog = spawn(
+      "/bin/sh",
+      ["-c", WATCHDOG_SCRIPT, WATCHDOG_NAME, String(process.pid), String(child.pid)],
+      { detached: true, stdio: "ignore" },
+    );
+    // The watchdog must not keep the harness alive, and must not die with it.
+    watchdog.unref?.();
+  }
+
+  return () => {
+    onExitKills.delete(killOnExit);
+  };
+}

--- a/javascript/src/agents/claude-code/skill-injection.ts
+++ b/javascript/src/agents/claude-code/skill-injection.ts
@@ -1,18 +1,16 @@
 /**
- * Optional skill injection + a post-hoc assertion that a skill was actually
- * read during a scenario run.
+ * Skill injection into a working directory, plus the helpers a test reads the
+ * conversation with afterwards.
  *
- * Ported from the install-orchard test helper (`claude-code-adapter.ts`):
  *  - {@link injectSkill} copies a `SKILL.md` into `<workingDirectory>/.skills/
- *    <name>/SKILL.md` so Claude Code auto-discovers it, then writes a `CLAUDE.md`
- *    that points at every discovered skill (only when one does not already
- *    exist).
+ *    <name>/SKILL.md` so Claude Code auto-discovers it, then points the
+ *    working directory's `CLAUDE.md` at every discovered skill.
+ *  - {@link pointClaudeMdAtSkills} is that second step on its own, for a
+ *    working directory whose skills were installed some other way.
  *  - {@link assertSkillWasRead} scans the conversation messages for evidence
  *    that the skill's `SKILL.md` was read, throwing (naming the skill) when no
  *    such evidence exists.
- *
- * Behavior is intentionally identical to the reference; only the typing and
- * module boundary changed.
+ *  - {@link bashCommands} lists the shell commands the agent ran.
  */
 
 import fs from "fs";
@@ -24,8 +22,7 @@ import type { ScenarioExecutionStateLike } from "../../domain";
 
 /**
  * Copy a `SKILL.md` into the working directory's `.skills/<name>/` so Claude
- * Code discovers it, and write a `CLAUDE.md` pointing at all discovered skills
- * (unless one already exists).
+ * Code discovers it, and point `CLAUDE.md` at all discovered skills.
  *
  * The skill name is derived from the SKILL.md's parent directory name, matching
  * the reference helper (`path.basename(path.dirname(skillPath))`).
@@ -44,36 +41,47 @@ export function injectSkill(workingDirectory: string, skillPath: string): void {
   fs.mkdirSync(skillDir, { recursive: true });
   fs.copyFileSync(skillPath, path.join(skillDir, "SKILL.md"));
 
-  writeClaudeMdPointingToSkills(workingDirectory);
+  pointClaudeMdAtSkills(workingDirectory);
 }
 
 /**
- * Write a `CLAUDE.md` that instructs Claude Code to read every discovered
- * `.skills/<name>/SKILL.md` first. No-op when a `CLAUDE.md` already exists or no
- * skills are present.
+ * Make the working directory's `CLAUDE.md` tell Claude Code to read every
+ * `.skills/<name>/SKILL.md` before doing anything else.
+ *
+ * Claude Code does not discover `.skills/` in an arbitrary directory on its
+ * own, so the instruction has to be in `CLAUDE.md`. A fixture project often
+ * ships a `CLAUDE.md` of its own, which is part of what the agent is tested
+ * against: it is kept, and only the skills it does not mention yet are
+ * appended. Calling this twice changes nothing the second time. A directory
+ * with no skills is left alone.
  */
-function writeClaudeMdPointingToSkills(workingDirectory: string): void {
+export function pointClaudeMdAtSkills(workingDirectory: string): void {
   const skillsDir = path.join(workingDirectory, ".skills");
-  const claudeMdPath = path.join(workingDirectory, "CLAUDE.md");
+  if (!fs.existsSync(skillsDir)) return;
 
-  if (!fs.existsSync(skillsDir) || fs.existsSync(claudeMdPath)) return;
-
-  const skillDirs = fs
+  const skillPaths = fs
     .readdirSync(skillsDir, { withFileTypes: true })
     .filter(
-      (d) =>
-        d.isDirectory() &&
-        fs.existsSync(path.join(skillsDir, d.name, "SKILL.md")),
-    );
+      (entry) =>
+        entry.isDirectory() &&
+        fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md")),
+    )
+    .map((entry) => `.skills/${entry.name}/SKILL.md`);
+  if (skillPaths.length === 0) return;
 
-  if (skillDirs.length === 0) return;
+  const claudeMdPath = path.join(workingDirectory, "CLAUDE.md");
+  const existing = fs.existsSync(claudeMdPath)
+    ? fs.readFileSync(claudeMdPath, "utf8")
+    : "";
+  const missing = skillPaths.filter((skillPath) => !existing.includes(skillPath));
+  if (missing.length === 0) return;
 
-  const instructions = skillDirs
-    .map((d) => `.skills/${d.name}/SKILL.md`)
-    .join(" and ");
-  fs.writeFileSync(
+  const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  fs.appendFileSync(
     claudeMdPath,
-    `Read and follow the instructions in ${instructions} before doing anything else.\n`,
+    `${separator}Read and follow the instructions in ${missing.join(
+      " and ",
+    )} before doing anything else.\n`,
   );
 }
 
@@ -108,4 +116,26 @@ export function assertSkillWasRead(
         `The agent may have ignored the skill and hallucinated instructions.`,
     );
   }
+}
+
+/**
+ * The shell commands the agent ran, read from the `Bash` tool calls of the
+ * conversation.
+ *
+ * A phrase in the transcript is not a command that ran: the skill text the
+ * agent read and its own explanation of what it did not do both quote
+ * commands. Only a `tool-call` part naming the `Bash` tool counts, which is
+ * what the adapter emits with `output: "messages"`.
+ */
+export function bashCommands(state: ScenarioExecutionStateLike): string[] {
+  const commands: string[] = [];
+  for (const message of state.messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (part.type !== "tool-call" || part.toolName !== "Bash") continue;
+      const input = part.input as { command?: unknown } | undefined;
+      if (typeof input?.command === "string") commands.push(input.command);
+    }
+  }
+  return commands;
 }

--- a/javascript/src/agents/claude-code/stream-json.ts
+++ b/javascript/src/agents/claude-code/stream-json.ts
@@ -7,6 +7,19 @@
  * line-splitting + block-rendering so the adapter stays thin and the rendering
  * rules are independently testable.
  *
+ * Two renderings of the same transcript come out of {@link parseStreamJson}:
+ *  - `text`: the assistant-visible text with tool calls and results rendered
+ *    inline as readable lines.
+ *  - `modelMessages`: AI SDK `ModelMessage`s with `tool-call` and
+ *    `tool-result` parts, the shape the judge, the user simulator and the
+ *    LangWatch run view read structurally (see {@link toModelMessages}).
+ *
+ * Both apply the same {@link TranscriptLimits}: a tool result can carry
+ * hundreds of kilobytes (an exported trace, a log file), and the judge reads
+ * the whole conversation on every step, so an uncapped result pushes a long
+ * run past the judge's context window for a reason that has nothing to do
+ * with the agent under test.
+ *
  * Hardening over the original reference port:
  *  - `tool_result` blocks whose `content` is an array/object are rendered
  *    readably (text parts extracted, else JSON-stringified) — never the
@@ -21,6 +34,8 @@
  *    trust the CLI's own fielded status instead of inferring success from the
  *    exit code alone.
  */
+
+import type { ModelMessage } from "ai";
 
 /**
  * Minimal structural logger. Mirrors {@link Logger} in the adapter module; kept
@@ -84,6 +99,25 @@ export interface ClaudeResultEnvelope {
 }
 
 /**
+ * How much of a tool call and of a tool result may reach the conversation.
+ *
+ * A result is the evidence the agent gathered, and what a judge reads of it is
+ * short: command names, URLs and ids, which stand at the start of the output.
+ * A call carries what the agent wrote (a file, a report, a test), which is the
+ * work under judgement, so it keeps far more room, and there are few such
+ * calls in a run.
+ */
+export interface TranscriptLimits {
+  maxToolResultChars: number;
+  maxToolInputChars: number;
+}
+
+export const DEFAULT_TRANSCRIPT_LIMITS: TranscriptLimits = {
+  maxToolResultChars: 8000,
+  maxToolInputChars: 30000,
+};
+
+/**
  * Top-level event `type`s we knowingly render or skip without warning. The
  * "unknown event" warning exists to flag wire-format drift, so every type the
  * CLI routinely emits must be listed — otherwise the warning fires on a healthy
@@ -103,6 +137,55 @@ const KNOWN_EVENT_TYPES = new Set([
   "rate_limit_event",
   "stream_event",
 ]);
+
+/**
+ * The blocks the converters read. Anything else is a block Claude Code can
+ * write that the conversation has no part for, most often an `image` or a
+ * `document` a tool returned.
+ */
+const KNOWN_BLOCK_TYPES = new Set([
+  "text",
+  "thinking",
+  "redacted_thinking",
+  "tool_use",
+  "tool_result",
+]);
+
+/** `JSON.stringify` that never throws (circular refs, custom toString, etc. → fallback string). */
+export function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "[unserializable value]";
+    }
+  }
+}
+
+function truncateText(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const dropped = text.length - limit;
+  return `${text.slice(0, limit)}\n… [${dropped} more characters]`;
+}
+
+/**
+ * The call cap over every string inside a tool input, structure kept. Nested
+ * objects and arrays are walked, not only the top level: a payload such as
+ * `{ body: { html } }` carries the same unbounded text a top-level field would.
+ */
+function truncateToolInput(input: unknown, limit: number): unknown {
+  if (typeof input === "string") return truncateText(input, limit);
+  if (Array.isArray(input)) return input.map((item) => truncateToolInput(item, limit));
+  if (input === null || typeof input !== "object") return input;
+  return Object.fromEntries(
+    Object.entries(input as Record<string, unknown>).map(([key, value]) => [
+      key,
+      truncateToolInput(value, limit),
+    ]),
+  );
+}
 
 /**
  * Render a `tool_result` block's `content` to a readable string.
@@ -135,73 +218,217 @@ function renderToolResultContent(content: unknown): string {
   return safeStringify(content);
 }
 
-/** `JSON.stringify` that never throws (circular refs, custom toString, etc. → fallback string). */
-export function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value) ?? "";
-  } catch {
-    try {
-      return String(value);
-    } catch {
-      return "[unserializable value]";
-    }
-  }
+/**
+ * What a block of a type the conversation has no part for leaves behind. The
+ * judge reads the transcript, so a block that silently disappeared would read
+ * as a turn the agent never took; a line naming the type keeps the turn whole
+ * and says what is not shown.
+ */
+function unsupportedBlockText(block: ClaudeStreamContentBlock): string {
+  return `[${String(block.type ?? "unknown")} block, not shown in the transcript]`;
 }
 
 /**
  * Render a single content block to text.
  *  - `text`        → the text
- *  - `tool_use`    → `Tool Called: name({...input})`
- *  - `tool_result` → `Tool Result: <readable content>`
- *  - anything else → empty string (dropped from the concatenated text)
+ *  - `tool_use`    → `Tool Called: name({...input})`, input capped
+ *  - `tool_result` → `Tool Result: <readable content>`, capped
+ *  - `thinking`    → nothing; it is not part of the conversation
+ *  - anything else → a line naming the block type
  */
-function renderBlock(block: ClaudeStreamContentBlock): string {
+function renderBlock(block: ClaudeStreamContentBlock, limits: TranscriptLimits): string {
   switch (block.type) {
     case "text":
       return typeof block.text === "string" ? block.text : "";
     case "tool_use":
-      return `Tool Called: ${block.name ?? "unknown"}(${safeStringify(
-        block.input,
+      return `Tool Called: ${block.name ?? "unknown"}(${truncateText(
+        safeStringify(block.input),
+        limits.maxToolInputChars,
       )})`;
     case "tool_result":
-      return `Tool Result: ${renderToolResultContent(block.content)}`;
-    default:
+      return `Tool Result: ${truncateText(
+        renderToolResultContent(block.content),
+        limits.maxToolResultChars,
+      )}`;
+    case "thinking":
+    case "redacted_thinking":
       return "";
+    default:
+      return unsupportedBlockText(block);
   }
 }
 
 /** Concatenated assistant-visible text for one inner message. */
-function renderMessage(message: ClaudeStreamInnerMessage): string {
+function renderMessage(message: ClaudeStreamInnerMessage, limits: TranscriptLimits): string {
   const content = message.content;
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
-  return content.map(renderBlock).filter(Boolean).join("\n");
+  return content
+    .map((block) => renderBlock(block, limits))
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** One assistant turn: the text it wrote, then the tool calls it made. */
+function assistantMessageFromBlocks(
+  content: ClaudeStreamContentBlock[],
+  toolNamesByCallId: Map<string, string>,
+  limits: TranscriptLimits,
+): ModelMessage | null {
+  const texts: string[] = [];
+  const toolCalls: Array<{
+    type: "tool-call";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }> = [];
+
+  for (const block of content) {
+    if (block.type === "text" && typeof block.text === "string") {
+      texts.push(block.text);
+    } else if (block.type === "tool_use") {
+      const id = String(block["id"] ?? "");
+      const name = block.name ?? "tool";
+      toolNamesByCallId.set(id, name);
+      toolCalls.push({
+        type: "tool-call",
+        toolCallId: id,
+        toolName: name,
+        input: truncateToolInput(block.input ?? {}, limits.maxToolInputChars),
+      });
+    } else if (!KNOWN_BLOCK_TYPES.has(block.type ?? "")) {
+      texts.push(unsupportedBlockText(block));
+    }
+    // Thinking blocks are dropped: they are not part of the conversation.
+  }
+
+  if (texts.length === 0 && toolCalls.length === 0) return null;
+  // The text part stays even when empty, so a turn that only called tools
+  // still carries its calls next to a string content.
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: texts.join("\n") }, ...toolCalls],
+  };
 }
 
 /**
- * Parse Claude Code stream-json stdout into the concatenated assistant text and
- * the list of parsed messages.
+ * One user turn: the tool results it answers with become a `tool` message, and
+ * whatever text it carries becomes a `user` message after it.
+ */
+function userMessagesFromBlocks(
+  content: ClaudeStreamContentBlock[],
+  toolNamesByCallId: Map<string, string>,
+  limits: TranscriptLimits,
+): ModelMessage[] {
+  const messages: ModelMessage[] = [];
+
+  const toolResults = content
+    .filter((block) => block.type === "tool_result")
+    .map((block) => {
+      const callId = String(block["tool_use_id"] ?? "");
+      const value = truncateText(
+        renderToolResultContent(block.content),
+        limits.maxToolResultChars,
+      );
+      return {
+        type: "tool-result" as const,
+        toolCallId: callId,
+        toolName: toolNamesByCallId.get(callId) ?? "tool",
+        output: block["is_error"]
+          ? { type: "error-text" as const, value }
+          : { type: "text" as const, value },
+      };
+    });
+  if (toolResults.length > 0) {
+    messages.push({ role: "tool", content: toolResults });
+  }
+
+  const texts = content
+    .filter(
+      (block) =>
+        (block.type === "text" && typeof block.text === "string") ||
+        !KNOWN_BLOCK_TYPES.has(block.type ?? ""),
+    )
+    .map((block) =>
+      block.type === "text" ? (block.text as string) : unsupportedBlockText(block),
+    );
+  if (texts.length > 0) {
+    messages.push({ role: "user", content: texts.join("\n") });
+  }
+
+  return messages;
+}
+
+/**
+ * Converts the inner messages of a stream-json transcript into AI SDK model
+ * messages, the format `@langwatch/scenario` works with.
+ *
+ * Claude Code writes Anthropic-format messages: an assistant turn is an array
+ * of `thinking`, `text` and `tool_use` blocks, and each tool result comes back
+ * as a `user` message holding `tool_result` blocks. Each assistant turn
+ * becomes one text part (the text blocks joined, an empty string when the turn
+ * only called tools) followed by one `tool-call` part per `tool_use` block.
+ * Each `tool_result` block becomes a `tool-result` part of a `tool` message,
+ * with the tool name looked up from the call it answers. Thinking blocks are
+ * dropped. A block of any other type leaves a line naming it.
+ */
+export function toModelMessages(
+  rawMessages: ClaudeStreamInnerMessage[],
+  limits: TranscriptLimits = DEFAULT_TRANSCRIPT_LIMITS,
+): ModelMessage[] {
+  const toolNamesByCallId = new Map<string, string>();
+  const messages: ModelMessage[] = [];
+
+  for (const raw of rawMessages) {
+    const { role, content } = raw;
+    if (role !== "assistant" && role !== "user") continue;
+    if (typeof content === "string") {
+      messages.push({ role, content });
+      continue;
+    }
+    if (!Array.isArray(content)) continue;
+
+    if (role === "assistant") {
+      const message = assistantMessageFromBlocks(content, toolNamesByCallId, limits);
+      if (message) messages.push(message);
+      continue;
+    }
+    messages.push(...userMessagesFromBlocks(content, toolNamesByCallId, limits));
+  }
+
+  return messages;
+}
+
+/**
+ * Parse Claude Code stream-json stdout into the concatenated assistant text,
+ * the structured model messages, and the list of parsed lines.
  *
  * @param stdout - Raw stdout (possibly many newline-delimited JSON objects).
  * @param logger - Optional structural logger; receives an "unknown event"
  *   `warn` for any line whose parsed `type` is unrecognized — at most ONCE per
  *   distinct type per call, so a repeated novel type cannot flood the log.
  *   Never throws on a malformed line — non-JSON lines are skipped.
- * @returns `{ text, messages, sessionId, result }` — `text` is the joined
- *   assistant-visible text, `messages` is every successfully-parsed line,
- *   `sessionId` is the top-level `session_id` Claude Code stamps on its
- *   `system`/init line (and may restamp on later events; last-wins, left
- *   `undefined` when no line carries one), and `result` is the terminal
- *   {@link ClaudeResultEnvelope} read off the `type: "result"` line (an empty
- *   object when none was emitted). The adapter threads `sessionId` to continue a
- *   session across turns and inspects `result` to tell a real failure — including
- *   a stale `--resume` — from a healthy run (see the adapter's `call`).
+ * @param limits - How much of a tool call and a tool result reaches either
+ *   rendering. Defaults to {@link DEFAULT_TRANSCRIPT_LIMITS}.
+ * @returns `{ text, modelMessages, messages, sessionId, result }`: `text` is
+ *   the joined assistant-visible text, `modelMessages` the same transcript as
+ *   AI SDK messages ({@link toModelMessages}), `messages` is every
+ *   successfully-parsed line, `sessionId` is the top-level `session_id` Claude
+ *   Code stamps on its `system`/init line (and may restamp on later events;
+ *   last-wins, left `undefined` when no line carries one), and `result` is the
+ *   terminal {@link ClaudeResultEnvelope} read off the `type: "result"` line
+ *   (an empty object when none was emitted). The adapter threads `sessionId`
+ *   to continue a session across turns and inspects `result` to tell a real
+ *   failure, including a stale `--resume`, from a healthy run (see the
+ *   adapter's `call`).
  */
 export function parseStreamJson(
   stdout: string,
   logger?: StreamLogger,
+  limits: TranscriptLimits = DEFAULT_TRANSCRIPT_LIMITS,
 ): {
   text: string;
+  modelMessages: ModelMessage[];
   messages: ClaudeStreamMessage[];
   sessionId?: string;
   result: ClaudeResultEnvelope;
@@ -265,13 +492,20 @@ export function parseStreamJson(
     }
   }
 
-  const text = messages
-    .filter((m): m is ClaudeStreamMessage & { message: ClaudeStreamInnerMessage } =>
-      Boolean(m.message),
-    )
-    .map((m) => renderMessage(m.message))
+  const innerMessages = messages
+    .map((m) => m.message)
+    .filter((m): m is ClaudeStreamInnerMessage => Boolean(m));
+
+  const text = innerMessages
+    .map((m) => renderMessage(m, limits))
     .filter(Boolean)
     .join("\n\n");
 
-  return { text, messages, sessionId, result };
+  return {
+    text,
+    modelMessages: toModelMessages(innerMessages, limits),
+    messages,
+    sessionId,
+    result,
+  };
 }

--- a/specs/claude-code-adapter.feature
+++ b/specs/claude-code-adapter.feature
@@ -132,3 +132,9 @@ Feature: Claude Code adapter environment, transcript and process lifecycle
     Given a turn ran to completion
     When the harness process emits exit
     Then nothing is sent to that CLI's process group
+
+  @unit
+  Scenario: Live CLI output is logged as the CLI wrote it
+    Given the CLI writes a multibyte character split across two chunks
+    When a turn runs
+    Then the logged stdout and stderr carry the character intact

--- a/specs/claude-code-adapter.feature
+++ b/specs/claude-code-adapter.feature
@@ -116,6 +116,12 @@ Feature: Claude Code adapter environment, transcript and process lifecycle
     And the watchdog is not spawned again for a CLI that has no pid
 
   @unit
+  Scenario: A watchdog that cannot start does not fail the turn
+    Given the watchdog process reports a spawn error
+    When a turn runs
+    Then the turn resolves with the CLI's output
+
+  @unit
   Scenario: A CLI still running when the harness exits gets SIGKILL
     Given a turn is running
     When the harness process emits exit

--- a/specs/claude-code-adapter.feature
+++ b/specs/claude-code-adapter.feature
@@ -1,0 +1,128 @@
+Feature: Claude Code adapter environment, transcript and process lifecycle
+  As a skill test author
+  I want the Claude Code adapter to shape the CLI environment, report the turn as structured messages and leave no process behind
+  So that a skill suite can drop its own adapter and a killed test run stops costing tokens
+
+  Background:
+    Given a Claude Code adapter driven against a fake CLI process
+
+  @unit
+  Scenario: The CLI environment is this process's with the configured keys on top
+    Given the harness environment holds an API key and a batch run id
+    And the adapter is configured with env setting a new key and removing the batch run id
+    When a turn runs
+    Then the CLI receives the new key
+    And the CLI does not receive the batch run id
+    And the CLI still receives the API key
+    And the CLI receives FORCE_COLOR set to 0
+
+  @unit
+  Scenario: A turn is returned as AI SDK messages when output is messages
+    Given the adapter is configured with output messages
+    And the CLI transcript holds an assistant text, a tool call and its result
+    When a turn runs
+    Then the turn is an assistant message with a text part and a tool-call part
+    And a tool message with a tool-result part naming the tool
+
+  @unit
+  Scenario: A turn is returned as text by default
+    Given the CLI transcript holds an assistant text, a tool call and its result
+    When a turn runs
+    Then the turn is the text with the tool call and its result rendered inline
+
+  @unit
+  Scenario: A transcript becomes AI SDK messages with tool-call and tool-result parts
+    Given a transcript holding thinking, text, tool_use and tool_result blocks
+    When the transcript is converted
+    Then each assistant turn is a text part followed by a tool-call part per tool_use block
+    And each tool_result block is a tool-result part of a tool message naming the tool it answers
+    And the thinking is not in the messages
+
+  @unit
+  Scenario: An assistant turn that only calls tools keeps an empty text part
+    Given a transcript whose assistant turn holds only a tool_use block
+    When the transcript is converted
+    Then the assistant message holds an empty text part followed by the tool-call part
+
+  @unit
+  Scenario: A block the conversation cannot carry leaves a line naming it
+    Given a transcript holding an image block on an assistant turn and a document block on a user turn
+    When the transcript is converted
+    Then the assistant text ends with a line naming the image block
+    And the user message is a line naming the document block
+
+  @unit
+  Scenario: A failed tool result is an error-text output
+    Given a transcript whose tool_result block is marked as an error
+    When the transcript is converted
+    Then the tool-result part carries an error-text output
+
+  @unit
+  Scenario: Tool inputs and results are capped in both renderings
+    Given a transcript whose tool call input and tool result each carry far more text than a judge can read
+    When the transcript is converted
+    Then the tool call input is capped and says how many characters were dropped
+    And a string nested inside the input is capped the same way
+    And the tool result is capped the same way
+    And the text rendering of the same transcript is capped the same way
+    And a small tool call is left alone
+
+  @unit
+  Scenario: The caps are configurable on the adapter
+    Given the adapter is configured with output messages and a tool result cap of 100 characters
+    And the CLI transcript holds a tool result of 500 characters
+    When a turn runs
+    Then the tool-result part holds 100 characters plus the dropped count
+
+  @unit
+  Scenario: The Bash commands of a run are read from the tool-call parts
+    Given a conversation with a Bash tool call, a Read tool call and text quoting a command
+    When the Bash commands are read
+    Then only the command of the Bash tool call is listed
+
+  @unit
+  Scenario: An existing CLAUDE.md is pointed at the installed skills
+    Given a working directory with two installed skills and a CLAUDE.md that mentions one of them
+    When the CLAUDE.md is pointed at the skills
+    Then the CLAUDE.md keeps its content
+    And it gains an instruction to read the skill it did not mention
+    And pointing it again changes nothing
+
+  @unit
+  Scenario: A working directory without skills is left alone
+    Given a working directory with no .skills folder
+    When the CLAUDE.md is pointed at the skills
+    Then no CLAUDE.md is written
+
+  @unit
+  Scenario: The CLI is spawned as the leader of its own process group
+    When a turn runs
+    Then the CLI is spawned detached
+
+  @unit
+  Scenario: A timeout kills the whole process group
+    Given the adapter is configured with a short timeout
+    And the CLI never closes
+    When the timeout elapses
+    Then SIGTERM is sent to the CLI's process group
+    And SIGKILL follows to the same group shortly after
+    And the turn rejects with a timeout error
+
+  @unit
+  Scenario: A watchdog outlives the harness and is told both pids
+    When a turn runs
+    Then a detached shell watchdog is spawned with the harness pid and the CLI pid
+    And the watchdog is unreferenced so it keeps the harness alive no longer than the CLI
+    And the watchdog is not spawned again for a CLI that has no pid
+
+  @unit
+  Scenario: A CLI still running when the harness exits gets SIGKILL
+    Given a turn is running
+    When the harness process emits exit
+    Then SIGKILL is sent to the CLI's process group
+
+  @unit
+  Scenario: A turn that finished is not killed on harness exit
+    Given a turn ran to completion
+    When the harness process emits exit
+    Then nothing is sent to that CLI's process group


### PR DESCRIPTION
## Why

The LangWatch skills suite drives Claude Code through its own adapter because the SDK one lacked four things the suite needs: control over the CLI environment, a structured (tool-call) rendering of the turn, caps on tool output so a long run does not push the judge past its context window, and a way to point a fixture's existing CLAUDE.md at the installed skills. This PR brings those into `claudeCodeAgent` so that suite (and anyone else testing skills) can drop the private copy.

It also fixes a process leak. When the harness that spawned `claude -p` dies with a turn still running (a vitest worker killed under memory pressure, a Ctrl-C, a session restart), the CLI and everything it spawned (a dev server, a pytest run, a CLI daemon) reparent to pid 1 and keep running, burning tokens and RAM into a pipe nobody reads. On one machine that was 17 claude processes and 13 GB of swap.

## What

New config on `ClaudeCodeAgentAdapterConfig`:

- `env`: applied over the harness environment, a key set to `undefined` is removed, `FORCE_COLOR=0` set last.
- `output: "text" | "messages"`: the default stays text; `"messages"` returns AI SDK messages with `tool-call` and `tool-result` parts (error results as `error-text`), so the judge and the LangWatch run view read tool calls structurally.
- `maxToolResultChars` (8000) and `maxToolInputChars` (30000): both renderings cap a tool result and every string inside a tool call input, nested ones included, and append the dropped count.

New exports: `toModelMessages`, `TranscriptLimits`, `bashCommands` (the commands of `Bash` tool-call parts, nothing quoted in prose), `pointClaudeMdAtSkills`. `injectSkill` now appends the missing skill references to an existing CLAUDE.md instead of leaving it untouched; a block type the conversation has no part for (image, document) leaves a line naming it instead of disappearing; thinking blocks are dropped from both renderings.

Process lifecycle (`process-lifecycle.ts`), three measures, each covering a case the others cannot:

1. The CLI is spawned as the leader of its own process group; the `timeout` kill is a group kill (SIGTERM, then SIGKILL two seconds later).
2. The harness `exit` SIGKILLs every group still running (normal exit, `process.exit()`, uncaught exception).
3. A detached `/bin/sh` watchdog (`claude-code-watchdog` in `ps`) polls the harness pid and the CLI pid once a second and terminates the CLI's group when the harness is gone (covers SIGKILL). It exits on its own when the CLI exits, so a healthy turn leaves nothing behind.

Windows keeps the previous spawn and only measure 2.

## Tests

`specs/claude-code-adapter.feature` (17 scenarios, all `@unit`) bound in `claude-code-adapter.test.ts`: 22 new tests, 73 total in the file, full suite 1533 passed. The lifecycle tests route the spawn mock by binary so the watchdog spawn is asserted (harness pid, CLI pid, detached, `unref`), `process.kill` is spied to assert group kills on timeout and on harness exit, and a child without a pid gets no watchdog so the earlier tests keep their spawn counts.

Docs: `agent-integration/claude-code.mdx` gains the four config rows and sections on structured output, environment and process lifecycle.

## Follow-up

langwatch/langwatch will pin the released version and replace `skills/_tests/helpers/claude-code-adapter.ts` with a thin wrapper over `claudeCodeAgent`.
