### PR TITLE
ci: open release pull requests as drafts

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -13,6 +13,12 @@ on:
     branches:
       - main
   pull_request:
+    # `ready_for_review` is what runs the heavy job for a pull request that
+    # opened as a draft, which every release-please pull request now does. The
+    # default trigger types do not include it, so without this line the last run
+    # on a draft, with the heavy job skipped, would stand as the required check
+    # for a release nobody tested. See specs/release-pr-drafts.feature.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -33,6 +33,12 @@ on:
     branches:
       - main
   pull_request:
+    # `ready_for_review` is what runs the heavy job for a pull request that
+    # opened as a draft, which every release-please pull request now does. The
+    # default trigger types do not include it, so without this line the last run
+    # on a draft, with the heavy job skipped, would stand as the required check
+    # for a release nobody tested. See specs/release-pr-drafts.feature.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -55,6 +55,12 @@ on:
     branches:
       - main
   pull_request:
+    # `ready_for_review` is what runs the heavy job for a pull request that
+    # opened as a draft, which every release-please pull request now does. The
+    # default trigger types do not include it, so without this line the last run
+    # on a draft, with the heavy job skipped, would stand as the required check
+    # for a release nobody tested. See specs/release-pr-drafts.feature.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -84,7 +90,10 @@ jobs:
 
   test:
     needs: changes
-    if: needs.changes.outputs.relevant == 'true'
+    # The draft half of the condition is what keeps a release-please pull
+    # request from running this suite on every merge to main. It comes back on
+    # `ready_for_review`. See specs/release-pr-drafts.feature.
+    if: needs.changes.outputs.relevant == 'true' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     # `pull-requests: write` is what lets the examples gate say on the pull

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,29 @@
 name: release-please
 
+# Why the release pull requests open as drafts (`draft-pull-request` in
+# .release-please-config.json, which is strict JSON and cannot hold this note).
+#
+# release-please creates-or-updates one release pull request per package, so
+# every merge to main force-pushes those branches. The diff is a changelog plus
+# a version field, and the aggregator workflows path-filter on the package
+# directory those files live in, correctly, since a dependency bump touches the
+# same files and a path filter cannot tell the two apart. So a two-file metadata
+# change pulled the JavaScript suite, the Python suite and the examples legs on
+# every merge, for as long as the release pull request stayed open.
+#
+# The heavy jobs of javascript-ci, python-ci and docs-ci already skip a draft,
+# so this buys the reduction with no new mechanism, and the full suite still
+# runs before anything ships: marking the pull request ready to review fires
+# `ready_for_review`, which those three list in their trigger types precisely so
+# the heavy jobs get their run then. A draft cannot be merged, so "ready for
+# review" is the same click as "I am releasing this".
+#
+# Setting it here rather than by hand matters on the next cycle: release-please
+# updates an existing release pull request, but once one merges it opens a fresh
+# pull request for the following version, and that one would be non-draft again.
+#
+# Spec: specs/release-pr-drafts.feature
+
 on:
   push:
     branches:

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -31,6 +31,7 @@
       ]
     }
   },
+  "draft-pull-request": true,
   "bootstrap-sha": "bce696d",
   "release-search-depth": 400,
   "tag-separator": "/",

--- a/RELEASE_PLEASE.md
+++ b/RELEASE_PLEASE.md
@@ -42,9 +42,26 @@ type(scope): description
 ## Release Process
 
 1. **Make Changes**: Create PRs with conventional commit messages
-2. **Merge to Main**: Release Please will create release PRs automatically
+2. **Merge to Main**: Release Please will create release PRs automatically, as drafts
 3. **Review Release PR**: Check the generated changelog and version bumps
-4. **Merge Release PR**: This triggers the automated publishing workflows
+4. **Mark it Ready for Review**: This runs the full test suite against the release commit
+5. **Merge Release PR**: This triggers the automated publishing workflows
+
+### Why the release PRs are drafts
+
+Release Please updates its release PRs on every merge to `main`, and the
+aggregator workflows path-filter on the package directory the version bump
+lands in. Without the draft, a changelog and a version field ran the JavaScript
+suite, the Python suite and the examples legs on every merge, for as long as the
+release PR stayed open.
+
+The heavy jobs of `javascript-ci`, `python-ci` and `docs-ci` skip a draft, and
+they list `ready_for_review` in their trigger types, so marking the release PR
+ready runs the full suite before anything ships. A draft cannot be merged, so
+marking it ready is the same click as deciding to release. The setting is
+`draft-pull-request` in `.release-please-config.json`, and
+`scripts/validate-aggregator-workflows.sh` fails if it or either half of the
+gate is removed. Spec: `specs/release-pr-drafts.feature`.
 
 ## Manual Release (if needed)
 

--- a/scripts/validate-aggregator-workflows.sh
+++ b/scripts/validate-aggregator-workflows.sh
@@ -8,6 +8,33 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 pass() { echo "  PASS: $1"; }
 fail() { echo "  FAIL: $1"; FAIL=1; }
 
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Decides whether a job condition genuinely keeps the job off a draft pull
+# request. Searching the condition for the comparison is not enough:
+# `needs.changes.outputs.relevant == 'true' || github.event.pull_request.draft
+# == false` contains it and still runs the heavy job on a relevant draft. The
+# comparison has to be one of the top-level `&&` conjuncts, which is what makes
+# it hold whatever the rest of the expression decides. Exit 0 accepts.
+DRAFT_GATE_PY="$TMP_DIR/draft_gate.py"
+cat > "$DRAFT_GATE_PY" <<'EOF'
+import re, sys
+
+# The two spellings of "this pull request is not a draft". Both read as false
+# on a push, where `github.event.pull_request` does not exist.
+NOT_A_DRAFT = re.compile(
+    r"^(?:github\.event\.pull_request\.draft\s*==\s*false"
+    r"|!\s*github\.event\.pull_request\.draft)$"
+)
+
+condition = sys.argv[1] if len(sys.argv) > 1 else ""
+for conjunct in condition.split("&&"):
+    if NOT_A_DRAFT.match(conjunct.strip().strip("()").strip()):
+        sys.exit(0)
+sys.exit(1)
+EOF
+
 # check_workflow <file> <name> <inner_job> <aggregator> <filter1> <filter2>
 check_workflow() {
   local wf="$1"
@@ -151,16 +178,17 @@ EOF
   # merge to main runs the suite again on a pull request nobody is reviewing.
   # See specs/release-pr-drafts.feature.
   echo "--- $inner_job skips a draft pull request ---"
-  if python3 - "$wf" "$inner_job" <<'EOF'
+  local cond
+  cond="$(python3 - "$wf" "$inner_job" <<'EOF'
 import yaml, sys
 with open(sys.argv[1]) as f:
     d = yaml.safe_load(f)
-cond = str(d.get('jobs', {}).get(sys.argv[2], {}).get('if', ''))
-if 'github.event.pull_request.draft == false' not in cond:
-    print(f"if condition does not skip drafts: {cond!r}")
-    sys.exit(1)
+print(str(d.get('jobs', {}).get(sys.argv[2], {}).get('if', '')))
 EOF
-  then pass "$name: $inner_job skips a draft"; else fail "$name: $inner_job runs on a draft"; fi
+)"
+  if python3 "$DRAFT_GATE_PY" "$cond"
+  then pass "$name: $inner_job skips a draft"
+  else fail "$name: $inner_job does not gate on the pull request not being a draft: ${cond:-<no if condition>}"; fi
 
   echo "--- pull_request types include ready_for_review ---"
   if python3 - "$wf" <<'EOF'
@@ -346,8 +374,7 @@ else fail "python-ci: examples are not covered on runs without secrets"; fi
 # event shape, and GitHub takes the LAST write for a key, which is what makes
 # an unconditional pair of writes visible here.
 echo "--- the resolver's decision, over every event shape ---"
-RESOLVER_SH="$(mktemp)"
-trap 'rm -f "$RESOLVER_SH"' EXIT
+RESOLVER_SH="$TMP_DIR/resolver.sh"
 if python3 - "$REPO_ROOT/.github/workflows/python-ci.yml" > "$RESOLVER_SH" <<'EOF'
 import yaml, sys
 
@@ -399,6 +426,36 @@ fi
 # would otherwise notice: the suite would simply start running on every merge
 # to main again.
 # ---------------------------------------------------------------------------
+echo ""
+echo "=== Validating the draft-gate check itself ==="
+# The check above decides whether a condition keeps the heavy job off a draft.
+# Its own failure mode is accepting a condition that does not, which would let
+# the gate be removed in a rewrite while the validator kept reporting PASS.
+echo "--- the draft-gate check, over conditions that do and do not gate ---"
+DRAFT_GATE_BAD=0
+# <expected: accept|reject> <condition>
+check_draft_gate() {
+  local got
+  if python3 "$DRAFT_GATE_PY" "$2"; then got=accept; else got=reject; fi
+  if [ "$got" != "$1" ]; then
+    echo "    $got, expected $1, for: ${2:-<empty>}"
+    DRAFT_GATE_BAD=1
+  fi
+}
+check_draft_gate accept "needs.changes.outputs.relevant == 'true' && github.event.pull_request.draft == false"
+check_draft_gate accept "github.event.pull_request.draft == false"
+check_draft_gate accept "needs.changes.outputs.relevant == 'true' && !github.event.pull_request.draft"
+check_draft_gate reject "needs.changes.outputs.relevant == 'true' || github.event.pull_request.draft == false"
+check_draft_gate reject "needs.changes.outputs.relevant == 'true' && (github.event.pull_request.draft == false || github.event_name == 'push')"
+check_draft_gate reject "needs.changes.outputs.relevant == 'true' && github.event.pull_request.draft == true"
+check_draft_gate reject "needs.changes.outputs.relevant == 'true'"
+check_draft_gate reject ""
+if [ "$DRAFT_GATE_BAD" -eq 0 ]; then
+  pass "the draft-gate check accepts only a condition that gates on the draft"
+else
+  fail "the draft-gate check misjudges some condition"
+fi
+
 echo ""
 echo "=== Validating release-please opens drafts ==="
 if python3 - "$REPO_ROOT/.release-please-config.json" <<'EOF'

--- a/scripts/validate-aggregator-workflows.sh
+++ b/scripts/validate-aggregator-workflows.sh
@@ -144,6 +144,42 @@ if missing:
 EOF
   then pass "$name: path filters ($filter1, $filter2) present"; else fail "$name: path filters missing (expected $filter1 and $filter2)"; fi
 
+  # The two halves of the draft gate, which only work together. The heavy job
+  # skips a draft, and `ready_for_review` is what gives it its run once the
+  # draft is marked ready. Drop the trigger type and a release-please pull
+  # request merges on a run that skipped the suite; drop the condition and every
+  # merge to main runs the suite again on a pull request nobody is reviewing.
+  # See specs/release-pr-drafts.feature.
+  echo "--- $inner_job skips a draft pull request ---"
+  if python3 - "$wf" "$inner_job" <<'EOF'
+import yaml, sys
+with open(sys.argv[1]) as f:
+    d = yaml.safe_load(f)
+cond = str(d.get('jobs', {}).get(sys.argv[2], {}).get('if', ''))
+if 'github.event.pull_request.draft == false' not in cond:
+    print(f"if condition does not skip drafts: {cond!r}")
+    sys.exit(1)
+EOF
+  then pass "$name: $inner_job skips a draft"; else fail "$name: $inner_job runs on a draft"; fi
+
+  echo "--- pull_request types include ready_for_review ---"
+  if python3 - "$wf" <<'EOF'
+import yaml, sys
+with open(sys.argv[1]) as f:
+    d = yaml.safe_load(f)
+on = d.get('on', d.get(True, {}))
+pr = on.get('pull_request') if isinstance(on, dict) else None
+types = (pr or {}).get('types')
+if not isinstance(types, list):
+    print("pull_request declares no types, so ready_for_review never fires")
+    sys.exit(1)
+missing = [t for t in ('opened', 'synchronize', 'reopened', 'ready_for_review') if t not in types]
+if missing:
+    print(f"missing trigger types: {missing}; declared: {types}")
+    sys.exit(1)
+EOF
+  then pass "$name: pull_request types cover ready_for_review"; else fail "$name: pull_request types miss ready_for_review"; fi
+
   echo "--- $inner_job needs changes ---"
   if python3 - "$wf" "$inner_job" <<'EOF'
 import yaml, sys
@@ -353,6 +389,28 @@ then
 else
   fail "python-ci: could not extract the secrets resolver to run it"
 fi
+
+# ---------------------------------------------------------------------------
+# Release pull requests open as drafts (see specs/release-pr-drafts.feature)
+#
+# The draft gate above only saves anything if release-please actually opens its
+# pull requests as drafts. That setting lives in a strict-JSON config nobody
+# reads on the way past, and turning it off is a one-word edit that no test
+# would otherwise notice: the suite would simply start running on every merge
+# to main again.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Validating release-please opens drafts ==="
+if python3 - "$REPO_ROOT/.release-please-config.json" <<'EOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    config = json.load(f)
+if config.get("draft-pull-request") is not True:
+    print(f"draft-pull-request is {config.get('draft-pull-request')!r}, expected True")
+    sys.exit(1)
+EOF
+then pass "release-please: release pull requests open as drafts"
+else fail "release-please: release pull requests do not open as drafts"; fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/specs/release-pr-drafts.feature
+++ b/specs/release-pr-drafts.feature
@@ -32,6 +32,8 @@ Feature: Release pull requests open as drafts
   Scenario: Every aggregator workflow skips its heavy job on a draft
     When each aggregator workflow's heavy job condition is read
     Then the condition requires the pull request not to be a draft
+    And it requires it as a conjunct, so nothing else in the condition can
+      run the heavy job on a draft anyway
 
   @unit
   Scenario: Every aggregator workflow runs when a draft is marked ready

--- a/specs/release-pr-drafts.feature
+++ b/specs/release-pr-drafts.feature
@@ -1,0 +1,50 @@
+Feature: Release pull requests open as drafts
+  As a maintainer of this repository
+  I want release-please to open its release pull requests as drafts
+  So that a version bump does not run the full test suite on every merge to main
+
+  release-please creates-or-updates one release pull request per package. Every
+  merge to main force-pushes those branches, and the diff is a changelog plus a
+  version field in `package.json` or `pyproject.toml`. Both aggregator workflows
+  path-filter on their own package directory, correctly, since a dependency bump
+  touches the same files, and a path filter cannot tell a version bump from a
+  dependency bump. So a two-file metadata change pulled the JavaScript suite,
+  the Python suite and the examples legs, on every merge, for as long as the
+  release pull request stayed open.
+
+  The heavy jobs already skip a draft. Opening these pull requests as drafts
+  therefore buys the reduction with no new mechanism, and the full suite still
+  runs before anything ships: marking the pull request ready to review fires
+  `ready_for_review`, which the aggregator workflows list in their trigger types
+  precisely so the heavy jobs get their run then. A draft cannot be merged, so
+  "ready for review" is the same click as "I am releasing this".
+
+  Background:
+    Given release-please is configured by `.release-please-config.json`
+    And the aggregator workflows are `javascript-ci`, `python-ci` and `docs-ci`
+
+  @unit
+  Scenario: The release configuration opens release pull requests as drafts
+    When the release-please configuration is read
+    Then it sets draft-pull-request
+
+  @unit
+  Scenario: Every aggregator workflow skips its heavy job on a draft
+    When each aggregator workflow's heavy job condition is read
+    Then the condition requires the pull request not to be a draft
+
+  @unit
+  Scenario: Every aggregator workflow runs when a draft is marked ready
+    When each aggregator workflow's pull_request trigger is read
+    Then its types include ready_for_review
+    And its types still include opened, synchronize and reopened
+
+  Scenario: A merge to main refreshes a release pull request without running the suite
+    Given an open release pull request in draft
+    When a commit lands on main and release-please updates that pull request
+    Then the aggregator workflows report success with their heavy jobs skipped
+
+  Scenario: Marking the release pull request ready runs the full suite
+    Given an open release pull request in draft
+    When a maintainer marks it ready for review
+    Then the aggregator workflows run their heavy jobs against the release commit


### PR DESCRIPTION
## What

Release Please now opens its release pull requests as drafts, the way langwatch/langwatch does.

## Why

Release Please creates-or-updates one release pull request per package, so every merge to `main` force-pushes those branches. The diff is a changelog plus a version field, and `javascript-ci`, `python-ci` and `docs-ci` path-filter on the package directory those files live in. That filter is correct, since a dependency bump touches the same files and a path filter cannot tell a version bump from a dependency bump. The result was the full JavaScript suite, the full Python suite and the examples legs running on every merge to main, for as long as a release pull request stayed open.

## How

- `draft-pull-request: true` in `.release-please-config.json`.
- `python-ci`'s `test` job skips a draft. `javascript-ci` and `docs-ci` already did.
- All three list `ready_for_review` in their `pull_request` trigger types. Without it the last run on the draft, with the heavy job skipped, would stand as the required check for a release nobody tested.

Nothing ships untested. Marking the release pull request ready to review fires `ready_for_review` and runs the full suite against the release commit. A draft cannot be merged, so that click is the same decision as releasing.

## Guardrail

Each of the three pieces is silent on its own: drop the config setting and the suite runs on every merge again, drop the trigger type and a release merges on a skipped run. `scripts/validate-aggregator-workflows.sh` now fails on any of them, and meta-ci already runs that script on every pull request. Verified by removing each piece and watching the validator go red.

## Spec

`specs/release-pr-drafts.feature`

## Release note

The first release pull request after this merges opens as a draft. Review it, mark it ready for review to run the suite, then merge as before.
