### PR TITLE
chore(release): ship the javascript voice work as 1.7.0

### DIFF
--- a/javascript/.release-please-shim
+++ b/javascript/.release-please-shim
@@ -1,1 +1,1 @@
-release-please shadow marker (v2), next: 1.0.0
+release-please shadow marker (v2), next: 1.7.0


### PR DESCRIPTION
## Why
The draft release PR #977 computed the next javascript version as 2.0.0 because #950 dropped the `UserSimulatorAgentWithVoice` re-export shim (a breaking-change footer). Nothing consumed that export and it was not usable on its own, so the drop is not a breaking change for users. The voice work from #982 should ship as a minor.

## What changed
One commit carrying the `Release-As: 1.7.0` footer. It touches only `javascript/.release-please-shim` (marker text `next: 1.0.0` to `next: 1.7.0`) so the manifest attributes the commit to the javascript component.

## What happens on merge
The repo squashes with the commit messages as the body, so the footer survives. release-please runs on the push to main and rewrites #977 as `chore(main): release javascript 1.7.0` with the same changelog. The python component is untouched.

## Human verification
1. After merge, open #977 and confirm the title and `javascript/package.json` say 1.7.0.
2. Confirm `.release-please-manifest.json` in #977 shows `"javascript": "1.7.0"`.

Refs #977, #982, langwatch/langwatch#7978
